### PR TITLE
feat(i18n): add complete Russian translation

### DIFF
--- a/translations/plasmazones_ru.ts
+++ b/translations/plasmazones_ru.ts
@@ -1,0 +1,5573 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ru">
+<context>
+    <name>plasmazones</name>
+    <message>
+        <location filename="../src/editor/controller/settings.cpp" line="52"/>
+        <source>A zone with this name already exists</source>
+        <translation>Зона с таким именем уже существует</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/AddZoneCommand.cpp" line="16"/>
+        <source>Add Zone</source>
+        <comment>@action</comment>
+        <translation>Добавить зону</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/shortcutmanager.cpp" line="592"/>
+        <source>Apply Layout %1</source>
+        <translation>Применить раскладку %1</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/ApplyTemplateCommand.cpp" line="14"/>
+        <source>Apply Template: %1</source>
+        <comment>@action</comment>
+        <translation>Применить шаблон: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/zoneops.cpp" line="185"/>
+        <source>Bring Forward</source>
+        <comment>@action</comment>
+        <translation>Переместить вперёд</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/zoneops.cpp" line="175"/>
+        <source>Bring to Front</source>
+        <comment>@action</comment>
+        <translation>На передний план</translation>
+    </message>
+    <message>
+        <location filename="../src/dbus/windowdragadaptor.cpp" line="357"/>
+        <source>Cancel Zone Overlay</source>
+        <translation>Отменить наложение зон</translation>
+    </message>
+    <message>
+        <location filename="../src/dbus/windowdragadaptor.cpp" line="412"/>
+        <source>Layout Picker: Move Left</source>
+        <translation>Выбор раскладки: влево</translation>
+    </message>
+    <message>
+        <location filename="../src/dbus/windowdragadaptor.cpp" line="416"/>
+        <source>Layout Picker: Move Right</source>
+        <translation>Выбор раскладки: вправо</translation>
+    </message>
+    <message>
+        <location filename="../src/dbus/windowdragadaptor.cpp" line="420"/>
+        <source>Layout Picker: Move Up</source>
+        <translation>Выбор раскладки: вверх</translation>
+    </message>
+    <message>
+        <location filename="../src/dbus/windowdragadaptor.cpp" line="424"/>
+        <source>Layout Picker: Move Down</source>
+        <translation>Выбор раскладки: вниз</translation>
+    </message>
+    <message>
+        <location filename="../src/dbus/windowdragadaptor.cpp" line="428"/>
+        <location filename="../src/dbus/windowdragadaptor.cpp" line="430"/>
+        <source>Layout Picker: Confirm</source>
+        <translation>Выбор раскладки: подтвердить</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/UpdateGapOverrideCommand.cpp" line="21"/>
+        <source>Change Edge Gap</source>
+        <comment>@action</comment>
+        <translation>Изменить краевой зазор</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/UpdateGapOverrideCommand.cpp" line="20"/>
+        <source>Change Overlay Style</source>
+        <comment>@action</comment>
+        <translation>Изменить стиль наложения</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/ChangeSelectionCommand.cpp" line="14"/>
+        <source>Change Selection</source>
+        <comment>@action</comment>
+        <translation>Изменить выделение</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/UpdateShaderIdCommand.cpp" line="15"/>
+        <source>Change Shader Effect</source>
+        <comment>@action</comment>
+        <translation>Изменить эффект шейдера</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/UpdateShaderParamsCommand.cpp" line="17"/>
+        <source>Change Shader Parameter</source>
+        <comment>@action</comment>
+        <translation>Изменить параметр шейдера</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/UpdateShaderParamsCommand.cpp" line="29"/>
+        <source>Change Shader Parameters</source>
+        <comment>@action</comment>
+        <translation>Изменить параметры шейдера</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/ChangeZOrderCommand.cpp" line="13"/>
+        <source>Change Z-Order</source>
+        <comment>@action</comment>
+        <translation>Изменить порядок наложения</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/UpdateZoneAppearanceCommand.cpp" line="15"/>
+        <source>Change Zone Appearance</source>
+        <comment>@action</comment>
+        <translation>Изменить внешний вид зоны</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/UpdateFixedGeometryCommand.cpp" line="15"/>
+        <source>Change Zone Dimensions</source>
+        <comment>@action</comment>
+        <translation>Изменить размеры зоны</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/UpdateZoneNumberCommand.cpp" line="16"/>
+        <source>Change Zone Number</source>
+        <comment>@action</comment>
+        <translation>Изменить номер зоны</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/UpdateGapOverrideCommand.cpp" line="16"/>
+        <source>Change Zone Padding</source>
+        <comment>@action</comment>
+        <translation>Изменить отступ зоны</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/UpdateVisibilityCommand.cpp" line="17"/>
+        <source>Change Zone Visibility</source>
+        <comment>@action</comment>
+        <translation>Изменить видимость зоны</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/ClearAllZonesCommand.cpp" line="12"/>
+        <source>Clear All Zones</source>
+        <comment>@action</comment>
+        <translation>Очистить все зоны</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/gaps.cpp" line="327"/>
+        <source>Clear Edge Gap Override</source>
+        <comment>@action</comment>
+        <translation>Сбросить переопределение краевого зазора</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/main.cpp" line="151"/>
+        <source>Create new layout</source>
+        <translation>Создать новую раскладку</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/clipboard.cpp" line="96"/>
+        <source>Cut %1 Zones</source>
+        <comment>@action</comment>
+        <translation>Вырезать зоны (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/multiselect.cpp" line="34"/>
+        <source>Delete %1 Zones</source>
+        <comment>@action</comment>
+        <translation>Удалить зоны (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/DeleteZoneCommand.cpp" line="14"/>
+        <location filename="../src/editor/undo/commands/DeleteZoneWithFillCommand.cpp" line="14"/>
+        <source>Delete Zone</source>
+        <comment>@action</comment>
+        <translation>Удалить зону</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/multiselect.cpp" line="62"/>
+        <source>Duplicate %1 Zones</source>
+        <comment>@action</comment>
+        <translation>Дублировать зоны (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/DuplicateZoneCommand.cpp" line="15"/>
+        <source>Duplicate Zone</source>
+        <comment>@action</comment>
+        <translation>Дублировать зону</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/FillZoneCommand.cpp" line="13"/>
+        <source>Fill Zone</source>
+        <comment>@action</comment>
+        <translation>Заполнить зону</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/layout.cpp" line="528"/>
+        <source>Invalid layout data format</source>
+        <translation>Неверный формат данных раскладки</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/layout.cpp" line="1041"/>
+        <location filename="../src/editor/controller/layout.cpp" line="1079"/>
+        <source>File path cannot be empty</source>
+        <translation>Путь к файлу не может быть пустым</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/layout.cpp" line="1048"/>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="334"/>
+        <source>Failed to import layout: %1</source>
+        <translation>Не удалось импортировать раскладку: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/layout.cpp" line="1059"/>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="341"/>
+        <source>That file is not a layout this app can read.</source>
+        <translation>Этот файл не является раскладкой, которую может прочитать приложение.</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/layout.cpp" line="1102"/>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="386"/>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="545"/>
+        <source>Could not write the export. Check that the folder is writable.</source>
+        <translation>Не удалось записать экспорт. Убедитесь, что папка доступна для записи.</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/layout.cpp" line="1084"/>
+        <source>No layout loaded to export</source>
+        <translation>Нет загруженной раскладки для экспорта</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/layout.cpp" line="1091"/>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="377"/>
+        <source>Failed to export layout: %1</source>
+        <translation>Не удалось экспортировать раскладку: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/layout.cpp" line="493"/>
+        <source>Layout ID cannot be empty</source>
+        <translation>Идентификатор раскладки не может быть пустым</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/main.cpp" line="147"/>
+        <source>Layout ID to edit</source>
+        <translation>Идентификатор раскладки для редактирования</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/daemon/osd.cpp" line="165"/>
+        <source>Layout Locked</source>
+        <translation>Раскладка заблокирована</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/daemon/osd.cpp" line="214"/>
+        <source>Disabled on this monitor</source>
+        <translation>Отключено на этом экране</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/daemon/osd.cpp" line="225"/>
+        <source>Desktop %1</source>
+        <translation>Рабочий стол %1</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/daemon/osd.cpp" line="227"/>
+        <location filename="../src/daemon/daemon/osd.cpp" line="238"/>
+        <source>Disabled on %1</source>
+        <translation>Отключено на %1</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/daemon/osd.cpp" line="236"/>
+        <source>Disabled on this activity</source>
+        <translation>Отключено в этой комнате</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/daemon/osd.cpp" line="266"/>
+        <source>No layout assigned</source>
+        <translation>Раскладка не назначена</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/layout.cpp" line="498"/>
+        <source>Layout service not initialized</source>
+        <translation>Служба раскладок не инициализирована</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/daemon/osd.cpp" line="138"/>
+        <source>Layout: %1</source>
+        <translation>Раскладка: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/multiselect.cpp" line="106"/>
+        <location filename="../src/editor/controller/multiselect.cpp" line="361"/>
+        <source>Move %1 Zones</source>
+        <comment>@action</comment>
+        <translation>Переместить зоны (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/UpdateZoneGeometryCommand.cpp" line="14"/>
+        <source>Move Zone</source>
+        <comment>@action</comment>
+        <translation>Переместить зону</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/layout.cpp" line="433"/>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="184"/>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="192"/>
+        <source>New Layout</source>
+        <translation>Новая раскладка</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/main.cpp" line="152"/>
+        <source>Open in read-only preview mode</source>
+        <translation>Открыть в режиме предпросмотра только для чтения</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/clipboard.cpp" line="196"/>
+        <location filename="../src/editor/undo/commands/PasteZonesCommand.cpp" line="14"/>
+        <source>Paste %1 Zones</source>
+        <comment>@action</comment>
+        <translation>Вставить зоны (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/UpdateLayoutNameCommand.cpp" line="13"/>
+        <source>Rename Layout</source>
+        <comment>@action</comment>
+        <translation>Переименовать раскладку</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/UpdateZoneNameCommand.cpp" line="14"/>
+        <source>Rename Zone</source>
+        <comment>@action</comment>
+        <translation>Переименовать зону</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/main.cpp" line="215"/>
+        <source>Window tiling and zone management</source>
+        <translation>Мозаичное размещение окон и управление зонами</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/main.cpp" line="220"/>
+        <source>Replace existing daemon instance</source>
+        <translation>Заменить существующий экземпляр службы</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/main.cpp" line="224"/>
+        <source>Enable debug logging for all PlasmaZones categories</source>
+        <translation>Включить отладочное журналирование для всех категорий PlasmaZones</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/main.cpp" line="228"/>
+        <source>Write log output to &lt;file&gt; instead of stderr</source>
+        <translation>Записывать вывод журнала в &lt;file&gt; вместо stderr</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/main.cpp" line="229"/>
+        <source>file</source>
+        <translation>файл</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/shader.cpp" line="271"/>
+        <source>Reset Shader Parameters</source>
+        <comment>@action</comment>
+        <translation>Сбросить параметры шейдера</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/multiselect.cpp" line="189"/>
+        <source>Resize %1 Zones</source>
+        <comment>@action</comment>
+        <translation>Изменить размер зон (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/DividerResizeCommand.cpp" line="15"/>
+        <source>Resize Zones</source>
+        <comment>@action</comment>
+        <translation>Изменить размер зон</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/zoneops.cpp" line="190"/>
+        <source>Send Backward</source>
+        <comment>@action</comment>
+        <translation>Переместить назад</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/zoneops.cpp" line="180"/>
+        <source>Send to Back</source>
+        <comment>@action</comment>
+        <translation>На задний план</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/layout.cpp" line="843"/>
+        <source>Services not initialized</source>
+        <translation>Службы не инициализированы</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/zones.cpp" line="197"/>
+        <location filename="../src/editor/controller/zones.cpp" line="233"/>
+        <source>Services not initialized</source>
+        <comment>@info</comment>
+        <translation>Службы не инициализированы</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/shortcutmanager.cpp" line="610"/>
+        <source>Snap to Zone %1</source>
+        <translation>Прилепить к зоне %1</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/SplitZoneCommand.cpp" line="16"/>
+        <source>Split Zone</source>
+        <comment>@action</comment>
+        <translation>Разделить зону</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/shader.cpp" line="287"/>
+        <source>Switch Shader Effect</source>
+        <comment>@action</comment>
+        <translation>Переключить эффект шейдера</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/main.cpp" line="149"/>
+        <source>Target screen name</source>
+        <translation>Имя целевого экрана</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/daemon/osd.cpp" line="295"/>
+        <location filename="../src/settings/rulemodel.cpp" line="285"/>
+        <source>Tiling: %1</source>
+        <translation>Мозаичное размещение: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/UpdateGapOverrideCommand.cpp" line="18"/>
+        <source>Toggle Per-Side Edge Gap</source>
+        <comment>@action</comment>
+        <translation>Переключить краевой зазор для каждой стороны</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/ToggleGeometryModeCommand.cpp" line="17"/>
+        <source>Toggle Relative/Fixed Size</source>
+        <comment>@action</comment>
+        <translation>Переключить относительный/фиксированный размер</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/UpdateFullScreenGeometryCommand.cpp" line="15"/>
+        <source>Toggle Use Full Screen Area</source>
+        <comment>@action</comment>
+        <translation>Переключить использование всей области экрана</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/BatchUpdateAppearanceCommand.cpp" line="21"/>
+        <source>Update Appearance for %1 Zones</source>
+        <comment>@action</comment>
+        <translation>Обновить внешний вид зон (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/BatchUpdateAppearanceCommand.cpp" line="73"/>
+        <source>Update Color for %1 Zones</source>
+        <comment>@action</comment>
+        <translation>Обновить цвет зон (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/main.cpp" line="142"/>
+        <source>Visual layout editor for PlasmaZones</source>
+        <translation>Визуальный редактор раскладок для PlasmaZones</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/clipboard.cpp" line="34"/>
+        <location filename="../src/editor/controller/clipboard.cpp" line="107"/>
+        <source>Zone manager not initialized</source>
+        <comment>@info</comment>
+        <translation>Диспетчер зон не инициализирован</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/settings.cpp" line="40"/>
+        <source>Zone name contains invalid characters: &lt; &gt; &quot; &apos; \</source>
+        <translation>Имя зоны содержит недопустимые символы: &lt; &gt; &quot; &apos; \</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/zones.cpp" line="106"/>
+        <location filename="../src/editor/controller/zones.cpp" line="212"/>
+        <location filename="../src/editor/controller/zones.cpp" line="248"/>
+        <location filename="../src/editor/controller/zones.cpp" line="327"/>
+        <source>Zone not found</source>
+        <comment>@info</comment>
+        <translation>Зона не найдена</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/settings.cpp" line="94"/>
+        <source>Zone number %1 is already in use</source>
+        <translation>Номер зоны %1 уже используется</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/settings.cpp" line="74"/>
+        <source>Zone number cannot exceed 99</source>
+        <translation>Номер зоны не может превышать 99</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/settings.cpp" line="31"/>
+        <source>Zone name cannot exceed %1 characters</source>
+        <translation>Имя зоны не может превышать %1 символов</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/settings.cpp" line="71"/>
+        <source>Zone number must be at least 1</source>
+        <translation>Номер зоны должен быть не менее 1</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/daemon.cpp" line="2159"/>
+        <source>The PlasmaZones KWin effect plugin is not installed where KWin can find it. Reinstall PlasmaZones.</source>
+        <translation>Модуль эффекта PlasmaZones для KWin не установлен в месте, где KWin может его найти. Переустановите PlasmaZones.</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/daemon.cpp" line="2198"/>
+        <source>The PlasmaZones KWin effect was built for KWin %1 but KWin %2 is running, so KWin will not load it. Rebuild and reinstall PlasmaZones against the running KWin.</source>
+        <translation>Эффект PlasmaZones для KWin был собран для KWin %1, но запущен KWin %2, поэтому KWin не загрузит его. Пересоберите и переустановите PlasmaZones для запущенного KWin.</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/daemon.cpp" line="2225"/>
+        <source>The PlasmaZones KWin effect has not registered with the daemon, so window dragging and shortcuts will not work. Make sure it is enabled in System Settings &gt; Desktop Effects, then restart the Plasma session.</source>
+        <translation>Эффект PlasmaZones для KWin не зарегистрировался в службе, поэтому перетаскивание окон и комбинации клавиш не будут работать. Убедитесь, что он включён в разделе «Параметры системы &gt; Эффекты рабочего стола», затем перезапустите сеанс Plasma.</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/daemon.cpp" line="2244"/>
+        <source>PlasmaZones: window manager integration inactive</source>
+        <translation>PlasmaZones: интеграция с диспетчером окон неактивна</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="70"/>
+        <source> (Copy)</source>
+        <extracomment>Suffix appended to the name of a duplicated algorithm. Keep the leading space.</extracomment>
+        <translation> (копия)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="329"/>
+        <location filename="../src/settings/algorithmservice.cpp" line="401"/>
+        <location filename="../src/settings/algorithmservice.cpp" line="413"/>
+        <source>Could not read the algorithm file. Check that it still exists and is readable.</source>
+        <translation>Не удалось прочитать файл алгоритма. Убедитесь, что он всё ещё существует и доступен для чтения.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="338"/>
+        <source>Only Luau algorithm files (.luau) can be imported.</source>
+        <translation>Импортировать можно только файлы алгоритмов Luau (.luau).</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="343"/>
+        <source>Algorithm file names may contain only letters, digits, hyphens, and underscores.</source>
+        <translation>Имена файлов алгоритмов могут содержать только буквы, цифры, дефисы и подчёркивания.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="356"/>
+        <location filename="../src/settings/algorithmservice.cpp" line="418"/>
+        <source>That algorithm file is too large to load. Algorithms are limited to 1 MB.</source>
+        <translation>Этот файл алгоритма слишком велик для загрузки. Размер алгоритмов ограничен 1 МБ.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="387"/>
+        <source>Too many algorithms share this name. Remove some and try again.</source>
+        <translation>Слишком много алгоритмов используют это имя. Удалите некоторые из них и попробуйте снова.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="426"/>
+        <source>Could not copy the algorithm file. Check available disk space and permissions.</source>
+        <translation>Не удалось скопировать файл алгоритма. Проверьте наличие свободного места на диске и права доступа.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="492"/>
+        <source>Algorithm was created but not picked up by the registry. Try refreshing or restarting the application.</source>
+        <translation>Алгоритм создан, но не был подхвачен реестром. Попробуйте обновить или перезапустить приложение.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="552"/>
+        <source>No algorithm is selected to delete.</source>
+        <translation>Не выбран алгоритм для удаления.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="559"/>
+        <source>Only user-created algorithms can be deleted.</source>
+        <translation>Удалять можно только алгоритмы, созданные пользователем.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="566"/>
+        <source>Algorithm file not found.</source>
+        <translation>Файл алгоритма не найден.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="580"/>
+        <source>The user algorithms directory does not exist.</source>
+        <translation>Каталог пользовательских алгоритмов не существует.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="581"/>
+        <source>That file is outside the user algorithms directory.</source>
+        <translation>Этот файл находится вне каталога пользовательских алгоритмов.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="594"/>
+        <source>Could not delete algorithm file. Check file permissions.</source>
+        <translation>Не удалось удалить файл алгоритма. Проверьте права доступа к файлу.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="604"/>
+        <location filename="../src/settings/algorithmservice.cpp" line="720"/>
+        <source>The algorithm file could not be found.</source>
+        <translation>Не удалось найти файл алгоритма.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="610"/>
+        <source>That algorithm is no longer registered.</source>
+        <translation>Этот алгоритм больше не зарегистрирован.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="628"/>
+        <source>Too many copies of this algorithm already exist. Rename or delete some before duplicating.</source>
+        <translation>Уже существует слишком много копий этого алгоритма. Переименуйте или удалите некоторые из них перед дублированием.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="636"/>
+        <source>The algorithm file path could not be resolved.</source>
+        <translation>Не удалось определить путь к файлу алгоритма.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="643"/>
+        <location filename="../src/settings/algorithmservice.cpp" line="654"/>
+        <source>Could not read source algorithm file.</source>
+        <translation>Не удалось прочитать исходный файл алгоритма.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="695"/>
+        <source>Could not duplicate the algorithm. Its metadata table is not in a shape this app can rewrite.</source>
+        <translation>Не удалось продублировать алгоритм. Его таблица метаданных имеет структуру, которую приложение не может перезаписать.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="730"/>
+        <location filename="../src/settings/algorithmservice.cpp" line="739"/>
+        <source>Could not read the algorithm file for export.</source>
+        <translation>Не удалось прочитать файл алгоритма для экспорта.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="702"/>
+        <source>Could not write duplicate algorithm file. Check disk space and permissions.</source>
+        <translation>Не удалось записать файл дубликата алгоритма. Проверьте наличие свободного места на диске и права доступа.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="714"/>
+        <source>No export destination specified.</source>
+        <translation>Не указано место назначения для экспорта.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="745"/>
+        <source>Could not write to export destination.</source>
+        <translation>Не удалось записать в место назначения экспорта.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="782"/>
+        <source>Too many algorithms already share this name. Rename or delete some before creating another.</source>
+        <translation>Это имя уже используют слишком много алгоритмов. Переименуйте или удалите некоторые из них перед созданием нового.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="816"/>
+        <location filename="../src/settings/algorithmservice.cpp" line="859"/>
+        <source>The selected template could not be used. Pick another template or start blank.</source>
+        <translation>Не удалось использовать выбранный шаблон. Выберите другой шаблон или начните с пустого.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="833"/>
+        <source>The selected template could not be found. Pick another template or start blank.</source>
+        <translation>Не удалось найти выбранный шаблон. Выберите другой шаблон или начните с пустого.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="841"/>
+        <location filename="../src/settings/algorithmservice.cpp" line="849"/>
+        <source>The selected template could not be read. Pick another template or start blank.</source>
+        <translation>Не удалось прочитать выбранный шаблон. Выберите другой шаблон или начните с пустого.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="878"/>
+        <source>Could not write algorithm file. Check disk space and permissions.</source>
+        <translation>Не удалось записать файл алгоритма. Проверьте наличие свободного места на диске и права доступа.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/animationspagecontroller.cpp" line="131"/>
+        <source>Cannot modify sets while a discard is in progress.</source>
+        <translation>Невозможно изменить наборы, пока выполняется отмена изменений.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/animationspagecontroller.cpp" line="342"/>
+        <source>Cannot save while a discard is in progress.</source>
+        <translation>Невозможно сохранить, пока выполняется отмена изменений.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/animationspagecontroller.cpp" line="507"/>
+        <location filename="../src/settings/rulecontroller.cpp" line="150"/>
+        <source>Discard already in flight.</source>
+        <translation>Отмена изменений уже выполняется.</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/settings/animationspagecontroller.cpp" line="575"/>
+        <source>Could not restore %n profile file(s). They remain pending.</source>
+        <translation>
+            <numerusform>Не удалось восстановить %n файл профиля. Он остаётся в ожидании.</numerusform>
+            <numerusform>Не удалось восстановить %n файла профиля. Они остаются в ожидании.</numerusform>
+            <numerusform>Не удалось восстановить %n файлов профиля. Они остаются в ожидании.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/settings/animationspagecontroller.cpp" line="709"/>
+        <location filename="../src/settings/animationspagecontroller.cpp" line="719"/>
+        <source>Cannot modify presets while a discard is in progress.</source>
+        <translation>Невозможно изменить предустановки, пока выполняется отмена изменений.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/animationspagecontroller_shaders.cpp" line="165"/>
+        <location filename="../src/settings/decorationpagecontroller_browser.cpp" line="98"/>
+        <source>Could not create the user shader directory.</source>
+        <translation>Не удалось создать пользовательский каталог шейдеров.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/kzonesimporter.cpp" line="62"/>
+        <source>No KZones configuration found in kwinrc</source>
+        <translation>Настройки KZones не найдены в kwinrc</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/kzonesimporter.cpp" line="68"/>
+        <source>Failed to parse KZones layoutsJson: %1</source>
+        <translation>Не удалось разобрать layoutsJson KZones: %1</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/settings/kzonesimporter.cpp" line="73"/>
+        <source>Imported %n layout(s) from KZones</source>
+        <translation>
+            <numerusform>Импортирована %n раскладка из KZones</numerusform>
+            <numerusform>Импортированы %n раскладки из KZones</numerusform>
+            <numerusform>Импортировано %n раскладок из KZones</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/settings/kzonesimporter.cpp" line="75"/>
+        <source>No layouts found in KZones configuration</source>
+        <translation>В настройках KZones не найдено раскладок</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/kzonesimporter.cpp" line="83"/>
+        <source>No file path specified</source>
+        <translation>Путь к файлу не указан</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/kzonesimporter.cpp" line="88"/>
+        <source>Could not open file: %1</source>
+        <translation>Не удалось открыть файл: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/kzonesimporter.cpp" line="101"/>
+        <source>Failed to parse KZones JSON: %1</source>
+        <translation>Не удалось разобрать JSON KZones: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/kzonesimporter.cpp" line="111"/>
+        <source>KZones file does not contain a JSON array or object</source>
+        <translation>Файл KZones не содержит массива или объекта JSON</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/settings/kzonesimporter.cpp" line="116"/>
+        <source>Imported %n layout(s) from KZones file</source>
+        <translation>
+            <numerusform>Импортирована %n раскладка из файла KZones</numerusform>
+            <numerusform>Импортированы %n раскладки из файла KZones</numerusform>
+            <numerusform>Импортировано %n раскладок из файла KZones</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/settings/kzonesimporter.cpp" line="118"/>
+        <source>No valid layouts found in file</source>
+        <translation>В файле не найдено допустимых раскладок</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/main.cpp" line="108"/>
+        <source>PlasmaZones Settings</source>
+        <translation>Параметры PlasmaZones</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/main.cpp" line="113"/>
+        <source>Open a specific settings page</source>
+        <translation>Открыть определённую страницу параметров</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/main.cpp" line="116"/>
+        <source>Reveal a specific setting on the page (deep link)</source>
+        <translation>Показать определённый параметр на странице (прямая ссылка)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/main.cpp" line="120"/>
+        <source>Reveal a specific section on the page (deep link)</source>
+        <translation>Показать определённый раздел на странице (прямая ссылка)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="60"/>
+        <source>Identity</source>
+        <translation>Идентификация</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="66"/>
+        <source>Type</source>
+        <translation>Тип</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="79"/>
+        <source>State</source>
+        <translation>Состояние</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="85"/>
+        <source>Taskbar &amp; switcher</source>
+        <translation>Панель задач &amp; переключатель</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="91"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="238"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="243"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="788"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="147"/>
+        <source>Tiling</source>
+        <translation>Мозаичное размещение</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="96"/>
+        <source>Size</source>
+        <translation>Размер</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="104"/>
+        <source>Context</source>
+        <translation>Контекст</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="106"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="218"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="260"/>
+        <source>Other</source>
+        <translation>Прочее</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="117"/>
+        <source>The application&apos;s ID (Wayland app_id / desktop entry), e.g. org.kde.konsole.</source>
+        <translation>Идентификатор приложения (Wayland app_id / desktop entry), например org.kde.konsole.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="119"/>
+        <source>The window&apos;s class (WM_CLASS resource class), e.g. konsole.</source>
+        <translation>Класс окна (ресурсный класс WM_CLASS), например konsole.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="121"/>
+        <source>The application&apos;s desktop entry file name.</source>
+        <translation>Имя файла desktop entry приложения.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="123"/>
+        <source>The window&apos;s X11 role (WM_WINDOW_ROLE). Empty for Wayland-native windows.</source>
+        <translation>Роль окна в X11 (WM_WINDOW_ROLE). Пусто для окон, работающих в Wayland напрямую.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="125"/>
+        <source>The window&apos;s process ID.</source>
+        <translation>Идентификатор процесса окна.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="127"/>
+        <source>The window&apos;s title-bar text.</source>
+        <translation>Текст в заголовке окна.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="129"/>
+        <source>The window&apos;s type (Normal, Dialog, Utility, Notification, …).</source>
+        <translation>Тип окна (обычное, диалог, служебное, уведомление, …).</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="131"/>
+        <source>Whether the window is shown on all virtual desktops.</source>
+        <translation>Показывается ли окно на всех виртуальных рабочих столах.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="133"/>
+        <source>Whether the window is fullscreen.</source>
+        <translation>Развёрнуто ли окно на полный экран.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="135"/>
+        <source>Whether the window is minimized.</source>
+        <translation>Свёрнуто ли окно.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="137"/>
+        <source>Whether the window is maximized.</source>
+        <translation>Развёрнуто ли окно.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="139"/>
+        <source>Whether the window currently has keyboard focus.</source>
+        <translation>Имеет ли окно в данный момент фокус клавиатуры.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="141"/>
+        <source>Whether the window is a transient (a dialog or popup owned by another window).</source>
+        <translation>Является ли окно вспомогательным (диалог или всплывающее окно, принадлежащее другому окну).</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="143"/>
+        <source>Whether the window is a notification or on-screen display.</source>
+        <translation>Является ли окно уведомлением или экранным сообщением.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="145"/>
+        <source>The window&apos;s width in pixels.</source>
+        <translation>Ширина окна в пикселях.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="147"/>
+        <source>The window&apos;s height in pixels.</source>
+        <translation>Высота окна в пикселях.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="149"/>
+        <source>Whether the window is set to stay above other windows (always on top).</source>
+        <translation>Настроено ли окно оставаться поверх других окон (всегда сверху).</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="151"/>
+        <source>Whether the window is set to stay below other windows.</source>
+        <translation>Настроено ли окно оставаться под другими окнами.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="153"/>
+        <source>Whether the window is hidden from the taskbar.</source>
+        <translation>Скрыто ли окно с панели задач.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="155"/>
+        <source>Whether the window is hidden from the pager.</source>
+        <translation>Скрыто ли окно из переключателя рабочих столов.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="157"/>
+        <source>Whether the window is hidden from the window switcher (Alt+Tab).</source>
+        <translation>Скрыто ли окно из переключателя окон (Alt+Tab).</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="159"/>
+        <source>Whether the window is a modal dialog.</source>
+        <translation>Является ли окно модальным диалогом.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="161"/>
+        <source>Whether the window has a server-side title-bar and border.</source>
+        <translation>Имеет ли окно заголовок и рамку со стороны сервера.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="163"/>
+        <source>Whether the window can be resized.</source>
+        <translation>Можно ли изменять размер окна.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="169"/>
+        <source>The window&apos;s left-edge X position in pixels.</source>
+        <translation>Положение левого края окна по оси X в пикселях.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="171"/>
+        <source>The window&apos;s top-edge Y position in pixels.</source>
+        <translation>Положение верхнего края окна по оси Y в пикселях.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="173"/>
+        <source>The window&apos;s title without the application-name suffix the window manager adds.</source>
+        <translation>Заголовок окна без суффикса с именем приложения, который добавляет диспетчер окон.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="175"/>
+        <source>Whether the window has been floated out of tiling (snap or autotile).</source>
+        <translation>Сделано ли окно плавающим и выведено ли из мозаичного размещения (прилипание или автоматическое размещение).</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="177"/>
+        <source>Whether the window is snapped into a zone (manual-zone mode, where tiled windows are not snapped).</source>
+        <translation>Прилипло ли окно к зоне (режим ручных зон, когда размещённые мозаикой окна не прилипают).</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="180"/>
+        <source>Whether the window is managed by the autotile engine.</source>
+        <translation>Управляется ли окно движком автоматического размещения.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="182"/>
+        <source>The zone the window is snapped into (manual-zone mode only).</source>
+        <translation>Зона, к которой прилипло окно (только в режиме ручных зон).</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="184"/>
+        <source>The monitor the window is on.</source>
+        <translation>Экран, на котором находится окно.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="186"/>
+        <source>The virtual desktop the window is on.</source>
+        <translation>Виртуальный рабочий стол, на котором находится окно.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="188"/>
+        <source>The KDE Activity the window is on.</source>
+        <translation>Комната KDE, в которой находится окно.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="190"/>
+        <source>The engine mode the window is placed by (snapping or tiling).</source>
+        <translation>Режим движка, которым размещено окно (прилипание или мозаичное размещение).</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="192"/>
+        <source>How many windows are tiled on this monitor and desktop. Lets a rule switch the tiling algorithm as windows open and close, for example a centered single-window layout that gives way once a second window opens.</source>
+        <translation>Сколько окон размещено мозаикой на этом экране и рабочем столе. Позволяет правилу переключать алгоритм мозаичного размещения по мере открытия и закрытия окон, например раскладку с одним окном по центру, которая уступает место при открытии второго окна.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="226"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="402"/>
+        <source>Gaps</source>
+        <translation>Зазоры</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="249"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="168"/>
+        <source>Overlay</source>
+        <translation>Наложение</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="252"/>
+        <source>Animation</source>
+        <translation>Анимация</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="255"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="97"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="174"/>
+        <source>Appearance</source>
+        <translation>Внешний вид</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="258"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="188"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="212"/>
+        <source>Window</source>
+        <translation>Окно</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="274"/>
+        <source>Engine mode</source>
+        <translation>Режим движка</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="277"/>
+        <location filename="../src/settings/rulemodel.cpp" line="276"/>
+        <source>Snapping layout</source>
+        <translation>Раскладка прилипания</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="280"/>
+        <source>Tiling algorithm</source>
+        <translation>Алгоритм мозаичного размещения</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="304"/>
+        <source>Engine to disable</source>
+        <translation>Движок для отключения</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="307"/>
+        <source>Opacity (%)</source>
+        <translation>Непрозрачность (%)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="310"/>
+        <source>Zones</source>
+        <translation>Зоны</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="317"/>
+        <source>Restore position on login (off = don&apos;t restore)</source>
+        <translation>Восстанавливать положение при входе (выкл. = не восстанавливать)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="333"/>
+        <source>Hide title bars (off = force visible)</source>
+        <translation>Скрывать заголовки окон (выкл. = принудительно показывать)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="336"/>
+        <source>Show border (off = hide)</source>
+        <translation>Показывать рамку (выкл. = скрыть)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="339"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="420"/>
+        <source>Border width (px)</source>
+        <translation>Ширина рамки (пикс.)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="342"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="423"/>
+        <source>Corner radius (px)</source>
+        <translation>Радиус скругления углов (пикс.)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="348"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="411"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="292"/>
+        <source>Border color</source>
+        <translation>Цвет рамки</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="361"/>
+        <source>Inner gap (px)</source>
+        <translation>Внутренний зазор (пикс.)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="364"/>
+        <source>Outer gap (px)</source>
+        <translation>Внешний зазор (пикс.)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="367"/>
+        <source>Use per-side outer gaps (off = one uniform gap)</source>
+        <translation>Задавать внешние зазоры по сторонам (выкл. = один одинаковый зазор)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="374"/>
+        <source>Lock the layout (off = don&apos;t lock)</source>
+        <translation>Заблокировать раскладку (выкл. = не блокировать)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="381"/>
+        <source>Assign a default layout (off = leave unassigned)</source>
+        <translation>Назначить раскладку по умолчанию (выкл. = оставить без назначения)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="384"/>
+        <source>Top gap (px)</source>
+        <translation>Верхний зазор (пикс.)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="387"/>
+        <source>Bottom gap (px)</source>
+        <translation>Нижний зазор (пикс.)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="390"/>
+        <source>Left gap (px)</source>
+        <translation>Левый зазор (пикс.)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="393"/>
+        <source>Right gap (px)</source>
+        <translation>Правый зазор (пикс.)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="398"/>
+        <location filename="../src/settings/rulemodel.cpp" line="394"/>
+        <source>Overlay shader</source>
+        <translation>Шейдер наложения</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="401"/>
+        <location filename="../src/settings/rulemodel.cpp" line="400"/>
+        <source>Overlay style</source>
+        <translation>Стиль наложения</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="429"/>
+        <location filename="../src/settings/rulemodel.cpp" line="900"/>
+        <source>Monitor</source>
+        <translation>Экран</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="432"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="764"/>
+        <location filename="../src/settings/rulemodel.cpp" line="902"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="260"/>
+        <source>Desktop</source>
+        <translation>Рабочий стол</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="435"/>
+        <source>Event</source>
+        <translation>Событие</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="441"/>
+        <source>Shader effect</source>
+        <translation>Эффект шейдера</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="444"/>
+        <source>Duration (ms)</source>
+        <translation>Длительность (мс)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="447"/>
+        <source>Curve</source>
+        <translation>Кривая</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="462"/>
+        <source>Zone numbers like “1, 2”, or a range like “1-3”. Multiple zones snap the window to their combined area.</source>
+        <translation>Номера зон, например «1, 2», или диапазон, например «1-3». Несколько зон прилепляют окно к их общей области.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="235"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="787"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="834"/>
+        <location filename="../src/settings/rulemodel.cpp" line="241"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="145"/>
+        <source>Snapping</source>
+        <translation>Прилипание</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="837"/>
+        <location filename="../src/settings/rulemodel.cpp" line="243"/>
+        <source>Autotile</source>
+        <translation>Автоматическое размещение</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="840"/>
+        <location filename="../src/settings/rulemodel.cpp" line="245"/>
+        <source>Scrolling</source>
+        <translation>Прокрутка</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="845"/>
+        <source>Zone rectangles</source>
+        <translation>Прямоугольники зон</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="848"/>
+        <source>Layout preview</source>
+        <translation>Предпросмотр раскладки</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="539"/>
+        <source>Set engine mode</source>
+        <translation>Задать режим движка</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="165"/>
+        <source>Whether the window can be moved.</source>
+        <translation>Можно ли перемещать окно.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="167"/>
+        <source>Whether the window can be maximized.</source>
+        <translation>Можно ли развернуть окно.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="197"/>
+        <source>Whether the monitor is in portrait or landscape orientation. Lets a rule pick a different layout or algorithm on a rotated screen.</source>
+        <translation>В книжной или альбомной ориентации находится экран. Позволяет правилу выбирать другую раскладку или алгоритм на повёрнутом экране.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="201"/>
+        <source>The layout currently active on the monitor. Lets a rule change gaps, the overlay or the lock state for the screen showing a given layout. It cannot change which layout is assigned (that would be circular).</source>
+        <translation>Раскладка, активная в данный момент на экране. Позволяет правилу менять зазоры, наложение или состояние блокировки для экрана, на котором показана заданная раскладка. Изменить назначенную раскладку нельзя (это привело бы к зацикливанию).</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="246"/>
+        <source>Engine</source>
+        <translation>Движок</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="286"/>
+        <source>Max tiled windows</source>
+        <translation>Максимум окон в мозаике</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="289"/>
+        <source>Split ratio (%)</source>
+        <translation>Соотношение разделения (%)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="295"/>
+        <source>Insert position</source>
+        <translation>Положение вставки</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="320"/>
+        <source>Restore to zone on login (off = don&apos;t restore)</source>
+        <translation>Восстанавливать в зону при входе (выкл. = не восстанавливать)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="323"/>
+        <source>Restore size on unsnap (off = keep zone size)</source>
+        <translation>Восстанавливать размер при откреплении (выкл. = сохранять размер зоны)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="326"/>
+        <source>Layer</source>
+        <translation>Слой</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="351"/>
+        <source>Show opacity and tint (off = hide)</source>
+        <translation>Показывать непрозрачность и оттенок (выкл. = скрыть)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="354"/>
+        <source>Tint strength (%)</source>
+        <translation>Сила оттенка (%)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="357"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="353"/>
+        <source>Tint color</source>
+        <translation>Цвет оттенка</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="408"/>
+        <source>Inactive zone color</source>
+        <translation>Цвет неактивной зоны</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="414"/>
+        <source>Active opacity (%)</source>
+        <translation>Непрозрачность активной (%)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="417"/>
+        <source>Inactive opacity (%)</source>
+        <translation>Непрозрачность неактивной (%)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="426"/>
+        <source>Show zone numbers (off = hide)</source>
+        <translation>Показывать номера зон (выкл. = скрыть)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="438"/>
+        <source>Decoration packs</source>
+        <translation>Наборы оформления</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="542"/>
+        <source>Set snapping layout</source>
+        <translation>Задать раскладку прилипания</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="545"/>
+        <source>Set tiling algorithm</source>
+        <translation>Задать алгоритм мозаичного размещения</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="548"/>
+        <source>Set max tiled windows</source>
+        <translation>Задать максимум окон в мозаике</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="551"/>
+        <source>Set split ratio</source>
+        <translation>Задать соотношение разделения</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="554"/>
+        <source>Set master count</source>
+        <translation>Задать число главных окон</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="557"/>
+        <source>Set insert position</source>
+        <translation>Задать положение вставки</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="560"/>
+        <source>Set overflow behavior</source>
+        <translation>Задать поведение при переполнении</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="563"/>
+        <source>Set drag behavior</source>
+        <translation>Задать поведение перетаскивания</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="566"/>
+        <source>Set algorithm parameter</source>
+        <translation>Задать параметр алгоритма</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="569"/>
+        <source>Disable engine</source>
+        <translation>Отключить движок</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="572"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="908"/>
+        <source>Lock layout</source>
+        <translation>Заблокировать раскладку</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="575"/>
+        <source>Default layout assignment</source>
+        <translation>Назначение раскладки по умолчанию</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="578"/>
+        <source>Exclude window</source>
+        <translation>Исключить окно</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="581"/>
+        <source>Float window</source>
+        <translation>Сделать окно плавающим</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="584"/>
+        <source>Snap to zone(s)</source>
+        <translation>Прилепить к зоне (зонам)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="587"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="896"/>
+        <source>Restore position on login</source>
+        <translation>Восстанавливать положение при входе в систему</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="590"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="899"/>
+        <source>Restore to zone on login</source>
+        <translation>Восстанавливать в зону при входе в систему</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="596"/>
+        <source>Set window layer</source>
+        <translation>Задать слой окна</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="599"/>
+        <source>Override animation shader</source>
+        <translation>Переопределить шейдер анимации</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="602"/>
+        <source>Override decoration packs</source>
+        <translation>Переопределить наборы оформления</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="605"/>
+        <source>Override animation duration</source>
+        <translation>Переопределить длительность анимации</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="608"/>
+        <source>Override animation curve</source>
+        <translation>Переопределить кривую анимации</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="611"/>
+        <source>Set opacity</source>
+        <translation>Задать непрозрачность</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="614"/>
+        <source>Set overlay shader</source>
+        <translation>Задать шейдер наложения</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="617"/>
+        <source>Set overlay style</source>
+        <translation>Задать стиль наложения</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="620"/>
+        <source>Set overlay highlight color</source>
+        <translation>Задать цвет подсветки наложения</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="623"/>
+        <source>Set overlay inactive color</source>
+        <translation>Задать цвет неактивного наложения</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="626"/>
+        <source>Set overlay border color</source>
+        <translation>Задать цвет рамки наложения</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="629"/>
+        <source>Set overlay active opacity</source>
+        <translation>Задать непрозрачность активного наложения</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="632"/>
+        <source>Set overlay inactive opacity</source>
+        <translation>Задать непрозрачность неактивного наложения</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="635"/>
+        <source>Set overlay border width</source>
+        <translation>Задать ширину рамки наложения</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="638"/>
+        <source>Set overlay corner radius</source>
+        <translation>Задать радиус скругления углов наложения</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="641"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="923"/>
+        <source>Show zone numbers</source>
+        <translation>Показывать номера зон</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="644"/>
+        <source>Exclude from animations</source>
+        <translation>Исключить из анимаций</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="652"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="905"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="356"/>
+        <source>Hide title bars</source>
+        <translation>Скрывать заголовки окон</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="655"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="914"/>
+        <source>Show border</source>
+        <translation>Показывать рамку</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="658"/>
+        <source>Set border width</source>
+        <translation>Задать ширину рамки</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="661"/>
+        <source>Set corner radius</source>
+        <translation>Задать радиус скругления углов</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="664"/>
+        <source>Set focused border color</source>
+        <translation>Задать цвет рамки при фокусе</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="667"/>
+        <source>Set unfocused border color</source>
+        <translation>Задать цвет рамки без фокуса</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="670"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="917"/>
+        <source>Show opacity and tint</source>
+        <translation>Показывать непрозрачность и оттенок</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="673"/>
+        <source>Set tint strength</source>
+        <translation>Задать силу оттенка</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="676"/>
+        <source>Set tint color</source>
+        <translation>Задать цвет оттенка</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="679"/>
+        <source>Set inner gap</source>
+        <translation>Задать внутренний зазор</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="682"/>
+        <source>Set outer gap</source>
+        <translation>Задать внешний зазор</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="685"/>
+        <source>Use per-side outer gaps</source>
+        <translation>Использовать внешние зазоры для каждой стороны</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="688"/>
+        <source>Set top gap</source>
+        <translation>Задать верхний зазор</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="691"/>
+        <source>Set bottom gap</source>
+        <translation>Задать нижний зазор</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="694"/>
+        <source>Set left gap</source>
+        <translation>Задать левый зазор</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="697"/>
+        <source>Set right gap</source>
+        <translation>Задать правый зазор</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="700"/>
+        <location filename="../src/settings/rulemodel.cpp" line="331"/>
+        <source>Open on monitor</source>
+        <translation>Открывать на экране</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="703"/>
+        <location filename="../src/settings/rulemodel.cpp" line="336"/>
+        <source>Open on desktop</source>
+        <translation>Открывать на рабочем столе</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="712"/>
+        <source>is</source>
+        <translation>равно</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="714"/>
+        <source>contains</source>
+        <translation>содержит</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="716"/>
+        <source>starts with</source>
+        <translation>начинается с</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="718"/>
+        <source>ends with</source>
+        <translation>заканчивается на</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="720"/>
+        <source>matches regex</source>
+        <translation>соответствует регулярному выражению</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="722"/>
+        <source>matches app-id</source>
+        <translation>соответствует app-id</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="724"/>
+        <source>greater than</source>
+        <translation>больше чем</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="726"/>
+        <source>less than</source>
+        <translation>меньше чем</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="754"/>
+        <source>Unknown</source>
+        <translation>Неизвестно</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="755"/>
+        <source>Normal window</source>
+        <translation>Обычное окно</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="756"/>
+        <source>Dialog</source>
+        <translation>Диалог</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="757"/>
+        <source>Utility</source>
+        <translation>Служебное окно</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="758"/>
+        <source>Toolbar</source>
+        <translation>Панель инструментов</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="759"/>
+        <source>Splash screen</source>
+        <translation>Заставка</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="760"/>
+        <source>Menu</source>
+        <translation>Меню</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="761"/>
+        <source>Tooltip</source>
+        <translation>Подсказка</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="762"/>
+        <location filename="../src/settings/rulemodel.cpp" line="908"/>
+        <source>Notification</source>
+        <translation>Уведомление</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="763"/>
+        <source>Dock / panel</source>
+        <translation>Панель</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="765"/>
+        <source>On-screen display</source>
+        <translation>Экранное сообщение</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="766"/>
+        <source>Popup</source>
+        <translation>Всплывающее окно</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="792"/>
+        <source>Landscape</source>
+        <translation>Альбомная</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="793"/>
+        <source>Portrait</source>
+        <translation>Книжная</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="853"/>
+        <source>End of stack</source>
+        <translation>В конец стопки</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="856"/>
+        <source>After focused window</source>
+        <translation>После окна в фокусе</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="859"/>
+        <source>As master</source>
+        <translation>Как главное</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="864"/>
+        <source>Float overflow windows</source>
+        <translation>Делать плавающими лишние окна</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="867"/>
+        <source>Unlimited (no cap)</source>
+        <translation>Без ограничения</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="872"/>
+        <source>Float on drag</source>
+        <translation>Делать плавающим при перетаскивании</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="875"/>
+        <source>Reorder in stack</source>
+        <translation>Переупорядочить в стопке</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="880"/>
+        <source>Above other windows</source>
+        <translation>Поверх других окон</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="883"/>
+        <source>Normal stacking</source>
+        <translation>Обычный порядок</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="886"/>
+        <source>Below other windows</source>
+        <translation>Под другими окнами</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="899"/>
+        <source>Don&apos;t restore to zone on login</source>
+        <translation>Не восстанавливать в зону при входе в систему</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="902"/>
+        <source>Keep zone size on unsnap</source>
+        <translation>Сохранять размер зоны при откреплении</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="917"/>
+        <source>Hide opacity and tint</source>
+        <translation>Скрывать непрозрачность и оттенок</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="923"/>
+        <source>Hide zone numbers</source>
+        <translation>Скрывать номера зон</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="1110"/>
+        <source>Regular expression, e.g. ^(firefox|chromium)$</source>
+        <translation>Регулярное выражение, например ^(firefox|chromium)$</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="1113"/>
+        <source>Matches by reverse-DNS segments, so “firefox” also matches “org.mozilla.firefox”.</source>
+        <translation>Сопоставляется по сегментам обратного DNS, поэтому «firefox» также соответствует «org.mozilla.firefox».</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulecontroller.cpp" line="165"/>
+        <source>Failed to fetch the daemon&apos;s rule set.</source>
+        <translation>Не удалось получить набор правил службы.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulecontroller.cpp" line="247"/>
+        <source>The daemon rejected one or more rules.</source>
+        <translation>Служба отклонила одно или несколько правил.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulecontroller.cpp" line="375"/>
+        <source>A save is already in flight.</source>
+        <translation>Сохранение уже выполняется.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulecontroller.cpp" line="386"/>
+        <source>The daemon&apos;s rules changed while you were editing. Review or use Save anyway to overwrite.</source>
+        <translation>Правила службы изменились, пока вы редактировали. Просмотрите их или используйте «Всё равно сохранить», чтобы перезаписать.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulecontroller.cpp" line="397"/>
+        <source>One or more rules failed validation and could not be saved. See the log for details.</source>
+        <translation>Одно или несколько правил не прошли проверку и не были сохранены. Подробности см. в журнале.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulecontroller.cpp" line="657"/>
+        <source>%1 (copy)</source>
+        <translation>%1 (копия)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="164"/>
+        <location filename="../src/settings/rulemodel.cpp" line="171"/>
+        <location filename="../src/settings/rulemodel.cpp" line="179"/>
+        <location filename="../src/settings/rulemodel.cpp" line="206"/>
+        <location filename="../src/settings/rulemodel.cpp" line="214"/>
+        <location filename="../src/settings/rulemodel.cpp" line="219"/>
+        <source>%1: %2</source>
+        <translation>%1: %2</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="215"/>
+        <source>On</source>
+        <translation>Вкл</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="216"/>
+        <source>Off</source>
+        <translation>Выкл</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="272"/>
+        <source>Engine: %1</source>
+        <translation>Движок: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="277"/>
+        <source>Snapping: %1</source>
+        <translation>Прилипание: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="296"/>
+        <source>Disabled</source>
+        <translation>Отключено</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="298"/>
+        <source>Disable: %1</source>
+        <translation>Отключить: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="301"/>
+        <source>Excluded</source>
+        <translation>Исключено</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="305"/>
+        <source>No animations</source>
+        <translation>Без анимаций</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="308"/>
+        <source>Float</source>
+        <translation>Плавающее</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="318"/>
+        <source>Snap to zone</source>
+        <translation>Прилепить к зоне</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="321"/>
+        <source>Snap to zone %1</source>
+        <translation>Прилепить к зоне %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="323"/>
+        <source>Snap to zones %1</source>
+        <translation>Прилепить к зонам %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="332"/>
+        <source>Open on monitor: %1</source>
+        <translation>Открывать на экране: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="336"/>
+        <source>Open on desktop %1</source>
+        <translation>Открывать на рабочем столе %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="345"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="276"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="345"/>
+        <source>Opacity</source>
+        <translation>Непрозрачность</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="349"/>
+        <location filename="../src/settings/rulemodel.cpp" line="354"/>
+        <source>Opacity (invalid)</source>
+        <translation>Непрозрачность (недопустимо)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="356"/>
+        <source>Opacity: %1%</source>
+        <translation>Непрозрачность: %1%</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="360"/>
+        <source>Block animation shader</source>
+        <translation>Блокировать шейдер анимации</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="361"/>
+        <source>Shader: %1</source>
+        <translation>Шейдер: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="366"/>
+        <location filename="../src/settings/rulemodel.cpp" line="379"/>
+        <source>Block decoration</source>
+        <translation>Блокировать оформление</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="381"/>
+        <source>Decoration: %1</source>
+        <translation>Оформление: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="385"/>
+        <source>Duration: %1 ms</source>
+        <translation>Длительность: %1 мс</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="385"/>
+        <source>Animation duration</source>
+        <translation>Длительность анимации</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="389"/>
+        <source>Animation curve</source>
+        <translation>Кривая анимации</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="390"/>
+        <source>Curve: %1</source>
+        <translation>Кривая: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="395"/>
+        <source>Overlay shader: %1</source>
+        <translation>Шейдер наложения: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="896"/>
+        <source>Don&apos;t restore position on login</source>
+        <translation>Не восстанавливать положение при входе в систему</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="905"/>
+        <source>Show title bars</source>
+        <translation>Показывать заголовки окон</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="908"/>
+        <source>Don&apos;t lock layout</source>
+        <translation>Не блокировать раскладку</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="911"/>
+        <source>Assign default layout</source>
+        <translation>Назначить раскладку по умолчанию</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="911"/>
+        <source>Don&apos;t assign default layout</source>
+        <translation>Не назначать раскладку по умолчанию</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="914"/>
+        <source>Hide border</source>
+        <translation>Скрывать рамку</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="429"/>
+        <source>Border width: %1 px</source>
+        <translation>Ширина рамки: %1 px</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="432"/>
+        <source>Corner radius: %1 px</source>
+        <translation>Радиус скругления углов: %1 px</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="439"/>
+        <location filename="../src/settings/rulemodel.cpp" line="467"/>
+        <source>Accent</source>
+        <translation>Акцент</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="441"/>
+        <source>Focused border: %1</source>
+        <translation>Рамка в фокусе: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="443"/>
+        <source>Unfocused border: %1</source>
+        <translation>Рамка без фокуса: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="535"/>
+        <source>Gap: %1 px</source>
+        <translation>Зазор: %1 px</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="538"/>
+        <source>Outer gap: %1 px</source>
+        <translation>Внешний зазор: %1 px</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="920"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="411"/>
+        <source>Per-side outer gaps</source>
+        <translation>Внешние зазоры для каждой стороны</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="920"/>
+        <source>Uniform outer gap</source>
+        <translation>Единый внешний зазор</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="405"/>
+        <source>Overlay style: %1</source>
+        <translation>Стиль наложения: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="412"/>
+        <source>Algorithm parameter</source>
+        <translation>Параметр алгоритма</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="413"/>
+        <source>Algorithm: %1</source>
+        <translation>Алгоритм: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="454"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="348"/>
+        <source>Tint strength</source>
+        <translation>Сила оттенка</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="460"/>
+        <source>Tint strength (invalid)</source>
+        <translation>Сила оттенка (недопустимо)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="462"/>
+        <source>Tint strength: %1%</source>
+        <translation>Сила оттенка: %1%</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="468"/>
+        <source>Tint color: %1</source>
+        <translation>Цвет оттенка: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="472"/>
+        <source>Max tiled windows: %1</source>
+        <translation>Максимум окон в мозаике: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="475"/>
+        <source>Master count: %1</source>
+        <translation>Число главных окон: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="479"/>
+        <source>Split ratio: %1%</source>
+        <translation>Соотношение разделения: %1%</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="482"/>
+        <source>Insert: %1</source>
+        <translation>Вставка: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="486"/>
+        <source>Overflow: %1</source>
+        <translation>Переполнение: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="490"/>
+        <source>Drag: %1</source>
+        <translation>Перетаскивание: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="497"/>
+        <source>Window layer</source>
+        <translation>Слой окна</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="505"/>
+        <source>Window layer (invalid)</source>
+        <translation>Слой окна (недопустимо)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="507"/>
+        <source>Layer: %1</source>
+        <translation>Слой: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="513"/>
+        <source>Highlight color: %1</source>
+        <translation>Цвет подсветки: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="516"/>
+        <source>Inactive zone color: %1</source>
+        <translation>Цвет неактивной зоны: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="519"/>
+        <source>Overlay border color: %1</source>
+        <translation>Цвет рамки наложения: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="522"/>
+        <source>Active opacity: %1%</source>
+        <translation>Непрозрачность активной: %1%</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="525"/>
+        <source>Inactive opacity: %1%</source>
+        <translation>Непрозрачность неактивной: %1%</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="528"/>
+        <source>Overlay border width: %1 px</source>
+        <translation>Ширина рамки наложения: %1 px</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="531"/>
+        <source>Overlay corner radius: %1 px</source>
+        <translation>Радиус скругления углов наложения: %1 px</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="541"/>
+        <source>Top gap: %1 px</source>
+        <translation>Верхний зазор: %1 px</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="544"/>
+        <source>Bottom gap: %1 px</source>
+        <translation>Нижний зазор: %1 px</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="547"/>
+        <source>Left gap: %1 px</source>
+        <translation>Левый зазор: %1 px</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="550"/>
+        <source>Right gap: %1 px</source>
+        <translation>Правый зазор: %1 px</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="625"/>
+        <source>Everywhere</source>
+        <translation>Везде</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="857"/>
+        <source>Monitor &amp; Layout</source>
+        <translation>Экран &amp; раскладка</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="859"/>
+        <source>Applications</source>
+        <translation>Приложения</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="861"/>
+        <source>Activities</source>
+        <translation>Комнаты</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="863"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="107"/>
+        <source>Animations</source>
+        <translation>Анимации</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="865"/>
+        <source>Advanced / Custom</source>
+        <translation>Дополнительно / пользовательское</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="867"/>
+        <source>System</source>
+        <translation>Система</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="876"/>
+        <source>Application</source>
+        <translation>Приложение</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="878"/>
+        <source>Window class</source>
+        <translation>Класс окна</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="880"/>
+        <source>Desktop file</source>
+        <translation>Файл desktop</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="882"/>
+        <source>Window role</source>
+        <translation>Роль окна</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="884"/>
+        <source>Process ID</source>
+        <translation>Идентификатор процесса</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="886"/>
+        <source>Title</source>
+        <translation>Заголовок</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="888"/>
+        <source>Window type</source>
+        <translation>Тип окна</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="890"/>
+        <source>Sticky</source>
+        <translation>На всех рабочих столах</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="892"/>
+        <source>Fullscreen</source>
+        <translation>Полный экран</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="894"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="629"/>
+        <source>Maximized</source>
+        <translation>Развёрнуто</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="896"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="620"/>
+        <source>Minimized</source>
+        <translation>Свёрнуто</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="898"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="622"/>
+        <source>Focused</source>
+        <translation>В фокусе</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="904"/>
+        <source>Activity</source>
+        <translation>Комната</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="906"/>
+        <source>Transient</source>
+        <translation>Вспомогательное</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="910"/>
+        <source>Width</source>
+        <translation>Ширина</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="912"/>
+        <source>Height</source>
+        <translation>Высота</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="914"/>
+        <source>Keep above</source>
+        <translation>Поверх других окон</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="916"/>
+        <source>Keep below</source>
+        <translation>Под другими окнами</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="918"/>
+        <source>Skip taskbar</source>
+        <translation>Не показывать на панели задач</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="920"/>
+        <source>Skip pager</source>
+        <translation>Не показывать в переключателе рабочих столов</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="922"/>
+        <source>Skip switcher</source>
+        <translation>Не показывать в переключателе окон</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="924"/>
+        <source>Modal</source>
+        <translation>Модальное</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="926"/>
+        <source>Decorated</source>
+        <translation>С оформлением</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="928"/>
+        <source>Resizable</source>
+        <translation>С изменяемым размером</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="930"/>
+        <source>Movable</source>
+        <translation>Перемещаемое</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="932"/>
+        <source>Maximizable</source>
+        <translation>Разворачиваемое</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="934"/>
+        <source>Position X</source>
+        <translation>Позиция X</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="936"/>
+        <source>Position Y</source>
+        <translation>Позиция Y</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="938"/>
+        <source>Title (no suffix)</source>
+        <translation>Заголовок (без суффикса)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/decorationpagecontroller_browser.cpp" line="46"/>
+        <location filename="../src/settings/rulemodel.cpp" line="940"/>
+        <source>Floating</source>
+        <translation>Плавающее</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/decorationpagecontroller_browser.cpp" line="44"/>
+        <location filename="../src/settings/rulemodel.cpp" line="942"/>
+        <source>Snapped</source>
+        <translation>Прилипшее</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/decorationpagecontroller_browser.cpp" line="42"/>
+        <location filename="../src/settings/rulemodel.cpp" line="944"/>
+        <source>Tiled</source>
+        <translation>Размещённое мозаикой</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/decorationpagecontroller_browser.cpp" line="50"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="315"/>
+        <source>Popups</source>
+        <translation>Всплывающие окна</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/decorationpagecontroller_browser.cpp" line="56"/>
+        <source>Layout Picker</source>
+        <translation>Выбор раскладки</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/decorationpagecontroller_browser.cpp" line="119"/>
+        <source>Global default</source>
+        <translation>Глобальное значение по умолчанию</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="946"/>
+        <source>Zone</source>
+        <translation>Зона</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="948"/>
+        <source>Mode</source>
+        <translation>Режим</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="950"/>
+        <source>Tiled window count</source>
+        <translation>Число окон в мозаике</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="952"/>
+        <source>Screen orientation</source>
+        <translation>Ориентация экрана</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="954"/>
+        <source>Active layout</source>
+        <translation>Активная раскладка</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="962"/>
+        <source>Any window</source>
+        <translation>Любое окно</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="976"/>
+        <source>(condition group)</source>
+        <translation>(группа условий)</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/settings/rulemodel.cpp" line="983"/>
+        <source>%n condition(s)</source>
+        <translation>
+            <numerusform>%n условие</numerusform>
+            <numerusform>%n условия</numerusform>
+            <numerusform>%n условий</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="989"/>
+        <source>No action</source>
+        <translation>Без действия</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="58"/>
+        <source>New monitor rule</source>
+        <translation>Новое правило экрана</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="62"/>
+        <source>New desktop rule</source>
+        <translation>Новое правило рабочего стола</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="70"/>
+        <source>New application rule</source>
+        <translation>Новое правило приложения</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="74"/>
+        <source>New activity rule</source>
+        <translation>Новое правило комнаты</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="78"/>
+        <source>New animation rule</source>
+        <translation>Новое правило анимации</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="88"/>
+        <source>New custom rule</source>
+        <translation>Новое пользовательское правило</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="121"/>
+        <source>Set a layout on a monitor</source>
+        <translation>Задать раскладку на экране</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="122"/>
+        <source>Pick a snapping layout to use on one monitor.</source>
+        <translation>Выберите раскладку прилипания для использования на одном экране.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="123"/>
+        <source>Set a tiling algorithm on a monitor</source>
+        <translation>Задать алгоритм мозаики на экране</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="124"/>
+        <source>Pick an autotile algorithm to use on one monitor.</source>
+        <translation>Выберите алгоритм автомозаики для использования на одном экране.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="126"/>
+        <source>Lock the layout on a monitor</source>
+        <translation>Заблокировать раскладку на экране</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="127"/>
+        <source>Pin the active layout on one monitor so it can&apos;t be switched. This is the rule-driven version of the lock-layout shortcut.</source>
+        <translation>Закрепите активную раскладку на одном экране, чтобы её нельзя было переключить. Это версия комбинации клавиш блокировки раскладки в виде правила.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="130"/>
+        <source>Set a layout on a virtual desktop</source>
+        <translation>Задать раскладку на виртуальном рабочем столе</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="131"/>
+        <source>Pick a snapping layout to use on one virtual desktop.</source>
+        <translation>Выберите раскладку прилипания для использования на одном виртуальном рабочем столе.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="133"/>
+        <source>Set a layout for portrait monitors</source>
+        <translation>Задать раскладку для экранов в книжной ориентации</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="134"/>
+        <source>Pick a snapping layout to use whenever a monitor is in portrait orientation. Handy for rotating screens.</source>
+        <translation>Выберите раскладку прилипания для использования, когда экран находится в книжной ориентации. Удобно для поворачивающихся экранов.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="137"/>
+        <location filename="../src/settings/ruletemplates.cpp" line="215"/>
+        <source>Open an app in a zone</source>
+        <translation>Открыть приложение в зоне</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="138"/>
+        <source>Snap one application&apos;s windows into a chosen zone when they open.</source>
+        <translation>Прилеплять окна одного приложения к выбранной зоне при их открытии.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="140"/>
+        <location filename="../src/settings/ruletemplates.cpp" line="226"/>
+        <source>Open an app on a monitor</source>
+        <translation>Открыть приложение на экране</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="141"/>
+        <source>Send one application&apos;s windows to a chosen monitor when they open.</source>
+        <translation>Отправлять окна одного приложения на выбранный экран при их открытии.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="143"/>
+        <location filename="../src/settings/ruletemplates.cpp" line="234"/>
+        <source>Float an app</source>
+        <translation>Сделать приложение плавающим</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="144"/>
+        <source>Keep one application&apos;s windows floating instead of tiled. The windows stay managed, unlike a full exclusion.</source>
+        <translation>Оставлять окна одного приложения плавающими вместо размещения мозаикой. Окна остаются управляемыми, в отличие от полного исключения.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="147"/>
+        <location filename="../src/settings/ruletemplates.cpp" line="244"/>
+        <source>Exclude an app from tiling</source>
+        <translation>Исключить приложение из мозаики</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="148"/>
+        <source>Keep one application&apos;s windows out of the snap and autotile engines entirely.</source>
+        <translation>Полностью исключить окна одного приложения из движков прилипания и автомозаики.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="150"/>
+        <location filename="../src/settings/ruletemplates.cpp" line="251"/>
+        <source>Don&apos;t animate small windows</source>
+        <translation>Не анимировать маленькие окна</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="151"/>
+        <source>Skip open and close animations for windows narrower than a chosen width. Handy for tiny popups and tool windows.</source>
+        <translation>Пропускать анимации открытия и закрытия для окон уже выбранной ширины. Удобно для крошечных всплывающих и служебных окон.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="164"/>
+        <source>Snapping layout on monitor</source>
+        <translation>Раскладка прилипания на экране</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="171"/>
+        <source>Tiling algorithm on monitor</source>
+        <translation>Алгоритм мозаики на экране</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="186"/>
+        <source>Lock layout on monitor</source>
+        <translation>Блокировка раскладки на экране</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="197"/>
+        <source>Snapping layout on virtual desktop</source>
+        <translation>Раскладка прилипания на виртуальном рабочем столе</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="207"/>
+        <source>Layout for portrait monitors</source>
+        <translation>Раскладка для экранов в книжной ориентации</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="56"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="64"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="170"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="228"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="437"/>
+        <source>monitor</source>
+        <translation>экран</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="56"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="435"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="447"/>
+        <source>display</source>
+        <translation>дисплей</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="56"/>
+        <source>mode</source>
+        <translation>режим</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="57"/>
+        <source>active layout</source>
+        <translation>активная раскладка</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="59"/>
+        <source>rendering</source>
+        <translation>отрисовка</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="59"/>
+        <source>backend</source>
+        <translation>движок</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="59"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="185"/>
+        <source>opengl</source>
+        <translation>opengl</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="60"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="185"/>
+        <source>vulkan</source>
+        <translation>vulkan</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="60"/>
+        <source>backup</source>
+        <translation>резервная копия</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="60"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="550"/>
+        <source>export</source>
+        <translation>экспорт</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="61"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="552"/>
+        <source>import</source>
+        <translation>импорт</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="61"/>
+        <source>reset</source>
+        <translation>сброс</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="63"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="482"/>
+        <source>split</source>
+        <translation>разделение</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="63"/>
+        <source>subdivide</source>
+        <translation>подразделение</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="63"/>
+        <source>region</source>
+        <translation>область</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="66"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="172"/>
+        <source>layout</source>
+        <translation>раскладка</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="66"/>
+        <source>zone</source>
+        <translation>зона</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="66"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="567"/>
+        <source>grid</source>
+        <translation>сетка</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="67"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="138"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="155"/>
+        <source>preset</source>
+        <translation>предустановка</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="67"/>
+        <source>template</source>
+        <translation>шаблон</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="68"/>
+        <source>aspect ratio</source>
+        <translation>соотношение сторон</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="75"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="125"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="422"/>
+        <source>overlay</source>
+        <translation>наложение</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="75"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="422"/>
+        <source>trigger</source>
+        <translation>триггер</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="75"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="409"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="413"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="562"/>
+        <source>edge</source>
+        <translation>край</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="76"/>
+        <source>magnet</source>
+        <translation>магнит</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="76"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="84"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="117"/>
+        <source>snap</source>
+        <translation>прилипание</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="78"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="164"/>
+        <source>color</source>
+        <translation>цвет</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="78"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="285"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="288"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="290"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="292"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="307"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="332"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="335"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="338"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="349"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="352"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="354"/>
+        <source>colour</source>
+        <translation>цвет</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="78"/>
+        <source>opacity</source>
+        <translation>непрозрачность</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="79"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="298"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="300"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="343"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="346"/>
+        <source>transparency</source>
+        <translation>прозрачность</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="79"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="285"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="332"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="352"/>
+        <source>theme</source>
+        <translation>тема</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="79"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="147"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="159"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="164"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="326"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="329"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="392"/>
+        <source>border</source>
+        <translation>рамка</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="81"/>
+        <source>zone selector</source>
+        <translation>выбор зоны</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="81"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="442"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="557"/>
+        <source>picker</source>
+        <translation>выбор</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="81"/>
+        <source>chooser</source>
+        <translation>выбор</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="82"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="125"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="153"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="240"/>
+        <source>popup</source>
+        <translation>всплывающее окно</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="84"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="112"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="116"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="119"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="147"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="164"/>
+        <source>window</source>
+        <translation>окно</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="84"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="119"/>
+        <source>drag</source>
+        <translation>перетаскивание</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="85"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="424"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="444"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="497"/>
+        <source>modifier</source>
+        <translation>модификатор</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="85"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="90"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="105"/>
+        <source>key</source>
+        <translation>клавиша</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="87"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="102"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="170"/>
+        <source>priority</source>
+        <translation>приоритет</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="87"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="102"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="501"/>
+        <source>order</source>
+        <translation>порядок</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="87"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="102"/>
+        <source>precedence</source>
+        <translation>старшинство</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="89"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="104"/>
+        <source>shortcut</source>
+        <translation>комбинация клавиш</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="89"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="104"/>
+        <source>hotkey</source>
+        <translation>горячая клавиша</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="89"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="104"/>
+        <source>keybind</source>
+        <translation>привязка клавиш</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="90"/>
+        <source>keyboard</source>
+        <translation>клавиатура</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="92"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="143"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="158"/>
+        <source>shader</source>
+        <translation>шейдер</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="92"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="143"/>
+        <source>effect</source>
+        <translation>эффект</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="92"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="159"/>
+        <source>glow</source>
+        <translation>свечение</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="96"/>
+        <source>tile</source>
+        <translation>плитка</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="96"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="235"/>
+        <source>tiling</source>
+        <translation>мозаичное размещение</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="96"/>
+        <source>auto</source>
+        <translation>авто</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="97"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="166"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="404"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="407"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="412"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="417"/>
+        <source>gap</source>
+        <translation>зазор</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="97"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="167"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="404"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="407"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="412"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="417"/>
+        <source>spacing</source>
+        <translation>интервал</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="99"/>
+        <source>algorithm</source>
+        <translation>алгоритм</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="99"/>
+        <source>bsp</source>
+        <translation>bsp</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="99"/>
+        <source>binary</source>
+        <translation>двоичный</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="100"/>
+        <source>spiral</source>
+        <translation>спираль</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="100"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="481"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="489"/>
+        <source>master</source>
+        <translation>главная область</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="100"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="494"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="497"/>
+        <source>stack</source>
+        <translation>стопка</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="109"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="112"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="125"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="133"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="136"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="188"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="317"/>
+        <source>animation</source>
+        <translation>анимация</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="109"/>
+        <source>duration</source>
+        <translation>длительность</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="109"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="138"/>
+        <source>easing</source>
+        <translation>плавность</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="110"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="138"/>
+        <source>curve</source>
+        <translation>кривая</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="110"/>
+        <source>spring</source>
+        <translation>пружина</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="110"/>
+        <source>speed</source>
+        <translation>скорость</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="113"/>
+        <source>open</source>
+        <translation>открытие</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="113"/>
+        <source>close</source>
+        <translation>закрытие</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="113"/>
+        <source>minimize</source>
+        <translation>свернуть</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="116"/>
+        <source>movement</source>
+        <translation>перемещение</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="117"/>
+        <source>maximize</source>
+        <translation>развернуть</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="119"/>
+        <source>dragging</source>
+        <translation>перетаскивание</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="120"/>
+        <source>move</source>
+        <translation>переместить</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="120"/>
+        <source>wobble</source>
+        <translation>колебание</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="120"/>
+        <source>physics</source>
+        <translation>физика</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="123"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="151"/>
+        <source>osd</source>
+        <translation>OSD</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="123"/>
+        <source>notification</source>
+        <translation>уведомление</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="123"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="151"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="538"/>
+        <source>on-screen display</source>
+        <translation>экранное сообщение</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="127"/>
+        <source>desktop</source>
+        <translation>рабочий стол</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="127"/>
+        <source>virtual desktop</source>
+        <translation>виртуальный рабочий стол</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="128"/>
+        <source>workspace</source>
+        <translation>рабочая область</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="128"/>
+        <source>switch</source>
+        <translation>переключение</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="128"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="663"/>
+        <source>peek</source>
+        <translation>заглянуть</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="129"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="663"/>
+        <source>show desktop</source>
+        <translation>показать рабочий стол</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="131"/>
+        <source>side panel</source>
+        <translation>боковая панель</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="131"/>
+        <source>panel</source>
+        <translation>панель</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="131"/>
+        <source>drawer</source>
+        <translation>выдвижная панель</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="133"/>
+        <source>widget</source>
+        <translation>виджет</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="136"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="172"/>
+        <source>editor</source>
+        <translation>редактор</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="136"/>
+        <source>layout editor</source>
+        <translation>редактор раскладок</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="139"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="141"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="156"/>
+        <source>profile</source>
+        <translation>профиль</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="141"/>
+        <source>motion set</source>
+        <translation>набор движений</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="116"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="141"/>
+        <source>motion</source>
+        <translation>движение</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="165"/>
+        <source>title bar</source>
+        <translation>заголовок окна</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="147"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="151"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="153"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="165"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="357"/>
+        <source>decoration</source>
+        <translation>оформление</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="112"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="148"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="166"/>
+        <source>appearance</source>
+        <translation>внешний вид</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="166"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="404"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="407"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="412"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="417"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="503"/>
+        <source>gaps</source>
+        <translation>зазоры</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="167"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="405"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="408"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="413"/>
+        <source>padding</source>
+        <translation>отступ</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="167"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="405"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="408"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="413"/>
+        <source>margin</source>
+        <translation>поле</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="169"/>
+        <source>rule</source>
+        <translation>правило</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="169"/>
+        <source>exclude</source>
+        <translation>исключить</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="169"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="510"/>
+        <source>float</source>
+        <translation>сделать плавающим</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="170"/>
+        <source>activity</source>
+        <translation>комната</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="172"/>
+        <source>design</source>
+        <translation>оформление</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="173"/>
+        <source>zones</source>
+        <translation>зоны</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="175"/>
+        <source>about</source>
+        <translation>о программе</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="175"/>
+        <source>version</source>
+        <translation>версия</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="175"/>
+        <source>license</source>
+        <translation>лицензия</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="176"/>
+        <source>credits</source>
+        <translation>авторы</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="182"/>
+        <source>Rendering</source>
+        <translation>Отрисовка</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="184"/>
+        <source>Rendering backend</source>
+        <translation>Движок отрисовки</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="185"/>
+        <source>graphics</source>
+        <translation>графика</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="237"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="388"/>
+        <source>Window filtering</source>
+        <translation>Фильтрация окон</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="239"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="390"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="533"/>
+        <source>Exclude transient windows</source>
+        <translation>Исключать вспомогательные окна</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="240"/>
+        <source>dialog</source>
+        <translation>диалоговое окно</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="153"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="240"/>
+        <source>tooltip</source>
+        <translation>подсказка</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="247"/>
+        <source>Reset</source>
+        <translation>Сбросить</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="248"/>
+        <source>reset to defaults</source>
+        <translation>сбросить к значениям по умолчанию</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="248"/>
+        <source>defaults</source>
+        <translation>значения по умолчанию</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="248"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="459"/>
+        <source>restore</source>
+        <translation>восстановить</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="254"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="266"/>
+        <source>Triggers</source>
+        <translation>Триггеры</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="256"/>
+        <source>Zone Span</source>
+        <translation>Охват зон</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="258"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="85"/>
+        <source>Display</source>
+        <translation>Отображение</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/decorationpagecontroller_browser.cpp" line="52"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="261"/>
+        <source>Snap Assist</source>
+        <translation>Помощник прилипания</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="263"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="268"/>
+        <source>Window Handling</source>
+        <translation>Обработка окон</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="264"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="269"/>
+        <source>Focus</source>
+        <translation>Фокус</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="274"/>
+        <source>Colors</source>
+        <translation>Цвета</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="278"/>
+        <source>Border</source>
+        <translation>Рамка</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="280"/>
+        <source>Zone Labels</source>
+        <translation>Подписи зон</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="282"/>
+        <source>Effects</source>
+        <translation>Эффекты</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="186"/>
+        <source>Shader Effects</source>
+        <translation>Эффекты шейдеров</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="284"/>
+        <source>System accent color</source>
+        <translation>Системный акцентный цвет</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="285"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="296"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="332"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="352"/>
+        <source>scheme</source>
+        <translation>схема</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="405"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="287"/>
+        <source>Highlight color</source>
+        <translation>Цвет подсветки</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="288"/>
+        <source>active</source>
+        <translation>активный</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="288"/>
+        <source>hover</source>
+        <translation>наведение</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="290"/>
+        <source>Inactive color</source>
+        <translation>Цвет неактивной зоны</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="290"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="338"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="363"/>
+        <source>unfocused</source>
+        <translation>без фокуса</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="292"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="335"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="338"/>
+        <source>outline</source>
+        <translation>контур</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="295"/>
+        <source>Import colors</source>
+        <translation>Импорт цветов</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="296"/>
+        <source>pywal</source>
+        <translation>pywal</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="296"/>
+        <source>json</source>
+        <translation>json</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="296"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="552"/>
+        <source>load</source>
+        <translation>загрузить</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="298"/>
+        <source>Active opacity</source>
+        <translation>Непрозрачность активной зоны</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="298"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="300"/>
+        <source>alpha</source>
+        <translation>альфа</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="300"/>
+        <source>Inactive opacity</source>
+        <translation>Непрозрачность неактивной зоны</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="302"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="324"/>
+        <source>Border width</source>
+        <translation>Ширина рамки</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="302"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="324"/>
+        <source>thickness</source>
+        <translation>толщина</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="243"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="246"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="302"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="312"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="324"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="395"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="398"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="486"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="541"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="544"/>
+        <source>size</source>
+        <translation>размер</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="304"/>
+        <source>Border radius</source>
+        <translation>Радиус скругления</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="304"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="326"/>
+        <source>rounding</source>
+        <translation>скругление</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="304"/>
+        <source>corner</source>
+        <translation>угол</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="306"/>
+        <source>Label color</source>
+        <translation>Цвет надписи</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="307"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="312"/>
+        <source>text</source>
+        <translation>текст</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="307"/>
+        <source>font</source>
+        <translation>шрифт</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="308"/>
+        <source>Font</source>
+        <translation>Шрифт</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="309"/>
+        <source>typeface</source>
+        <translation>гарнитура</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="309"/>
+        <source>family</source>
+        <translation>семейство</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="309"/>
+        <source>style</source>
+        <translation>начертание</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="311"/>
+        <source>Label scale</source>
+        <translation>Масштаб надписи</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="312"/>
+        <source>multiplier</source>
+        <translation>множитель</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="314"/>
+        <source>Zone numbers</source>
+        <translation>Номера зон</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="315"/>
+        <source>index</source>
+        <translation>индекс</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="315"/>
+        <source>digit</source>
+        <translation>цифра</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="315"/>
+        <source>label</source>
+        <translation>надпись</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="317"/>
+        <source>Flash on layout switch</source>
+        <translation>Мигать при переключении раскладки</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="317"/>
+        <source>blink</source>
+        <translation>мигание</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="187"/>
+        <source>Frame rate</source>
+        <translation>Частота кадров</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="71"/>
+        <source>User layouts</source>
+        <translation>Пользовательские раскладки</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="148"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="158"/>
+        <source>surface</source>
+        <translation>поверхность</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="155"/>
+        <source>decoration set</source>
+        <translation>набор оформления</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="155"/>
+        <source>set</source>
+        <translation>набор</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="156"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="158"/>
+        <source>pack</source>
+        <translation>пакет</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="159"/>
+        <source>glass</source>
+        <translation>стекло</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="160"/>
+        <source>blur</source>
+        <translation>размытие</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="188"/>
+        <source>fps</source>
+        <translation>fps</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="188"/>
+        <source>refresh</source>
+        <translation>обновление</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="189"/>
+        <source>Audio Spectrum</source>
+        <translation>Звуковой спектр</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="191"/>
+        <source>Audio spectrum</source>
+        <translation>Звуковой спектр</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="192"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="195"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="198"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="201"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="203"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="206"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="209"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="213"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="216"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="218"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="221"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="223"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="225"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="228"/>
+        <source>cava</source>
+        <translation>cava</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="192"/>
+        <source>music</source>
+        <translation>музыка</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="192"/>
+        <source>visualizer</source>
+        <translation>визуализатор</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="193"/>
+        <source>sound</source>
+        <translation>звук</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="194"/>
+        <source>Spectrum bars</source>
+        <translation>Полосы спектра</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="195"/>
+        <source>bands</source>
+        <translation>полосы</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="195"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="209"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="213"/>
+        <source>frequency</source>
+        <translation>частота</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="197"/>
+        <source>Noise reduction</source>
+        <translation>Шумоподавление</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="198"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="201"/>
+        <source>smoothing</source>
+        <translation>сглаживание</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="198"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="201"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="221"/>
+        <source>smooth</source>
+        <translation>плавный</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="200"/>
+        <source>Extra smoothing</source>
+        <translation>Дополнительное сглаживание</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="202"/>
+        <source>Automatic gain</source>
+        <translation>Автоматическое усиление</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="203"/>
+        <source>autosens</source>
+        <translation>авточувствительность</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="203"/>
+        <source>sensitivity</source>
+        <translation>чувствительность</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="204"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="206"/>
+        <source>gain</source>
+        <translation>усиление</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="205"/>
+        <source>Sensitivity</source>
+        <translation>Чувствительность</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="208"/>
+        <source>Lowest frequency</source>
+        <translation>Нижняя частота</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="209"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="213"/>
+        <source>cutoff</source>
+        <translation>срез</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="210"/>
+        <source>bass</source>
+        <translation>бас</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="212"/>
+        <source>Highest frequency</source>
+        <translation>Верхняя частота</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="214"/>
+        <source>treble</source>
+        <translation>высокие частоты</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="215"/>
+        <source>Channels</source>
+        <translation>Каналы</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="216"/>
+        <source>stereo</source>
+        <translation>стерео</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="216"/>
+        <source>mono</source>
+        <translation>моно</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="217"/>
+        <source>Reverse bar order</source>
+        <translation>Обратный порядок полос</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="218"/>
+        <source>flip</source>
+        <translation>перевернуть</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="218"/>
+        <source>mirror</source>
+        <translation>зеркально</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="220"/>
+        <source>Monstercat filter</source>
+        <translation>Фильтр Monstercat</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="221"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="223"/>
+        <source>filter</source>
+        <translation>фильтр</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="222"/>
+        <source>Wave filter</source>
+        <translation>Волновой фильтр</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="223"/>
+        <source>wave</source>
+        <translation>волна</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="224"/>
+        <source>Audio backend</source>
+        <translation>Звуковой движок</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="225"/>
+        <source>pipewire</source>
+        <translation>pipewire</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="225"/>
+        <source>pulseaudio</source>
+        <translation>pulseaudio</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="226"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="229"/>
+        <source>capture</source>
+        <translation>захват</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="227"/>
+        <source>Audio source</source>
+        <translation>Источник звука</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="228"/>
+        <source>device</source>
+        <translation>устройство</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="231"/>
+        <source>Layout assignment</source>
+        <translation>Назначение раскладки</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="233"/>
+        <source>Don&apos;t assign a layout by default</source>
+        <translation>Не назначать раскладку по умолчанию</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="234"/>
+        <source>default</source>
+        <translation>по умолчанию</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="234"/>
+        <source>assign</source>
+        <translation>назначить</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="234"/>
+        <source>snapping</source>
+        <translation>прилипание</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="320"/>
+        <source>Borders</source>
+        <translation>Рамки</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="322"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="123"/>
+        <source>Decorations</source>
+        <translation>Оформление</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="326"/>
+        <source>Corner radius</source>
+        <translation>Радиус скругления углов</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="328"/>
+        <source>Apply borders to</source>
+        <translation>Применять рамки к</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="329"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="343"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="360"/>
+        <source>scope</source>
+        <translation>область действия</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="329"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="343"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="360"/>
+        <source>which windows</source>
+        <translation>какие окна</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="331"/>
+        <source>Use system accent color</source>
+        <translation>Использовать акцентный цвет системы</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="334"/>
+        <source>Active border color</source>
+        <translation>Цвет рамки активного окна</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="335"/>
+        <source>focused</source>
+        <translation>в фокусе</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="337"/>
+        <source>Inactive border color</source>
+        <translation>Цвет рамки неактивного окна</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="340"/>
+        <source>Opacity and tint</source>
+        <translation>Непрозрачность и оттенок</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="342"/>
+        <source>Apply opacity and tint to</source>
+        <translation>Применять непрозрачность и оттенок к</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="346"/>
+        <source>translucent</source>
+        <translation>полупрозрачный</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="349"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="354"/>
+        <source>wash</source>
+        <translation>заливка</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="349"/>
+        <source>blend</source>
+        <translation>смешивание</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="351"/>
+        <source>Use system accent color for the tint</source>
+        <translation>Использовать акцентный цвет системы для оттенка</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="354"/>
+        <source>accent</source>
+        <translation>акцент</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="357"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="360"/>
+        <source>titlebar</source>
+        <translation>заголовок окна</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="357"/>
+        <source>header</source>
+        <translation>шапка</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="359"/>
+        <source>Hide title bars on</source>
+        <translation>Скрывать заголовки окон на</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="362"/>
+        <source>Focus fade duration</source>
+        <translation>Длительность плавного изменения фокуса</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="346"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="363"/>
+        <source>fade</source>
+        <translation>плавное появление</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="363"/>
+        <source>dim</source>
+        <translation>затемнение</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="364"/>
+        <source>cross-fade</source>
+        <translation>перекрёстное затухание</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="370"/>
+        <source>Performance</source>
+        <translation>Производительность</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="372"/>
+        <source>Animate only the active window</source>
+        <translation>Анимировать только активное окно</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="373"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="377"/>
+        <source>performance</source>
+        <translation>производительность</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="373"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="377"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="381"/>
+        <source>power</source>
+        <translation>энергопотребление</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="373"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="377"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="382"/>
+        <source>battery</source>
+        <translation>батарея</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="374"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="378"/>
+        <source>gpu</source>
+        <translation>gpu</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="374"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="378"/>
+        <source>heat</source>
+        <translation>нагрев</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="376"/>
+        <source>Pause while you are away</source>
+        <translation>Приостанавливать, когда вас нет</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="378"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="381"/>
+        <source>idle</source>
+        <translation>простой</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="380"/>
+        <source>Idle after</source>
+        <translation>Простой через</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="381"/>
+        <source>timeout</source>
+        <translation>тайм-аут</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="403"/>
+        <source>Inner gap</source>
+        <translation>Внутренний зазор</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="405"/>
+        <source>inner</source>
+        <translation>внутренний</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="406"/>
+        <source>Outer gap</source>
+        <translation>Внешний зазор</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="408"/>
+        <source>outer</source>
+        <translation>внешний</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="414"/>
+        <source>side</source>
+        <translation>сторона</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="416"/>
+        <source>Smart gaps</source>
+        <translation>Умные зазоры</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="418"/>
+        <source>smart</source>
+        <translation>умный</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="418"/>
+        <source>single</source>
+        <translation>одиночный</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="422"/>
+        <source>Activate on every drag</source>
+        <translation>Активировать при каждом перетаскивании</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="424"/>
+        <source>Hold to activate</source>
+        <translation>Удерживать для активации</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="424"/>
+        <source>deactivate</source>
+        <translation>деактивировать</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="426"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="430"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="499"/>
+        <source>Toggle mode</source>
+        <translation>Режим переключения</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="426"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="430"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="499"/>
+        <source>tap</source>
+        <translation>касание</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="426"/>
+        <source>activation</source>
+        <translation>активация</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="428"/>
+        <source>Span modifier</source>
+        <translation>Модификатор охвата</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="428"/>
+        <source>zone span</source>
+        <translation>охват зоны</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="428"/>
+        <source>paint</source>
+        <translation>рисование</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="430"/>
+        <source>span</source>
+        <translation>охват</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="432"/>
+        <source>Edge threshold</source>
+        <translation>Порог у края</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="432"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="562"/>
+        <source>distance</source>
+        <translation>расстояние</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="432"/>
+        <source>multi-zone</source>
+        <translation>несколько зон</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="434"/>
+        <source>Show zones on all monitors</source>
+        <translation>Показывать зоны на всех экранах</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="435"/>
+        <source>screens</source>
+        <translation>экраны</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="437"/>
+        <source>Filter by aspect ratio</source>
+        <translation>Фильтр по соотношению сторон</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="437"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="453"/>
+        <source>layouts</source>
+        <translation>раскладки</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="441"/>
+        <source>Always show after snapping</source>
+        <translation>Всегда показывать после прилипания</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="442"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="444"/>
+        <source>snap assist</source>
+        <translation>помощник прилипания</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="444"/>
+        <source>Hold to enable</source>
+        <translation>Удерживать для включения</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="446"/>
+        <source>Re-snap on resolution change</source>
+        <translation>Заново прилеплять при смене разрешения</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="447"/>
+        <source>resolution</source>
+        <translation>разрешение</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="449"/>
+        <source>Open new windows in the last-used zone</source>
+        <translation>Открывать новые окна в последней использованной зоне</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="450"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="469"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="514"/>
+        <source>new window</source>
+        <translation>новое окно</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="450"/>
+        <source>last zone</source>
+        <translation>последняя зона</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="452"/>
+        <source>Auto-assign new windows for all layouts</source>
+        <translation>Автоматически назначать новые окна для всех раскладок</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="453"/>
+        <source>auto-assign</source>
+        <translation>автоназначение</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="603"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="609"/>
+        <source>User sets</source>
+        <translation>Наборы пользователя</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="616"/>
+        <source>Opened</source>
+        <translation>Открыто</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="618"/>
+        <source>Closed</source>
+        <translation>Закрыто</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="626"/>
+        <source>Dragged</source>
+        <translation>Перетащено</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="631"/>
+        <source>Snapped Into Zone</source>
+        <translation>Прилеплено к зоне</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="633"/>
+        <source>Snapped Out of Zone</source>
+        <translation>Откреплено от зоны</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="635"/>
+        <source>Layout Switched</source>
+        <translation>Раскладка переключена</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="637"/>
+        <source>Shown</source>
+        <translation>Показано</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="638"/>
+        <source>Hidden</source>
+        <translation>Скрыто</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="639"/>
+        <source>Emphasized</source>
+        <translation>С акцентом</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="642"/>
+        <source>Zone Selector Shown</source>
+        <translation>Выбор зоны показан</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="644"/>
+        <source>Zone Selector Hidden</source>
+        <translation>Выбор зоны скрыт</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="646"/>
+        <source>Layout Picker Shown</source>
+        <translation>Выбор раскладки показан</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="648"/>
+        <source>Layout Picker Hidden</source>
+        <translation>Выбор раскладки скрыт</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="650"/>
+        <source>Snap Assist Shown</source>
+        <translation>Помощник прилипания показан</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="652"/>
+        <source>Snap Assist Hidden</source>
+        <translation>Помощник прилипания скрыт</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="655"/>
+        <source>Desktop Switched</source>
+        <translation>Рабочий стол переключён</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="593"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="902"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="455"/>
+        <source>Restore size on unsnap</source>
+        <translation>Восстанавливать размер при откреплении</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="456"/>
+        <source>unsnap</source>
+        <translation>открепление</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="456"/>
+        <source>original size</source>
+        <translation>исходный размер</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="458"/>
+        <source>Restore windows to their previous zone</source>
+        <translation>Восстанавливать окна в их предыдущую зону</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="459"/>
+        <source>login</source>
+        <translation>вход в систему</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="461"/>
+        <source>Restore unsnapped windows to their previous position</source>
+        <translation>Восстанавливать откреплённые окна в их предыдущее положение</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="462"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="506"/>
+        <source>floated</source>
+        <translation>плавающее</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="462"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="501"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="506"/>
+        <source>position</source>
+        <translation>положение</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="464"/>
+        <source>Unfloat to a zone when there is no previous zone</source>
+        <translation>Прилеплять к зоне, когда предыдущей зоны нет</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="465"/>
+        <source>unfloat</source>
+        <translation>сделать не плавающим</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="465"/>
+        <source>fallback</source>
+        <translation>запасной вариант</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="467"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="508"/>
+        <source>Sticky windows</source>
+        <translation>Окна на всех рабочих столах</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="467"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="508"/>
+        <source>all desktops</source>
+        <translation>все рабочие столы</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="467"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="508"/>
+        <source>sticky</source>
+        <translation>на всех рабочих столах</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="469"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="514"/>
+        <source>Focus new windows</source>
+        <translation>Передавать фокус новым окнам</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="114"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="374"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="469"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="471"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="514"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="516"/>
+        <source>focus</source>
+        <translation>фокус</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="471"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="516"/>
+        <source>Focus follows mouse</source>
+        <translation>Фокус следует за мышью</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="471"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="516"/>
+        <source>pointer</source>
+        <translation>указатель</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="238"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="283"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="474"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="219"/>
+        <source>Algorithm</source>
+        <translation>Алгоритм</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="476"/>
+        <source>Max windows</source>
+        <translation>Максимум окон</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="477"/>
+        <source>windows</source>
+        <translation>окна</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="477"/>
+        <source>maximum</source>
+        <translation>максимум</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="477"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="489"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="570"/>
+        <source>count</source>
+        <translation>количество</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="478"/>
+        <source>limit</source>
+        <translation>предел</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="480"/>
+        <source>Master ratio</source>
+        <translation>Соотношение главной области</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="481"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="489"/>
+        <source>center</source>
+        <translation>центр</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="481"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="486"/>
+        <source>ratio</source>
+        <translation>соотношение</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="482"/>
+        <source>proportion</source>
+        <translation>пропорция</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="485"/>
+        <source>Ratio step size</source>
+        <translation>Шаг изменения соотношения</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="486"/>
+        <source>step</source>
+        <translation>шаг</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="486"/>
+        <source>increment</source>
+        <translation>приращение</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="292"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="488"/>
+        <source>Master count</source>
+        <translation>Число главных окон</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="490"/>
+        <source>number</source>
+        <translation>число</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="494"/>
+        <source>Always re-insert on drag</source>
+        <translation>Всегда вставлять заново при перетаскивании</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="494"/>
+        <source>insert</source>
+        <translation>вставка</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="496"/>
+        <source>Hold to re-insert into stack</source>
+        <translation>Удерживать для вставки обратно в стопку</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="499"/>
+        <source>stack preview</source>
+        <translation>предпросмотр стопки</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="501"/>
+        <source>New window placement</source>
+        <translation>Размещение новых окон</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="503"/>
+        <source>Respect minimum size</source>
+        <translation>Учитывать минимальный размер</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="503"/>
+        <source>minimum</source>
+        <translation>минимум</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="505"/>
+        <source>Restore untiled windows to their previous position</source>
+        <translation>Восстанавливать неразмещённые окна в их предыдущее положение</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="301"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="510"/>
+        <source>Drag behavior</source>
+        <translation>Поведение при перетаскивании</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="510"/>
+        <source>reorder</source>
+        <translation>переупорядочивание</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="298"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="512"/>
+        <source>Overflow behavior</source>
+        <translation>Поведение при переполнении</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="512"/>
+        <source>max windows</source>
+        <translation>максимум окон</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="512"/>
+        <source>unlimited</source>
+        <translation>без ограничений</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="520"/>
+        <source>Global animation defaults</source>
+        <translation>Глобальные параметры анимации по умолчанию</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="522"/>
+        <source>Multiple windows</source>
+        <translation>Несколько окон</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="523"/>
+        <source>sequence</source>
+        <translation>последовательность</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="523"/>
+        <source>simultaneous</source>
+        <translation>одновременно</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="523"/>
+        <source>one by one</source>
+        <translation>по очереди</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="525"/>
+        <source>Stagger delay</source>
+        <translation>Задержка между окнами</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="526"/>
+        <source>pause</source>
+        <translation>пауза</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="526"/>
+        <source>interval</source>
+        <translation>интервал</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="526"/>
+        <source>delay</source>
+        <translation>задержка</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="528"/>
+        <source>Minimum distance</source>
+        <translation>Минимальное расстояние</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="243"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="246"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="395"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="398"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="529"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="541"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="544"/>
+        <source>threshold</source>
+        <translation>порог</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="529"/>
+        <source>skip</source>
+        <translation>пропустить</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="529"/>
+        <source>geometry</source>
+        <translation>геометрия</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="531"/>
+        <source>Window Filtering</source>
+        <translation>Фильтрация окон</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="391"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="534"/>
+        <source>dialogs</source>
+        <translation>диалоги</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="391"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="534"/>
+        <source>popups</source>
+        <translation>всплывающие окна</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="534"/>
+        <source>tooltips</source>
+        <translation>подсказки</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="391"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="535"/>
+        <source>menus</source>
+        <translation>меню</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="537"/>
+        <source>Exclude notifications and OSDs</source>
+        <translation>Исключить уведомления и OSD</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="538"/>
+        <source>volume</source>
+        <translation>громкость</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="538"/>
+        <source>brightness</source>
+        <translation>яркость</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="242"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="394"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="540"/>
+        <source>Minimum window width</source>
+        <translation>Минимальная ширина окна</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="243"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="395"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="541"/>
+        <source>narrow</source>
+        <translation>узкое</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="245"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="397"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="543"/>
+        <source>Minimum window height</source>
+        <translation>Минимальная высота окна</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="246"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="398"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="544"/>
+        <source>short</source>
+        <translation>низкое</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="548"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="192"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="223"/>
+        <source>Configuration</source>
+        <translation>Настройка</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="549"/>
+        <source>Backup</source>
+        <translation>Резервная копия</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="550"/>
+        <source>save</source>
+        <translation>сохранить</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="550"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="552"/>
+        <source>data</source>
+        <translation>данные</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="551"/>
+        <source>Restore</source>
+        <translation>Восстановить</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="556"/>
+        <source>Zone selector popup</source>
+        <translation>Всплывающее окно выбора зоны</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="557"/>
+        <source>enable</source>
+        <translation>включить</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="557"/>
+        <source>toggle</source>
+        <translation>переключить</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="559"/>
+        <source>Position &amp; Trigger</source>
+        <translation>Положение и триггер</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="561"/>
+        <source>Trigger distance</source>
+        <translation>Расстояние срабатывания</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="562"/>
+        <source>proximity</source>
+        <translation>близость</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="564"/>
+        <source>Layout Arrangement</source>
+        <translation>Расположение раскладки</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="566"/>
+        <source>Arrangement</source>
+        <translation>Расположение</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="567"/>
+        <source>horizontal</source>
+        <translation>горизонтальное</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="567"/>
+        <source>vertical</source>
+        <translation>вертикальное</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="569"/>
+        <source>Grid columns</source>
+        <translation>Столбцы сетки</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="570"/>
+        <source>columns</source>
+        <translation>столбцы</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="570"/>
+        <source>per row</source>
+        <translation>в строке</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="572"/>
+        <source>Max visible rows</source>
+        <translation>Максимум видимых строк</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="573"/>
+        <source>rows</source>
+        <translation>строки</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="573"/>
+        <source>scroll</source>
+        <translation>прокрутка</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="573"/>
+        <source>visible</source>
+        <translation>видимых</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="575"/>
+        <source>Preview Size</source>
+        <translation>Размер предпросмотра</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="579"/>
+        <source>Snapping Layout Priority</source>
+        <translation>Приоритет раскладок при прилипании</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="581"/>
+        <source>Tiling Algorithm Priority</source>
+        <translation>Приоритет алгоритмов мозаичного размещения</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="583"/>
+        <source>Snapping Quick Shortcuts</source>
+        <translation>Быстрые комбинации клавиш прилипания</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="585"/>
+        <source>Tiling Quick Shortcuts</source>
+        <translation>Быстрые комбинации клавиш мозаичного размещения</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="591"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="593"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="595"/>
+        <source>User shaders</source>
+        <translation>Пользовательские шейдеры</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="597"/>
+        <source>Easing Presets</source>
+        <translation>Предустановки плавности</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="599"/>
+        <source>Spring Presets</source>
+        <translation>Предустановки пружины</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="601"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="607"/>
+        <source>Save current state</source>
+        <translation>Сохранить текущее состояние</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="605"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="611"/>
+        <source>Saved sets</source>
+        <translation>Сохранённые наборы</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="663"/>
+        <source>Peeked at Desktop</source>
+        <translation>Заглядывание на рабочий стол</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="713"/>
+        <source>Snap Out of Zone</source>
+        <translation>Открепление от зоны</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="665"/>
+        <source>Slide In</source>
+        <translation>Вдвигание</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="667"/>
+        <source>Slide Out</source>
+        <translation>Выдвигание</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="669"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="687"/>
+        <source>Fade In</source>
+        <translation>Появление</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="671"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="689"/>
+        <source>Fade Out</source>
+        <translation>Исчезание</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="672"/>
+        <source>Hover</source>
+        <translation>Наведение</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="673"/>
+        <source>Press</source>
+        <translation>Нажатие</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="675"/>
+        <source>Toggle On</source>
+        <translation>Включение</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="677"/>
+        <source>Toggle Off</source>
+        <translation>Отключение</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="679"/>
+        <source>Show (badge)</source>
+        <translation>Показ (значок)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="681"/>
+        <source>Hide (badge)</source>
+        <translation>Скрытие (значок)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="683"/>
+        <source>Pulse (badge)</source>
+        <translation>Пульсация (значок)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="684"/>
+        <source>Tint</source>
+        <translation>Оттенок</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="685"/>
+        <source>Dim</source>
+        <translation>Затемнение</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="691"/>
+        <source>Reorder</source>
+        <translation>Переупорядочивание</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="693"/>
+        <source>Expand (accordion)</source>
+        <translation>Разворачивание (аккордеон)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="695"/>
+        <source>Collapse (accordion)</source>
+        <translation>Сворачивание (аккордеон)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="697"/>
+        <source>Progress</source>
+        <translation>Прогресс</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="699"/>
+        <source>Zone Highlight</source>
+        <translation>Подсветка зоны</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="701"/>
+        <source>Zone Highlight: Pop</source>
+        <translation>Подсветка зоны: всплывание</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="703"/>
+        <source>Zone Highlight: Border</source>
+        <translation>Подсветка зоны: рамка</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="705"/>
+        <source>Zone Overlay: Layout-Switch Flash</source>
+        <translation>Наложение зоны: вспышка при смене раскладки</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="707"/>
+        <source>Cursor Hover</source>
+        <translation>Наведение курсора</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="709"/>
+        <source>Cursor Click</source>
+        <translation>Щелчок курсора</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="711"/>
+        <source>Snap Into Zone (Fill Preview)</source>
+        <translation>Прилипание к зоне (предпросмотр заполнения)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="715"/>
+        <source>Snap Resize (Drag Preview)</source>
+        <translation>Изменение размера прилипанием (предпросмотр перетаскивания)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller.cpp" line="661"/>
+        <source>Zone %1</source>
+        <translation>Зона %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller.cpp" line="663"/>
+        <source>%1 — %2</source>
+        <translation>%1 — %2</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="216"/>
+        <source>Layout created, but aspect-ratio class could not be applied: %1</source>
+        <translation>Раскладка создана, но класс соотношения сторон применить не удалось: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="230"/>
+        <source>Could not create the layout. The daemon returned an empty layout ID.</source>
+        <translation>Не удалось создать раскладку. Служба вернула пустой идентификатор раскладки.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="238"/>
+        <source>Could not create the layout. The daemon may not be running.</source>
+        <translation>Не удалось создать раскладку. Возможно, служба не запущена.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="257"/>
+        <source>Could not delete layout: %1</source>
+        <translation>Не удалось удалить раскладку: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="273"/>
+        <source>Could not duplicate layout: %1</source>
+        <translation>Не удалось создать копию раскладки: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="323"/>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="472"/>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="565"/>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="929"/>
+        <source>That file path is not allowed.</source>
+        <translation>Этот путь к файлу недопустим.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="355"/>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="530"/>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="497"/>
+        <source>That export path is not allowed.</source>
+        <translation>Этот путь экспорта недопустим.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="400"/>
+        <source>Failed to update layout visibility: %1</source>
+        <translation>Не удалось обновить видимость раскладки: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="413"/>
+        <source>Failed to update auto-assign: %1</source>
+        <translation>Не удалось обновить автоназначение: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="427"/>
+        <source>Failed to update aspect ratio: %1</source>
+        <translation>Не удалось обновить соотношение сторон: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_lifecycle.cpp" line="187"/>
+        <source>Failed to apply assignment changes: %1</source>
+        <translation>Не удалось применить изменения назначения: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="77"/>
+        <source>Overview</source>
+        <translation>Обзор</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="81"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="232"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="302"/>
+        <source>General</source>
+        <translation>Общие</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="91"/>
+        <source>Placement</source>
+        <translation>Размещение</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/decorationpagecontroller_browser.cpp" line="40"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="253"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="312"/>
+        <source>Windows</source>
+        <translation>Окна</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="132"/>
+        <source>Rules</source>
+        <translation>Правила</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="136"/>
+        <source>Editor</source>
+        <translation>Редактор</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="138"/>
+        <source>About</source>
+        <translation>О программе</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="151"/>
+        <source>Virtual Screens</source>
+        <translation>Виртуальные экраны</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="153"/>
+        <source>Layouts</source>
+        <translation>Раскладки</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="243"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="171"/>
+        <source>Behavior</source>
+        <translation>Поведение</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/decorationpagecontroller_browser.cpp" line="54"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="181"/>
+        <source>Zone Selector</source>
+        <translation>Выбор зоны</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="194"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="225"/>
+        <source>Priority</source>
+        <translation>Приоритет</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="197"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="228"/>
+        <source>Quick Shortcuts</source>
+        <translation>Быстрые комбинации клавиш</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="199"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="287"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="322"/>
+        <source>Shaders</source>
+        <translation>Шейдеры</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="239"/>
+        <source>Transitions</source>
+        <translation>Переходы</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="247"/>
+        <source>Motion</source>
+        <translation>Движение</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="264"/>
+        <source>Window Motion</source>
+        <translation>Движение окна</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="271"/>
+        <source>Window Dragging</source>
+        <translation>Перетаскивание окна</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="306"/>
+        <source>Surfaces</source>
+        <translation>Поверхности</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="319"/>
+        <source>Decoration Sets</source>
+        <translation>Наборы оформления</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="249"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="308"/>
+        <source>Library</source>
+        <translation>Библиотека</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/decorationpagecontroller_browser.cpp" line="48"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="254"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="313"/>
+        <source>OSDs</source>
+        <translation>OSD</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="257"/>
+        <source>Overlays</source>
+        <translation>Наложения</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="274"/>
+        <source>Side Panels</source>
+        <translation>Боковые панели</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="276"/>
+        <source>Widgets</source>
+        <translation>Виджеты</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="279"/>
+        <source>Layout Editor</source>
+        <translation>Редактор раскладок</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="282"/>
+        <source>Presets</source>
+        <translation>Предустановки</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="285"/>
+        <source>Motion Sets</source>
+        <translation>Наборы движения</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shaderpackinstaller.cpp" line="303"/>
+        <source>Shader pack installed.</source>
+        <translation>Пакет шейдеров установлен.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shaderpackinstaller.cpp" line="305"/>
+        <source>The dropped path is not a valid shader pack directory.</source>
+        <translation>Указанный путь не является каталогом пакета шейдеров.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shaderpackinstaller.cpp" line="307"/>
+        <source>The shader pack is missing metadata.json (or it is a symlink).</source>
+        <translation>В пакете шейдеров отсутствует metadata.json (или это символическая ссылка).</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shaderpackinstaller.cpp" line="309"/>
+        <source>The user shader directory could not be created.</source>
+        <translation>Не удалось создать пользовательский каталог шейдеров.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shaderpackinstaller.cpp" line="311"/>
+        <source>A shader pack with this name is already installed.</source>
+        <translation>Пакет шейдеров с таким именем уже установлен.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shaderpackinstaller.cpp" line="313"/>
+        <source>The shader pack exceeds the maximum allowed size or file count.</source>
+        <translation>Пакет шейдеров превышает максимально допустимый размер или число файлов.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shaderpackinstaller.cpp" line="315"/>
+        <source>Copying the shader pack failed. The partial install was rolled back.</source>
+        <translation>Не удалось скопировать пакет шейдеров. Частичная установка отменена.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shaderpackinstaller.cpp" line="317"/>
+        <source>Unknown shader pack installer error.</source>
+        <translation>Неизвестная ошибка установщика пакетов шейдеров.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/snappingzonescontroller.cpp" line="78"/>
+        <source>Color import file does not exist: %1</source>
+        <translation>Файл импорта цветов не существует: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/snappingzonescontroller.cpp" line="96"/>
+        <source>Color import file does not resolve to a regular file: %1</source>
+        <translation>Файл импорта цветов не является обычным файлом: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/snappingzonescontroller.cpp" line="101"/>
+        <source>Color import file must be a .json file: %1</source>
+        <translation>Файл импорта цветов должен иметь расширение .json: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="449"/>
+        <location filename="../src/settings/shadersetstore.cpp" line="545"/>
+        <source>A set named &quot;%1&quot; already exists.</source>
+        <translation>Набор с именем &quot;%1&quot; уже существует.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="355"/>
+        <location filename="../src/settings/shadersetstore.cpp" line="540"/>
+        <location filename="../src/settings/shadersetstore.cpp" line="551"/>
+        <location filename="../src/settings/shadersetstore.cpp" line="617"/>
+        <location filename="../src/settings/shadersetstore.cpp" line="622"/>
+        <source>Could not read the set &quot;%1&quot;.</source>
+        <translation>Не удалось прочитать набор &quot;%1&quot;.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="169"/>
+        <source>Could not back up the existing set, so it was left untouched.</source>
+        <translation>Не удалось создать резервную копию существующего набора, поэтому он остался без изменений.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="234"/>
+        <source>Could not write the set to disk.</source>
+        <translation>Не удалось записать набор на диск.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="359"/>
+        <source>&quot;%1&quot; was written by a newer version of PlasmaZones.</source>
+        <translation>&quot;%1&quot; был записан более новой версией PlasmaZones.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="367"/>
+        <source>&quot;%1&quot; does not match this page.</source>
+        <translation>&quot;%1&quot; не соответствует этой странице.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="371"/>
+        <source>Could not apply &quot;%1&quot;.</source>
+        <translation>Не удалось применить &quot;%1&quot;.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="439"/>
+        <location filename="../src/settings/shadersetstore.cpp" line="533"/>
+        <source>That name cannot be used. Try one with letters or numbers in it.</source>
+        <translation>Это имя использовать нельзя. Попробуйте имя с буквами или цифрами.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="459"/>
+        <source>There is nothing to capture yet.</source>
+        <translation>Пока нечего сохранять.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="500"/>
+        <location filename="../src/settings/shadersetstore.cpp" line="508"/>
+        <source>Could not delete &quot;%1&quot;.</source>
+        <translation>Не удалось удалить &quot;%1&quot;.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="432"/>
+        <location filename="../src/settings/shadersetstore.cpp" line="526"/>
+        <source>A set needs a name.</source>
+        <translation>Набору нужно имя.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="589"/>
+        <source>Renamed the set, but the old file could not be removed. Delete it by hand from the sets folder.</source>
+        <translation>Набор переименован, но старый файл удалить не удалось. Удалите его вручную из папки наборов.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="605"/>
+        <source>Could not write to that location.</source>
+        <translation>Не удалось записать в это расположение.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="631"/>
+        <source>Could not write to %1.</source>
+        <translation>Не удалось записать в %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="652"/>
+        <source>That file is not a readable set.</source>
+        <translation>Этот файл не является читаемым набором.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="656"/>
+        <source>That set was written by a newer version of PlasmaZones.</source>
+        <translation>Этот набор был записан более новой версией PlasmaZones.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="663"/>
+        <source>That set is empty.</source>
+        <translation>Этот набор пуст.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="670"/>
+        <source>That set does not match this page.</source>
+        <translation>Этот набор не соответствует этой странице.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="681"/>
+        <source>That set has no usable name.</source>
+        <translation>У этого набора нет пригодного имени.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="466"/>
+        <location filename="../src/settings/shadersetstore.cpp" line="688"/>
+        <location filename="../src/settings/shadersetstore.cpp" line="710"/>
+        <source>Could not create the sets folder.</source>
+        <translation>Не удалось создать папку наборов.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="715"/>
+        <source>Could not open the sets folder.</source>
+        <translation>Не удалось открыть папку наборов.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/animationpresetlibrary.cpp" line="130"/>
+        <location filename="../src/settings/animationpresetlibrary.cpp" line="199"/>
+        <source>A preset needs a name.</source>
+        <translation>Предустановке нужно имя.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/animationpresetlibrary.cpp" line="140"/>
+        <source>That name cannot be used for a preset.</source>
+        <translation>Это имя нельзя использовать для предустановки.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/animationpresetlibrary.cpp" line="150"/>
+        <location filename="../src/settings/animationpresetlibrary.cpp" line="159"/>
+        <location filename="../src/settings/animationpresetlibrary.cpp" line="178"/>
+        <source>Could not save the preset &quot;%1&quot;.</source>
+        <translation>Не удалось сохранить предустановку &quot;%1&quot;.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/animationpresetlibrary.cpp" line="253"/>
+        <source>Could not find the preset &quot;%1&quot;.</source>
+        <translation>Не удалось найти предустановку &quot;%1&quot;.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/animationpresetlibrary.cpp" line="261"/>
+        <location filename="../src/settings/animationpresetlibrary.cpp" line="271"/>
+        <source>Could not delete the preset &quot;%1&quot;.</source>
+        <translation>Не удалось удалить предустановку &quot;%1&quot;.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/animationspagecontroller_overrides.cpp" line="260"/>
+        <location filename="../src/settings/animationspagecontroller_shaders.cpp" line="407"/>
+        <source>Cannot reset while a discard is in progress.</source>
+        <translation>Нельзя выполнить сброс, пока идёт отмена изменений.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/animationspagecontroller_overrides.cpp" line="282"/>
+        <source>Some animation overrides could not be reset.</source>
+        <translation>Некоторые переопределения анимаций сбросить не удалось.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="488"/>
+        <source>Settings can only be exported to a local file.</source>
+        <translation>Параметры можно экспортировать только в локальный файл.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="529"/>
+        <source>That is the settings file this app is using. Export to a different file.</source>
+        <translation>Это файл параметров, который использует приложение. Экспортируйте в другой файл.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="556"/>
+        <source>Settings can only be imported from a local file.</source>
+        <translation>Параметры можно импортировать только из локального файла.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="570"/>
+        <source>That settings file is no longer there.</source>
+        <translation>Этого файла параметров больше нет.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="584"/>
+        <source>Those are the settings this app is already using. Pick a different file to import.</source>
+        <translation>Это параметры, которые приложение уже использует. Выберите другой файл для импорта.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="607"/>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="612"/>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="617"/>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="641"/>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="685"/>
+        <source>That is not a settings file this app can read.</source>
+        <translation>Это не файл параметров, который приложение может прочитать.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="657"/>
+        <source>Could not back up your current settings, so nothing was imported.</source>
+        <translation>Не удалось создать резервную копию текущих параметров, поэтому ничего не импортировано.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="670"/>
+        <source>Could not read that older settings file.</source>
+        <translation>Не удалось прочитать этот более старый файл параметров.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="677"/>
+        <source>Could not read that settings file.</source>
+        <translation>Не удалось прочитать этот файл параметров.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="697"/>
+        <source>Could not replace your settings with that file.</source>
+        <translation>Не удалось заменить ваши параметры этим файлом.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="725"/>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="730"/>
+        <source>Your settings could not be put back. A copy is saved at %1.</source>
+        <translation>Не удалось восстановить ваши параметры. Копия сохранена в %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="770"/>
+        <source>Your settings were imported, but the animation pages still show the old ones. Reopen the settings window to see the imported values.</source>
+        <translation>Ваши параметры импортированы, но на страницах анимаций по-прежнему показаны старые. Откройте окно параметров заново, чтобы увидеть импортированные значения.</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
## Summary
Adds a full **Russian (`ru`)** translation — all **1022 strings** translated, including the **three Russian plural forms** (one/few/many) for the four `%n` strings.

- Generated `translations/plasmazones_ru.ts` against current sources with `lupdate` (single `plasmazones` context).
- Terminology follows KDE Plasma's Russian conventions: `окно`=window, `экран`=screen, `зона`=zone, `раскладка`=layout, `мозаичное размещение`=tiling, `прилипание`=snap, `наложение`=overlay, `шейдер`=shader, `внешний вид`=appearance, `комната`=activity (KDE's official rendering), `книжная`/`альбомная`=portrait/landscape.
- Russian **sentence case** (not English title case), with correct case and gender agreement, and the copula em-dash where Russian punctuation genuinely calls for it.

## Review
Ran a **3-pass native-Russian review** (6 → 3 → **0 findings**, converged clean). Fixes included aligning portrait to the standard `книжная`/`альбомная` pair (the machine draft had mixed `Портретная`), appearance→`внешний вид`, monitor→`экран`, `(invalid)`→`(недопустимо)`, and putting an animation-event label into the nominal form its siblings use.

## Verification
- Placeholders (`%1`/`%2`/`%n`) and XML entities preserved (0 mismatches).
- Technical proper nouns (OpenGL, Vulkan, pywal, cava, ...) kept in Latin.
- Well-formed XML; CMake picks it up via the `plasmazones_*.ts` glob.
- `lrelease` compiles: **1022 finished / 0 unfinished** (with the correct 3 plural forms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)