### PR TITLE
fix(settings): scope per-page Reset/Discard to each page's own subtree

### DIFF
--- a/src/config/settings.cpp
+++ b/src/config/settings.cpp
@@ -1472,6 +1472,18 @@ PhosphorAnimationShaders::ShaderProfileTree Settings::shaderProfileTree() const
         PhosphorAnimationShaders::ShaderProfileTree::fromJson(QJsonObject::fromVariantMap(map)));
 }
 
+PhosphorAnimationShaders::ShaderProfileTree Settings::committedShaderProfileTree() const
+{
+    // Baseline snapshot, not the live store — mirrors isKeyModified()'s
+    // m_baseline lookup and the shaderProfileTree() prune so the two trees
+    // compare prune-for-prune. No empty→ConfigDefaults fallback: the shader
+    // tree's schema default IS the empty tree (unlike the decoration tree).
+    const QVariantMap map =
+        m_baseline.value(ConfigDefaults::animationsGroup()).value(ConfigDefaults::shaderProfileTreeKey()).toMap();
+    return pruneShaderProfileTreeToSupportedPaths(
+        PhosphorAnimationShaders::ShaderProfileTree::fromJson(QJsonObject::fromVariantMap(map)));
+}
+
 void Settings::setShaderProfileTree(const PhosphorAnimationShaders::ShaderProfileTree& tree)
 {
     // Prune incoming tree at the persistence boundary — same rationale
@@ -1537,6 +1549,20 @@ PhosphorSurfaceShaders::DecorationProfileTree Settings::decorationProfileTree() 
     // the schema never returns empty here. The guard covers a store constructed
     // WITHOUT the schema default (e.g. a bare test stub): fall back to the same
     // canonical default rather than to an empty tree.
+    if (map.isEmpty())
+        return ConfigDefaults::decorationProfileTree();
+    return PhosphorSurfaceShaders::DecorationProfileTree::fromJson(QJsonObject::fromVariantMap(map));
+}
+
+PhosphorSurfaceShaders::DecorationProfileTree Settings::committedDecorationProfileTree() const
+{
+    // Read the baseline snapshot, not the live store — mirrors isKeyModified()'s
+    // m_baseline.value(group).value(key) lookup so the two stay in lockstep. The
+    // empty→ConfigDefaults fallback matches decorationProfileTree() so a
+    // never-modified key compares equal to the live tree (both canonicalise to
+    // the same default) instead of spuriously reporting a diff.
+    const QVariantMap map =
+        m_baseline.value(ConfigDefaults::decorationsGroup()).value(ConfigDefaults::decorationProfileTreeKey()).toMap();
     if (map.isEmpty())
         return ConfigDefaults::decorationProfileTree();
     return PhosphorSurfaceShaders::DecorationProfileTree::fromJson(QJsonObject::fromVariantMap(map));

--- a/src/config/settings.h
+++ b/src/config/settings.h
@@ -995,6 +995,13 @@ public:
     PhosphorAnimationShaders::ShaderProfileTree shaderProfileTree() const override;
     void setShaderProfileTree(const PhosphorAnimationShaders::ShaderProfileTree& tree) override;
 
+    /// The committed-baseline shader tree. Reads the ShaderProfileTree key from
+    /// the same committed baseline `isKeyModified()` uses, and applies the
+    /// identical supported-path prune as `shaderProfileTree()` so a
+    /// per-surface Discard/dirty check compares live-vs-committed on equal
+    /// footing. See `committedDecorationProfileTree()` for the sibling rationale.
+    PhosphorAnimationShaders::ShaderProfileTree committedShaderProfileTree() const override;
+
     /// String facade for the shaderProfileTreeJson Q_PROPERTY. Routes
     /// through the existing tree accessors so persistence is identical;
     /// the Q_PROPERTY entry is purely so the meta-object dirty-tracking
@@ -1010,6 +1017,16 @@ public:
     void setDecorationProfileTree(const PhosphorSurfaceShaders::DecorationProfileTree& tree) override;
     QString decorationProfileTreeJson() const override;
     void setDecorationProfileTreeJson(const QString& json) override;
+
+    /// The committed-baseline decoration tree — the last-persisted value that
+    /// per-page Discard reverts to and the per-surface decoration dirty check
+    /// compares against. Reads the DecorationProfileTree key from the same
+    /// committed baseline `isKeyModified()` uses, with the identical
+    /// empty→ConfigDefaults fallback as `decorationProfileTree()`, so a
+    /// subtree-scoped Discard sees baseline-vs-current on equal footing. Not on
+    /// ISettings: the committed baseline is a Settings-internal dirty-tracking
+    /// concept, and only SettingsController's per-page kebab consumes it.
+    PhosphorSurfaceShaders::DecorationProfileTree committedDecorationProfileTree() const;
 
     // Decorations.Performance — PhosphorConfig::Store-backed.
     bool decorationAnimateFocusedOnly() const override;

--- a/src/core/settings_interfaces.h
+++ b/src/core/settings_interfaces.h
@@ -507,6 +507,18 @@ public:
     virtual PhosphorAnimationShaders::ShaderProfileTree shaderProfileTree() const = 0;
     virtual void setShaderProfileTree(const PhosphorAnimationShaders::ShaderProfileTree& tree) = 0;
 
+    /// The committed-baseline shader tree — the last-persisted value the
+    /// per-surface animation dirty check and per-page Discard compare the live
+    /// tree against. The default returns the live tree, so a stub with no
+    /// baseline notion reports "never diverged"; the concrete Settings overrides
+    /// it to read its committed baseline. Implementations MUST apply the same
+    /// supported-path prune as shaderProfileTree() so live-vs-committed compares
+    /// prune-for-prune.
+    virtual PhosphorAnimationShaders::ShaderProfileTree committedShaderProfileTree() const
+    {
+        return shaderProfileTree();
+    }
+
     // Animation window filtering — gates animations BEFORE the app-rule
     // cascade. A class-pattern rule whose pattern matches the window's class
     // overrides the filter at the resolver layer, so users can re-enable

--- a/src/settings/animationspagecontroller.cpp
+++ b/src/settings/animationspagecontroller.cpp
@@ -175,24 +175,19 @@ AnimationsPageController::AnimationsPageController(PhosphorAnimationShaders::Ani
                 &AnimationsPageController::shaderEffectsChanged);
     }
     if (m_settings) {
-        // Qt::DirectConnection is mandatory here: the
-        // m_mutatingShaderTree depth check below distinguishes "our
-        // own write" (depth > 0) from "external reload" (depth == 0),
-        // and that only works when the NOTIFY fires SYNCHRONOUSLY
-        // inside the MutatingShaderTreeScope. A queued connection
-        // would dispatch the lambda after the scope's destructor has
-        // already restored depth=0, the guard sees external-reload
-        // semantics, and the lambda silently clears m_shaderTreeDirty
-        // on the user's own write — a silent revert of staged edits.
+        // Sole emitter of pendingChangesChanged for shader-tree edits: EVERY
+        // tree change (our own mutators, an external Discard/import/load) funnels
+        // through Settings::setShaderProfileTree → this NOTIFY. Because dirtiness
+        // is now value-based (hasPendingChanges diffs live-vs-committed), the
+        // lambda no longer distinguishes own-writes from reloads or touches any
+        // flag — it just refreshes the cards and re-evaluates the dirty state.
         //
-        // m_asyncRevertInFlight guards a second race:
-        // SettingsController::discard() pairs our discard() with a
-        // follow-up Settings::load(), which fires shaderProfileTreeChanged
-        // while the asyncRevert worker is still running. The lambda must
-        // NOT clear m_shaderTreeDirty in that window — the worker's
-        // finished handler owns the terminal clear-and-emit sequence as
-        // part of discardResult — so it short-circuits while the flag is
-        // set.
+        // The async guard stays: SettingsController::discard() pairs our async
+        // discard() with a follow-up Settings::load() that fires this NOTIFY
+        // while the worker is still running. The worker's finished handler owns
+        // the terminal pendingChangesChanged + discardResult sequence, so the
+        // lambda must not fire pendingChangesChanged in that window or it would
+        // race the terminal emit and break the chrome's wait-counter.
         connect(
             m_settings, &ISettings::shaderProfileTreeChanged, this,
             [this]() {
@@ -200,25 +195,9 @@ AnimationsPageController::AnimationsPageController(PhosphorAnimationShaders::Ani
                 // can't tell which path moved without diffing. QML pages refresh
                 // every visible event card on this signal which is cheap enough.
                 Q_EMIT shaderProfileChanged(QString());
-                // If this signal arrived from an external reload (Discard from
-                // another page, import, settings.load()), the on-disk tree is
-                // now authoritative — drop the staged-dirty flag so
-                // hasPendingChanges() does not report phantom edits. The
-                // m_mutatingShaderTree guard distinguishes our own writes
-                // (which keep the dirty flag set) from external reloads.
-                //
-                // While an asyncRevert worker is running, skip the clear:
-                // the worker's finished handler will reset m_shaderTreeDirty
-                // and emit pendingChangesChanged + discardResult together as
-                // the terminal sequence. Letting the lambda clear early would
-                // race the terminal emit and could fire pendingChangesChanged
-                // before discardResult, breaking the chrome's wait-counter.
                 if (m_asyncRevertInFlight)
                     return;
-                if (m_mutatingShaderTree == 0 && m_shaderTreeDirty) {
-                    m_shaderTreeDirty = false;
-                    Q_EMIT pendingChangesChanged();
-                }
+                Q_EMIT pendingChangesChanged();
             },
             Qt::DirectConnection);
     }
@@ -320,7 +299,16 @@ bool AnimationsPageController::dropFileSnapshotIfUnchanged(const QString& filePa
 
 bool AnimationsPageController::hasPendingChanges() const
 {
-    return !m_pendingFileSnapshots.isEmpty() || m_shaderTreeDirty;
+    // Value-based, not a sticky flag: the shader tree is dirty exactly when the
+    // live tree differs from the committed baseline. This lets a per-page kebab
+    // revert only ONE surface's tree paths and have hasPendingChanges() report
+    // the truth — a sticky bool would either stay set after a scoped revert
+    // (phantom "unsaved changes" footer) or get cleared wholesale by an external
+    // scoped write (dropping OTHER pages' still-pending tree edits). Files stay
+    // snapshot-based because a file has no committed-baseline value to diff.
+    if (!m_pendingFileSnapshots.isEmpty())
+        return true;
+    return m_settings != nullptr && m_settings->shaderProfileTree() != m_settings->committedShaderProfileTree();
 }
 
 bool AnimationsPageController::isDirty() const
@@ -333,11 +321,10 @@ void AnimationsPageController::apply()
     // Refuse Apply while an asyncRevertPending worker is still
     // rewriting profile files from its captured snapshot. Without
     // this, an apply() call mid-revert would clear m_pendingFileSnapshots
-    // and m_shaderTreeDirty — letting the worker's still-running
-    // file restores silently UNDO writes the user wanted to keep,
-    // then emit discardResult(true) on a now-clean page. Symmetric
-    // to the per-mutator guards (setOverride etc.) and to
-    // RuleController::m_asyncCommitInFlight.
+    // — letting the worker's still-running file restores silently UNDO
+    // writes the user wanted to keep, then emit discardResult(true) on a
+    // now-clean page. Symmetric to the per-mutator guards (setOverride
+    // etc.) and to RuleController::m_asyncCommitInFlight.
     if (m_asyncRevertInFlight) {
         Q_EMIT applyResult(false, PhosphorI18n::tr("Cannot save while a discard is in progress."));
         return;
@@ -363,19 +350,35 @@ void AnimationsPageController::commitPending()
 {
     const bool had = hasPendingChanges();
     m_pendingFileSnapshots.clear();
-    m_shaderTreeDirty = false;
+    // No shader-tree flag to clear: tree dirtiness is value-based now. The tree's
+    // committed baseline is refreshed by Settings::save() (captureBaseline), which
+    // runs in the same apply pass; SettingsController::save() calls
+    // refreshDirtyState() afterwards so this controller re-evaluates once the
+    // baseline has caught up (apply() may run before the settings save in the
+    // domain walk, leaving the tree transiently "divergent" here).
     if (had)
         Q_EMIT pendingChangesChanged();
+}
+
+void AnimationsPageController::refreshDirtyState()
+{
+    // Poke the value-based dirty check after an external commit point the
+    // controller can't observe on its own — specifically Settings::save()'s
+    // captureBaseline, which makes committedShaderProfileTree() catch up to the
+    // live tree without firing shaderProfileTreeChanged (the value didn't move,
+    // only the baseline did). The pendingChangesChanged → dirtyChanged forwarder
+    // gates on an actual flip, so a no-op refresh costs nothing.
+    Q_EMIT pendingChangesChanged();
 }
 
 bool AnimationsPageController::revertPending()
 {
     // discard() / revertPending() is the StagingDomain contract for "undo
-    // everything since the last apply". This method:
-    //   * Restores every snapshotted profile file from disk.
-    //   * Clears our own dirty flag (m_shaderTreeDirty) only when all
-    //     snapshots restore successfully — partial-failure keeps the flag
-    //     so a retry path still sees hasPendingChanges()==true.
+    // everything since the last apply". This method restores every snapshotted
+    // profile file from disk and returns whether the snapshot map fully emptied
+    // (a retained entry is a restore that FAILED, so a caller must not declare
+    // the session clean while one stands). It owns the FILE half only — the
+    // shader tree is value-based and reverted by the caller (see below).
     //
     // IMPORTANT CALLER CONTRACT: the in-memory shader tree on m_settings
     // (Settings::shaderProfileTree) is NOT reverted here — that state is
@@ -454,13 +457,10 @@ bool AnimationsPageController::revertPending()
     }
     m_pendingFileSnapshots = std::move(retained);
 
-    // Clear shader-tree dirty when (and only when) every file snapshot was
-    // successfully restored. If `retained` is non-empty, some restores
-    // failed and the caller may retry — leave the dirty flag so the
-    // retry path still sees hasPendingChanges()==true.
-    if (m_pendingFileSnapshots.isEmpty()) {
-        m_shaderTreeDirty = false;
-    }
+    // No shader-tree flag to clear: tree dirtiness is value-based, and reverting
+    // the tree is the caller's job (Settings::load() on global discard, or the
+    // scoped tree revert in SettingsController::discardPage for a per-page
+    // discard). This method owns the FILE half only.
 
     // Bulk emit so QML sub-pages refresh exactly the rows that moved.
     for (const QString& path : overrideEvents)
@@ -475,6 +475,59 @@ bool AnimationsPageController::revertPending()
     // import, a defaults reset) must not do so while one is still staged: the
     // next Discard would write it back over the new state.
     return m_pendingFileSnapshots.isEmpty();
+}
+
+bool AnimationsPageController::revertPendingUnder(const QStringList& eventPaths)
+{
+    // Scoped synchronous revert for the per-page kebab Discard: restore ONLY the
+    // snapshotted override files at eventPaths, leaving every other page's staged
+    // file edits (and any preset / motion-set snapshots) pending. Mirrors
+    // revertPending's per-file restore, filtered to the in-scope file keys. Same
+    // async-in-flight refusal — a concurrent worker owns the snapshot map.
+    if (m_asyncRevertInFlight) {
+        qCWarning(lcConfig) << "revertPendingUnder: blocked while an async discard is in flight";
+        return false;
+    }
+
+    QStringList restoredEvents;
+    bool allRestored = true;
+    for (const QString& path : eventPaths) {
+        if (!isValidEventPath(path))
+            continue;
+        const QString filePath = profileFilePath(path);
+        const auto it = m_pendingFileSnapshots.constFind(filePath);
+        if (it == m_pendingFileSnapshots.cend())
+            continue; // no staged edit for this path
+
+        bool restored = false;
+        if (!it.value().has_value()) {
+            // File was absent pre-edit — remove it if the edit created one.
+            if (!QFile::exists(filePath) || QFile::remove(filePath))
+                restored = true;
+        } else {
+            QSaveFile f(filePath);
+            if (f.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+                f.write(*it.value());
+                if (f.commit())
+                    restored = true;
+            }
+        }
+
+        if (!restored) {
+            qCWarning(lcConfig) << "revertPendingUnder: failed to restore" << filePath;
+            allRestored = false;
+            continue; // keep the snapshot so a retry can pick it up
+        }
+        m_pendingFileSnapshots.remove(filePath);
+        restoredEvents.append(path);
+    }
+
+    // Refresh exactly the rows that moved; one dirty re-eval for the batch.
+    for (const QString& path : restoredEvents)
+        Q_EMIT overrideChanged(path);
+    if (!restoredEvents.isEmpty())
+        Q_EMIT pendingChangesChanged();
+    return allRestored;
 }
 
 bool AnimationsPageController::asyncRevertInFlight() const
@@ -554,8 +607,10 @@ void AnimationsPageController::asyncRevertPending()
                 if (!result.retained.contains(key))
                     m_pendingFileSnapshots.remove(key);
             }
-            if (m_pendingFileSnapshots.isEmpty())
-                m_shaderTreeDirty = false;
+            // No shader-tree flag to clear: tree dirtiness is value-based. The
+            // global discard that dispatched this worker pairs it with a
+            // Settings::load() that re-baselines the tree, so hasPendingChanges()
+            // reads clean once the files are restored below.
 
             for (const QString& path : result.overrideEvents)
                 Q_EMIT overrideChanged(path);

--- a/src/settings/animationspagecontroller.cpp
+++ b/src/settings/animationspagecontroller.cpp
@@ -330,10 +330,10 @@ void AnimationsPageController::apply()
         return;
     }
     commitPending();
-    // commitPending is synchronous (just clears the snapshot map +
-    // dirty bit; the per-edit writes already hit disk through
-    // setOverride). Signal completion immediately so the chrome's
-    // applyAllAsync wait-counter ticks down.
+    // commitPending is synchronous (just clears the snapshot map; the
+    // per-edit writes already hit disk through setOverride, and shader-tree
+    // dirtiness is value-based against the committed baseline). Signal
+    // completion immediately so the chrome's applyAllAsync wait-counter ticks down.
     Q_EMIT applyResult(true, QString());
 }
 

--- a/src/settings/animationspagecontroller.h
+++ b/src/settings/animationspagecontroller.h
@@ -187,6 +187,27 @@ public:
     /// in both cases. A caller must not treat -1 as "nothing to clear".
     int clearAllOverrides();
 
+    /// Scoped sibling of clearAllOverrides for the per-page kebab: clear only the
+    /// override files at @p eventPaths (one settings page's own event-path
+    /// subtree), leaving every other page's overrides untouched. Same snapshot /
+    /// return-code contract as clearAllOverrides (-1 = refused or partial). @p
+    /// eventPaths must be built-in event paths; non-built-in entries are skipped.
+    int clearOverridesUnder(const QStringList& eventPaths);
+
+    /// Scoped sibling of revertPending: restore ONLY the snapshotted override
+    /// files at @p eventPaths from their pre-edit content, leaving every other
+    /// page's staged file edits (and any preset / motion-set snapshots) pending.
+    /// Refuses (returns false) while an async discard owns the snapshot map. The
+    /// caller reverts the shader tree for the same paths separately (the tree is
+    /// Settings-owned; see the revertPending() caller contract). @return true
+    /// when every in-scope snapshot restored (or there were none).
+    bool revertPendingUnder(const QStringList& eventPaths);
+
+    /// True iff any of @p eventPaths carries a staged (snapshotted) override-file
+    /// edit — the file half of a per-page dirty check. The shader-tree half is a
+    /// value comparison the caller runs against committedShaderProfileTree().
+    bool hasScopedPendingFiles(const QStringList& eventPaths) const;
+
     /// Library of user-saved Profile presets. Each entry is a Profile JSON
     /// (`curve`, `duration`, `name`, …) sitting in the same `profiles/`
     /// dir as overrides — distinguished by the `name` field NOT matching
@@ -394,6 +415,14 @@ public:
     /// would double-dispatch, see settingscontroller_lifecycle.cpp).
     void commitPending();
 
+    /// Re-evaluate the value-based dirty state after an external commit point the
+    /// controller cannot observe on its own — chiefly Settings::save()'s
+    /// captureBaseline, which advances committedShaderProfileTree() without moving
+    /// the live tree (so no shaderProfileTreeChanged fires). SettingsController::
+    /// save() calls this right after m_settings.save(); the dirtyChanged forwarder
+    /// gates on an actual flip so a no-op refresh is free.
+    void refreshDirtyState();
+
     /// Restore every file in the snapshot to its pre-edit state and
     /// clear the snapshot. Called from `SettingsController::load()`
     /// (Discard). Emits `overrideChanged`/`userPresetsChanged`/
@@ -484,7 +513,6 @@ private:
     /// reflect GUI-thread state. Never alias them by reference —
     /// merging is done by key set in the worker's finished handler.
     QHash<QString, std::optional<QByteArray>> m_pendingFileSnapshots;
-    bool m_shaderTreeDirty = false;
     /// In-flight guard for asyncRevertPending — set true on dispatch
     /// and cleared in the QFutureWatcher::finished handler. A second
     /// asyncRevertPending invocation while a worker is running would
@@ -499,14 +527,6 @@ private:
     /// forward on this cached state keeps the framework's dirty
     /// Q_PROPERTY NOTIFY contract honest.
     bool m_lastHadPendingChanges = false;
-    /// Set to true while a controller-owned setter is mutating the
-    /// shader profile tree on m_settings. The shaderProfileTreeChanged
-    /// handler checks `m_mutatingShaderTree > 0` to distinguish our own
-    /// writes (which keep m_shaderTreeDirty true) from external reloads
-    /// (which should clear it). Counter, not bool: a nested re-entrant
-    /// write inside the same setShaderProfileTree call chain must not
-    /// prematurely clear the outer scope's protection.
-    int m_mutatingShaderTree = 0;
     /// Memoised eventSections() result — taxonomy is static for the
     /// process lifetime so subsequent QML rebinds reuse the same list.
     /// Populated lazily on first call. NOTE: if `ProfilePaths::

--- a/src/settings/animationspagecontroller_overrides.cpp
+++ b/src/settings/animationspagecontroller_overrides.cpp
@@ -288,4 +288,47 @@ int AnimationsPageController::clearAllOverrides()
     return cleared;
 }
 
+int AnimationsPageController::clearOverridesUnder(const QStringList& eventPaths)
+{
+    // Scoped clearAllOverrides: same refusal/partial contract, but only over the
+    // caller's own page subtree. clearOverride() is a no-op (false) for a path
+    // with no override file, so passing the full in-scope path list clears just
+    // the real overrides and snapshots each for a later Discard.
+    if (m_asyncRevertInFlight) {
+        qCWarning(lcConfig) << "clearOverridesUnder: refusing while an async discard is in flight";
+        Q_EMIT toastRequested(PhosphorI18n::tr("Cannot reset while a discard is in progress."));
+        return -1;
+    }
+    int cleared = 0;
+    int failed = 0;
+    for (const QString& path : eventPaths) {
+        if (!isValidEventPath(path))
+            continue;
+        if (clearOverride(path))
+            ++cleared;
+        else if (hasOverride(path))
+            ++failed;
+    }
+    if (failed > 0) {
+        qCWarning(lcConfig) << "clearOverridesUnder:" << failed << "override files could not be removed";
+        Q_EMIT toastRequested(PhosphorI18n::tr("Some animation overrides could not be reset."));
+        return -1;
+    }
+    return cleared;
+}
+
+bool AnimationsPageController::hasScopedPendingFiles(const QStringList& eventPaths) const
+{
+    // The file half of a per-page dirty check: any in-scope path whose override
+    // file carries a staged (snapshotted) edit. Keyed by the same file path
+    // setOverride/clearOverride snapshot under.
+    for (const QString& path : eventPaths) {
+        if (!isValidEventPath(path))
+            continue;
+        if (m_pendingFileSnapshots.contains(profileFilePath(path)))
+            return true;
+    }
+    return false;
+}
+
 } // namespace PlasmaZones

--- a/src/settings/animationspagecontroller_overrides.cpp
+++ b/src/settings/animationspagecontroller_overrides.cpp
@@ -141,8 +141,8 @@ bool AnimationsPageController::setOverride(const QString& path, const QVariantMa
     // taken before the worker started. A simultaneous setOverride on
     // a path the worker is processing would race: last writer wins on
     // disk (non-deterministic), and the worker's finished handler
-    // would clear the dirty bit afterward — silently dropping the
-    // user's concurrent edit. The QML chrome already gates the
+    // would drop this path's snapshot when it merges its results back,
+    // silently losing the user's concurrent edit. The QML chrome already gates the
     // editor controls on `discarding`, but defence-in-depth at the
     // C++ Q_INVOKABLE entry point protects programmatic callers.
     if (m_asyncRevertInFlight) {

--- a/src/settings/animationspagecontroller_shaders.cpp
+++ b/src/settings/animationspagecontroller_shaders.cpp
@@ -58,33 +58,6 @@ namespace PlasmaZones {
 // unqualified — matches the sibling main TU's using-declaration.
 using namespace animations_controller_detail;
 
-namespace {
-/// RAII scope guard for AnimationsPageController::m_mutatingShaderTree.
-/// Increments the depth on construction, decrements on destruction —
-/// including the exception path through setShaderProfileTree, where a
-/// bare set/clear pair would leave the depth stuck >0 and silently
-/// disable external-reload dirty clearance for the rest of the process.
-/// Counter (not flag): the NOTIFY-driven external-reload handler's
-/// guard checks `depth > 0`, so a nested re-entrant write (inner scope
-/// destructs first) does NOT prematurely clear the outer's protection.
-struct MutatingShaderTreeScope
-{
-    int& depth;
-    explicit MutatingShaderTreeScope(int& d)
-        : depth(d)
-    {
-        ++depth;
-    }
-    ~MutatingShaderTreeScope()
-    {
-        --depth;
-    }
-    MutatingShaderTreeScope(const MutatingShaderTreeScope&) = delete;
-    MutatingShaderTreeScope& operator=(const MutatingShaderTreeScope&) = delete;
-};
-
-} // namespace
-
 bool AnimationsPageController::supportsShaderLeg(const QString& path) const
 {
     return eventPathSupportsShaderLeg(path);
@@ -316,12 +289,9 @@ bool AnimationsPageController::setShaderOverride(const QString& path, const QStr
         if (tree.directOverride(path) == disabledProfile)
             return true;
         tree.setOverride(path, disabledProfile);
-        {
-            MutatingShaderTreeScope guard(m_mutatingShaderTree);
-            m_settings->setShaderProfileTree(tree);
-        }
-        m_shaderTreeDirty = true;
-        Q_EMIT pendingChangesChanged();
+        m_settings->setShaderProfileTree(tree);
+        // pendingChangesChanged is emitted by the shaderProfileTreeChanged
+        // handler (the sole emitter for tree edits); dirtiness is value-based.
         return true;
     }
 
@@ -356,12 +326,8 @@ bool AnimationsPageController::setShaderOverride(const QString& path, const QStr
     if (tree.directOverride(path) == profile)
         return true;
     tree.setOverride(path, profile);
-    {
-        MutatingShaderTreeScope guard(m_mutatingShaderTree);
-        m_settings->setShaderProfileTree(tree);
-    }
-    m_shaderTreeDirty = true;
-    Q_EMIT pendingChangesChanged();
+    m_settings->setShaderProfileTree(tree);
+    // pendingChangesChanged is emitted by the shaderProfileTreeChanged handler.
     return true;
 }
 
@@ -378,12 +344,8 @@ bool AnimationsPageController::clearShaderOverride(const QString& path)
     if (!tree.hasOverride(path))
         return false;
     tree.clearOverride(path);
-    {
-        MutatingShaderTreeScope guard(m_mutatingShaderTree);
-        m_settings->setShaderProfileTree(tree);
-    }
-    m_shaderTreeDirty = true;
-    Q_EMIT pendingChangesChanged();
+    m_settings->setShaderProfileTree(tree);
+    // pendingChangesChanged is emitted by the shaderProfileTreeChanged handler.
     return true;
 }
 
@@ -413,12 +375,8 @@ int AnimationsPageController::clearShaderOverrideDescendants(const QString& path
         return 0;
     for (const QString& p : toClear)
         tree.clearOverride(p);
-    {
-        MutatingShaderTreeScope guard(m_mutatingShaderTree);
-        m_settings->setShaderProfileTree(tree);
-    }
-    m_shaderTreeDirty = true;
-    Q_EMIT pendingChangesChanged();
+    m_settings->setShaderProfileTree(tree);
+    // pendingChangesChanged is emitted by the shaderProfileTreeChanged handler.
     return toClear.size();
 }
 

--- a/src/settings/settingscontroller_lifecycle.cpp
+++ b/src/settings/settingscontroller_lifecycle.cpp
@@ -136,6 +136,14 @@ void SettingsController::save()
     // Save main settings (includes editor settings + VS configs persisted above)
     m_settings.save();
 
+    // save() re-captured the committed baseline, so the animation controller's
+    // value-based shader-tree dirty check must re-evaluate: apply() (commitPending)
+    // may have run earlier in the domain walk, while the tree still read
+    // "divergent" against the not-yet-recaptured baseline. This is a no-op flip
+    // guard away from free when nothing changed.
+    if (m_animationsPage != nullptr)
+        m_animationsPage->refreshDirtyState();
+
     // RuleController and AnimationsPageController are registered
     // as their own StagingDomains and the framework's applyAllAsync
     // walks them directly. Both registrations happen in

--- a/src/settings/settingscontroller_pagestate.cpp
+++ b/src/settings/settingscontroller_pagestate.cpp
@@ -15,6 +15,10 @@
 
 #include "../core/logging.h"
 
+#include <PhosphorAnimation/ProfilePaths.h>
+#include <PhosphorAnimation/ShaderProfileTree.h>
+#include <PhosphorSurface/DecorationProfileTree.h>
+
 #include <QDebug>
 
 namespace PlasmaZones {
@@ -42,28 +46,29 @@ bool isShortcutsPage(const QString& page)
 // Quick-layout slots are numbered 1..9 (see SettingsController::getQuickLayoutSlot).
 constexpr int kQuickLayoutSlotCount = 9;
 
-// Every animation leaf shares the single AnimationsPageController staging
-// domain (there is no per-subpage granularity), so pageGroupChildren("animations")
-// — the canonical leaf set — identifies them all. Discard reverts the whole tree.
+// Every animation leaf shares the single AnimationsPageController staging domain
+// AND the single ShaderProfileTree key, but Reset/Discard/dirty are NOT
+// whole-tree: each surface leaf (windows/osds/overlays/desktops/motion/dragging/
+// panels/widgets/editor) owns one event-path subtree (see animationPageScope),
+// the general leaf owns only the config keys, and the sets/shaders library leaves
+// act on the whole editable tree. Scoping keeps a Reset on one surface from
+// wiping the others (mirrors the decoration domain below).
 bool isAnimationPage(const QString& page)
 {
     return SettingsController::pageGroupChildren().value(QStringLiteral("animations")).contains(page);
 }
 
-// The animation-tree config keys (Animations + Animations.WindowFiltering
-// groups). revertPending() covers the per-event override FILES and the
-// shader-tree dirty flag, but the caller contract (see revertPending()) says
-// the in-memory Settings keys — shader tree, animation Profile blob, window
-// filtering — are NOT reverted there; a follow-up must revert them, exactly
-// what discardKeys() does. Kept together here as the animation "value" surface,
-// paired with revertPending() for the full discard.
-const Settings::ConfigKeyList& animationConfigKeys()
+// The animation config keys OTHER than the per-event surfaces: the global
+// enable, the baseline motion Profile blob, and window filtering. Owned by the
+// Animations → General leaf. The ShaderProfileTree key is deliberately ABSENT —
+// it is per-event state scoped through animationPageScope, not a General-page
+// key. (The per-event override FILES are likewise not config keys.)
+const Settings::ConfigKeyList& animationGeneralConfigKeys()
 {
     using CD = ConfigDefaults;
     static const Settings::ConfigKeyList keys{
         {CD::animationsGroup(), CD::enabledKey()},
         {CD::animationsGroup(), CD::animationProfileKey()},
-        {CD::animationsGroup(), CD::shaderProfileTreeKey()},
         {CD::animationsWindowFilteringGroup(), CD::transientWindowsKey()},
         {CD::animationsWindowFilteringGroup(), CD::notificationsAndOsdKey()},
         {CD::animationsWindowFilteringGroup(), CD::minimumWindowWidthKey()},
@@ -72,14 +77,179 @@ const Settings::ConfigKeyList& animationConfigKeys()
     return keys;
 }
 
-// Every decoration leaf edits the single shared DecorationProfileTree settings
-// key (one JSON blob covering windows + OSDs + popups), so
+// The WHOLE animation "value" surface — General's keys PLUS the ShaderProfileTree
+// key. Used only by the non-surface library leaves (sets/shaders), whose
+// Reset/Discard act on the entire editable tree (paired with clearAllOverrides /
+// revertPending for the per-event FILES).
+const Settings::ConfigKeyList& animationConfigKeys()
+{
+    using CD = ConfigDefaults;
+    static const Settings::ConfigKeyList keys = []() {
+        Settings::ConfigKeyList k = animationGeneralConfigKeys();
+        k.append({CD::animationsGroup(), CD::shaderProfileTreeKey()});
+        return k;
+    }();
+    return keys;
+}
+
+// The per-page scope of an animation leaf. A surface leaf owns one event-path
+// root subtree (some with a carve-out); General owns only config keys; the
+// library leaves own the whole tree.
+struct AnimationPageScope
+{
+    enum Kind {
+        EventSubtree,
+        ConfigOnly,
+        WholeTree
+    };
+    Kind kind = WholeTree;
+    // For EventSubtree: a path is in scope iff it is under an `include` root AND
+    // not under an `exclude` root. window.movement (Motion) EXCLUDES
+    // window.movement.move, which the Dragging page owns — the one carve-out.
+    QStringList include;
+    QStringList exclude;
+};
+
+AnimationPageScope animationPageScope(const QString& page)
+{
+    if (page == QLatin1String("animations-general"))
+        return {AnimationPageScope::ConfigOnly, {}, {}};
+    // Roots mirror the surfacePath prefixes the QML pages bind and the
+    // ProfilePaths taxonomy. Keep in lockstep with the *Page.qml event lists.
+    static const QHash<QString, QPair<QStringList, QStringList>> kEventRoots{
+        {QStringLiteral("animations-windows"), {{QStringLiteral("window.appearance")}, {}}},
+        {QStringLiteral("animations-window-motion"),
+         {{QStringLiteral("window.movement")}, {QStringLiteral("window.movement.move")}}},
+        {QStringLiteral("animations-window-dragging"), {{QStringLiteral("window.movement.move")}, {}}},
+        {QStringLiteral("animations-osds"), {{QStringLiteral("osd")}, {}}},
+        {QStringLiteral("animations-overlays"), {{QStringLiteral("popup")}, {}}},
+        {QStringLiteral("animations-desktops"), {{QStringLiteral("desktop")}, {}}},
+        {QStringLiteral("animations-side-panels"), {{QStringLiteral("panel")}, {}}},
+        {QStringLiteral("animations-widgets"), {{QStringLiteral("widget")}, {}}},
+        {QStringLiteral("animations-editor"), {{QStringLiteral("editor")}, {}}},
+    };
+    const auto it = kEventRoots.constFind(page);
+    if (it != kEventRoots.cend())
+        return {AnimationPageScope::EventSubtree, it->first, it->second};
+    // animations-presets / animations-motionsets / animations-shaders.
+    return {AnimationPageScope::WholeTree, {}, {}};
+}
+
+// True iff @p path is @p root or a descendant of it, for any root in @p roots.
+bool animationPathUnderAny(const QString& path, const QStringList& roots)
+{
+    for (const QString& root : roots) {
+        if (path == root || path.startsWith(root + QLatin1Char('.')))
+            return true;
+    }
+    return false;
+}
+
+// True iff @p path falls inside an EventSubtree scope (under an include root,
+// clear of every exclude root).
+bool animationPathInScope(const QString& path, const AnimationPageScope& scope)
+{
+    return animationPathUnderAny(path, scope.include) && !animationPathUnderAny(path, scope.exclude);
+}
+
+// Built-in event paths that fall inside @p scope — the file-backed paths a
+// surface leaf's Reset/Discard/dirty acts on.
+QStringList animationScopedBuiltInPaths(const AnimationPageScope& scope)
+{
+    QStringList out;
+    for (const QString& path : PhosphorAnimation::ProfilePaths::allBuiltInPaths()) {
+        if (animationPathInScope(path, scope))
+            out.append(path);
+    }
+    return out;
+}
+
+// True iff the two shader trees' overrides differ anywhere inside @p scope. Walks
+// the union of both trees' overridden paths (so an override present in one and
+// absent in the other counts) filtered to the scope — this also catches
+// plugin-added paths that allBuiltInPaths() would miss.
+bool shaderTreeScopeDiffers(const PhosphorAnimationShaders::ShaderProfileTree& current,
+                            const PhosphorAnimationShaders::ShaderProfileTree& baseline,
+                            const AnimationPageScope& scope)
+{
+    QSet<QString> paths;
+    for (const QString& p : current.overriddenPaths())
+        if (animationPathInScope(p, scope))
+            paths.insert(p);
+    for (const QString& p : baseline.overriddenPaths())
+        if (animationPathInScope(p, scope))
+            paths.insert(p);
+    for (const QString& p : paths) {
+        if (current.hasOverride(p) != baseline.hasOverride(p))
+            return true;
+        if (current.directOverride(p) != baseline.directOverride(p))
+            return true;
+    }
+    return false;
+}
+
+// Every decoration leaf reads/writes the single shared DecorationProfileTree
+// settings key (one JSON blob covering windows + OSDs + popups), so
 // pageGroupChildren("decorations") — the canonical leaf set — identifies them
-// all and Reset/Discard act on the whole tree, mirroring the animation shared
-// domain above.
+// all. Reset/Discard/dirty are NOT whole-tree, though: the three surface pages
+// each own one root subtree (see decorationSurfaceRoot), so resetting OSDs must
+// not touch the Windows overrides. Only the sets/shaders library leaves act on
+// the whole editable tree.
 bool isDecorationPage(const QString& page)
 {
     return SettingsController::pageGroupChildren().value(QStringLiteral("decorations")).contains(page);
+}
+
+// The DecorationProfileTree root a decoration surface page owns. The three
+// surface pages each edit exactly one root subtree — "window" (+ .tiled/.snapped/
+// .floating), "osd", or "popup" (+ .snapAssist/.zoneSelector/.layoutPicker) — so
+// per-page Reset/Discard/dirty must be scoped to that root or one surface's
+// revert clobbers the others (the bug this mapping fixes). The roots mirror the
+// surfacePath prefixes the QML pages bind (DecorationWindowsPage etc.) and the
+// DecorationSupportedPaths taxonomy. Returns an empty string for the non-surface
+// decoration leaves — the sets library and the read-only shaders browser — whose
+// Reset/Discard/dirty act on the whole editable tree (every root at once).
+QString decorationSurfaceRoot(const QString& page)
+{
+    static const QHash<QString, QString> roots{
+        {QStringLiteral("decorations-windows"), QStringLiteral("window")},
+        {QStringLiteral("decorations-osds"), QStringLiteral("osd")},
+        {QStringLiteral("decorations-popups"), QStringLiteral("popup")},
+    };
+    return roots.value(page);
+}
+
+// True iff @p path is @p root itself or a descendant of it ("window" owns
+// "window", "window.tiled", …; "osd" owns only "osd"). The dot guard keeps a
+// sibling root with a shared prefix from leaking in — there are none today, but
+// it costs nothing and documents the intent.
+bool decorationPathInRoot(const QString& path, const QString& root)
+{
+    return path == root || path.startsWith(root + QLatin1Char('.'));
+}
+
+// True iff the two trees' direct overrides differ anywhere under @p root. The
+// baseline (path "") is never under a surface root, so it is correctly excluded
+// — no surface page edits the global baseline (decoration sets carry none
+// either; see decorationpagecontroller_sets.cpp). Walks the union of both trees'
+// overridden paths so an override PRESENT in one and ABSENT in the other counts.
+bool decorationRootDiffers(const PhosphorSurfaceShaders::DecorationProfileTree& current,
+                           const PhosphorSurfaceShaders::DecorationProfileTree& baseline, const QString& root)
+{
+    QSet<QString> paths;
+    for (const QString& p : current.overriddenPaths())
+        if (decorationPathInRoot(p, root))
+            paths.insert(p);
+    for (const QString& p : baseline.overriddenPaths())
+        if (decorationPathInRoot(p, root))
+            paths.insert(p);
+    for (const QString& p : paths) {
+        if (current.hasOverride(p) != baseline.hasOverride(p))
+            return true;
+        if (current.directOverride(p) != baseline.directOverride(p))
+            return true;
+    }
+    return false;
 }
 
 // The decoration "value" surface: one Store-backed key. It cannot ride the
@@ -288,13 +458,30 @@ bool SettingsController::isPageDirty(const QString& page) const
         return m_staging.hasStagedVirtualScreenConfigs();
     }
 
-    // Animation pages share one staging domain, so any of them is dirty exactly
-    // when the tree has unsaved edits. Value-based like the manifest pages, so
-    // the badge and the kebab's Discard-enabled state stay correct on every
-    // subpage. Two sources: the controller's file/shader-tree pending state
-    // (hasPendingChanges) AND the plain animation Settings keys (profile,
-    // shader tree value, window filtering) tracked against the baseline.
+    // Animation pages share one staging domain and one ShaderProfileTree key, but
+    // dirty is value-based PER SCOPE so a revert on one surface never lights
+    // another's badge (mirrors the decoration domain below). A surface leaf is
+    // dirty iff its own event subtree carries a staged override FILE or its shader
+    // tree diverges from baseline within scope; General is dirty iff its config
+    // keys diverge; the library leaves fall back to whole-tree (any file or key
+    // edit shows there).
     if (isAnimationPage(page)) {
+        const AnimationPageScope scope = animationPageScope(page);
+        if (scope.kind == AnimationPageScope::ConfigOnly) {
+            for (const auto& gk : animationGeneralConfigKeys()) {
+                if (m_settings.isKeyModified(gk.first, gk.second))
+                    return true;
+            }
+            return false;
+        }
+        if (scope.kind == AnimationPageScope::EventSubtree) {
+            if (m_animationsPage != nullptr
+                && m_animationsPage->hasScopedPendingFiles(animationScopedBuiltInPaths(scope)))
+                return true;
+            return shaderTreeScopeDiffers(m_settings.shaderProfileTree(), m_settings.committedShaderProfileTree(),
+                                          scope);
+        }
+        // WholeTree library leaves (sets / shaders).
         if (m_animationsPage != nullptr && m_animationsPage->hasPendingChanges())
             return true;
         for (const auto& gk : animationConfigKeys()) {
@@ -304,14 +491,20 @@ bool SettingsController::isPageDirty(const QString& page) const
         return false;
     }
 
-    // Decoration pages share the single DecorationProfileTree key — value-based
-    // like the manifest pages (see decorationConfigKeys for why the key can't
-    // live in the manifest itself). Every tree-backed decoration leaf
-    // (windows/osds/popups plus the sets and shaders library pages; the
+    // Decoration pages share the single DecorationProfileTree key but are
+    // value-based per SURFACE ROOT: a surface page (windows/osds/popups) is dirty
+    // iff its own root subtree differs from the committed baseline, so a revert on
+    // one surface never lights another's badge. The non-surface leaves (sets
+    // library, read-only shaders browser) have no root of their own, so they fall
+    // back to whole-tree dirty — any decoration edit shows there. The
     // manifest-owned window-appearance leaf is handled by the manifest branch
-    // above) reports the same state, matching the shared-domain semantics: an
-    // edit on any decoration page is an edit of the one tree.
+    // above.
     if (isDecorationPage(page)) {
+        const QString root = decorationSurfaceRoot(page);
+        if (!root.isEmpty()) {
+            return decorationRootDiffers(m_settings.decorationProfileTree(),
+                                         m_settings.committedDecorationProfileTree(), root);
+        }
         for (const auto& gk : decorationConfigKeys()) {
             if (m_settings.isKeyModified(gk.first, gk.second))
                 return true;
@@ -347,8 +540,9 @@ bool SettingsController::pageSupportsReset(const QString& page) const
     // appearance page, whose Windows.* + Gaps.* keys are in the manifest); ordering
     // pages drop the custom order; shortcuts pages unassign every quick slot; the
     // virtual screens page unsplits every monitor; animation pages clear every
-    // per-event override and reset the animation config keys; decoration pages
-    // reset the shared DecorationProfileTree key.
+    // per-event override and reset the animation config keys; decoration surface
+    // pages clear their own root subtree of the DecorationProfileTree (the
+    // sets/shaders leaves the whole key).
     return pageOwnedConfigKeys().contains(page) || isOrderingPage(page) || isShortcutsPage(page)
         || page == QLatin1String("virtualscreens") || isAnimationPage(page) || isDecorationPage(page);
 }
@@ -450,62 +644,89 @@ void SettingsController::resetPage(const QString& page)
         }
     }
 
-    // Animation pages (whole tree, shared domain): reset to defaults =
-    // clear every per-event override file AND reset the animation config keys
-    // (Profile, ShaderProfileTree, WindowFiltering, Enabled) to their
-    // schema defaults. Both are STAGED like ordinary animation edits — the
-    // cleared files are snapshotted, so a subsequent Discard restores them, and
-    // Save commits. User presets / motion-set libraries are left alone (like
-    // user rules on the Rules page). Suppress onSettingsPropertyChanged during
-    // the config reset; mark the active page dirty explicitly below.
+    // Animation pages: reset to defaults, scoped like the decoration domain
+    // below. A SURFACE leaf clears only its own event subtree — its per-event
+    // override FILES and its shader-tree overrides — leaving the other surfaces,
+    // General's config keys, and the library untouched. General resets only its
+    // config keys (enable / motion Profile / filtering). A library leaf resets
+    // the whole tree (every file + every animation key). All staged like ordinary
+    // edits: cleared files are snapshotted so Discard restores them, and Save
+    // commits. Suppress onSettingsPropertyChanged during the reset; reconcile the
+    // whole animation leaf set below (a scoped reset can flip a sibling's badge,
+    // and any stale m_dirtyPages entry must clear too).
     if (isAnimationPage(page)) {
+        const AnimationPageScope scope = animationPageScope(page);
         {
             const LoadingScope loadingScope(m_loading);
-            // -1 means the reset did not complete (refused mid-discard, or some
-            // override files could not be removed), so resetting the config keys
-            // would leave the page half reset and reported clean. The page has
-            // already toasted the reason; the user can retry once it is resolved.
-            if (m_animationsPage != nullptr && m_animationsPage->clearAllOverrides() < 0) {
-                // A partial failure may have cleared and staged some overrides
-                // before the survivor; reconcile so the footer's needsSave
-                // matches the page badges (this call is not m_loading-gated,
-                // and it is a no-op for the untouched mid-discard refusal).
-                // The config keys stay un-reset; a retry finishes the job.
-                reconcilePagesDirty(pageGroupChildren().value(QStringLiteral("animations")));
-                return;
+            if (scope.kind == AnimationPageScope::ConfigOnly) {
+                m_settings.resetKeys(animationGeneralConfigKeys());
+            } else if (scope.kind == AnimationPageScope::EventSubtree) {
+                // Files first. -1 means the clear did not complete (refused
+                // mid-discard, or a file could not be removed): leave the shader
+                // tree un-reset so the page stays visibly dirty for a retry rather
+                // than reporting a half-done reset as clean. The page toasts why.
+                if (m_animationsPage != nullptr
+                    && m_animationsPage->clearOverridesUnder(animationScopedBuiltInPaths(scope)) < 0) {
+                    reconcilePagesDirty(pageGroupChildren().value(QStringLiteral("animations")));
+                    return;
+                }
+                // Shader tree: clear only this scope's overrides (default = none).
+                PhosphorAnimationShaders::ShaderProfileTree tree = m_settings.shaderProfileTree();
+                bool changed = false;
+                const QStringList overridden = tree.overriddenPaths();
+                for (const QString& path : overridden) {
+                    if (animationPathInScope(path, scope) && tree.clearOverride(path))
+                        changed = true;
+                }
+                if (changed)
+                    m_settings.setShaderProfileTree(tree);
+            } else {
+                // WholeTree library leaf: files + every animation key.
+                if (m_animationsPage != nullptr && m_animationsPage->clearAllOverrides() < 0) {
+                    reconcilePagesDirty(pageGroupChildren().value(QStringLiteral("animations")));
+                    return;
+                }
+                m_settings.resetKeys(animationConfigKeys());
             }
-            // Outside the page-controller null check: the config keys are settings
-            // state and do not depend on the page controller existing.
-            m_settings.resetKeys(animationConfigKeys());
         }
-        // isPageDirty(animation) is value-based (hasPendingChanges || any
-        // animation key modified). Reconcile EVERY animation leaf, not just the
-        // active page: the shared domain means an edit made while a sibling
-        // subpage was active left ITS m_dirtyPages entry behind, and a reset
-        // that lands back on the committed baseline must clear those too or
-        // needsSave() sticks true with no badge to explain it. Batched so
-        // dirtyPagesChanged fires at most once (like the discard path).
         reconcilePagesDirty(pageGroupChildren().value(QStringLiteral("animations")));
         return;
     }
 
-    // Decoration pages (whole tree, shared domain): reset the single
-    // DecorationProfileTree key to its schema default — the empty/neutral tree
-    // (borders are rule-owned; the tree carries only opt-in shader-pack
-    // decoration). Staged like ordinary edits: Save commits, Discard restores
-    // the baseline. Same NOTIFY-storm suppression as the manifest path.
+    // Decoration pages: reset to the schema default (the empty/neutral tree —
+    // borders are rule-owned, the tree carries only opt-in shader-pack
+    // decoration). A SURFACE page clears only its own root subtree's overrides,
+    // leaving the other two roots (and the global baseline) standing; a
+    // non-surface leaf (sets/shaders, empty root) resets the whole tree key.
+    // Staged like ordinary edits: Save commits, Discard restores the baseline.
+    // Same NOTIFY-storm suppression as the manifest path.
     if (isDecorationPage(page)) {
         {
             const LoadingScope loadingScope(m_loading);
-            m_settings.resetKeys(decorationConfigKeys());
+            const QString root = decorationSurfaceRoot(page);
+            if (root.isEmpty()) {
+                m_settings.resetKeys(decorationConfigKeys());
+            } else {
+                PhosphorSurfaceShaders::DecorationProfileTree tree = m_settings.decorationProfileTree();
+                bool changed = false;
+                // overriddenPaths() returns a copy, so clearing during the walk
+                // is safe. Only this root's overrides go; the default for a
+                // surface subtree is "no overrides".
+                const QStringList paths = tree.overriddenPaths();
+                for (const QString& path : paths) {
+                    if (decorationPathInRoot(path, root) && tree.clearOverride(path))
+                        changed = true;
+                }
+                if (changed)
+                    m_settings.setDecorationProfileTree(tree);
+            }
         }
         // isPageDirty(decoration) is value-based. Reconcile EVERY decoration
-        // leaf, not just the active page: the shared key means an edit made
-        // while a sibling leaf was active left ITS m_dirtyPages entry behind,
-        // and a reset that lands back on the committed baseline must clear
-        // those too or needsSave() sticks true with no badge to explain it
-        // (mirrors the discardPage decoration branch). Batched so
-        // dirtyPagesChanged fires at most once.
+        // leaf, not just the active page: a subtree reset can flip a sibling
+        // parent/child leaf's badge, and any stale m_dirtyPages entry left by an
+        // edit made while another leaf was active must clear too or needsSave()
+        // sticks true with no badge to explain it (mirrors the discardPage
+        // decoration branch). Batched so dirtyPagesChanged fires at most once.
         reconcilePagesDirty(pageGroupChildren().value(QStringLiteral("decorations")));
         return;
     }
@@ -633,44 +854,112 @@ void SettingsController::discardPage(const QString& page)
         return;
     }
 
-    // Animation pages share one staging domain — discard reverts the whole tree
-    // in two halves. revertPending() restores the per-event override FILES and
-    // clears the shader-tree dirty flag; discardKeys() reverts the in-memory
-    // animation Settings keys (shader-tree value, Profile blob, window filtering)
-    // the revertPending() contract explicitly leaves for a follow-up. Reverting
-    // shaderProfileTree re-emits shaderProfileTreeChanged, which the controller
-    // observes to refresh — the load()-equivalent that contract requires.
+    // Animation pages: discard reverts to the committed baseline, scoped like the
+    // decoration domain below. A SURFACE leaf reverts only its own event subtree —
+    // its override FILES (revertPendingUnder) and its shader-tree paths (restored
+    // to baseline) — so discarding OSDs cannot drop a pending Windows edit.
+    // General reverts only its config keys. A library leaf reverts the whole tree
+    // (all files via revertPending + every animation key via discardKeys).
+    // Reverting the shader tree re-emits shaderProfileTreeChanged, which the
+    // controller observes to refresh the cards.
     if (isAnimationPage(page)) {
-        if (m_animationsPage != nullptr) {
-            m_animationsPage->revertPending();
-        }
-        {
+        const AnimationPageScope scope = animationPageScope(page);
+        if (scope.kind == AnimationPageScope::ConfigOnly) {
+            {
+                const LoadingScope loadingScope(m_loading);
+                m_settings.discardKeys(animationGeneralConfigKeys());
+            }
+        } else if (scope.kind == AnimationPageScope::EventSubtree) {
+            if (m_animationsPage != nullptr)
+                m_animationsPage->revertPendingUnder(animationScopedBuiltInPaths(scope));
+            // Shader tree: restore only this scope's paths to their baseline value
+            // (re-add / change / remove), leaving the other surfaces' staged edits.
+            const LoadingScope loadingScope(m_loading);
+            PhosphorAnimationShaders::ShaderProfileTree current = m_settings.shaderProfileTree();
+            const PhosphorAnimationShaders::ShaderProfileTree baseline = m_settings.committedShaderProfileTree();
+            QSet<QString> paths;
+            for (const QString& p : current.overriddenPaths())
+                if (animationPathInScope(p, scope))
+                    paths.insert(p);
+            for (const QString& p : baseline.overriddenPaths())
+                if (animationPathInScope(p, scope))
+                    paths.insert(p);
+            bool changed = false;
+            for (const QString& path : paths) {
+                if (baseline.hasOverride(path)) {
+                    const auto committed = baseline.directOverride(path);
+                    if (!current.hasOverride(path) || current.directOverride(path) != committed) {
+                        current.setOverride(path, committed);
+                        changed = true;
+                    }
+                } else if (current.clearOverride(path)) {
+                    changed = true;
+                }
+            }
+            if (changed)
+                m_settings.setShaderProfileTree(current);
+        } else {
+            // WholeTree library leaf.
+            if (m_animationsPage != nullptr)
+                m_animationsPage->revertPending();
             const LoadingScope loadingScope(m_loading);
             m_settings.discardKeys(animationConfigKeys());
         }
-        // Reconcile every animation leaf against the value-based truth so the
-        // global needsSave drops the entries the pendingChangesChanged handler
-        // had attributed to the tree. Value-based on purpose: revertPending()
-        // does not always leave hasPendingChanges() false (it refuses outright
-        // while an async discard is in flight, and it retains a file whose
-        // restore failed so a retry can pick it up). Batched: one emission at most.
+        // Reconcile every animation leaf against the value-based truth (this
+        // surface clean post-discard; siblings unchanged). Value-based on purpose:
+        // revertPendingUnder can refuse mid-async or retain a failed restore.
+        // Batched: one emission at most.
         reconcilePagesDirty(pageGroupChildren().value(QStringLiteral("animations")));
         return;
     }
 
-    // Decoration pages share the single DecorationProfileTree key — discard
-    // reverts it to the committed baseline. discardKeys re-emits
-    // decorationProfileTreeChanged, which DecorationPageController forwards as
-    // profilesChanged so the open cards refresh. Clear every decoration leaf's
-    // stale m_dirtyPages marker: the shared key means one leaf's edit may have
-    // badged the others.
+    // Decoration pages: discard reverts to the committed baseline. A SURFACE page
+    // reverts only its own root subtree — each such path is restored to the
+    // baseline's value (re-added, changed, or removed) while the other two roots'
+    // staged edits stand — so discarding OSDs cannot drop a pending Windows edit.
+    // A non-surface leaf (sets/shaders, empty root) reverts the whole tree key via
+    // discardKeys. Either way the setDecorationProfileTree / discardKeys write
+    // re-emits decorationProfileTreeChanged, which DecorationPageController
+    // forwards as profilesChanged so the open cards refresh.
     if (isDecorationPage(page)) {
         {
             const LoadingScope loadingScope(m_loading);
-            m_settings.discardKeys(decorationConfigKeys());
+            const QString root = decorationSurfaceRoot(page);
+            if (root.isEmpty()) {
+                m_settings.discardKeys(decorationConfigKeys());
+            } else {
+                PhosphorSurfaceShaders::DecorationProfileTree current = m_settings.decorationProfileTree();
+                const PhosphorSurfaceShaders::DecorationProfileTree baseline =
+                    m_settings.committedDecorationProfileTree();
+                // Union of this root's overridden paths across both trees so a
+                // path that only exists in one (a staged add, or a baseline
+                // override the user cleared) is reconciled in the right direction.
+                QSet<QString> paths;
+                for (const QString& p : current.overriddenPaths())
+                    if (decorationPathInRoot(p, root))
+                        paths.insert(p);
+                for (const QString& p : baseline.overriddenPaths())
+                    if (decorationPathInRoot(p, root))
+                        paths.insert(p);
+                bool changed = false;
+                for (const QString& path : paths) {
+                    if (baseline.hasOverride(path)) {
+                        const auto committed = baseline.directOverride(path);
+                        if (!current.hasOverride(path) || current.directOverride(path) != committed) {
+                            current.setOverride(path, committed);
+                            changed = true;
+                        }
+                    } else if (current.clearOverride(path)) {
+                        changed = true;
+                    }
+                }
+                if (changed)
+                    m_settings.setDecorationProfileTree(current);
+            }
         }
-        // Reconcile every decoration leaf against the value-based truth (all
-        // clean post-discard). Batched: one emission at most.
+        // Reconcile every decoration leaf against the value-based truth (this
+        // surface clean post-discard; siblings unchanged). Batched: one emission
+        // at most.
         reconcilePagesDirty(pageGroupChildren().value(QStringLiteral("decorations")));
         return;
     }

--- a/tests/unit/config/test_settings_decoration_tree.cpp
+++ b/tests/unit/config/test_settings_decoration_tree.cpp
@@ -230,6 +230,34 @@ private Q_SLOTS:
         QCOMPARE(spy.count(), 0);
         QCOMPARE(settings.decorationProfileTree(), tree);
     }
+
+    /// committedDecorationProfileTree() is the baseline the per-surface
+    /// decoration dirty check and scoped Discard compare against. It must track
+    /// the last load/save commit, NOT live edits — setDecorationProfileTree
+    /// persists to the store immediately but does not re-baseline, so live and
+    /// committed diverge until save(). A regression here silently breaks
+    /// per-page dirty/Discard for the decoration surface pages.
+    void testCommittedDecorationProfileTree_tracksBaselineNotLiveEdits()
+    {
+        IsolatedConfigGuard guard;
+        Settings a;
+
+        // Fresh load: committed baseline equals the live tree (the ConfigDefaults
+        // default), and carries no window.tiled override.
+        QVERIFY(a.committedDecorationProfileTree() == a.decorationProfileTree());
+        QVERIFY(!a.committedDecorationProfileTree().hasOverride(QStringLiteral("window.tiled")));
+
+        // Edit without save: live gains the window.tiled leaf; committed holds.
+        a.setDecorationProfileTree(makeBaselinePlusLeafTree());
+        QVERIFY(a.decorationProfileTree().hasOverride(QStringLiteral("window.tiled")));
+        QVERIFY(!a.committedDecorationProfileTree().hasOverride(QStringLiteral("window.tiled")));
+        QVERIFY(a.decorationProfileTree() != a.committedDecorationProfileTree());
+
+        // save() re-captures the baseline: committed catches up to live.
+        a.save();
+        QVERIFY(a.committedDecorationProfileTree().hasOverride(QStringLiteral("window.tiled")));
+        QVERIFY(a.committedDecorationProfileTree() == a.decorationProfileTree());
+    }
 };
 
 QTEST_MAIN(TestSettingsDecorationTree)

--- a/tests/unit/config/test_settings_shader_tree.cpp
+++ b/tests/unit/config/test_settings_shader_tree.cpp
@@ -331,6 +331,39 @@ private Q_SLOTS:
         Settings reloaded;
         QCOMPARE(reloaded.autoAssignAllLayouts(), true);
     }
+
+    /// committedShaderProfileTree() is the baseline the per-surface animation
+    /// dirty check compares the live tree against. It must track the last
+    /// load/save commit, NOT live edits — a setShaderProfileTree write persists
+    /// to the store immediately but does not re-baseline, so live and committed
+    /// diverge until the next save(). This is the mechanism that replaced the
+    /// old sticky m_shaderTreeDirty flag; a regression here silently breaks
+    /// per-page dirty/Discard for every animation surface.
+    void testCommittedShaderProfileTree_tracksBaselineNotLiveEdits()
+    {
+        IsolatedConfigGuard guard;
+        Settings a;
+
+        // Fresh load: committed baseline equals the live tree.
+        QVERIFY(a.committedShaderProfileTree() == a.shaderProfileTree());
+        QVERIFY(!a.committedShaderProfileTree().hasOverride(QStringLiteral("osd.show")));
+
+        // Edit without save: the live tree gains the override; the committed
+        // baseline holds its pre-edit value, so the two diverge.
+        PhosphorAnimationShaders::ShaderProfileTree tree;
+        PhosphorAnimationShaders::ShaderProfile profile;
+        profile.effectId = QStringLiteral("pixelate");
+        tree.setOverride(QStringLiteral("osd.show"), profile);
+        a.setShaderProfileTree(tree);
+        QVERIFY(a.shaderProfileTree().hasOverride(QStringLiteral("osd.show")));
+        QVERIFY(!a.committedShaderProfileTree().hasOverride(QStringLiteral("osd.show")));
+        QVERIFY(a.shaderProfileTree() != a.committedShaderProfileTree());
+
+        // save() re-captures the baseline: committed catches up to live.
+        a.save();
+        QVERIFY(a.committedShaderProfileTree().hasOverride(QStringLiteral("osd.show")));
+        QVERIFY(a.committedShaderProfileTree() == a.shaderProfileTree());
+    }
 };
 
 QTEST_MAIN(TestSettingsShaderTree)

--- a/tests/unit/settings/test_animations_page_controller.cpp
+++ b/tests/unit/settings/test_animations_page_controller.cpp
@@ -299,6 +299,75 @@ private Q_SLOTS:
         QCOMPARE(c.clearAllOverrides(), 0);
     }
 
+    // Per-page kebab Reset: clearing ONE surface's scope must leave every other
+    // surface's override files standing (the cross-page-isolation bug fix).
+    void clearOverridesUnder_clearsOnlyScopedFiles()
+    {
+        QTemporaryDir tmp;
+        QVERIFY(tmp.isValid());
+        AnimationsPageController c;
+        c.setUserProfilesDirOverride(tmp.path());
+
+        const QVariantMap profile{{QStringLiteral("duration"), 250}};
+        QVERIFY(c.setOverride(QStringLiteral("osd.show"), profile));
+        QVERIFY(c.setOverride(QStringLiteral("window.appearance.open"), profile));
+
+        // Scope = the OSDs page (osd + its leaves). window.* must survive.
+        const QStringList osdScope{QStringLiteral("osd"), QStringLiteral("osd.show"), QStringLiteral("osd.pop"),
+                                   QStringLiteral("osd.hide")};
+        QCOMPARE(c.clearOverridesUnder(osdScope), 1);
+        QVERIFY(!c.hasOverride(QStringLiteral("osd.show")));
+        QVERIFY(c.hasOverride(QStringLiteral("window.appearance.open")));
+        // Re-running over the same scope now clears nothing.
+        QCOMPARE(c.clearOverridesUnder(osdScope), 0);
+    }
+
+    // Per-page kebab Discard: reverting ONE surface's scope restores only that
+    // surface's files and leaves the others staged (still pending).
+    void revertPendingUnder_restoresOnlyScopedFiles()
+    {
+        QTemporaryDir tmp;
+        QVERIFY(tmp.isValid());
+        AnimationsPageController c;
+        c.setUserProfilesDirOverride(tmp.path());
+
+        const QVariantMap profile{{QStringLiteral("duration"), 250}};
+        QVERIFY(c.setOverride(QStringLiteral("osd.show"), profile));
+        QVERIFY(c.setOverride(QStringLiteral("window.appearance.open"), profile));
+        QVERIFY(c.hasPendingChanges());
+
+        const QStringList osdScope{QStringLiteral("osd"), QStringLiteral("osd.show"), QStringLiteral("osd.pop"),
+                                   QStringLiteral("osd.hide")};
+        const QStringList windowScope{QStringLiteral("window.appearance"), QStringLiteral("window.appearance.open")};
+
+        // The OSD file did not exist before this session, so reverting removes it;
+        // the window edit stays pending and on disk.
+        QVERIFY(c.revertPendingUnder(osdScope));
+        QVERIFY(!c.hasOverride(QStringLiteral("osd.show")));
+        QVERIFY(!c.hasScopedPendingFiles(osdScope));
+        QVERIFY(c.hasOverride(QStringLiteral("window.appearance.open")));
+        QVERIFY(c.hasScopedPendingFiles(windowScope));
+        QVERIFY(c.hasPendingChanges());
+    }
+
+    // hasScopedPendingFiles reports the file half of a per-page dirty check and
+    // must ignore edits outside the queried scope.
+    void hasScopedPendingFiles_reflectsOnlyScope()
+    {
+        QTemporaryDir tmp;
+        QVERIFY(tmp.isValid());
+        AnimationsPageController c;
+        c.setUserProfilesDirOverride(tmp.path());
+
+        const QStringList osdScope{QStringLiteral("osd"), QStringLiteral("osd.show")};
+        const QStringList editorScope{QStringLiteral("editor"), QStringLiteral("editor.snapIn")};
+
+        QVERIFY(!c.hasScopedPendingFiles(osdScope));
+        QVERIFY(c.setOverride(QStringLiteral("osd.show"), {{QStringLiteral("duration"), 100}}));
+        QVERIFY(c.hasScopedPendingFiles(osdScope));
+        QVERIFY(!c.hasScopedPendingFiles(editorScope));
+    }
+
     // ─── Effective resolution ─────────────────────────────────────────────
 
     void resolvedProfile_unsetReturnsLibraryDefaults()


### PR DESCRIPTION
## Problem

Per-page **Reset/Discard** (the breadcrumb kebab) on the decoration and animation settings families acted on the whole shared config blob, so reverting one page clobbered its siblings. Reported symptom: resetting **Decoration → OSDs** also reset **Decoration → Windows**.

Only these two families were affected. Manifest KConfig pages (one-owner-per-key), ordering, shortcuts, virtual-screens, layouts, and rules each revert their own distinct state and were already correct.

## Decoration

The three surface pages share one `DecorationProfileTree`. Each now owns just its root subtree — `decorations-windows`→`window`, `-osds`→`osd`, `-popups`→`popup`:

- **Reset** clears only that root's overrides.
- **Discard** reverts only that root's paths against the committed baseline.
- **Dirty** compares only that root.

Adds `Settings::committedDecorationProfileTree()` to drive the scoped discard/dirty. The sets/shaders library leaves keep whole-tree behavior.

## Animation (same bug, larger fix)

The ten animation leaf pages share the shader tree **and** per-event override files. Adds `animationPageScope()` mapping each leaf to its event-path roots — including the **`window.movement` (Motion) vs `window.movement.move` (Dragging)** carve-out — splits `animationGeneralConfigKeys()` out of the whole-tree `animationConfigKeys()`, and adds scoped controller ops (`clearOverridesUnder` / `revertPendingUnder` / `hasScopedPendingFiles`).

This required making the shader-tree dirty state **value-based**: the sticky `m_shaderTreeDirty` flag (with its `MutatingShaderTreeScope` counter and the external-reload auto-clear branch) cannot express a scoped revert correctly. `hasPendingChanges()` now compares `shaderProfileTree()` against a new `committedShaderProfileTree()` baseline; the four shader mutators let the `shaderProfileTreeChanged` handler be the sole `pendingChangesChanged` emitter; and a new `refreshDirtyState()` hook re-evaluates after `Settings::save()` re-captures the baseline (apply can run before the settings save in the domain walk).

## Testing

- Full project build clean; **287/287 tests pass** (`ctest -j`).
- Adds 3 tests proving scoped file isolation (`clearOverridesUnder` / `revertPendingUnder` / `hasScopedPendingFiles` touch only the queried surface).
- **Not exercised here:** the live KWin apply-all/discard-all chrome (no Wayland session available). The value-based conversion is safe against that path because `save()` force-clears `needsSave` and re-captures the baseline in the same pass. Worth a manual smoke test: edit two animation surfaces, reset one, confirm the other survives, then Save.

🤖 Generated with [Claude Code](https://claude.com/claude-code)