### PR TITLE
feat(i18n): add complete Polish translation

### DIFF
--- a/translations/plasmazones_pl.ts
+++ b/translations/plasmazones_pl.ts
@@ -1,0 +1,5573 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pl">
+<context>
+    <name>plasmazones</name>
+    <message>
+        <location filename="../src/editor/controller/settings.cpp" line="52"/>
+        <source>A zone with this name already exists</source>
+        <translation>Strefa o tej nazwie już istnieje</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/AddZoneCommand.cpp" line="16"/>
+        <source>Add Zone</source>
+        <comment>@action</comment>
+        <translation>Dodaj strefę</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/shortcutmanager.cpp" line="592"/>
+        <source>Apply Layout %1</source>
+        <translation>Zastosuj układ %1</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/ApplyTemplateCommand.cpp" line="14"/>
+        <source>Apply Template: %1</source>
+        <comment>@action</comment>
+        <translation>Zastosuj szablon: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/zoneops.cpp" line="185"/>
+        <source>Bring Forward</source>
+        <comment>@action</comment>
+        <translation>Przesuń do przodu</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/zoneops.cpp" line="175"/>
+        <source>Bring to Front</source>
+        <comment>@action</comment>
+        <translation>Przenieś na wierzch</translation>
+    </message>
+    <message>
+        <location filename="../src/dbus/windowdragadaptor.cpp" line="357"/>
+        <source>Cancel Zone Overlay</source>
+        <translation>Anuluj nakładkę stref</translation>
+    </message>
+    <message>
+        <location filename="../src/dbus/windowdragadaptor.cpp" line="412"/>
+        <source>Layout Picker: Move Left</source>
+        <translation>Wybór układu: przesuń w lewo</translation>
+    </message>
+    <message>
+        <location filename="../src/dbus/windowdragadaptor.cpp" line="416"/>
+        <source>Layout Picker: Move Right</source>
+        <translation>Wybór układu: przesuń w prawo</translation>
+    </message>
+    <message>
+        <location filename="../src/dbus/windowdragadaptor.cpp" line="420"/>
+        <source>Layout Picker: Move Up</source>
+        <translation>Wybór układu: przesuń w górę</translation>
+    </message>
+    <message>
+        <location filename="../src/dbus/windowdragadaptor.cpp" line="424"/>
+        <source>Layout Picker: Move Down</source>
+        <translation>Wybór układu: przesuń w dół</translation>
+    </message>
+    <message>
+        <location filename="../src/dbus/windowdragadaptor.cpp" line="428"/>
+        <location filename="../src/dbus/windowdragadaptor.cpp" line="430"/>
+        <source>Layout Picker: Confirm</source>
+        <translation>Wybór układu: potwierdź</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/UpdateGapOverrideCommand.cpp" line="21"/>
+        <source>Change Edge Gap</source>
+        <comment>@action</comment>
+        <translation>Zmień odstęp krawędziowy</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/UpdateGapOverrideCommand.cpp" line="20"/>
+        <source>Change Overlay Style</source>
+        <comment>@action</comment>
+        <translation>Zmień styl nakładki</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/ChangeSelectionCommand.cpp" line="14"/>
+        <source>Change Selection</source>
+        <comment>@action</comment>
+        <translation>Zmień zaznaczenie</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/UpdateShaderIdCommand.cpp" line="15"/>
+        <source>Change Shader Effect</source>
+        <comment>@action</comment>
+        <translation>Zmień efekt shadera</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/UpdateShaderParamsCommand.cpp" line="17"/>
+        <source>Change Shader Parameter</source>
+        <comment>@action</comment>
+        <translation>Zmień parametr shadera</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/UpdateShaderParamsCommand.cpp" line="29"/>
+        <source>Change Shader Parameters</source>
+        <comment>@action</comment>
+        <translation>Zmień parametry shadera</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/ChangeZOrderCommand.cpp" line="13"/>
+        <source>Change Z-Order</source>
+        <comment>@action</comment>
+        <translation>Zmień kolejność Z</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/UpdateZoneAppearanceCommand.cpp" line="15"/>
+        <source>Change Zone Appearance</source>
+        <comment>@action</comment>
+        <translation>Zmień wygląd strefy</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/UpdateFixedGeometryCommand.cpp" line="15"/>
+        <source>Change Zone Dimensions</source>
+        <comment>@action</comment>
+        <translation>Zmień wymiary strefy</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/UpdateZoneNumberCommand.cpp" line="16"/>
+        <source>Change Zone Number</source>
+        <comment>@action</comment>
+        <translation>Zmień numer strefy</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/UpdateGapOverrideCommand.cpp" line="16"/>
+        <source>Change Zone Padding</source>
+        <comment>@action</comment>
+        <translation>Zmień wypełnienie strefy</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/UpdateVisibilityCommand.cpp" line="17"/>
+        <source>Change Zone Visibility</source>
+        <comment>@action</comment>
+        <translation>Zmień widoczność strefy</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/ClearAllZonesCommand.cpp" line="12"/>
+        <source>Clear All Zones</source>
+        <comment>@action</comment>
+        <translation>Wyczyść wszystkie strefy</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/gaps.cpp" line="327"/>
+        <source>Clear Edge Gap Override</source>
+        <comment>@action</comment>
+        <translation>Wyczyść zastąpienie odstępu krawędziowego</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/main.cpp" line="151"/>
+        <source>Create new layout</source>
+        <translation>Utwórz nowy układ</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/clipboard.cpp" line="96"/>
+        <source>Cut %1 Zones</source>
+        <comment>@action</comment>
+        <translation>Wytnij strefy (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/multiselect.cpp" line="34"/>
+        <source>Delete %1 Zones</source>
+        <comment>@action</comment>
+        <translation>Usuń strefy (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/DeleteZoneCommand.cpp" line="14"/>
+        <location filename="../src/editor/undo/commands/DeleteZoneWithFillCommand.cpp" line="14"/>
+        <source>Delete Zone</source>
+        <comment>@action</comment>
+        <translation>Usuń strefę</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/multiselect.cpp" line="62"/>
+        <source>Duplicate %1 Zones</source>
+        <comment>@action</comment>
+        <translation>Powiel strefy (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/DuplicateZoneCommand.cpp" line="15"/>
+        <source>Duplicate Zone</source>
+        <comment>@action</comment>
+        <translation>Powiel strefę</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/FillZoneCommand.cpp" line="13"/>
+        <source>Fill Zone</source>
+        <comment>@action</comment>
+        <translation>Wypełnij strefę</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/layout.cpp" line="528"/>
+        <source>Invalid layout data format</source>
+        <translation>Nieprawidłowy format danych układu</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/layout.cpp" line="1041"/>
+        <location filename="../src/editor/controller/layout.cpp" line="1079"/>
+        <source>File path cannot be empty</source>
+        <translation>Ścieżka pliku nie może być pusta</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/layout.cpp" line="1048"/>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="334"/>
+        <source>Failed to import layout: %1</source>
+        <translation>Nie udało się zaimportować układu: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/layout.cpp" line="1059"/>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="341"/>
+        <source>That file is not a layout this app can read.</source>
+        <translation>Ten plik nie jest układem, który ta aplikacja potrafi odczytać.</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/layout.cpp" line="1102"/>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="386"/>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="545"/>
+        <source>Could not write the export. Check that the folder is writable.</source>
+        <translation>Nie udało się zapisać eksportu. Sprawdź, czy w folderze można zapisywać.</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/layout.cpp" line="1084"/>
+        <source>No layout loaded to export</source>
+        <translation>Nie wczytano żadnego układu do wyeksportowania</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/layout.cpp" line="1091"/>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="377"/>
+        <source>Failed to export layout: %1</source>
+        <translation>Nie udało się wyeksportować układu: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/layout.cpp" line="493"/>
+        <source>Layout ID cannot be empty</source>
+        <translation>Identyfikator układu nie może być pusty</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/main.cpp" line="147"/>
+        <source>Layout ID to edit</source>
+        <translation>Identyfikator układu do edycji</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/daemon/osd.cpp" line="165"/>
+        <source>Layout Locked</source>
+        <translation>Układ zablokowany</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/daemon/osd.cpp" line="214"/>
+        <source>Disabled on this monitor</source>
+        <translation>Wyłączone na tym ekranie</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/daemon/osd.cpp" line="225"/>
+        <source>Desktop %1</source>
+        <translation>Pulpit %1</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/daemon/osd.cpp" line="227"/>
+        <location filename="../src/daemon/daemon/osd.cpp" line="238"/>
+        <source>Disabled on %1</source>
+        <translation>Wyłączone na %1</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/daemon/osd.cpp" line="236"/>
+        <source>Disabled on this activity</source>
+        <translation>Wyłączone w tej aktywności</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/daemon/osd.cpp" line="266"/>
+        <source>No layout assigned</source>
+        <translation>Nie przypisano układu</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/layout.cpp" line="498"/>
+        <source>Layout service not initialized</source>
+        <translation>Usługa układów nie została zainicjowana</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/daemon/osd.cpp" line="138"/>
+        <source>Layout: %1</source>
+        <translation>Układ: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/multiselect.cpp" line="106"/>
+        <location filename="../src/editor/controller/multiselect.cpp" line="361"/>
+        <source>Move %1 Zones</source>
+        <comment>@action</comment>
+        <translation>Przenieś strefy (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/UpdateZoneGeometryCommand.cpp" line="14"/>
+        <source>Move Zone</source>
+        <comment>@action</comment>
+        <translation>Przenieś strefę</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/layout.cpp" line="433"/>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="184"/>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="192"/>
+        <source>New Layout</source>
+        <translation>Nowy układ</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/main.cpp" line="152"/>
+        <source>Open in read-only preview mode</source>
+        <translation>Otwórz w trybie podglądu tylko do odczytu</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/clipboard.cpp" line="196"/>
+        <location filename="../src/editor/undo/commands/PasteZonesCommand.cpp" line="14"/>
+        <source>Paste %1 Zones</source>
+        <comment>@action</comment>
+        <translation>Wklej strefy (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/UpdateLayoutNameCommand.cpp" line="13"/>
+        <source>Rename Layout</source>
+        <comment>@action</comment>
+        <translation>Zmień nazwę układu</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/UpdateZoneNameCommand.cpp" line="14"/>
+        <source>Rename Zone</source>
+        <comment>@action</comment>
+        <translation>Zmień nazwę strefy</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/main.cpp" line="215"/>
+        <source>Window tiling and zone management</source>
+        <translation>Kafelkowanie okien i zarządzanie strefami</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/main.cpp" line="220"/>
+        <source>Replace existing daemon instance</source>
+        <translation>Zastąp istniejącą instancję demona</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/main.cpp" line="224"/>
+        <source>Enable debug logging for all PlasmaZones categories</source>
+        <translation>Włącz rejestrowanie diagnostyczne dla wszystkich kategorii PlasmaZones</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/main.cpp" line="228"/>
+        <source>Write log output to &lt;file&gt; instead of stderr</source>
+        <translation>Zapisuj dane rejestru do &lt;file&gt; zamiast do stderr</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/main.cpp" line="229"/>
+        <source>file</source>
+        <translation>plik</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/shader.cpp" line="271"/>
+        <source>Reset Shader Parameters</source>
+        <comment>@action</comment>
+        <translation>Wyzeruj parametry shadera</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/multiselect.cpp" line="189"/>
+        <source>Resize %1 Zones</source>
+        <comment>@action</comment>
+        <translation>Zmień rozmiar stref (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/DividerResizeCommand.cpp" line="15"/>
+        <source>Resize Zones</source>
+        <comment>@action</comment>
+        <translation>Zmień rozmiar stref</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/zoneops.cpp" line="190"/>
+        <source>Send Backward</source>
+        <comment>@action</comment>
+        <translation>Przesuń do tyłu</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/zoneops.cpp" line="180"/>
+        <source>Send to Back</source>
+        <comment>@action</comment>
+        <translation>Przenieś na spód</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/layout.cpp" line="843"/>
+        <source>Services not initialized</source>
+        <translation>Usługi nie zostały zainicjowane</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/zones.cpp" line="197"/>
+        <location filename="../src/editor/controller/zones.cpp" line="233"/>
+        <source>Services not initialized</source>
+        <comment>@info</comment>
+        <translation>Usługi nie zostały zainicjowane</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/shortcutmanager.cpp" line="610"/>
+        <source>Snap to Zone %1</source>
+        <translation>Przyciągnij do strefy %1</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/SplitZoneCommand.cpp" line="16"/>
+        <source>Split Zone</source>
+        <comment>@action</comment>
+        <translation>Podziel strefę</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/shader.cpp" line="287"/>
+        <source>Switch Shader Effect</source>
+        <comment>@action</comment>
+        <translation>Przełącz efekt shadera</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/main.cpp" line="149"/>
+        <source>Target screen name</source>
+        <translation>Nazwa docelowego ekranu</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/daemon/osd.cpp" line="295"/>
+        <location filename="../src/settings/rulemodel.cpp" line="285"/>
+        <source>Tiling: %1</source>
+        <translation>Kafelkowanie: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/UpdateGapOverrideCommand.cpp" line="18"/>
+        <source>Toggle Per-Side Edge Gap</source>
+        <comment>@action</comment>
+        <translation>Przełącz osobny odstęp krawędziowy dla stron</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/ToggleGeometryModeCommand.cpp" line="17"/>
+        <source>Toggle Relative/Fixed Size</source>
+        <comment>@action</comment>
+        <translation>Przełącz rozmiar względny/stały</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/UpdateFullScreenGeometryCommand.cpp" line="15"/>
+        <source>Toggle Use Full Screen Area</source>
+        <comment>@action</comment>
+        <translation>Przełącz użycie pełnego obszaru ekranu</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/BatchUpdateAppearanceCommand.cpp" line="21"/>
+        <source>Update Appearance for %1 Zones</source>
+        <comment>@action</comment>
+        <translation>Zaktualizuj wygląd stref (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/BatchUpdateAppearanceCommand.cpp" line="73"/>
+        <source>Update Color for %1 Zones</source>
+        <comment>@action</comment>
+        <translation>Zaktualizuj barwę stref (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/main.cpp" line="142"/>
+        <source>Visual layout editor for PlasmaZones</source>
+        <translation>Wizualny edytor układów dla PlasmaZones</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/clipboard.cpp" line="34"/>
+        <location filename="../src/editor/controller/clipboard.cpp" line="107"/>
+        <source>Zone manager not initialized</source>
+        <comment>@info</comment>
+        <translation>Menedżer stref nie został zainicjowany</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/settings.cpp" line="40"/>
+        <source>Zone name contains invalid characters: &lt; &gt; &quot; &apos; \</source>
+        <translation>Nazwa strefy zawiera nieprawidłowe znaki: &lt; &gt; &quot; &apos; \</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/zones.cpp" line="106"/>
+        <location filename="../src/editor/controller/zones.cpp" line="212"/>
+        <location filename="../src/editor/controller/zones.cpp" line="248"/>
+        <location filename="../src/editor/controller/zones.cpp" line="327"/>
+        <source>Zone not found</source>
+        <comment>@info</comment>
+        <translation>Nie znaleziono strefy</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/settings.cpp" line="94"/>
+        <source>Zone number %1 is already in use</source>
+        <translation>Numer strefy %1 jest już używany</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/settings.cpp" line="74"/>
+        <source>Zone number cannot exceed 99</source>
+        <translation>Numer strefy nie może przekraczać 99</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/settings.cpp" line="31"/>
+        <source>Zone name cannot exceed %1 characters</source>
+        <translation>Nazwa strefy nie może przekraczać %1 znaków</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/settings.cpp" line="71"/>
+        <source>Zone number must be at least 1</source>
+        <translation>Numer strefy musi wynosić co najmniej 1</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/daemon.cpp" line="2159"/>
+        <source>The PlasmaZones KWin effect plugin is not installed where KWin can find it. Reinstall PlasmaZones.</source>
+        <translation>Wtyczka efektu KWin dla PlasmaZones nie jest zainstalowana w miejscu, w którym KWin może ją znaleźć. Zainstaluj ponownie PlasmaZones.</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/daemon.cpp" line="2198"/>
+        <source>The PlasmaZones KWin effect was built for KWin %1 but KWin %2 is running, so KWin will not load it. Rebuild and reinstall PlasmaZones against the running KWin.</source>
+        <translation>Efekt KWin dla PlasmaZones został zbudowany dla KWin %1, ale uruchomiony jest KWin %2, więc KWin go nie wczyta. Przebuduj i zainstaluj ponownie PlasmaZones dla uruchomionego KWin.</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/daemon.cpp" line="2225"/>
+        <source>The PlasmaZones KWin effect has not registered with the daemon, so window dragging and shortcuts will not work. Make sure it is enabled in System Settings &gt; Desktop Effects, then restart the Plasma session.</source>
+        <translation>Efekt KWin dla PlasmaZones nie zarejestrował się w demonie, więc przeciąganie okien i skróty nie będą działać. Upewnij się, że jest włączony w Ustawieniach systemowych &gt; Efekty pulpitu, a następnie uruchom ponownie sesję Plasmy.</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/daemon.cpp" line="2244"/>
+        <source>PlasmaZones: window manager integration inactive</source>
+        <translation>PlasmaZones: integracja z menedżerem okien nieaktywna</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="70"/>
+        <source> (Copy)</source>
+        <extracomment>Suffix appended to the name of a duplicated algorithm. Keep the leading space.</extracomment>
+        <translation> (kopia)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="329"/>
+        <location filename="../src/settings/algorithmservice.cpp" line="401"/>
+        <location filename="../src/settings/algorithmservice.cpp" line="413"/>
+        <source>Could not read the algorithm file. Check that it still exists and is readable.</source>
+        <translation>Nie udało się odczytać pliku algorytmu. Sprawdź, czy nadal istnieje i czy można go odczytać.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="338"/>
+        <source>Only Luau algorithm files (.luau) can be imported.</source>
+        <translation>Można importować tylko pliki algorytmów Luau (.luau).</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="343"/>
+        <source>Algorithm file names may contain only letters, digits, hyphens, and underscores.</source>
+        <translation>Nazwy plików algorytmów mogą zawierać tylko litery, cyfry, łączniki i podkreślenia.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="356"/>
+        <location filename="../src/settings/algorithmservice.cpp" line="418"/>
+        <source>That algorithm file is too large to load. Algorithms are limited to 1 MB.</source>
+        <translation>Ten plik algorytmu jest zbyt duży, aby go wczytać. Algorytmy są ograniczone do 1 MB.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="387"/>
+        <source>Too many algorithms share this name. Remove some and try again.</source>
+        <translation>Zbyt wiele algorytmów ma tę samą nazwę. Usuń część z nich i spróbuj ponownie.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="426"/>
+        <source>Could not copy the algorithm file. Check available disk space and permissions.</source>
+        <translation>Nie udało się skopiować pliku algorytmu. Sprawdź dostępne miejsce na dysku i uprawnienia.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="492"/>
+        <source>Algorithm was created but not picked up by the registry. Try refreshing or restarting the application.</source>
+        <translation>Algorytm został utworzony, ale nie został wykryty przez rejestr. Spróbuj odświeżyć lub uruchomić ponownie aplikację.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="552"/>
+        <source>No algorithm is selected to delete.</source>
+        <translation>Nie wybrano żadnego algorytmu do usunięcia.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="559"/>
+        <source>Only user-created algorithms can be deleted.</source>
+        <translation>Można usuwać tylko algorytmy utworzone przez użytkownika.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="566"/>
+        <source>Algorithm file not found.</source>
+        <translation>Nie znaleziono pliku algorytmu.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="580"/>
+        <source>The user algorithms directory does not exist.</source>
+        <translation>Katalog algorytmów użytkownika nie istnieje.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="581"/>
+        <source>That file is outside the user algorithms directory.</source>
+        <translation>Ten plik znajduje się poza katalogiem algorytmów użytkownika.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="594"/>
+        <source>Could not delete algorithm file. Check file permissions.</source>
+        <translation>Nie udało się usunąć pliku algorytmu. Sprawdź uprawnienia do pliku.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="604"/>
+        <location filename="../src/settings/algorithmservice.cpp" line="720"/>
+        <source>The algorithm file could not be found.</source>
+        <translation>Nie udało się znaleźć pliku algorytmu.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="610"/>
+        <source>That algorithm is no longer registered.</source>
+        <translation>Ten algorytm nie jest już zarejestrowany.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="628"/>
+        <source>Too many copies of this algorithm already exist. Rename or delete some before duplicating.</source>
+        <translation>Istnieje już zbyt wiele kopii tego algorytmu. Zmień nazwę lub usuń część przed powieleniem.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="636"/>
+        <source>The algorithm file path could not be resolved.</source>
+        <translation>Nie udało się ustalić ścieżki pliku algorytmu.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="643"/>
+        <location filename="../src/settings/algorithmservice.cpp" line="654"/>
+        <source>Could not read source algorithm file.</source>
+        <translation>Nie udało się odczytać źródłowego pliku algorytmu.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="695"/>
+        <source>Could not duplicate the algorithm. Its metadata table is not in a shape this app can rewrite.</source>
+        <translation>Nie udało się powielić algorytmu. Jego tabela metadanych nie ma postaci, którą ta aplikacja potrafi przepisać.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="730"/>
+        <location filename="../src/settings/algorithmservice.cpp" line="739"/>
+        <source>Could not read the algorithm file for export.</source>
+        <translation>Nie udało się odczytać pliku algorytmu do eksportu.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="702"/>
+        <source>Could not write duplicate algorithm file. Check disk space and permissions.</source>
+        <translation>Nie udało się zapisać powielonego pliku algorytmu. Sprawdź miejsce na dysku i uprawnienia.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="714"/>
+        <source>No export destination specified.</source>
+        <translation>Nie określono miejsca docelowego eksportu.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="745"/>
+        <source>Could not write to export destination.</source>
+        <translation>Nie udało się zapisać do miejsca docelowego eksportu.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="782"/>
+        <source>Too many algorithms already share this name. Rename or delete some before creating another.</source>
+        <translation>Zbyt wiele algorytmów ma już tę samą nazwę. Zmień nazwę lub usuń część przed utworzeniem kolejnego.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="816"/>
+        <location filename="../src/settings/algorithmservice.cpp" line="859"/>
+        <source>The selected template could not be used. Pick another template or start blank.</source>
+        <translation>Nie udało się użyć wybranego szablonu. Wybierz inny szablon lub zacznij od pustego.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="833"/>
+        <source>The selected template could not be found. Pick another template or start blank.</source>
+        <translation>Nie udało się znaleźć wybranego szablonu. Wybierz inny szablon lub zacznij od pustego.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="841"/>
+        <location filename="../src/settings/algorithmservice.cpp" line="849"/>
+        <source>The selected template could not be read. Pick another template or start blank.</source>
+        <translation>Nie udało się odczytać wybranego szablonu. Wybierz inny szablon lub zacznij od pustego.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="878"/>
+        <source>Could not write algorithm file. Check disk space and permissions.</source>
+        <translation>Nie udało się zapisać pliku algorytmu. Sprawdź miejsce na dysku i uprawnienia.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/animationspagecontroller.cpp" line="131"/>
+        <source>Cannot modify sets while a discard is in progress.</source>
+        <translation>Nie można modyfikować zestawów w trakcie odrzucania.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/animationspagecontroller.cpp" line="342"/>
+        <source>Cannot save while a discard is in progress.</source>
+        <translation>Nie można zapisać w trakcie odrzucania.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/animationspagecontroller.cpp" line="507"/>
+        <location filename="../src/settings/rulecontroller.cpp" line="150"/>
+        <source>Discard already in flight.</source>
+        <translation>Odrzucanie już trwa.</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/settings/animationspagecontroller.cpp" line="575"/>
+        <source>Could not restore %n profile file(s). They remain pending.</source>
+        <translation>
+            <numerusform>Nie udało się przywrócić %n pliku profilu. Pozostaje on oczekujący.</numerusform>
+            <numerusform>Nie udało się przywrócić %n plików profilu. Pozostają one oczekujące.</numerusform>
+            <numerusform>Nie udało się przywrócić %n plików profilu. Pozostają one oczekujące.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/settings/animationspagecontroller.cpp" line="709"/>
+        <location filename="../src/settings/animationspagecontroller.cpp" line="719"/>
+        <source>Cannot modify presets while a discard is in progress.</source>
+        <translation>Nie można modyfikować nastaw w trakcie odrzucania.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/animationspagecontroller_shaders.cpp" line="165"/>
+        <location filename="../src/settings/decorationpagecontroller_browser.cpp" line="98"/>
+        <source>Could not create the user shader directory.</source>
+        <translation>Nie udało się utworzyć katalogu shaderów użytkownika.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/kzonesimporter.cpp" line="62"/>
+        <source>No KZones configuration found in kwinrc</source>
+        <translation>Nie znaleziono konfiguracji KZones w kwinrc</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/kzonesimporter.cpp" line="68"/>
+        <source>Failed to parse KZones layoutsJson: %1</source>
+        <translation>Nie udało się przetworzyć layoutsJson z KZones: %1</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/settings/kzonesimporter.cpp" line="73"/>
+        <source>Imported %n layout(s) from KZones</source>
+        <translation>
+            <numerusform>Zaimportowano %n układ z KZones</numerusform>
+            <numerusform>Zaimportowano %n układy z KZones</numerusform>
+            <numerusform>Zaimportowano %n układów z KZones</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/settings/kzonesimporter.cpp" line="75"/>
+        <source>No layouts found in KZones configuration</source>
+        <translation>Nie znaleziono układów w konfiguracji KZones</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/kzonesimporter.cpp" line="83"/>
+        <source>No file path specified</source>
+        <translation>Nie podano ścieżki pliku</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/kzonesimporter.cpp" line="88"/>
+        <source>Could not open file: %1</source>
+        <translation>Nie można otworzyć pliku: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/kzonesimporter.cpp" line="101"/>
+        <source>Failed to parse KZones JSON: %1</source>
+        <translation>Nie udało się przetworzyć pliku JSON KZones: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/kzonesimporter.cpp" line="111"/>
+        <source>KZones file does not contain a JSON array or object</source>
+        <translation>Plik KZones nie zawiera tablicy ani obiektu JSON</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/settings/kzonesimporter.cpp" line="116"/>
+        <source>Imported %n layout(s) from KZones file</source>
+        <translation>
+            <numerusform>Zaimportowano %n układ z pliku KZones</numerusform>
+            <numerusform>Zaimportowano %n układy z pliku KZones</numerusform>
+            <numerusform>Zaimportowano %n układów z pliku KZones</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/settings/kzonesimporter.cpp" line="118"/>
+        <source>No valid layouts found in file</source>
+        <translation>Nie znaleziono prawidłowych układów w pliku</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/main.cpp" line="108"/>
+        <source>PlasmaZones Settings</source>
+        <translation>Ustawienia PlasmaZones</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/main.cpp" line="113"/>
+        <source>Open a specific settings page</source>
+        <translation>Otwórz określoną stronę ustawień</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/main.cpp" line="116"/>
+        <source>Reveal a specific setting on the page (deep link)</source>
+        <translation>Pokaż określone ustawienie na stronie (odnośnik bezpośredni)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/main.cpp" line="120"/>
+        <source>Reveal a specific section on the page (deep link)</source>
+        <translation>Pokaż określoną sekcję na stronie (odnośnik bezpośredni)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="60"/>
+        <source>Identity</source>
+        <translation>Tożsamość</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="66"/>
+        <source>Type</source>
+        <translation>Typ</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="79"/>
+        <source>State</source>
+        <translation>Stan</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="85"/>
+        <source>Taskbar &amp; switcher</source>
+        <translation>Pasek zadań i przełącznik</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="91"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="238"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="243"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="788"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="147"/>
+        <source>Tiling</source>
+        <translation>Kafelkowanie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="96"/>
+        <source>Size</source>
+        <translation>Rozmiar</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="104"/>
+        <source>Context</source>
+        <translation>Kontekst</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="106"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="218"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="260"/>
+        <source>Other</source>
+        <translation>Inne</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="117"/>
+        <source>The application&apos;s ID (Wayland app_id / desktop entry), e.g. org.kde.konsole.</source>
+        <translation>Identyfikator aplikacji (Wayland app_id / wpis pulpitu), np. org.kde.konsole.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="119"/>
+        <source>The window&apos;s class (WM_CLASS resource class), e.g. konsole.</source>
+        <translation>Klasa okna (klasa zasobu WM_CLASS), np. konsole.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="121"/>
+        <source>The application&apos;s desktop entry file name.</source>
+        <translation>Nazwa pliku wpisu pulpitu aplikacji.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="123"/>
+        <source>The window&apos;s X11 role (WM_WINDOW_ROLE). Empty for Wayland-native windows.</source>
+        <translation>Rola X11 okna (WM_WINDOW_ROLE). Pusta dla okien natywnych Wayland.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="125"/>
+        <source>The window&apos;s process ID.</source>
+        <translation>Identyfikator procesu okna.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="127"/>
+        <source>The window&apos;s title-bar text.</source>
+        <translation>Tekst na pasku tytułu okna.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="129"/>
+        <source>The window&apos;s type (Normal, Dialog, Utility, Notification, …).</source>
+        <translation>Typ okna (Normalne, Okno dialogowe, Narzędziowe, Powiadomienie, …).</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="131"/>
+        <source>Whether the window is shown on all virtual desktops.</source>
+        <translation>Czy okno jest widoczne na wszystkich wirtualnych pulpitach.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="133"/>
+        <source>Whether the window is fullscreen.</source>
+        <translation>Czy okno jest w trybie pełnego ekranu.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="135"/>
+        <source>Whether the window is minimized.</source>
+        <translation>Czy okno jest zminimalizowane.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="137"/>
+        <source>Whether the window is maximized.</source>
+        <translation>Czy okno jest zmaksymalizowane.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="139"/>
+        <source>Whether the window currently has keyboard focus.</source>
+        <translation>Czy okno ma obecnie uaktywnienie klawiatury.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="141"/>
+        <source>Whether the window is a transient (a dialog or popup owned by another window).</source>
+        <translation>Czy okno jest tymczasowe (okno dialogowe lub wyskakujące należące do innego okna).</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="143"/>
+        <source>Whether the window is a notification or on-screen display.</source>
+        <translation>Czy okno jest powiadomieniem lub komunikatem ekranowym.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="145"/>
+        <source>The window&apos;s width in pixels.</source>
+        <translation>Szerokość okna w pikselach.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="147"/>
+        <source>The window&apos;s height in pixels.</source>
+        <translation>Wysokość okna w pikselach.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="149"/>
+        <source>Whether the window is set to stay above other windows (always on top).</source>
+        <translation>Czy okno jest ustawione tak, aby pozostawało nad innymi oknami (zawsze na wierzchu).</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="151"/>
+        <source>Whether the window is set to stay below other windows.</source>
+        <translation>Czy okno jest ustawione tak, aby pozostawało pod innymi oknami.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="153"/>
+        <source>Whether the window is hidden from the taskbar.</source>
+        <translation>Czy okno jest ukryte na pasku zadań.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="155"/>
+        <source>Whether the window is hidden from the pager.</source>
+        <translation>Czy okno jest ukryte w pagerze.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="157"/>
+        <source>Whether the window is hidden from the window switcher (Alt+Tab).</source>
+        <translation>Czy okno jest ukryte w przełączniku okien (Alt+Tab).</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="159"/>
+        <source>Whether the window is a modal dialog.</source>
+        <translation>Czy okno jest modalnym oknem dialogowym.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="161"/>
+        <source>Whether the window has a server-side title-bar and border.</source>
+        <translation>Czy okno ma pasek tytułu i obramowanie po stronie serwera.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="163"/>
+        <source>Whether the window can be resized.</source>
+        <translation>Czy można zmieniać rozmiar okna.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="169"/>
+        <source>The window&apos;s left-edge X position in pixels.</source>
+        <translation>Pozycja X lewej krawędzi okna w pikselach.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="171"/>
+        <source>The window&apos;s top-edge Y position in pixels.</source>
+        <translation>Pozycja Y górnej krawędzi okna w pikselach.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="173"/>
+        <source>The window&apos;s title without the application-name suffix the window manager adds.</source>
+        <translation>Tytuł okna bez przyrostka z nazwą aplikacji dodawanego przez menedżera okien.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="175"/>
+        <source>Whether the window has been floated out of tiling (snap or autotile).</source>
+        <translation>Czy okno zostało uczynione pływającym poza kafelkowaniem (przyciąganie lub automatyczne kafelkowanie).</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="177"/>
+        <source>Whether the window is snapped into a zone (manual-zone mode, where tiled windows are not snapped).</source>
+        <translation>Czy okno jest przyciągnięte do strefy (tryb ręcznych stref, w którym okna kafelkowane nie są przyciągane).</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="180"/>
+        <source>Whether the window is managed by the autotile engine.</source>
+        <translation>Czy oknem zarządza silnik automatycznego kafelkowania.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="182"/>
+        <source>The zone the window is snapped into (manual-zone mode only).</source>
+        <translation>Strefa, do której okno jest przyciągnięte (tylko tryb ręcznych stref).</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="184"/>
+        <source>The monitor the window is on.</source>
+        <translation>Ekran, na którym znajduje się okno.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="186"/>
+        <source>The virtual desktop the window is on.</source>
+        <translation>Wirtualny pulpit, na którym znajduje się okno.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="188"/>
+        <source>The KDE Activity the window is on.</source>
+        <translation>Aktywność KDE, na której znajduje się okno.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="190"/>
+        <source>The engine mode the window is placed by (snapping or tiling).</source>
+        <translation>Tryb silnika, w którym okno jest umieszczane (przyciąganie lub kafelkowanie).</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="192"/>
+        <source>How many windows are tiled on this monitor and desktop. Lets a rule switch the tiling algorithm as windows open and close, for example a centered single-window layout that gives way once a second window opens.</source>
+        <translation>Ile okien jest kafelkowanych na tym ekranie i pulpicie. Pozwala regule zmienić algorytm kafelkowania w miarę otwierania i zamykania okien, na przykład wyśrodkowany układ jednego okna, który ustępuje po otwarciu drugiego okna.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="226"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="402"/>
+        <source>Gaps</source>
+        <translation>Odstępy</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="249"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="168"/>
+        <source>Overlay</source>
+        <translation>Nakładka</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="252"/>
+        <source>Animation</source>
+        <translation>Animacja</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="255"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="97"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="174"/>
+        <source>Appearance</source>
+        <translation>Wygląd</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="258"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="188"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="212"/>
+        <source>Window</source>
+        <translation>Okno</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="274"/>
+        <source>Engine mode</source>
+        <translation>Tryb silnika</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="277"/>
+        <location filename="../src/settings/rulemodel.cpp" line="276"/>
+        <source>Snapping layout</source>
+        <translation>Układ przyciągania</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="280"/>
+        <source>Tiling algorithm</source>
+        <translation>Algorytm kafelkowania</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="304"/>
+        <source>Engine to disable</source>
+        <translation>Silnik do wyłączenia</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="307"/>
+        <source>Opacity (%)</source>
+        <translation>Nieprzezroczystość (%)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="310"/>
+        <source>Zones</source>
+        <translation>Strefy</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="317"/>
+        <source>Restore position on login (off = don&apos;t restore)</source>
+        <translation>Przywróć położenie przy logowaniu (wyłączone = nie przywracaj)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="333"/>
+        <source>Hide title bars (off = force visible)</source>
+        <translation>Ukryj paski tytułu (wyłączone = wymuś widoczność)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="336"/>
+        <source>Show border (off = hide)</source>
+        <translation>Pokaż obramowanie (wyłączone = ukryj)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="339"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="420"/>
+        <source>Border width (px)</source>
+        <translation>Szerokość obramowania (px)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="342"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="423"/>
+        <source>Corner radius (px)</source>
+        <translation>Promień narożnika (px)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="348"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="411"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="292"/>
+        <source>Border color</source>
+        <translation>Barwa obramowania</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="361"/>
+        <source>Inner gap (px)</source>
+        <translation>Wewnętrzny odstęp (px)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="364"/>
+        <source>Outer gap (px)</source>
+        <translation>Zewnętrzny odstęp (px)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="367"/>
+        <source>Use per-side outer gaps (off = one uniform gap)</source>
+        <translation>Osobne odstępy zewnętrzne dla każdej strony (wyłączone = jeden jednolity odstęp)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="374"/>
+        <source>Lock the layout (off = don&apos;t lock)</source>
+        <translation>Zablokuj układ (wyłączone = nie blokuj)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="381"/>
+        <source>Assign a default layout (off = leave unassigned)</source>
+        <translation>Przypisz domyślny układ (wyłączone = pozostaw nieprzypisany)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="384"/>
+        <source>Top gap (px)</source>
+        <translation>Górny odstęp (px)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="387"/>
+        <source>Bottom gap (px)</source>
+        <translation>Dolny odstęp (px)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="390"/>
+        <source>Left gap (px)</source>
+        <translation>Lewy odstęp (px)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="393"/>
+        <source>Right gap (px)</source>
+        <translation>Prawy odstęp (px)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="398"/>
+        <location filename="../src/settings/rulemodel.cpp" line="394"/>
+        <source>Overlay shader</source>
+        <translation>Shader nakładki</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="401"/>
+        <location filename="../src/settings/rulemodel.cpp" line="400"/>
+        <source>Overlay style</source>
+        <translation>Styl nakładki</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="429"/>
+        <location filename="../src/settings/rulemodel.cpp" line="900"/>
+        <source>Monitor</source>
+        <translation>Ekran</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="432"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="764"/>
+        <location filename="../src/settings/rulemodel.cpp" line="902"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="260"/>
+        <source>Desktop</source>
+        <translation>Pulpit</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="435"/>
+        <source>Event</source>
+        <translation>Zdarzenie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="441"/>
+        <source>Shader effect</source>
+        <translation>Efekt shadera</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="444"/>
+        <source>Duration (ms)</source>
+        <translation>Czas trwania (ms)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="447"/>
+        <source>Curve</source>
+        <translation>Krzywa</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="462"/>
+        <source>Zone numbers like “1, 2”, or a range like “1-3”. Multiple zones snap the window to their combined area.</source>
+        <translation>Numery stref, takie jak „1, 2”, lub zakres, taki jak „1-3”. Wiele stref przyciąga okno do ich połączonego obszaru.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="235"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="787"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="834"/>
+        <location filename="../src/settings/rulemodel.cpp" line="241"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="145"/>
+        <source>Snapping</source>
+        <translation>Przyciąganie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="837"/>
+        <location filename="../src/settings/rulemodel.cpp" line="243"/>
+        <source>Autotile</source>
+        <translation>Automatyczne kafelkowanie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="840"/>
+        <location filename="../src/settings/rulemodel.cpp" line="245"/>
+        <source>Scrolling</source>
+        <translation>Przewijanie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="845"/>
+        <source>Zone rectangles</source>
+        <translation>Prostokąty stref</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="848"/>
+        <source>Layout preview</source>
+        <translation>Podgląd układu</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="539"/>
+        <source>Set engine mode</source>
+        <translation>Ustaw tryb silnika</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="165"/>
+        <source>Whether the window can be moved.</source>
+        <translation>Czy okno można przesuwać.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="167"/>
+        <source>Whether the window can be maximized.</source>
+        <translation>Czy okno można zmaksymalizować.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="197"/>
+        <source>Whether the monitor is in portrait or landscape orientation. Lets a rule pick a different layout or algorithm on a rotated screen.</source>
+        <translation>Czy ekran jest w orientacji pionowej czy poziomej. Pozwala regule wybrać inny układ lub algorytm na obróconym ekranie.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="201"/>
+        <source>The layout currently active on the monitor. Lets a rule change gaps, the overlay or the lock state for the screen showing a given layout. It cannot change which layout is assigned (that would be circular).</source>
+        <translation>Układ obecnie aktywny na ekranie. Pozwala regule zmienić odstępy, nakładkę lub stan blokady dla ekranu wyświetlającego dany układ. Nie może zmienić, który układ jest przypisany (byłoby to zapętlone).</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="246"/>
+        <source>Engine</source>
+        <translation>Silnik</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="286"/>
+        <source>Max tiled windows</source>
+        <translation>Maksymalna liczba kafelkowanych okien</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="289"/>
+        <source>Split ratio (%)</source>
+        <translation>Proporcja podziału (%)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="295"/>
+        <source>Insert position</source>
+        <translation>Pozycja wstawiania</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="320"/>
+        <source>Restore to zone on login (off = don&apos;t restore)</source>
+        <translation>Przywróć do strefy przy logowaniu (wyłączone = nie przywracaj)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="323"/>
+        <source>Restore size on unsnap (off = keep zone size)</source>
+        <translation>Przywróć rozmiar przy odczepieniu (wyłączone = zachowaj rozmiar strefy)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="326"/>
+        <source>Layer</source>
+        <translation>Warstwa</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="351"/>
+        <source>Show opacity and tint (off = hide)</source>
+        <translation>Pokaż nieprzezroczystość i zabarwienie (wyłączone = ukryj)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="354"/>
+        <source>Tint strength (%)</source>
+        <translation>Siła zabarwienia (%)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="357"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="353"/>
+        <source>Tint color</source>
+        <translation>Barwa zabarwienia</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="408"/>
+        <source>Inactive zone color</source>
+        <translation>Barwa nieaktywnej strefy</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="414"/>
+        <source>Active opacity (%)</source>
+        <translation>Nieprzezroczystość aktywnej (%)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="417"/>
+        <source>Inactive opacity (%)</source>
+        <translation>Nieprzezroczystość nieaktywnej (%)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="426"/>
+        <source>Show zone numbers (off = hide)</source>
+        <translation>Pokaż numery stref (wyłączone = ukryj)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="438"/>
+        <source>Decoration packs</source>
+        <translation>Pakiety dekoracji</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="542"/>
+        <source>Set snapping layout</source>
+        <translation>Ustaw układ przyciągania</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="545"/>
+        <source>Set tiling algorithm</source>
+        <translation>Ustaw algorytm kafelkowania</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="548"/>
+        <source>Set max tiled windows</source>
+        <translation>Ustaw maksymalną liczbę kafelkowanych okien</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="551"/>
+        <source>Set split ratio</source>
+        <translation>Ustaw proporcję podziału</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="554"/>
+        <source>Set master count</source>
+        <translation>Ustaw liczbę okien głównych</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="557"/>
+        <source>Set insert position</source>
+        <translation>Ustaw pozycję wstawiania</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="560"/>
+        <source>Set overflow behavior</source>
+        <translation>Ustaw zachowanie przy przepełnieniu</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="563"/>
+        <source>Set drag behavior</source>
+        <translation>Ustaw zachowanie przeciągania</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="566"/>
+        <source>Set algorithm parameter</source>
+        <translation>Ustaw parametr algorytmu</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="569"/>
+        <source>Disable engine</source>
+        <translation>Wyłącz silnik</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="572"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="908"/>
+        <source>Lock layout</source>
+        <translation>Zablokuj układ</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="575"/>
+        <source>Default layout assignment</source>
+        <translation>Przypisanie domyślnego układu</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="578"/>
+        <source>Exclude window</source>
+        <translation>Wyklucz okno</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="581"/>
+        <source>Float window</source>
+        <translation>Uczyń okno pływającym</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="584"/>
+        <source>Snap to zone(s)</source>
+        <translation>Przyciągnij do strefy/stref</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="587"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="896"/>
+        <source>Restore position on login</source>
+        <translation>Przywróć położenie po zalogowaniu</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="590"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="899"/>
+        <source>Restore to zone on login</source>
+        <translation>Przywróć do strefy po zalogowaniu</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="596"/>
+        <source>Set window layer</source>
+        <translation>Ustaw warstwę okna</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="599"/>
+        <source>Override animation shader</source>
+        <translation>Zastąp shader animacji</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="602"/>
+        <source>Override decoration packs</source>
+        <translation>Zastąp pakiety dekoracji</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="605"/>
+        <source>Override animation duration</source>
+        <translation>Zastąp czas trwania animacji</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="608"/>
+        <source>Override animation curve</source>
+        <translation>Zastąp krzywą animacji</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="611"/>
+        <source>Set opacity</source>
+        <translation>Ustaw nieprzezroczystość</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="614"/>
+        <source>Set overlay shader</source>
+        <translation>Ustaw shader nakładki</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="617"/>
+        <source>Set overlay style</source>
+        <translation>Ustaw styl nakładki</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="620"/>
+        <source>Set overlay highlight color</source>
+        <translation>Ustaw barwę podświetlenia nakładki</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="623"/>
+        <source>Set overlay inactive color</source>
+        <translation>Ustaw barwę nieaktywnej nakładki</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="626"/>
+        <source>Set overlay border color</source>
+        <translation>Ustaw barwę obramowania nakładki</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="629"/>
+        <source>Set overlay active opacity</source>
+        <translation>Ustaw nieprzezroczystość aktywnej nakładki</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="632"/>
+        <source>Set overlay inactive opacity</source>
+        <translation>Ustaw nieprzezroczystość nieaktywnej nakładki</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="635"/>
+        <source>Set overlay border width</source>
+        <translation>Ustaw szerokość obramowania nakładki</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="638"/>
+        <source>Set overlay corner radius</source>
+        <translation>Ustaw promień narożnika nakładki</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="641"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="923"/>
+        <source>Show zone numbers</source>
+        <translation>Pokaż numery stref</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="644"/>
+        <source>Exclude from animations</source>
+        <translation>Wyklucz z animacji</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="652"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="905"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="356"/>
+        <source>Hide title bars</source>
+        <translation>Ukryj paski tytułu</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="655"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="914"/>
+        <source>Show border</source>
+        <translation>Pokaż obramowanie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="658"/>
+        <source>Set border width</source>
+        <translation>Ustaw szerokość obramowania</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="661"/>
+        <source>Set corner radius</source>
+        <translation>Ustaw promień narożnika</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="664"/>
+        <source>Set focused border color</source>
+        <translation>Ustaw barwę obramowania aktywnego okna</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="667"/>
+        <source>Set unfocused border color</source>
+        <translation>Ustaw barwę obramowania nieaktywnego okna</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="670"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="917"/>
+        <source>Show opacity and tint</source>
+        <translation>Pokaż nieprzezroczystość i zabarwienie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="673"/>
+        <source>Set tint strength</source>
+        <translation>Ustaw siłę zabarwienia</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="676"/>
+        <source>Set tint color</source>
+        <translation>Ustaw barwę zabarwienia</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="679"/>
+        <source>Set inner gap</source>
+        <translation>Ustaw odstęp wewnętrzny</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="682"/>
+        <source>Set outer gap</source>
+        <translation>Ustaw odstęp zewnętrzny</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="685"/>
+        <source>Use per-side outer gaps</source>
+        <translation>Użyj odstępów zewnętrznych dla każdej strony</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="688"/>
+        <source>Set top gap</source>
+        <translation>Ustaw odstęp górny</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="691"/>
+        <source>Set bottom gap</source>
+        <translation>Ustaw odstęp dolny</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="694"/>
+        <source>Set left gap</source>
+        <translation>Ustaw odstęp lewy</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="697"/>
+        <source>Set right gap</source>
+        <translation>Ustaw odstęp prawy</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="700"/>
+        <location filename="../src/settings/rulemodel.cpp" line="331"/>
+        <source>Open on monitor</source>
+        <translation>Otwórz na ekranie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="703"/>
+        <location filename="../src/settings/rulemodel.cpp" line="336"/>
+        <source>Open on desktop</source>
+        <translation>Otwórz na pulpicie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="712"/>
+        <source>is</source>
+        <translation>jest</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="714"/>
+        <source>contains</source>
+        <translation>zawiera</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="716"/>
+        <source>starts with</source>
+        <translation>zaczyna się od</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="718"/>
+        <source>ends with</source>
+        <translation>kończy się na</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="720"/>
+        <source>matches regex</source>
+        <translation>pasuje do wyrażenia regularnego</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="722"/>
+        <source>matches app-id</source>
+        <translation>pasuje do app-id</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="724"/>
+        <source>greater than</source>
+        <translation>większe niż</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="726"/>
+        <source>less than</source>
+        <translation>mniejsze niż</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="754"/>
+        <source>Unknown</source>
+        <translation>Nieznane</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="755"/>
+        <source>Normal window</source>
+        <translation>Zwykłe okno</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="756"/>
+        <source>Dialog</source>
+        <translation>Okno dialogowe</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="757"/>
+        <source>Utility</source>
+        <translation>Narzędzie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="758"/>
+        <source>Toolbar</source>
+        <translation>Pasek narzędzi</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="759"/>
+        <source>Splash screen</source>
+        <translation>Ekran powitalny</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="760"/>
+        <source>Menu</source>
+        <translation>Menu</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="761"/>
+        <source>Tooltip</source>
+        <translation>Podpowiedź</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="762"/>
+        <location filename="../src/settings/rulemodel.cpp" line="908"/>
+        <source>Notification</source>
+        <translation>Powiadomienie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="763"/>
+        <source>Dock / panel</source>
+        <translation>Dok / panel</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="765"/>
+        <source>On-screen display</source>
+        <translation>Komunikat na ekranie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="766"/>
+        <source>Popup</source>
+        <translation>Okno wyskakujące</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="792"/>
+        <source>Landscape</source>
+        <translation>Poziomo</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="793"/>
+        <source>Portrait</source>
+        <translation>Pionowo</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="853"/>
+        <source>End of stack</source>
+        <translation>Koniec stosu</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="856"/>
+        <source>After focused window</source>
+        <translation>Za aktywnym oknem</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="859"/>
+        <source>As master</source>
+        <translation>Jako główne</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="864"/>
+        <source>Float overflow windows</source>
+        <translation>Uczyń nadmiarowe okna pływającymi</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="867"/>
+        <source>Unlimited (no cap)</source>
+        <translation>Bez ograniczeń</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="872"/>
+        <source>Float on drag</source>
+        <translation>Uczyń pływającym przy przeciąganiu</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="875"/>
+        <source>Reorder in stack</source>
+        <translation>Zmień kolejność w stosie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="880"/>
+        <source>Above other windows</source>
+        <translation>Nad innymi oknami</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="883"/>
+        <source>Normal stacking</source>
+        <translation>Zwykłe ułożenie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="886"/>
+        <source>Below other windows</source>
+        <translation>Pod innymi oknami</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="899"/>
+        <source>Don&apos;t restore to zone on login</source>
+        <translation>Nie przywracaj do strefy po zalogowaniu</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="902"/>
+        <source>Keep zone size on unsnap</source>
+        <translation>Zachowaj rozmiar strefy przy odczepieniu</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="917"/>
+        <source>Hide opacity and tint</source>
+        <translation>Ukryj nieprzezroczystość i zabarwienie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="923"/>
+        <source>Hide zone numbers</source>
+        <translation>Ukryj numery stref</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="1110"/>
+        <source>Regular expression, e.g. ^(firefox|chromium)$</source>
+        <translation>Wyrażenie regularne, np. ^(firefox|chromium)$</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="1113"/>
+        <source>Matches by reverse-DNS segments, so “firefox” also matches “org.mozilla.firefox”.</source>
+        <translation>Dopasowuje według segmentów odwróconego DNS, więc „firefox” pasuje też do „org.mozilla.firefox”.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulecontroller.cpp" line="165"/>
+        <source>Failed to fetch the daemon&apos;s rule set.</source>
+        <translation>Nie udało się pobrać zestawu reguł usługi.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulecontroller.cpp" line="247"/>
+        <source>The daemon rejected one or more rules.</source>
+        <translation>Usługa odrzuciła jedną lub więcej reguł.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulecontroller.cpp" line="375"/>
+        <source>A save is already in flight.</source>
+        <translation>Zapis jest już w toku.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulecontroller.cpp" line="386"/>
+        <source>The daemon&apos;s rules changed while you were editing. Review or use Save anyway to overwrite.</source>
+        <translation>Reguły usługi zmieniły się podczas edycji. Przejrzyj je lub użyj Zapisz mimo to, aby zastąpić.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulecontroller.cpp" line="397"/>
+        <source>One or more rules failed validation and could not be saved. See the log for details.</source>
+        <translation>Jedna lub więcej reguł nie przeszło sprawdzenia i nie mogło zostać zapisanych. Szczegóły znajdziesz w dzienniku.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulecontroller.cpp" line="657"/>
+        <source>%1 (copy)</source>
+        <translation>%1 (kopia)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="164"/>
+        <location filename="../src/settings/rulemodel.cpp" line="171"/>
+        <location filename="../src/settings/rulemodel.cpp" line="179"/>
+        <location filename="../src/settings/rulemodel.cpp" line="206"/>
+        <location filename="../src/settings/rulemodel.cpp" line="214"/>
+        <location filename="../src/settings/rulemodel.cpp" line="219"/>
+        <source>%1: %2</source>
+        <translation>%1: %2</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="215"/>
+        <source>On</source>
+        <translation>Wł.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="216"/>
+        <source>Off</source>
+        <translation>Wył.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="272"/>
+        <source>Engine: %1</source>
+        <translation>Silnik: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="277"/>
+        <source>Snapping: %1</source>
+        <translation>Przyciąganie: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="296"/>
+        <source>Disabled</source>
+        <translation>Wyłączone</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="298"/>
+        <source>Disable: %1</source>
+        <translation>Wyłącz: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="301"/>
+        <source>Excluded</source>
+        <translation>Wykluczone</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="305"/>
+        <source>No animations</source>
+        <translation>Bez animacji</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="308"/>
+        <source>Float</source>
+        <translation>Pływające</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="318"/>
+        <source>Snap to zone</source>
+        <translation>Przyciągnij do strefy</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="321"/>
+        <source>Snap to zone %1</source>
+        <translation>Przyciągnij do strefy %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="323"/>
+        <source>Snap to zones %1</source>
+        <translation>Przyciągnij do stref %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="332"/>
+        <source>Open on monitor: %1</source>
+        <translation>Otwórz na ekranie: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="336"/>
+        <source>Open on desktop %1</source>
+        <translation>Otwórz na pulpicie %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="345"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="276"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="345"/>
+        <source>Opacity</source>
+        <translation>Nieprzezroczystość</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="349"/>
+        <location filename="../src/settings/rulemodel.cpp" line="354"/>
+        <source>Opacity (invalid)</source>
+        <translation>Nieprzezroczystość (nieprawidłowa)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="356"/>
+        <source>Opacity: %1%</source>
+        <translation>Nieprzezroczystość: %1%</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="360"/>
+        <source>Block animation shader</source>
+        <translation>Zablokuj shader animacji</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="361"/>
+        <source>Shader: %1</source>
+        <translation>Shader: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="366"/>
+        <location filename="../src/settings/rulemodel.cpp" line="379"/>
+        <source>Block decoration</source>
+        <translation>Zablokuj dekorację</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="381"/>
+        <source>Decoration: %1</source>
+        <translation>Dekoracja: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="385"/>
+        <source>Duration: %1 ms</source>
+        <translation>Czas trwania: %1 ms</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="385"/>
+        <source>Animation duration</source>
+        <translation>Czas trwania animacji</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="389"/>
+        <source>Animation curve</source>
+        <translation>Krzywa animacji</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="390"/>
+        <source>Curve: %1</source>
+        <translation>Krzywa: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="395"/>
+        <source>Overlay shader: %1</source>
+        <translation>Shader nakładki: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="896"/>
+        <source>Don&apos;t restore position on login</source>
+        <translation>Nie przywracaj położenia po zalogowaniu</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="905"/>
+        <source>Show title bars</source>
+        <translation>Pokaż paski tytułu</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="908"/>
+        <source>Don&apos;t lock layout</source>
+        <translation>Nie blokuj układu</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="911"/>
+        <source>Assign default layout</source>
+        <translation>Przypisz domyślny układ</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="911"/>
+        <source>Don&apos;t assign default layout</source>
+        <translation>Nie przypisuj domyślnego układu</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="914"/>
+        <source>Hide border</source>
+        <translation>Ukryj obramowanie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="429"/>
+        <source>Border width: %1 px</source>
+        <translation>Szerokość obramowania: %1 px</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="432"/>
+        <source>Corner radius: %1 px</source>
+        <translation>Promień narożnika: %1 px</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="439"/>
+        <location filename="../src/settings/rulemodel.cpp" line="467"/>
+        <source>Accent</source>
+        <translation>Akcent</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="441"/>
+        <source>Focused border: %1</source>
+        <translation>Obramowanie aktywnego okna: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="443"/>
+        <source>Unfocused border: %1</source>
+        <translation>Obramowanie nieaktywnego okna: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="535"/>
+        <source>Gap: %1 px</source>
+        <translation>Odstęp: %1 px</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="538"/>
+        <source>Outer gap: %1 px</source>
+        <translation>Odstęp zewnętrzny: %1 px</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="920"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="411"/>
+        <source>Per-side outer gaps</source>
+        <translation>Odstępy zewnętrzne dla każdej strony</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="920"/>
+        <source>Uniform outer gap</source>
+        <translation>Jednolity odstęp zewnętrzny</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="405"/>
+        <source>Overlay style: %1</source>
+        <translation>Styl nakładki: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="412"/>
+        <source>Algorithm parameter</source>
+        <translation>Parametr algorytmu</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="413"/>
+        <source>Algorithm: %1</source>
+        <translation>Algorytm: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="454"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="348"/>
+        <source>Tint strength</source>
+        <translation>Siła zabarwienia</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="460"/>
+        <source>Tint strength (invalid)</source>
+        <translation>Siła zabarwienia (nieprawidłowa)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="462"/>
+        <source>Tint strength: %1%</source>
+        <translation>Siła zabarwienia: %1%</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="468"/>
+        <source>Tint color: %1</source>
+        <translation>Barwa zabarwienia: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="472"/>
+        <source>Max tiled windows: %1</source>
+        <translation>Maksymalna liczba kafelkowanych okien: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="475"/>
+        <source>Master count: %1</source>
+        <translation>Liczba okien głównych: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="479"/>
+        <source>Split ratio: %1%</source>
+        <translation>Proporcja podziału: %1%</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="482"/>
+        <source>Insert: %1</source>
+        <translation>Wstawianie: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="486"/>
+        <source>Overflow: %1</source>
+        <translation>Przepełnienie: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="490"/>
+        <source>Drag: %1</source>
+        <translation>Przeciąganie: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="497"/>
+        <source>Window layer</source>
+        <translation>Warstwa okna</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="505"/>
+        <source>Window layer (invalid)</source>
+        <translation>Warstwa okna (nieprawidłowa)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="507"/>
+        <source>Layer: %1</source>
+        <translation>Warstwa: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="513"/>
+        <source>Highlight color: %1</source>
+        <translation>Barwa podświetlenia: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="516"/>
+        <source>Inactive zone color: %1</source>
+        <translation>Barwa nieaktywnej strefy: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="519"/>
+        <source>Overlay border color: %1</source>
+        <translation>Barwa obramowania nakładki: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="522"/>
+        <source>Active opacity: %1%</source>
+        <translation>Nieprzezroczystość aktywnej: %1%</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="525"/>
+        <source>Inactive opacity: %1%</source>
+        <translation>Nieprzezroczystość nieaktywnej: %1%</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="528"/>
+        <source>Overlay border width: %1 px</source>
+        <translation>Szerokość obramowania nakładki: %1 px</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="531"/>
+        <source>Overlay corner radius: %1 px</source>
+        <translation>Promień narożnika nakładki: %1 px</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="541"/>
+        <source>Top gap: %1 px</source>
+        <translation>Odstęp górny: %1 px</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="544"/>
+        <source>Bottom gap: %1 px</source>
+        <translation>Odstęp dolny: %1 px</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="547"/>
+        <source>Left gap: %1 px</source>
+        <translation>Odstęp lewy: %1 px</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="550"/>
+        <source>Right gap: %1 px</source>
+        <translation>Odstęp prawy: %1 px</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="625"/>
+        <source>Everywhere</source>
+        <translation>Wszędzie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="857"/>
+        <source>Monitor &amp; Layout</source>
+        <translation>Ekran &amp; układ</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="859"/>
+        <source>Applications</source>
+        <translation>Programy</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="861"/>
+        <source>Activities</source>
+        <translation>Aktywności</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="863"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="107"/>
+        <source>Animations</source>
+        <translation>Animacje</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="865"/>
+        <source>Advanced / Custom</source>
+        <translation>Zaawansowane / własne</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="867"/>
+        <source>System</source>
+        <translation>System</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="876"/>
+        <source>Application</source>
+        <translation>Program</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="878"/>
+        <source>Window class</source>
+        <translation>Klasa okna</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="880"/>
+        <source>Desktop file</source>
+        <translation>Plik desktop</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="882"/>
+        <source>Window role</source>
+        <translation>Rola okna</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="884"/>
+        <source>Process ID</source>
+        <translation>Identyfikator procesu</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="886"/>
+        <source>Title</source>
+        <translation>Tytuł</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="888"/>
+        <source>Window type</source>
+        <translation>Typ okna</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="890"/>
+        <source>Sticky</source>
+        <translation>Przyklejone</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="892"/>
+        <source>Fullscreen</source>
+        <translation>Pełny ekran</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="894"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="629"/>
+        <source>Maximized</source>
+        <translation>Zmaksymalizowane</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="896"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="620"/>
+        <source>Minimized</source>
+        <translation>Zminimalizowane</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="898"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="622"/>
+        <source>Focused</source>
+        <translation>Uaktywnione</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="904"/>
+        <source>Activity</source>
+        <translation>Aktywność</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="906"/>
+        <source>Transient</source>
+        <translation>Tymczasowe</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="910"/>
+        <source>Width</source>
+        <translation>Szerokość</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="912"/>
+        <source>Height</source>
+        <translation>Wysokość</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="914"/>
+        <source>Keep above</source>
+        <translation>Utrzymuj na wierzchu</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="916"/>
+        <source>Keep below</source>
+        <translation>Utrzymuj pod spodem</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="918"/>
+        <source>Skip taskbar</source>
+        <translation>Pomiń pasek zadań</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="920"/>
+        <source>Skip pager</source>
+        <translation>Pomiń przełącznik pulpitów</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="922"/>
+        <source>Skip switcher</source>
+        <translation>Pomiń przełącznik okien</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="924"/>
+        <source>Modal</source>
+        <translation>Modalne</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="926"/>
+        <source>Decorated</source>
+        <translation>Z dekoracją</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="928"/>
+        <source>Resizable</source>
+        <translation>Można zmieniać rozmiar</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="930"/>
+        <source>Movable</source>
+        <translation>Można przemieszczać</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="932"/>
+        <source>Maximizable</source>
+        <translation>Można maksymalizować</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="934"/>
+        <source>Position X</source>
+        <translation>Położenie X</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="936"/>
+        <source>Position Y</source>
+        <translation>Położenie Y</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="938"/>
+        <source>Title (no suffix)</source>
+        <translation>Tytuł (bez przyrostka)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/decorationpagecontroller_browser.cpp" line="46"/>
+        <location filename="../src/settings/rulemodel.cpp" line="940"/>
+        <source>Floating</source>
+        <translation>Pływające</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/decorationpagecontroller_browser.cpp" line="44"/>
+        <location filename="../src/settings/rulemodel.cpp" line="942"/>
+        <source>Snapped</source>
+        <translation>Przyciągnięte</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/decorationpagecontroller_browser.cpp" line="42"/>
+        <location filename="../src/settings/rulemodel.cpp" line="944"/>
+        <source>Tiled</source>
+        <translation>Kafelkowane</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/decorationpagecontroller_browser.cpp" line="50"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="315"/>
+        <source>Popups</source>
+        <translation>Okna wyskakujące</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/decorationpagecontroller_browser.cpp" line="56"/>
+        <source>Layout Picker</source>
+        <translation>Wybór układu</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/decorationpagecontroller_browser.cpp" line="119"/>
+        <source>Global default</source>
+        <translation>Globalne domyślne</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="946"/>
+        <source>Zone</source>
+        <translation>Strefa</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="948"/>
+        <source>Mode</source>
+        <translation>Tryb</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="950"/>
+        <source>Tiled window count</source>
+        <translation>Liczba kafelkowanych okien</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="952"/>
+        <source>Screen orientation</source>
+        <translation>Orientacja ekranu</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="954"/>
+        <source>Active layout</source>
+        <translation>Aktywny układ</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="962"/>
+        <source>Any window</source>
+        <translation>Dowolne okno</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="976"/>
+        <source>(condition group)</source>
+        <translation>(grupa warunków)</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/settings/rulemodel.cpp" line="983"/>
+        <source>%n condition(s)</source>
+        <translation>
+            <numerusform>%n warunek</numerusform>
+            <numerusform>%n warunki</numerusform>
+            <numerusform>%n warunków</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="989"/>
+        <source>No action</source>
+        <translation>Brak działania</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="58"/>
+        <source>New monitor rule</source>
+        <translation>Nowa reguła ekranu</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="62"/>
+        <source>New desktop rule</source>
+        <translation>Nowa reguła pulpitu</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="70"/>
+        <source>New application rule</source>
+        <translation>Nowa reguła programu</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="74"/>
+        <source>New activity rule</source>
+        <translation>Nowa reguła aktywności</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="78"/>
+        <source>New animation rule</source>
+        <translation>Nowa reguła animacji</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="88"/>
+        <source>New custom rule</source>
+        <translation>Nowa reguła własna</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="121"/>
+        <source>Set a layout on a monitor</source>
+        <translation>Ustaw układ na ekranie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="122"/>
+        <source>Pick a snapping layout to use on one monitor.</source>
+        <translation>Wybierz układ przyciągania używany na jednym ekranie.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="123"/>
+        <source>Set a tiling algorithm on a monitor</source>
+        <translation>Ustaw algorytm kafelkowania na ekranie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="124"/>
+        <source>Pick an autotile algorithm to use on one monitor.</source>
+        <translation>Wybierz algorytm automatycznego kafelkowania używany na jednym ekranie.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="126"/>
+        <source>Lock the layout on a monitor</source>
+        <translation>Zablokuj układ na ekranie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="127"/>
+        <source>Pin the active layout on one monitor so it can&apos;t be switched. This is the rule-driven version of the lock-layout shortcut.</source>
+        <translation>Przypnij aktywny układ na jednym ekranie, aby nie można go było przełączyć. To sterowana regułą wersja skrótu blokady układu.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="130"/>
+        <source>Set a layout on a virtual desktop</source>
+        <translation>Ustaw układ na wirtualnym pulpicie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="131"/>
+        <source>Pick a snapping layout to use on one virtual desktop.</source>
+        <translation>Wybierz układ przyciągania używany na jednym wirtualnym pulpicie.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="133"/>
+        <source>Set a layout for portrait monitors</source>
+        <translation>Ustaw układ dla ekranów pionowych</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="134"/>
+        <source>Pick a snapping layout to use whenever a monitor is in portrait orientation. Handy for rotating screens.</source>
+        <translation>Wybierz układ przyciągania używany zawsze, gdy ekran jest w orientacji pionowej. Przydatne dla obracanych ekranów.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="137"/>
+        <location filename="../src/settings/ruletemplates.cpp" line="215"/>
+        <source>Open an app in a zone</source>
+        <translation>Otwórz program w strefie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="138"/>
+        <source>Snap one application&apos;s windows into a chosen zone when they open.</source>
+        <translation>Przyciągaj okna jednego programu do wybranej strefy podczas ich otwierania.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="140"/>
+        <location filename="../src/settings/ruletemplates.cpp" line="226"/>
+        <source>Open an app on a monitor</source>
+        <translation>Otwórz program na ekranie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="141"/>
+        <source>Send one application&apos;s windows to a chosen monitor when they open.</source>
+        <translation>Wysyłaj okna jednego programu na wybrany ekran podczas ich otwierania.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="143"/>
+        <location filename="../src/settings/ruletemplates.cpp" line="234"/>
+        <source>Float an app</source>
+        <translation>Uczyń program pływającym</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="144"/>
+        <source>Keep one application&apos;s windows floating instead of tiled. The windows stay managed, unlike a full exclusion.</source>
+        <translation>Utrzymuj okna jednego programu jako pływające zamiast kafelkowanych. Okna pozostają zarządzane, inaczej niż przy pełnym wykluczeniu.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="147"/>
+        <location filename="../src/settings/ruletemplates.cpp" line="244"/>
+        <source>Exclude an app from tiling</source>
+        <translation>Wyklucz program z kafelkowania</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="148"/>
+        <source>Keep one application&apos;s windows out of the snap and autotile engines entirely.</source>
+        <translation>Utrzymuj okna jednego programu całkowicie poza silnikami przyciągania i automatycznego kafelkowania.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="150"/>
+        <location filename="../src/settings/ruletemplates.cpp" line="251"/>
+        <source>Don&apos;t animate small windows</source>
+        <translation>Nie animuj małych okien</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="151"/>
+        <source>Skip open and close animations for windows narrower than a chosen width. Handy for tiny popups and tool windows.</source>
+        <translation>Pomiń animacje otwierania i zamykania dla okien węższych niż wybrana szerokość. Przydatne dla drobnych okien wyskakujących i okien narzędziowych.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="164"/>
+        <source>Snapping layout on monitor</source>
+        <translation>Układ przyciągania na ekranie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="171"/>
+        <source>Tiling algorithm on monitor</source>
+        <translation>Algorytm kafelkowania na ekranie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="186"/>
+        <source>Lock layout on monitor</source>
+        <translation>Blokada układu na ekranie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="197"/>
+        <source>Snapping layout on virtual desktop</source>
+        <translation>Układ przyciągania na wirtualnym pulpicie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="207"/>
+        <source>Layout for portrait monitors</source>
+        <translation>Układ dla ekranów pionowych</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="56"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="64"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="170"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="228"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="437"/>
+        <source>monitor</source>
+        <translation>ekran</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="56"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="435"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="447"/>
+        <source>display</source>
+        <translation>wyświetlacz</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="56"/>
+        <source>mode</source>
+        <translation>tryb</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="57"/>
+        <source>active layout</source>
+        <translation>aktywny układ</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="59"/>
+        <source>rendering</source>
+        <translation>renderowanie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="59"/>
+        <source>backend</source>
+        <translation>silnik</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="59"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="185"/>
+        <source>opengl</source>
+        <translation>opengl</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="60"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="185"/>
+        <source>vulkan</source>
+        <translation>vulkan</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="60"/>
+        <source>backup</source>
+        <translation>kopia zapasowa</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="60"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="550"/>
+        <source>export</source>
+        <translation>eksport</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="61"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="552"/>
+        <source>import</source>
+        <translation>import</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="61"/>
+        <source>reset</source>
+        <translation>wyzerowanie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="63"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="482"/>
+        <source>split</source>
+        <translation>podział</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="63"/>
+        <source>subdivide</source>
+        <translation>dalszy podział</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="63"/>
+        <source>region</source>
+        <translation>obszar</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="66"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="172"/>
+        <source>layout</source>
+        <translation>układ</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="66"/>
+        <source>zone</source>
+        <translation>strefa</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="66"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="567"/>
+        <source>grid</source>
+        <translation>siatka</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="67"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="138"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="155"/>
+        <source>preset</source>
+        <translation>nastawa</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="67"/>
+        <source>template</source>
+        <translation>szablon</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="68"/>
+        <source>aspect ratio</source>
+        <translation>proporcje</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="75"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="125"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="422"/>
+        <source>overlay</source>
+        <translation>nakładka</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="75"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="422"/>
+        <source>trigger</source>
+        <translation>wyzwalacz</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="75"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="409"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="413"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="562"/>
+        <source>edge</source>
+        <translation>krawędź</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="76"/>
+        <source>magnet</source>
+        <translation>magnes</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="76"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="84"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="117"/>
+        <source>snap</source>
+        <translation>przyciąganie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="78"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="164"/>
+        <source>color</source>
+        <translation>kolor</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="78"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="285"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="288"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="290"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="292"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="307"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="332"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="335"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="338"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="349"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="352"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="354"/>
+        <source>colour</source>
+        <translation>kolor</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="78"/>
+        <source>opacity</source>
+        <translation>nieprzezroczystość</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="79"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="298"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="300"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="343"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="346"/>
+        <source>transparency</source>
+        <translation>przezroczystość</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="79"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="285"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="332"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="352"/>
+        <source>theme</source>
+        <translation>motyw</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="79"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="147"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="159"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="164"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="326"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="329"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="392"/>
+        <source>border</source>
+        <translation>obramowanie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="81"/>
+        <source>zone selector</source>
+        <translation>wybór strefy</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="81"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="442"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="557"/>
+        <source>picker</source>
+        <translation>wybierak</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="81"/>
+        <source>chooser</source>
+        <translation>wybierak</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="82"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="125"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="153"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="240"/>
+        <source>popup</source>
+        <translation>okno wyskakujące</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="84"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="112"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="116"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="119"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="147"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="164"/>
+        <source>window</source>
+        <translation>okno</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="84"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="119"/>
+        <source>drag</source>
+        <translation>przeciąganie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="85"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="424"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="444"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="497"/>
+        <source>modifier</source>
+        <translation>modyfikator</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="85"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="90"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="105"/>
+        <source>key</source>
+        <translation>klawisz</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="87"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="102"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="170"/>
+        <source>priority</source>
+        <translation>priorytet</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="87"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="102"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="501"/>
+        <source>order</source>
+        <translation>kolejność</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="87"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="102"/>
+        <source>precedence</source>
+        <translation>pierwszeństwo</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="89"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="104"/>
+        <source>shortcut</source>
+        <translation>skrót</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="89"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="104"/>
+        <source>hotkey</source>
+        <translation>klawisz skrótu</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="89"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="104"/>
+        <source>keybind</source>
+        <translation>skrót klawiszowy</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="90"/>
+        <source>keyboard</source>
+        <translation>klawiatura</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="92"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="143"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="158"/>
+        <source>shader</source>
+        <translation>shader</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="92"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="143"/>
+        <source>effect</source>
+        <translation>efekt</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="92"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="159"/>
+        <source>glow</source>
+        <translation>poświata</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="96"/>
+        <source>tile</source>
+        <translation>kafelek</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="96"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="235"/>
+        <source>tiling</source>
+        <translation>kafelkowanie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="96"/>
+        <source>auto</source>
+        <translation>automatycznie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="97"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="166"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="404"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="407"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="412"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="417"/>
+        <source>gap</source>
+        <translation>odstęp</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="97"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="167"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="404"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="407"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="412"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="417"/>
+        <source>spacing</source>
+        <translation>odstępy</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="99"/>
+        <source>algorithm</source>
+        <translation>algorytm</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="99"/>
+        <source>bsp</source>
+        <translation>bsp</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="99"/>
+        <source>binary</source>
+        <translation>binarny</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="100"/>
+        <source>spiral</source>
+        <translation>spirala</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="100"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="481"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="489"/>
+        <source>master</source>
+        <translation>główny</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="100"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="494"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="497"/>
+        <source>stack</source>
+        <translation>stos</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="109"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="112"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="125"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="133"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="136"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="188"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="317"/>
+        <source>animation</source>
+        <translation>animacja</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="109"/>
+        <source>duration</source>
+        <translation>czas trwania</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="109"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="138"/>
+        <source>easing</source>
+        <translation>wygładzanie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="110"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="138"/>
+        <source>curve</source>
+        <translation>krzywa</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="110"/>
+        <source>spring</source>
+        <translation>sprężyna</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="110"/>
+        <source>speed</source>
+        <translation>prędkość</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="113"/>
+        <source>open</source>
+        <translation>otwórz</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="113"/>
+        <source>close</source>
+        <translation>zamknij</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="113"/>
+        <source>minimize</source>
+        <translation>minimalizuj</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="116"/>
+        <source>movement</source>
+        <translation>ruch</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="117"/>
+        <source>maximize</source>
+        <translation>maksymalizuj</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="119"/>
+        <source>dragging</source>
+        <translation>przeciąganie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="120"/>
+        <source>move</source>
+        <translation>przenieś</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="120"/>
+        <source>wobble</source>
+        <translation>drganie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="120"/>
+        <source>physics</source>
+        <translation>fizyka</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="123"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="151"/>
+        <source>osd</source>
+        <translation>OSD</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="123"/>
+        <source>notification</source>
+        <translation>powiadomienie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="123"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="151"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="538"/>
+        <source>on-screen display</source>
+        <translation>wyświetlacz ekranowy</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="127"/>
+        <source>desktop</source>
+        <translation>pulpit</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="127"/>
+        <source>virtual desktop</source>
+        <translation>wirtualny pulpit</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="128"/>
+        <source>workspace</source>
+        <translation>przestrzeń robocza</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="128"/>
+        <source>switch</source>
+        <translation>przełącz</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="128"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="663"/>
+        <source>peek</source>
+        <translation>podejrzyj</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="129"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="663"/>
+        <source>show desktop</source>
+        <translation>pokaż pulpit</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="131"/>
+        <source>side panel</source>
+        <translation>panel boczny</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="131"/>
+        <source>panel</source>
+        <translation>panel</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="131"/>
+        <source>drawer</source>
+        <translation>szuflada</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="133"/>
+        <source>widget</source>
+        <translation>widżet</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="136"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="172"/>
+        <source>editor</source>
+        <translation>edytor</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="136"/>
+        <source>layout editor</source>
+        <translation>edytor układów</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="139"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="141"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="156"/>
+        <source>profile</source>
+        <translation>profil</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="141"/>
+        <source>motion set</source>
+        <translation>zestaw ruchu</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="116"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="141"/>
+        <source>motion</source>
+        <translation>ruch</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="165"/>
+        <source>title bar</source>
+        <translation>pasek tytułu</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="147"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="151"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="153"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="165"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="357"/>
+        <source>decoration</source>
+        <translation>dekoracja</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="112"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="148"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="166"/>
+        <source>appearance</source>
+        <translation>wygląd</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="166"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="404"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="407"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="412"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="417"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="503"/>
+        <source>gaps</source>
+        <translation>odstępy</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="167"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="405"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="408"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="413"/>
+        <source>padding</source>
+        <translation>wypełnienie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="167"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="405"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="408"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="413"/>
+        <source>margin</source>
+        <translation>margines</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="169"/>
+        <source>rule</source>
+        <translation>reguła</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="169"/>
+        <source>exclude</source>
+        <translation>wyklucz</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="169"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="510"/>
+        <source>float</source>
+        <translation>uczyń pływającym</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="170"/>
+        <source>activity</source>
+        <translation>aktywność</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="172"/>
+        <source>design</source>
+        <translation>projekt</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="173"/>
+        <source>zones</source>
+        <translation>strefy</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="175"/>
+        <source>about</source>
+        <translation>informacje</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="175"/>
+        <source>version</source>
+        <translation>wersja</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="175"/>
+        <source>license</source>
+        <translation>licencja</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="176"/>
+        <source>credits</source>
+        <translation>zasługi</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="182"/>
+        <source>Rendering</source>
+        <translation>Renderowanie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="184"/>
+        <source>Rendering backend</source>
+        <translation>Silnik renderowania</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="185"/>
+        <source>graphics</source>
+        <translation>grafika</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="237"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="388"/>
+        <source>Window filtering</source>
+        <translation>Filtrowanie okien</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="239"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="390"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="533"/>
+        <source>Exclude transient windows</source>
+        <translation>Wyklucz okna tymczasowe</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="240"/>
+        <source>dialog</source>
+        <translation>okno dialogowe</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="153"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="240"/>
+        <source>tooltip</source>
+        <translation>podpowiedź</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="247"/>
+        <source>Reset</source>
+        <translation>Wyzeruj</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="248"/>
+        <source>reset to defaults</source>
+        <translation>przywróć domyślne</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="248"/>
+        <source>defaults</source>
+        <translation>domyślne</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="248"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="459"/>
+        <source>restore</source>
+        <translation>przywróć</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="254"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="266"/>
+        <source>Triggers</source>
+        <translation>Wyzwalacze</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="256"/>
+        <source>Zone Span</source>
+        <translation>Rozpiętość strefy</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="258"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="85"/>
+        <source>Display</source>
+        <translation>Wyświetlanie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/decorationpagecontroller_browser.cpp" line="52"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="261"/>
+        <source>Snap Assist</source>
+        <translation>Asystent przyciągania</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="263"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="268"/>
+        <source>Window Handling</source>
+        <translation>Obsługa okien</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="264"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="269"/>
+        <source>Focus</source>
+        <translation>Uaktywnienie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="274"/>
+        <source>Colors</source>
+        <translation>Kolory</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="278"/>
+        <source>Border</source>
+        <translation>Obramowanie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="280"/>
+        <source>Zone Labels</source>
+        <translation>Etykiety stref</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="282"/>
+        <source>Effects</source>
+        <translation>Efekty</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="186"/>
+        <source>Shader Effects</source>
+        <translation>Efekty shaderów</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="284"/>
+        <source>System accent color</source>
+        <translation>Systemowa barwa akcentu</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="285"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="296"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="332"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="352"/>
+        <source>scheme</source>
+        <translation>zestaw kolorów</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="405"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="287"/>
+        <source>Highlight color</source>
+        <translation>Barwa podświetlenia</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="288"/>
+        <source>active</source>
+        <translation>aktywny</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="288"/>
+        <source>hover</source>
+        <translation>najechanie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="290"/>
+        <source>Inactive color</source>
+        <translation>Barwa nieaktywna</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="290"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="338"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="363"/>
+        <source>unfocused</source>
+        <translation>nieuaktywniony</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="292"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="335"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="338"/>
+        <source>outline</source>
+        <translation>kontur</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="295"/>
+        <source>Import colors</source>
+        <translation>Importuj kolory</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="296"/>
+        <source>pywal</source>
+        <translation>pywal</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="296"/>
+        <source>json</source>
+        <translation>json</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="296"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="552"/>
+        <source>load</source>
+        <translation>wczytaj</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="298"/>
+        <source>Active opacity</source>
+        <translation>Nieprzezroczystość aktywnej</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="298"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="300"/>
+        <source>alpha</source>
+        <translation>alfa</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="300"/>
+        <source>Inactive opacity</source>
+        <translation>Nieprzezroczystość nieaktywnej</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="302"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="324"/>
+        <source>Border width</source>
+        <translation>Szerokość obramowania</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="302"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="324"/>
+        <source>thickness</source>
+        <translation>grubość</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="243"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="246"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="302"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="312"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="324"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="395"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="398"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="486"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="541"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="544"/>
+        <source>size</source>
+        <translation>rozmiar</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="304"/>
+        <source>Border radius</source>
+        <translation>Zaokrąglenie obramowania</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="304"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="326"/>
+        <source>rounding</source>
+        <translation>zaokrąglanie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="304"/>
+        <source>corner</source>
+        <translation>narożnik</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="306"/>
+        <source>Label color</source>
+        <translation>Barwa etykiety</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="307"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="312"/>
+        <source>text</source>
+        <translation>tekst</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="307"/>
+        <source>font</source>
+        <translation>czcionka</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="308"/>
+        <source>Font</source>
+        <translation>Czcionka</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="309"/>
+        <source>typeface</source>
+        <translation>krój pisma</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="309"/>
+        <source>family</source>
+        <translation>rodzina</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="309"/>
+        <source>style</source>
+        <translation>styl</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="311"/>
+        <source>Label scale</source>
+        <translation>Skala etykiety</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="312"/>
+        <source>multiplier</source>
+        <translation>mnożnik</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="314"/>
+        <source>Zone numbers</source>
+        <translation>Numery stref</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="315"/>
+        <source>index</source>
+        <translation>indeks</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="315"/>
+        <source>digit</source>
+        <translation>cyfra</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="315"/>
+        <source>label</source>
+        <translation>etykieta</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="317"/>
+        <source>Flash on layout switch</source>
+        <translation>Mignij przy przełączeniu układu</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="317"/>
+        <source>blink</source>
+        <translation>miganie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="187"/>
+        <source>Frame rate</source>
+        <translation>Liczba klatek na sekundę</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="71"/>
+        <source>User layouts</source>
+        <translation>Układy użytkownika</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="148"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="158"/>
+        <source>surface</source>
+        <translation>powierzchnia</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="155"/>
+        <source>decoration set</source>
+        <translation>zestaw dekoracji</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="155"/>
+        <source>set</source>
+        <translation>zestaw</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="156"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="158"/>
+        <source>pack</source>
+        <translation>paczka</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="159"/>
+        <source>glass</source>
+        <translation>szkło</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="160"/>
+        <source>blur</source>
+        <translation>rozmycie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="188"/>
+        <source>fps</source>
+        <translation>fps</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="188"/>
+        <source>refresh</source>
+        <translation>odświeżanie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="189"/>
+        <source>Audio Spectrum</source>
+        <translation>Widmo dźwięku</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="191"/>
+        <source>Audio spectrum</source>
+        <translation>Widmo dźwięku</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="192"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="195"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="198"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="201"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="203"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="206"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="209"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="213"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="216"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="218"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="221"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="223"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="225"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="228"/>
+        <source>cava</source>
+        <translation>cava</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="192"/>
+        <source>music</source>
+        <translation>muzyka</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="192"/>
+        <source>visualizer</source>
+        <translation>wizualizacja</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="193"/>
+        <source>sound</source>
+        <translation>dźwięk</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="194"/>
+        <source>Spectrum bars</source>
+        <translation>Słupki widma</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="195"/>
+        <source>bands</source>
+        <translation>pasma</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="195"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="209"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="213"/>
+        <source>frequency</source>
+        <translation>częstotliwość</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="197"/>
+        <source>Noise reduction</source>
+        <translation>Redukcja szumów</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="198"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="201"/>
+        <source>smoothing</source>
+        <translation>wygładzanie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="198"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="201"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="221"/>
+        <source>smooth</source>
+        <translation>gładki</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="200"/>
+        <source>Extra smoothing</source>
+        <translation>Dodatkowe wygładzanie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="202"/>
+        <source>Automatic gain</source>
+        <translation>Automatyczne wzmocnienie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="203"/>
+        <source>autosens</source>
+        <translation>autoczułość</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="203"/>
+        <source>sensitivity</source>
+        <translation>czułość</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="204"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="206"/>
+        <source>gain</source>
+        <translation>wzmocnienie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="205"/>
+        <source>Sensitivity</source>
+        <translation>Czułość</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="208"/>
+        <source>Lowest frequency</source>
+        <translation>Najniższa częstotliwość</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="209"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="213"/>
+        <source>cutoff</source>
+        <translation>odcięcie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="210"/>
+        <source>bass</source>
+        <translation>bas</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="212"/>
+        <source>Highest frequency</source>
+        <translation>Najwyższa częstotliwość</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="214"/>
+        <source>treble</source>
+        <translation>soprany</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="215"/>
+        <source>Channels</source>
+        <translation>Kanały</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="216"/>
+        <source>stereo</source>
+        <translation>stereo</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="216"/>
+        <source>mono</source>
+        <translation>mono</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="217"/>
+        <source>Reverse bar order</source>
+        <translation>Odwróć kolejność słupków</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="218"/>
+        <source>flip</source>
+        <translation>obróć</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="218"/>
+        <source>mirror</source>
+        <translation>odbij</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="220"/>
+        <source>Monstercat filter</source>
+        <translation>Filtr Monstercat</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="221"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="223"/>
+        <source>filter</source>
+        <translation>filtr</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="222"/>
+        <source>Wave filter</source>
+        <translation>Filtr falowy</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="223"/>
+        <source>wave</source>
+        <translation>fala</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="224"/>
+        <source>Audio backend</source>
+        <translation>Silnik dźwięku</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="225"/>
+        <source>pipewire</source>
+        <translation>pipewire</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="225"/>
+        <source>pulseaudio</source>
+        <translation>pulseaudio</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="226"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="229"/>
+        <source>capture</source>
+        <translation>przechwytywanie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="227"/>
+        <source>Audio source</source>
+        <translation>Źródło dźwięku</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="228"/>
+        <source>device</source>
+        <translation>urządzenie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="231"/>
+        <source>Layout assignment</source>
+        <translation>Przypisanie układu</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="233"/>
+        <source>Don&apos;t assign a layout by default</source>
+        <translation>Nie przypisuj układu domyślnie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="234"/>
+        <source>default</source>
+        <translation>domyślne</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="234"/>
+        <source>assign</source>
+        <translation>przypisz</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="234"/>
+        <source>snapping</source>
+        <translation>przyciąganie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="320"/>
+        <source>Borders</source>
+        <translation>Obramowania</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="322"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="123"/>
+        <source>Decorations</source>
+        <translation>Dekoracje</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="326"/>
+        <source>Corner radius</source>
+        <translation>Promień narożnika</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="328"/>
+        <source>Apply borders to</source>
+        <translation>Zastosuj obramowania do</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="329"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="343"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="360"/>
+        <source>scope</source>
+        <translation>zakres</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="329"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="343"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="360"/>
+        <source>which windows</source>
+        <translation>które okna</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="331"/>
+        <source>Use system accent color</source>
+        <translation>Użyj systemowej barwy akcentu</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="334"/>
+        <source>Active border color</source>
+        <translation>Barwa obramowania aktywnego okna</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="335"/>
+        <source>focused</source>
+        <translation>aktywne</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="337"/>
+        <source>Inactive border color</source>
+        <translation>Barwa obramowania nieaktywnego okna</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="340"/>
+        <source>Opacity and tint</source>
+        <translation>Nieprzezroczystość i zabarwienie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="342"/>
+        <source>Apply opacity and tint to</source>
+        <translation>Zastosuj nieprzezroczystość i zabarwienie do</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="346"/>
+        <source>translucent</source>
+        <translation>półprzezroczysty</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="349"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="354"/>
+        <source>wash</source>
+        <translation>przemycie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="349"/>
+        <source>blend</source>
+        <translation>mieszanie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="351"/>
+        <source>Use system accent color for the tint</source>
+        <translation>Użyj systemowej barwy akcentu do zabarwienia</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="354"/>
+        <source>accent</source>
+        <translation>akcent</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="357"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="360"/>
+        <source>titlebar</source>
+        <translation>pasek tytułu</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="357"/>
+        <source>header</source>
+        <translation>nagłówek</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="359"/>
+        <source>Hide title bars on</source>
+        <translation>Ukryj paski tytułu na</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="362"/>
+        <source>Focus fade duration</source>
+        <translation>Czas zanikania uaktywnienia</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="346"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="363"/>
+        <source>fade</source>
+        <translation>zanikanie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="363"/>
+        <source>dim</source>
+        <translation>przyciemnienie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="364"/>
+        <source>cross-fade</source>
+        <translation>przenikanie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="370"/>
+        <source>Performance</source>
+        <translation>Wydajność</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="372"/>
+        <source>Animate only the active window</source>
+        <translation>Animuj tylko aktywne okno</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="373"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="377"/>
+        <source>performance</source>
+        <translation>wydajność</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="373"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="377"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="381"/>
+        <source>power</source>
+        <translation>moc</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="373"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="377"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="382"/>
+        <source>battery</source>
+        <translation>bateria</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="374"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="378"/>
+        <source>gpu</source>
+        <translation>gpu</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="374"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="378"/>
+        <source>heat</source>
+        <translation>ciepło</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="376"/>
+        <source>Pause while you are away</source>
+        <translation>Wstrzymaj, gdy jesteś nieobecny</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="378"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="381"/>
+        <source>idle</source>
+        <translation>bezczynność</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="380"/>
+        <source>Idle after</source>
+        <translation>Bezczynność po</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="381"/>
+        <source>timeout</source>
+        <translation>limit czasu</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="403"/>
+        <source>Inner gap</source>
+        <translation>Odstęp wewnętrzny</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="405"/>
+        <source>inner</source>
+        <translation>wewnętrzny</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="406"/>
+        <source>Outer gap</source>
+        <translation>Odstęp zewnętrzny</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="408"/>
+        <source>outer</source>
+        <translation>zewnętrzny</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="414"/>
+        <source>side</source>
+        <translation>bok</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="416"/>
+        <source>Smart gaps</source>
+        <translation>Inteligentne odstępy</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="418"/>
+        <source>smart</source>
+        <translation>inteligentny</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="418"/>
+        <source>single</source>
+        <translation>pojedynczy</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="422"/>
+        <source>Activate on every drag</source>
+        <translation>Aktywuj przy każdym przeciąganiu</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="424"/>
+        <source>Hold to activate</source>
+        <translation>Przytrzymaj, aby aktywować</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="424"/>
+        <source>deactivate</source>
+        <translation>dezaktywuj</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="426"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="430"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="499"/>
+        <source>Toggle mode</source>
+        <translation>Tryb przełączania</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="426"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="430"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="499"/>
+        <source>tap</source>
+        <translation>stuknięcie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="426"/>
+        <source>activation</source>
+        <translation>aktywacja</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="428"/>
+        <source>Span modifier</source>
+        <translation>Modyfikator rozpiętości</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="428"/>
+        <source>zone span</source>
+        <translation>rozpiętość stref</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="428"/>
+        <source>paint</source>
+        <translation>rysowanie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="430"/>
+        <source>span</source>
+        <translation>rozpiętość</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="432"/>
+        <source>Edge threshold</source>
+        <translation>Próg krawędzi</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="432"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="562"/>
+        <source>distance</source>
+        <translation>odległość</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="432"/>
+        <source>multi-zone</source>
+        <translation>wiele stref</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="434"/>
+        <source>Show zones on all monitors</source>
+        <translation>Pokaż strefy na wszystkich ekranach</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="435"/>
+        <source>screens</source>
+        <translation>ekrany</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="437"/>
+        <source>Filter by aspect ratio</source>
+        <translation>Filtruj według proporcji</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="437"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="453"/>
+        <source>layouts</source>
+        <translation>układy</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="441"/>
+        <source>Always show after snapping</source>
+        <translation>Zawsze pokazuj po przyciągnięciu</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="442"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="444"/>
+        <source>snap assist</source>
+        <translation>asystent przyciągania</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="444"/>
+        <source>Hold to enable</source>
+        <translation>Przytrzymaj, aby włączyć</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="446"/>
+        <source>Re-snap on resolution change</source>
+        <translation>Przyciągnij ponownie po zmianie rozdzielczości</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="447"/>
+        <source>resolution</source>
+        <translation>rozdzielczość</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="449"/>
+        <source>Open new windows in the last-used zone</source>
+        <translation>Otwieraj nowe okna w ostatnio używanej strefie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="450"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="469"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="514"/>
+        <source>new window</source>
+        <translation>nowe okno</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="450"/>
+        <source>last zone</source>
+        <translation>ostatnia strefa</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="452"/>
+        <source>Auto-assign new windows for all layouts</source>
+        <translation>Automatycznie przypisuj nowe okna dla wszystkich układów</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="453"/>
+        <source>auto-assign</source>
+        <translation>automatyczne przypisywanie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="603"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="609"/>
+        <source>User sets</source>
+        <translation>Ustawienia użytkownika</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="616"/>
+        <source>Opened</source>
+        <translation>Otwarte</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="618"/>
+        <source>Closed</source>
+        <translation>Zamknięte</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="626"/>
+        <source>Dragged</source>
+        <translation>Przeciągnięte</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="631"/>
+        <source>Snapped Into Zone</source>
+        <translation>Przyciągnięte do strefy</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="633"/>
+        <source>Snapped Out of Zone</source>
+        <translation>Przyciągnięte poza strefę</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="635"/>
+        <source>Layout Switched</source>
+        <translation>Przełączono układ</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="637"/>
+        <source>Shown</source>
+        <translation>Pokazane</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="638"/>
+        <source>Hidden</source>
+        <translation>Ukryte</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="639"/>
+        <source>Emphasized</source>
+        <translation>Wyróżnione</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="642"/>
+        <source>Zone Selector Shown</source>
+        <translation>Pokazano selektor stref</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="644"/>
+        <source>Zone Selector Hidden</source>
+        <translation>Ukryto selektor stref</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="646"/>
+        <source>Layout Picker Shown</source>
+        <translation>Pokazano wybierak układów</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="648"/>
+        <source>Layout Picker Hidden</source>
+        <translation>Ukryto wybierak układów</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="650"/>
+        <source>Snap Assist Shown</source>
+        <translation>Pokazano asystenta przyciągania</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="652"/>
+        <source>Snap Assist Hidden</source>
+        <translation>Ukryto asystenta przyciągania</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="655"/>
+        <source>Desktop Switched</source>
+        <translation>Przełączono pulpit</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="593"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="902"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="455"/>
+        <source>Restore size on unsnap</source>
+        <translation>Przywróć rozmiar po odczepieniu</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="456"/>
+        <source>unsnap</source>
+        <translation>odczep</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="456"/>
+        <source>original size</source>
+        <translation>pierwotny rozmiar</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="458"/>
+        <source>Restore windows to their previous zone</source>
+        <translation>Przywracaj okna do ich poprzedniej strefy</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="459"/>
+        <source>login</source>
+        <translation>logowanie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="461"/>
+        <source>Restore unsnapped windows to their previous position</source>
+        <translation>Przywracaj odczepione okna do ich poprzedniego położenia</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="462"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="506"/>
+        <source>floated</source>
+        <translation>pływające</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="462"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="501"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="506"/>
+        <source>position</source>
+        <translation>położenie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="464"/>
+        <source>Unfloat to a zone when there is no previous zone</source>
+        <translation>Przenoś do strefy, gdy nie ma poprzedniej strefy</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="465"/>
+        <source>unfloat</source>
+        <translation>przestań być pływającym</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="465"/>
+        <source>fallback</source>
+        <translation>zapasowe</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="467"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="508"/>
+        <source>Sticky windows</source>
+        <translation>Przyklejone okna</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="467"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="508"/>
+        <source>all desktops</source>
+        <translation>wszystkie pulpity</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="467"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="508"/>
+        <source>sticky</source>
+        <translation>przyklejone</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="469"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="514"/>
+        <source>Focus new windows</source>
+        <translation>Uaktywniaj nowe okna</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="114"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="374"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="469"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="471"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="514"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="516"/>
+        <source>focus</source>
+        <translation>aktywacja</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="471"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="516"/>
+        <source>Focus follows mouse</source>
+        <translation>Uaktywnianie podąża za myszą</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="471"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="516"/>
+        <source>pointer</source>
+        <translation>wskaźnik</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="238"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="283"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="474"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="219"/>
+        <source>Algorithm</source>
+        <translation>Algorytm</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="476"/>
+        <source>Max windows</source>
+        <translation>Maksymalna liczba okien</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="477"/>
+        <source>windows</source>
+        <translation>okna</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="477"/>
+        <source>maximum</source>
+        <translation>maksimum</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="477"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="489"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="570"/>
+        <source>count</source>
+        <translation>liczba</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="478"/>
+        <source>limit</source>
+        <translation>limit</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="480"/>
+        <source>Master ratio</source>
+        <translation>Proporcja głównego obszaru</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="481"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="489"/>
+        <source>center</source>
+        <translation>środek</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="481"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="486"/>
+        <source>ratio</source>
+        <translation>proporcja</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="482"/>
+        <source>proportion</source>
+        <translation>udział</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="485"/>
+        <source>Ratio step size</source>
+        <translation>Wielkość kroku proporcji</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="486"/>
+        <source>step</source>
+        <translation>krok</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="486"/>
+        <source>increment</source>
+        <translation>przyrost</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="292"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="488"/>
+        <source>Master count</source>
+        <translation>Liczba okien głównych</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="490"/>
+        <source>number</source>
+        <translation>liczba</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="494"/>
+        <source>Always re-insert on drag</source>
+        <translation>Zawsze wstawiaj ponownie przy przeciąganiu</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="494"/>
+        <source>insert</source>
+        <translation>wstaw</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="496"/>
+        <source>Hold to re-insert into stack</source>
+        <translation>Przytrzymaj, aby ponownie wstawić do stosu</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="499"/>
+        <source>stack preview</source>
+        <translation>podgląd stosu</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="501"/>
+        <source>New window placement</source>
+        <translation>Rozmieszczenie nowych okien</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="503"/>
+        <source>Respect minimum size</source>
+        <translation>Uwzględniaj minimalny rozmiar</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="503"/>
+        <source>minimum</source>
+        <translation>minimum</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="505"/>
+        <source>Restore untiled windows to their previous position</source>
+        <translation>Przywracaj niekafelkowane okna do ich poprzedniego położenia</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="301"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="510"/>
+        <source>Drag behavior</source>
+        <translation>Zachowanie przeciągania</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="510"/>
+        <source>reorder</source>
+        <translation>zmień kolejność</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="298"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="512"/>
+        <source>Overflow behavior</source>
+        <translation>Zachowanie przy przepełnieniu</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="512"/>
+        <source>max windows</source>
+        <translation>maksymalna liczba okien</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="512"/>
+        <source>unlimited</source>
+        <translation>bez ograniczeń</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="520"/>
+        <source>Global animation defaults</source>
+        <translation>Globalne domyślne ustawienia animacji</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="522"/>
+        <source>Multiple windows</source>
+        <translation>Wiele okien</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="523"/>
+        <source>sequence</source>
+        <translation>sekwencja</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="523"/>
+        <source>simultaneous</source>
+        <translation>jednocześnie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="523"/>
+        <source>one by one</source>
+        <translation>kolejno</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="525"/>
+        <source>Stagger delay</source>
+        <translation>Opóźnienie kaskady</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="526"/>
+        <source>pause</source>
+        <translation>pauza</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="526"/>
+        <source>interval</source>
+        <translation>odstęp czasu</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="526"/>
+        <source>delay</source>
+        <translation>opóźnienie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="528"/>
+        <source>Minimum distance</source>
+        <translation>Minimalna odległość</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="243"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="246"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="395"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="398"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="529"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="541"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="544"/>
+        <source>threshold</source>
+        <translation>próg</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="529"/>
+        <source>skip</source>
+        <translation>pomiń</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="529"/>
+        <source>geometry</source>
+        <translation>geometria</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="531"/>
+        <source>Window Filtering</source>
+        <translation>Filtrowanie okien</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="391"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="534"/>
+        <source>dialogs</source>
+        <translation>okna dialogowe</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="391"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="534"/>
+        <source>popups</source>
+        <translation>okna wyskakujące</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="534"/>
+        <source>tooltips</source>
+        <translation>podpowiedzi</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="391"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="535"/>
+        <source>menus</source>
+        <translation>menu</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="537"/>
+        <source>Exclude notifications and OSDs</source>
+        <translation>Wyklucz powiadomienia i komunikaty OSD</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="538"/>
+        <source>volume</source>
+        <translation>głośność</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="538"/>
+        <source>brightness</source>
+        <translation>jasność</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="242"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="394"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="540"/>
+        <source>Minimum window width</source>
+        <translation>Minimalna szerokość okna</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="243"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="395"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="541"/>
+        <source>narrow</source>
+        <translation>wąskie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="245"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="397"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="543"/>
+        <source>Minimum window height</source>
+        <translation>Minimalna wysokość okna</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="246"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="398"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="544"/>
+        <source>short</source>
+        <translation>niskie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="548"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="192"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="223"/>
+        <source>Configuration</source>
+        <translation>Konfiguracja</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="549"/>
+        <source>Backup</source>
+        <translation>Kopia zapasowa</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="550"/>
+        <source>save</source>
+        <translation>zapis</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="550"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="552"/>
+        <source>data</source>
+        <translation>dane</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="551"/>
+        <source>Restore</source>
+        <translation>Przywróć</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="556"/>
+        <source>Zone selector popup</source>
+        <translation>Okno selektora stref</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="557"/>
+        <source>enable</source>
+        <translation>włącz</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="557"/>
+        <source>toggle</source>
+        <translation>przełącz</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="559"/>
+        <source>Position &amp; Trigger</source>
+        <translation>Położenie i wyzwalacz</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="561"/>
+        <source>Trigger distance</source>
+        <translation>Odległość wyzwalania</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="562"/>
+        <source>proximity</source>
+        <translation>bliskość</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="564"/>
+        <source>Layout Arrangement</source>
+        <translation>Rozmieszczenie układu</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="566"/>
+        <source>Arrangement</source>
+        <translation>Rozmieszczenie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="567"/>
+        <source>horizontal</source>
+        <translation>poziomo</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="567"/>
+        <source>vertical</source>
+        <translation>pionowo</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="569"/>
+        <source>Grid columns</source>
+        <translation>Kolumny siatki</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="570"/>
+        <source>columns</source>
+        <translation>kolumny</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="570"/>
+        <source>per row</source>
+        <translation>na wiersz</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="572"/>
+        <source>Max visible rows</source>
+        <translation>Maksymalna liczba widocznych wierszy</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="573"/>
+        <source>rows</source>
+        <translation>wiersze</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="573"/>
+        <source>scroll</source>
+        <translation>przewijanie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="573"/>
+        <source>visible</source>
+        <translation>widoczne</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="575"/>
+        <source>Preview Size</source>
+        <translation>Rozmiar podglądu</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="579"/>
+        <source>Snapping Layout Priority</source>
+        <translation>Priorytet układu przyciągania</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="581"/>
+        <source>Tiling Algorithm Priority</source>
+        <translation>Priorytet algorytmu kafelkowania</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="583"/>
+        <source>Snapping Quick Shortcuts</source>
+        <translation>Szybkie skróty przyciągania</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="585"/>
+        <source>Tiling Quick Shortcuts</source>
+        <translation>Szybkie skróty kafelkowania</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="591"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="593"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="595"/>
+        <source>User shaders</source>
+        <translation>Shadery użytkownika</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="597"/>
+        <source>Easing Presets</source>
+        <translation>Nastawy wygładzania</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="599"/>
+        <source>Spring Presets</source>
+        <translation>Nastawy sprężystości</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="601"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="607"/>
+        <source>Save current state</source>
+        <translation>Zapisz bieżący stan</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="605"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="611"/>
+        <source>Saved sets</source>
+        <translation>Zapisane zestawy</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="663"/>
+        <source>Peeked at Desktop</source>
+        <translation>Podejrzano pulpit</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="713"/>
+        <source>Snap Out of Zone</source>
+        <translation>Odczep od strefy</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="665"/>
+        <source>Slide In</source>
+        <translation>Wsunięcie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="667"/>
+        <source>Slide Out</source>
+        <translation>Wysunięcie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="669"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="687"/>
+        <source>Fade In</source>
+        <translation>Pojawienie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="671"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="689"/>
+        <source>Fade Out</source>
+        <translation>Zanikanie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="672"/>
+        <source>Hover</source>
+        <translation>Najechanie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="673"/>
+        <source>Press</source>
+        <translation>Naciśnięcie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="675"/>
+        <source>Toggle On</source>
+        <translation>Włączenie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="677"/>
+        <source>Toggle Off</source>
+        <translation>Wyłączenie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="679"/>
+        <source>Show (badge)</source>
+        <translation>Pokaż (plakietka)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="681"/>
+        <source>Hide (badge)</source>
+        <translation>Ukryj (plakietka)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="683"/>
+        <source>Pulse (badge)</source>
+        <translation>Pulsowanie (plakietka)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="684"/>
+        <source>Tint</source>
+        <translation>Zabarwienie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="685"/>
+        <source>Dim</source>
+        <translation>Przyciemnienie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="691"/>
+        <source>Reorder</source>
+        <translation>Zmiana kolejności</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="693"/>
+        <source>Expand (accordion)</source>
+        <translation>Rozwinięcie (akordeon)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="695"/>
+        <source>Collapse (accordion)</source>
+        <translation>Zwinięcie (akordeon)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="697"/>
+        <source>Progress</source>
+        <translation>Postęp</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="699"/>
+        <source>Zone Highlight</source>
+        <translation>Podświetlenie strefy</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="701"/>
+        <source>Zone Highlight: Pop</source>
+        <translation>Podświetlenie strefy: uskok</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="703"/>
+        <source>Zone Highlight: Border</source>
+        <translation>Podświetlenie strefy: obramowanie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="705"/>
+        <source>Zone Overlay: Layout-Switch Flash</source>
+        <translation>Nakładka strefy: błysk przy zmianie układu</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="707"/>
+        <source>Cursor Hover</source>
+        <translation>Najechanie kursorem</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="709"/>
+        <source>Cursor Click</source>
+        <translation>Kliknięcie kursorem</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="711"/>
+        <source>Snap Into Zone (Fill Preview)</source>
+        <translation>Przyciągnięcie do strefy (podgląd wypełnienia)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="715"/>
+        <source>Snap Resize (Drag Preview)</source>
+        <translation>Zmiana rozmiaru przyciągania (podgląd przeciągania)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller.cpp" line="661"/>
+        <source>Zone %1</source>
+        <translation>Strefa %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller.cpp" line="663"/>
+        <source>%1 — %2</source>
+        <translation>%1 — %2</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="216"/>
+        <source>Layout created, but aspect-ratio class could not be applied: %1</source>
+        <translation>Utworzono układ, ale nie udało się zastosować klasy proporcji: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="230"/>
+        <source>Could not create the layout. The daemon returned an empty layout ID.</source>
+        <translation>Nie udało się utworzyć układu. Usługa zwróciła pusty identyfikator układu.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="238"/>
+        <source>Could not create the layout. The daemon may not be running.</source>
+        <translation>Nie udało się utworzyć układu. Usługa może nie być uruchomiona.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="257"/>
+        <source>Could not delete layout: %1</source>
+        <translation>Nie udało się usunąć układu: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="273"/>
+        <source>Could not duplicate layout: %1</source>
+        <translation>Nie udało się powielić układu: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="323"/>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="472"/>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="565"/>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="929"/>
+        <source>That file path is not allowed.</source>
+        <translation>Ta ścieżka pliku jest niedozwolona.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="355"/>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="530"/>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="497"/>
+        <source>That export path is not allowed.</source>
+        <translation>Ta ścieżka eksportu jest niedozwolona.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="400"/>
+        <source>Failed to update layout visibility: %1</source>
+        <translation>Nie udało się zaktualizować widoczności układu: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="413"/>
+        <source>Failed to update auto-assign: %1</source>
+        <translation>Nie udało się zaktualizować automatycznego przypisania: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="427"/>
+        <source>Failed to update aspect ratio: %1</source>
+        <translation>Nie udało się zaktualizować proporcji: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_lifecycle.cpp" line="187"/>
+        <source>Failed to apply assignment changes: %1</source>
+        <translation>Nie udało się zastosować zmian przypisania: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="77"/>
+        <source>Overview</source>
+        <translation>Przegląd</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="81"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="232"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="302"/>
+        <source>General</source>
+        <translation>Ogólne</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="91"/>
+        <source>Placement</source>
+        <translation>Rozmieszczenie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/decorationpagecontroller_browser.cpp" line="40"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="253"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="312"/>
+        <source>Windows</source>
+        <translation>Okna</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="132"/>
+        <source>Rules</source>
+        <translation>Reguły</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="136"/>
+        <source>Editor</source>
+        <translation>Edytor</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="138"/>
+        <source>About</source>
+        <translation>O programie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="151"/>
+        <source>Virtual Screens</source>
+        <translation>Wirtualne ekrany</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="153"/>
+        <source>Layouts</source>
+        <translation>Układy</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="243"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="171"/>
+        <source>Behavior</source>
+        <translation>Zachowanie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/decorationpagecontroller_browser.cpp" line="54"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="181"/>
+        <source>Zone Selector</source>
+        <translation>Wybór strefy</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="194"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="225"/>
+        <source>Priority</source>
+        <translation>Priorytet</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="197"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="228"/>
+        <source>Quick Shortcuts</source>
+        <translation>Szybkie skróty</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="199"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="287"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="322"/>
+        <source>Shaders</source>
+        <translation>Shadery</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="239"/>
+        <source>Transitions</source>
+        <translation>Przejścia</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="247"/>
+        <source>Motion</source>
+        <translation>Ruch</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="264"/>
+        <source>Window Motion</source>
+        <translation>Ruch okna</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="271"/>
+        <source>Window Dragging</source>
+        <translation>Przeciąganie okna</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="306"/>
+        <source>Surfaces</source>
+        <translation>Powierzchnie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="319"/>
+        <source>Decoration Sets</source>
+        <translation>Zestawy dekoracji</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="249"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="308"/>
+        <source>Library</source>
+        <translation>Biblioteka</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/decorationpagecontroller_browser.cpp" line="48"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="254"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="313"/>
+        <source>OSDs</source>
+        <translation>OSD</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="257"/>
+        <source>Overlays</source>
+        <translation>Nakładki</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="274"/>
+        <source>Side Panels</source>
+        <translation>Panele boczne</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="276"/>
+        <source>Widgets</source>
+        <translation>Widżety</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="279"/>
+        <source>Layout Editor</source>
+        <translation>Edytor układów</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="282"/>
+        <source>Presets</source>
+        <translation>Nastawy</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="285"/>
+        <source>Motion Sets</source>
+        <translation>Zestawy ruchu</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shaderpackinstaller.cpp" line="303"/>
+        <source>Shader pack installed.</source>
+        <translation>Zainstalowano paczkę shaderów.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shaderpackinstaller.cpp" line="305"/>
+        <source>The dropped path is not a valid shader pack directory.</source>
+        <translation>Upuszczona ścieżka nie jest prawidłowym katalogiem paczki shaderów.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shaderpackinstaller.cpp" line="307"/>
+        <source>The shader pack is missing metadata.json (or it is a symlink).</source>
+        <translation>W paczce shaderów brakuje pliku metadata.json (lub jest to dowiązanie symboliczne).</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shaderpackinstaller.cpp" line="309"/>
+        <source>The user shader directory could not be created.</source>
+        <translation>Nie udało się utworzyć katalogu shaderów użytkownika.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shaderpackinstaller.cpp" line="311"/>
+        <source>A shader pack with this name is already installed.</source>
+        <translation>Paczka shaderów o tej nazwie jest już zainstalowana.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shaderpackinstaller.cpp" line="313"/>
+        <source>The shader pack exceeds the maximum allowed size or file count.</source>
+        <translation>Paczka shaderów przekracza maksymalny dozwolony rozmiar lub liczbę plików.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shaderpackinstaller.cpp" line="315"/>
+        <source>Copying the shader pack failed. The partial install was rolled back.</source>
+        <translation>Kopiowanie paczki shaderów nie powiodło się. Częściową instalację wycofano.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shaderpackinstaller.cpp" line="317"/>
+        <source>Unknown shader pack installer error.</source>
+        <translation>Nieznany błąd instalatora paczki shaderów.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/snappingzonescontroller.cpp" line="78"/>
+        <source>Color import file does not exist: %1</source>
+        <translation>Plik importu barw nie istnieje: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/snappingzonescontroller.cpp" line="96"/>
+        <source>Color import file does not resolve to a regular file: %1</source>
+        <translation>Plik importu barw nie wskazuje na zwykły plik: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/snappingzonescontroller.cpp" line="101"/>
+        <source>Color import file must be a .json file: %1</source>
+        <translation>Plik importu barw musi być plikiem .json: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="449"/>
+        <location filename="../src/settings/shadersetstore.cpp" line="545"/>
+        <source>A set named &quot;%1&quot; already exists.</source>
+        <translation>Zestaw o nazwie &quot;%1&quot; już istnieje.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="355"/>
+        <location filename="../src/settings/shadersetstore.cpp" line="540"/>
+        <location filename="../src/settings/shadersetstore.cpp" line="551"/>
+        <location filename="../src/settings/shadersetstore.cpp" line="617"/>
+        <location filename="../src/settings/shadersetstore.cpp" line="622"/>
+        <source>Could not read the set &quot;%1&quot;.</source>
+        <translation>Nie udało się odczytać zestawu &quot;%1&quot;.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="169"/>
+        <source>Could not back up the existing set, so it was left untouched.</source>
+        <translation>Nie udało się utworzyć kopii zapasowej istniejącego zestawu, więc pozostał nietknięty.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="234"/>
+        <source>Could not write the set to disk.</source>
+        <translation>Nie udało się zapisać zestawu na dysku.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="359"/>
+        <source>&quot;%1&quot; was written by a newer version of PlasmaZones.</source>
+        <translation>&quot;%1&quot; został zapisany przez nowszą wersję PlasmaZones.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="367"/>
+        <source>&quot;%1&quot; does not match this page.</source>
+        <translation>&quot;%1&quot; nie pasuje do tej strony.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="371"/>
+        <source>Could not apply &quot;%1&quot;.</source>
+        <translation>Nie udało się zastosować &quot;%1&quot;.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="439"/>
+        <location filename="../src/settings/shadersetstore.cpp" line="533"/>
+        <source>That name cannot be used. Try one with letters or numbers in it.</source>
+        <translation>Tej nazwy nie można użyć. Spróbuj nazwy zawierającej litery lub cyfry.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="459"/>
+        <source>There is nothing to capture yet.</source>
+        <translation>Nie ma jeszcze niczego do przechwycenia.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="500"/>
+        <location filename="../src/settings/shadersetstore.cpp" line="508"/>
+        <source>Could not delete &quot;%1&quot;.</source>
+        <translation>Nie udało się usunąć &quot;%1&quot;.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="432"/>
+        <location filename="../src/settings/shadersetstore.cpp" line="526"/>
+        <source>A set needs a name.</source>
+        <translation>Zestaw wymaga nazwy.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="589"/>
+        <source>Renamed the set, but the old file could not be removed. Delete it by hand from the sets folder.</source>
+        <translation>Zmieniono nazwę zestawu, ale nie udało się usunąć starego pliku. Usuń go ręcznie z katalogu zestawów.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="605"/>
+        <source>Could not write to that location.</source>
+        <translation>Nie udało się zapisać w tym miejscu.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="631"/>
+        <source>Could not write to %1.</source>
+        <translation>Nie udało się zapisać do %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="652"/>
+        <source>That file is not a readable set.</source>
+        <translation>Ten plik nie jest zestawem możliwym do odczytu.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="656"/>
+        <source>That set was written by a newer version of PlasmaZones.</source>
+        <translation>Ten zestaw został zapisany przez nowszą wersję PlasmaZones.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="663"/>
+        <source>That set is empty.</source>
+        <translation>Ten zestaw jest pusty.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="670"/>
+        <source>That set does not match this page.</source>
+        <translation>Ten zestaw nie pasuje do tej strony.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="681"/>
+        <source>That set has no usable name.</source>
+        <translation>Ten zestaw nie ma użytecznej nazwy.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="466"/>
+        <location filename="../src/settings/shadersetstore.cpp" line="688"/>
+        <location filename="../src/settings/shadersetstore.cpp" line="710"/>
+        <source>Could not create the sets folder.</source>
+        <translation>Nie udało się utworzyć katalogu zestawów.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="715"/>
+        <source>Could not open the sets folder.</source>
+        <translation>Nie udało się otworzyć katalogu zestawów.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/animationpresetlibrary.cpp" line="130"/>
+        <location filename="../src/settings/animationpresetlibrary.cpp" line="199"/>
+        <source>A preset needs a name.</source>
+        <translation>Nastawa wymaga nazwy.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/animationpresetlibrary.cpp" line="140"/>
+        <source>That name cannot be used for a preset.</source>
+        <translation>Tej nazwy nie można użyć dla nastawy.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/animationpresetlibrary.cpp" line="150"/>
+        <location filename="../src/settings/animationpresetlibrary.cpp" line="159"/>
+        <location filename="../src/settings/animationpresetlibrary.cpp" line="178"/>
+        <source>Could not save the preset &quot;%1&quot;.</source>
+        <translation>Nie udało się zapisać nastawy &quot;%1&quot;.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/animationpresetlibrary.cpp" line="253"/>
+        <source>Could not find the preset &quot;%1&quot;.</source>
+        <translation>Nie udało się odnaleźć nastawy &quot;%1&quot;.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/animationpresetlibrary.cpp" line="261"/>
+        <location filename="../src/settings/animationpresetlibrary.cpp" line="271"/>
+        <source>Could not delete the preset &quot;%1&quot;.</source>
+        <translation>Nie udało się usunąć nastawy &quot;%1&quot;.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/animationspagecontroller_overrides.cpp" line="260"/>
+        <location filename="../src/settings/animationspagecontroller_shaders.cpp" line="407"/>
+        <source>Cannot reset while a discard is in progress.</source>
+        <translation>Nie można wyzerować, gdy trwa odrzucanie.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/animationspagecontroller_overrides.cpp" line="282"/>
+        <source>Some animation overrides could not be reset.</source>
+        <translation>Nie udało się wyzerować niektórych zastąpień animacji.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="488"/>
+        <source>Settings can only be exported to a local file.</source>
+        <translation>Ustawienia można wyeksportować tylko do lokalnego pliku.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="529"/>
+        <source>That is the settings file this app is using. Export to a different file.</source>
+        <translation>To jest plik ustawień, którego używa ta aplikacja. Wyeksportuj do innego pliku.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="556"/>
+        <source>Settings can only be imported from a local file.</source>
+        <translation>Ustawienia można zaimportować tylko z lokalnego pliku.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="570"/>
+        <source>That settings file is no longer there.</source>
+        <translation>Tego pliku ustawień już tam nie ma.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="584"/>
+        <source>Those are the settings this app is already using. Pick a different file to import.</source>
+        <translation>To są ustawienia, których ta aplikacja już używa. Wybierz inny plik do zaimportowania.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="607"/>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="612"/>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="617"/>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="641"/>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="685"/>
+        <source>That is not a settings file this app can read.</source>
+        <translation>To nie jest plik ustawień, który ta aplikacja potrafi odczytać.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="657"/>
+        <source>Could not back up your current settings, so nothing was imported.</source>
+        <translation>Nie udało się utworzyć kopii zapasowej bieżących ustawień, więc nic nie zaimportowano.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="670"/>
+        <source>Could not read that older settings file.</source>
+        <translation>Nie udało się odczytać tego starszego pliku ustawień.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="677"/>
+        <source>Could not read that settings file.</source>
+        <translation>Nie udało się odczytać tego pliku ustawień.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="697"/>
+        <source>Could not replace your settings with that file.</source>
+        <translation>Nie udało się zastąpić ustawień tym plikiem.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="725"/>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="730"/>
+        <source>Your settings could not be put back. A copy is saved at %1.</source>
+        <translation>Nie udało się przywrócić ustawień. Kopia jest zapisana w %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="770"/>
+        <source>Your settings were imported, but the animation pages still show the old ones. Reopen the settings window to see the imported values.</source>
+        <translation>Ustawienia zostały zaimportowane, ale strony animacji nadal pokazują stare. Otwórz ponownie okno ustawień, aby zobaczyć zaimportowane wartości.</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
## Summary
Adds a full **Polish (`pl`)** translation — all **1022 strings** translated, including the **three Polish plural forms** (one/few/many) for the four `%n` strings.

- Generated `translations/plasmazones_pl.ts` against current sources with `lupdate` (single `plasmazones` context).
- Terminology follows KDE Plasma's Polish conventions: `okno`=window, `ekran`=screen, `strefa`=zone, `układ`=layout, `kafelkowanie`=tiling, `przyciąganie`=snap, `nakładka`=overlay, `barwa`=color, `uaktywnienie`=focus. `shader` is kept as the loanword and correctly declined (shadera / shadery / shaderów).
- Polish **sentence case** (not English title case), with correct case and gender agreement.

## Review
Ran a **3-pass native-Polish review** (7 → 22 → **0 findings**, converged clean). The middle pass caught a widespread issue a plain grep would have missed: `shader` had been translated as `cieniowanie` in ~15 places, hidden across Polish *declined* forms (`cieniowania`, `cieniowań`) — all corrected to the declined loanword. Also unified color→`barwa` for singular labels (with correct feminine agreement), focus→`uaktywnienie`, corner radius, and monitor→`ekran`.

## Verification
- Placeholders (`%1`/`%2`/`%n`) and XML entities preserved (0 mismatches).
- Technical proper nouns (OpenGL, Vulkan, pywal, cava, ...) kept in Latin.
- Well-formed XML; CMake picks it up via the `plasmazones_*.ts` glob.
- `lrelease` compiles: **1022 finished / 0 unfinished** (with the correct 3 plural forms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)