### PR TITLE
fix(animations): dead-timeline audit across the pack catalog

### DIFF
--- a/data/animations/broken-glass/effect.frag
+++ b/data/animations/broken-glass/effect.frag
@@ -146,7 +146,14 @@ vec4 pTransition(vec2 uv, float t) {
     // the bin of the current shard.
     float shardGroup = floor(shardMap.g * SHARD_LAYERS * 0.999);
 
-    if (shardGroup == i && (shardMap.x - pow(progress + 0.1, 2.0)) > 0.0) {
+    // BMW's threshold was pow(progress + 0.1, 2.0), which reaches 1.0 at
+    // progress = 0.9 — every shard (shardMap.x <= 1) had popped out by 90%
+    // of the leg, leaving a 10% empty band at the destroy tail (and the
+    // same dead band at the head of an open leg, the phosphor-peek
+    // dead-domain bug). Dropping the +0.1 bias lands the clear at exactly
+    // progress = 1; the only head-side cost is BMW's faint pre-cracked
+    // shard borders (threshold 0.01 at rest), which vanish.
+    if (shardGroup == i && (shardMap.x - pow(progress, 2.0)) > 0.0) {
       oColor = getClippedInputColor(coords);
     }
   }

--- a/data/animations/broken-glass/effect.frag
+++ b/data/animations/broken-glass/effect.frag
@@ -153,7 +153,7 @@ vec4 pTransition(vec2 uv, float t) {
     // dead-domain bug). Dropping the +0.1 bias lands the clear at exactly
     // progress = 1; the only head-side cost is BMW's faint pre-cracked
     // shard borders (threshold 0.01 at rest), which vanish.
-    if (shardGroup == i && (shardMap.x - pow(progress, 2.0)) > 0.0) {
+    if (shardGroup == i && (shardMap.x - progress * progress) > 0.0) {
       oColor = getClippedInputColor(coords);
     }
   }

--- a/data/animations/desktop-phosphor/effect.frag
+++ b/data/animations/desktop-phosphor/effect.frag
@@ -54,16 +54,29 @@ vec2 graphNodePos(vec2 cell) {
     return cell + 0.2 + 0.6 * hash22(cell);
 }
 
-// Per-cell activation time in (0, ~0.65]: a directional ramp (the circuit
+// Per-cell activation time in [0.02, ~0.77]: a directional ramp (the circuit
 // lights up along the switch direction) plus a per-cell stagger so the
 // front reads as signal propagation, not a straight wipe. `extent` is the
 // graph-space screen extent, so the projection is normalized to [0,1]
 // regardless of resolution or density.
+//
+// The projection is normalized by the direction's L1 extent (desktop-wipe's
+// idiom) so proj spans exactly [0,1] corner-to-corner for ANY direction. The
+// old fixed * 0.7071 was sized for the diagonal only: an axis-aligned switch
+// (the common left/right case under p_followSwitch) compressed proj to
+// [0.15, 0.85], so the first node lit at t ≈ 0.12 and the flood was done by
+// t ≈ 0.79 — the same dead head/tail phosphor-peek had, which an ease-out
+// progress curve stretches into a visible hang on a settled screen. The
+// activation window's budget [0.02, 0.77] is sized against the flood: the
+// slowest pixel clears at a_max + (0.12 + 1.13) / floodSpeed ≈ 0.98, so the
+// reveal uses the whole [0,1] domain and the completion floor stays a
+// backstop. ext >= 1 for a unit vector, so no division by zero.
 float nodeActivation(vec2 nodePos, vec2 dir, vec2 extent) {
     vec2 nodeUV = nodePos / max(extent, vec2(1.0e-4));
-    float proj = clamp(dot(nodeUV - 0.5, dir) * 0.7071 + 0.5, 0.0, 1.0);
+    float ext = abs(dir.x) + abs(dir.y);
+    float proj = clamp(dot(nodeUV - 0.5, dir) / ext + 0.5, 0.0, 1.0);
     float stagger = classicHash(floor(nodePos * 7.3));
-    return 0.06 + proj * 0.44 + stagger * 0.14;
+    return 0.02 + proj * 0.61 + stagger * 0.14;
 }
 
 #endif // PLASMAZONES_KWIN
@@ -99,9 +112,11 @@ vec4 pTransition(vec2 uv, float t) {
     float env = smoothstep(0.0, 0.06, t) * (1.0 - smoothstep(0.86, 0.97, t));
 
     // Flood speed in graph units per unit progress. The latest activation is
-    // ~0.64 and a pixel's own-cell node is at most ~1.14 units away, so by
-    // t = 1 the slowest front has travelled (1 - 0.64) * 6 = 2.16 units and
-    // every pixel has cleared its reveal smoothstep with margin.
+    // ~0.77 and a pixel's own-cell node is at most ~1.13 units away, so the
+    // slowest front clears its reveal smoothstep ((0.12 + 1.13) / 6 ≈ 0.21
+    // after activating) at t ≈ 0.98 — deliberately just inside the endpoint,
+    // so the reveal spans the whole timeline instead of settling early and
+    // hanging (see nodeActivation).
     const float floodSpeed = 6.0;
 
     // m: signed distance of the furthest-advanced reveal front past this

--- a/data/animations/fade/effect.frag
+++ b/data/animations/fade/effect.frag
@@ -14,13 +14,16 @@
 // dead-domain bug). Dial revealEnd back to 0.8 for the exact niri
 // timing.
 //
-// Niri's fade ships GENUINELY ASYMMETRIC close.glsl/open.glsl — open
-// uses `mix(0.95, 1.0, p)` for scale and `smoothstep(0.0, 0.8, p)` for
-// alpha, while close uses `mix(1.0, 0.95, p)` for scale and
-// `smoothstep(1.0, 0.2, p)` for alpha. These are different curves,
-// not a simple time-reversal, so the iTime flip alone can't express
-// both legs. We branch on `windowFadingIn` (open vs close leg) to select
-// the correct body, exposed as a `pIn`/`pOut` pair.
+// Niri's fade ships separate close.glsl/open.glsl bodies — open uses
+// `mix(0.95, 1.0, p)` for scale and `smoothstep(0.0, 0.8, p)` for
+// alpha, close `mix(1.0, 0.95, p)` and the reversed-edge
+// `smoothstep(1.0, 0.2, p)` (expressed below in the inverted-safe
+// form). Algebraically close(p) == open(1 − p) for BOTH curves and
+// every parameter choice (substitute q = 1 − p in either smoothstep
+// argument and the clamp terms are identical), so the pair is a pure
+// time-reversal. We still branch on `windowFadingIn` as a `pIn`/`pOut`
+// pair to mirror niri's two shipped files one-to-one, keeping each
+// leg's body diffable against its upstream original.
 //
 // Per the entry-point contract, the harness un-flips iTime to an
 // ABSOLUTE forward leg progress `t` in [0,1] running 0→1 on BOTH legs
@@ -42,9 +45,10 @@
 
 // Shared body for both legs. `t` is forward 0→1 leg progress (the harness
 // un-flipped iTime via legProgress()); `windowFadingIn` selects the niri
-// open vs close body — these legs are GENUINELY ASYMMETRIC (different
-// scale/alpha curves), not a simple time-reversal, so the direction is
-// threaded in rather than left to an iTime flip.
+// open vs close body. The legs are a pure time-reversal of each other
+// (see the header), but the split keeps each body diffable against its
+// niri file, so the direction is threaded in rather than left to an
+// iTime flip.
 vec4 fadeBody(vec2 uv, float t, bool windowFadingIn) {
     vec4 result;
     if (!windowFadingIn) {
@@ -68,7 +72,12 @@ vec4 fadeBody(vec2 uv, float t, bool windowFadingIn) {
         // boundaryMask: see noise.glsl. Crops off-window samples to transparent.
         vec4 color = surfaceColor(scaled_uv) * boundaryMask(scaled_uv);
 
-        float alpha = smoothstep(1.0 - p_revealStart, 1.0 - p_revealEnd, p);
+        // Inverted form rather than swapped arguments: smoothstep is
+        // undefined when edge0 >= edge1 per the GLSL spec, and niri's
+        // literal `smoothstep(1.0 - rS, 1.0 - rE, p)` is always reversed
+        // (rS caps at 0.49, rE floors at 0.51). Value-identical on a
+        // conformant driver: 1 - S(u) == S(1 - u).
+        float alpha = 1.0 - smoothstep(1.0 - p_revealEnd, 1.0 - p_revealStart, p);
 
         result = color * alpha;
     } else {

--- a/data/animations/fade/effect.frag
+++ b/data/animations/fade/effect.frag
@@ -3,9 +3,16 @@
 //
 // Fade transition — ported from liixini/shaders niri shader
 // (https://github.com/liixini/shaders/tree/main/fade). Gentle scale-
-// and-fade transition. Open eases scale 0.95→1.0 with smoothstep(0,0.8)
-// fade-in; close eases scale 1.0→0.95 with smoothstep(1.0,0.2)
-// fade-out.
+// and-fade transition. Open eases scale 0.95→1.0 while alpha ramps
+// smoothstep(revealStart, revealEnd, p); close mirrors both curves.
+//
+// Deviation from niri: revealEnd DEFAULTS to 1.0 where niri hardcodes
+// 0.8. smoothstep(0, 0.8) pins alpha at 1 for the last 20% of the open
+// leg (and the first 20% of the close leg) while the only other motion
+// is the final 1% of the scale ease — an imperceptible dead band that
+// an eased progress curve stretches into a hang (the phosphor-peek
+// dead-domain bug). Dial revealEnd back to 0.8 for the exact niri
+// timing.
 //
 // Niri's fade ships GENUINELY ASYMMETRIC close.glsl/open.glsl — open
 // uses `mix(0.95, 1.0, p)` for scale and `smoothstep(0.0, 0.8, p)` for

--- a/data/animations/fade/metadata.json
+++ b/data/animations/fade/metadata.json
@@ -1,7 +1,7 @@
 {
     "id": "fade",
     "name": "Fade",
-    "description": "Gentle scale-and-fade transition. Opening eases scale from 0.95 to 1.0 with a smoothstep(0,0.8) fade-in. Closing eases scale from 1.0 to 0.95 with a smoothstep(1.0,0.2) fade-out.",
+    "description": "Gentle scale-and-fade transition. Opening eases scale from 0.95 to 1.0 while the window fades in. Closing eases scale from 1.0 to 0.95 while it fades out.",
     "author": "PlasmaZones (ported from liixini/shaders, https://github.com/liixini/shaders)",
     "version": "1.0",
     "category": "Fade",
@@ -27,7 +27,7 @@
             "id": "revealEnd",
             "name": "Reveal End",
             "type": "float",
-            "default": 0.8,
+            "default": 1.0,
             "min": 0.51,
             "max": 1.0
         }

--- a/data/animations/fadecolor/effect.frag
+++ b/data/animations/fadecolor/effect.frag
@@ -3,7 +3,15 @@
 //
 // Fade Color transition — ported from liixini/shaders niri shader
 // (https://github.com/liixini/shaders/tree/main/fadecolor). Phased
-// fade — visibility ramps from 40% progress onward with smoothstep.
+// fade — visibility ramps from `p_colorPhase` onward with smoothstep.
+//
+// Deviation from niri: the phase DEFAULT is 0.0, not niri's hardcoded
+// 0.4. `reveal = smoothstep(phase, 1.0, p)` draws literally nothing
+// before p reaches the phase — at 0.4 the first 40% of an open leg is a
+// fully invisible window (and the last 40% of a close leg an invisible
+// corpse), which an eased progress curve stretches into perceived
+// launch lag (the phosphor-peek dead-domain bug). Raising the dial back
+// to 0.4 reproduces the niri timing exactly.
 //
 // Niri's fadecolor ships symmetric close.glsl/open.glsl — bodies are
 // identical apart from `p = niri_clamped_progress` vs

--- a/data/animations/fadecolor/metadata.json
+++ b/data/animations/fadecolor/metadata.json
@@ -1,7 +1,7 @@
 {
     "id": "fadecolor",
     "name": "Fade Color",
-    "description": "A phased fade where visibility ramps up from 40% progress onward with smoothstep.",
+    "description": "A phased fade where visibility ramps up with smoothstep. The Color Phase dial delays the start of the fade and matches the niri original at 0.4.",
     "author": "PlasmaZones (ported from liixini/shaders, https://github.com/liixini/shaders)",
     "version": "1.0",
     "category": "Fade",
@@ -11,7 +11,7 @@
             "id": "colorPhase",
             "name": "Color Phase",
             "type": "float",
-            "default": 0.4,
+            "default": 0.0,
             "min": 0.0,
             "max": 0.95
         }

--- a/data/animations/ink-splash/effect.frag
+++ b/data/animations/ink-splash/effect.frag
@@ -46,9 +46,11 @@ vec4 pTransition(vec2 uv, float t) {
     // Deviation from the verbatim niri body: the boundary's travel is
     // normalized to the farthest possible ink edge — the corner distance
     // in the same aspect metric as `d`, plus the distortion bound
-    // (|distortion| <= 0.5 * 0.5 + 0.5 * 0.18 = 0.34 for fbm in [0, 1])
-    // and the feather. Niri's bare `p * speed - 0.15` with speed 1.7 was
-    // tuned near a full-screen 16:9 surface (last finger lands ≈ 0.91);
+    // (|distortion| <= 0.5 * 0.5 + 0.5 * 0.18 = 0.34, attained as fbm
+    // approaches 0; fbm(p, 5, 2.1) tops out near 0.97 so the positive
+    // side stays under +0.32) and the feather. Niri's bare
+    // `p * speed - 0.15` with speed 1.7 was tuned near a full-screen
+    // 16:9 surface (last finger lands ≈ 0.91);
     // the corner metric shrinks as the window narrows, so on a square
     // window the splash was done by p ≈ 0.72 and the tail sat on a
     // static frame — the phosphor-peek dead-domain bug, aspect-

--- a/data/animations/ink-splash/effect.frag
+++ b/data/animations/ink-splash/effect.frag
@@ -8,9 +8,10 @@
 //
 // Niri's ink-splash ships symmetric close.glsl/open.glsl. PlasmaZones'
 // runtime flips iTime on reverse legs (1→0 on close, 0→1 on open),
-// so we use the niri OPEN body verbatim with `niri_clamped_progress`
-// translated to `clamp(iTime, 0.0, 1.0)` and the runtime flip
-// auto-mirrors the visual on close — no iIsReversed branch needed.
+// so we use the niri OPEN body with `niri_clamped_progress` translated
+// to `clamp(iTime, 0.0, 1.0)` and the runtime flip auto-mirrors the
+// visual on close — no iIsReversed branch needed. One timeline
+// deviation from the verbatim body: see the boundary comment below.
 //
 // niri's `niri_geo_to_tex` is the identity mat3 in PlasmaZones (geometry
 // == texture coords here), so the matrix multiply is dropped and
@@ -38,10 +39,27 @@ vec4 pTransition(vec2 uv, float t) {
     float fingers = fbm(uv * p_fingerScale * screenScale, 5, 2.1);
     float distortion = (blob - 0.5) * 0.5 + (fingers - 0.5) * 0.18;
     vec2 c = uv - vec2(0.5);
-    c.x *= iAnchorSize.x / max(iAnchorSize.y, 0.0001);
+    float aspx = iAnchorSize.x / max(iAnchorSize.y, 0.0001);
+    c.x *= aspx;
     float d = length(c);
     float splash_d = d + distortion;
-    float boundary = p * p_splashSpeed - 0.15;
+    // Deviation from the verbatim niri body: the boundary's travel is
+    // normalized to the farthest possible ink edge — the corner distance
+    // in the same aspect metric as `d`, plus the distortion bound
+    // (|distortion| <= 0.5 * 0.5 + 0.5 * 0.18 = 0.34 for fbm in [0, 1])
+    // and the feather. Niri's bare `p * speed - 0.15` with speed 1.7 was
+    // tuned near a full-screen 16:9 surface (last finger lands ≈ 0.91);
+    // the corner metric shrinks as the window narrows, so on a square
+    // window the splash was done by p ≈ 0.72 and the tail sat on a
+    // static frame — the phosphor-peek dead-domain bug, aspect-
+    // conditioned like the desktop-phosphor projection. With the extent
+    // factored out, splashSpeed = 1 (the new default) lands the last
+    // finger exactly at the end of the leg for any window shape; above 1
+    // it completes early and holds, wave-warp's documented front-speed
+    // contract. The -0.15 head bias (niri's) is preserved on both sides
+    // so t = 0 renders identically.
+    float maxD = 0.5 * length(vec2(aspx, 1.0)) + 0.34 + p_edgeSoftness;
+    float boundary = p * p_splashSpeed * (maxD + 0.15) - 0.15;
     float diff = splash_d - boundary;
     float reveal = smoothstep(p_edgeSoftness, -p_edgeSoftness, diff);
 

--- a/data/animations/ink-splash/metadata.json
+++ b/data/animations/ink-splash/metadata.json
@@ -27,8 +27,8 @@
             "id": "splashSpeed",
             "name": "Splash Speed",
             "type": "float",
-            "default": 1.7,
-            "min": 0.8,
+            "default": 1.0,
+            "min": 1.0,
             "max": 3.0
         },
         {

--- a/data/animations/inkwell-drop/effect.frag
+++ b/data/animations/inkwell-drop/effect.frag
@@ -42,9 +42,26 @@ vec4 pTransition(vec2 uv, float t) {
     // aspect ratio that makes length(c) circular in pixel space is the
     // expanded rect's, not the bare frame's. Mismatch was a slight
     // ellipticity scaling with shadow padding.
-    c.x *= iResolution.x / max(iResolution.y, 0.0001);
+    float aspx = iResolution.x / max(iResolution.y, 0.0001);
+    c.x *= aspx;
     float d = length(c);
-    float front = p * p_frontSpeed;
+    // Deviation from niri: the front's travel is normalized to THIS
+    // window's farthest corner, measured in the same aspect-corrected
+    // metric as `d`. Niri's bare `front = p * speed` with speed 1.5 was
+    // tuned near a full-screen 16:9 surface (farthest corner ≈ 1.30):
+    // even there the last corner cleared at p ≈ 0.88, and the corner
+    // metric shrinks as the window narrows (≈ 0.89 on a square window),
+    // so the ink was done by p ≈ 0.6 and the rest of the leg sat on a
+    // static frame — the phosphor-peek dead-domain bug, aspect-
+    // conditioned like the desktop-phosphor projection. With the corner
+    // distance factored out, frontSpeed = 1 (the new default) lands the
+    // front on the farthest corner exactly at the end of the leg for any
+    // window shape; above 1 it completes early and holds, wave-warp's
+    // documented front-speed contract. The +0.02 covers the reveal
+    // band's full-opacity edge below.
+    vec2 fcorner = max(impact, 1.0 - impact);
+    float maxD = length(vec2(fcorner.x * aspx, fcorner.y));
+    float front = p * p_frontSpeed * (maxD + 0.02);
     float ring1 = sin((d - front) * 80.0) * exp(-abs(d - front) * 6.0);
     float ring2 = sin((d - front + 0.08) * 80.0) * exp(-abs(d - front + 0.08) * 8.0) * 0.6;
     float ring3 = sin((d - front + 0.16) * 80.0) * exp(-abs(d - front + 0.16) * 10.0) * 0.4;

--- a/data/animations/inkwell-drop/metadata.json
+++ b/data/animations/inkwell-drop/metadata.json
@@ -27,8 +27,8 @@
             "id": "frontSpeed",
             "name": "Front Speed",
             "type": "float",
-            "default": 1.5,
-            "min": 0.7,
+            "default": 1.0,
+            "min": 1.0,
             "max": 3.0
         },
         {

--- a/data/animations/voronoi-shatter/effect.frag
+++ b/data/animations/voronoi-shatter/effect.frag
@@ -8,10 +8,11 @@
 //
 // Niri's voronoi-shatter ships symmetric close.glsl/open.glsl.
 // PlasmaZones' runtime flips iTime on reverse legs (1→0 on close, 0→1
-// on open), so we use the niri OPEN body verbatim with
-// `niri_clamped_progress` translated to `clamp(iTime, 0.0, 1.0)` and
-// the runtime flip auto-mirrors the visual on close — no iIsReversed
-// branch needed.
+// on open), so we use the niri OPEN body with `niri_clamped_progress`
+// translated to `clamp(iTime, 0.0, 1.0)` and the runtime flip
+// auto-mirrors the visual on close — no iIsReversed branch needed. One
+// timeline deviation from the verbatim body: see the reveal-band
+// comment below.
 //
 // niri's `niri_geo_to_tex` is the identity mat3 in PlasmaZones (geometry
 // == texture coords here), so the matrix multiply is dropped and
@@ -49,8 +50,22 @@ vec4 pTransition(vec2 uv, float t) {
         }
     }
     float seed = vs_hash2(cell).x;
-    float shard_p = smoothstep(seed * 0.5, seed * 0.5 + p_revealSpread, p);
-    float reveal = smoothstep(0.0, p_shardSoftness, shard_p);
+    // Deviation from the verbatim niri body. Niri layers two smoothsteps:
+    // shard_p = smoothstep(seed*0.5, seed*0.5 + spread, p), then
+    // reveal = smoothstep(0, softness, shard_p). The outer one saturates
+    // once shard_p reaches `softness` — the MIDDLE of the shard's band at
+    // the 0.5/0.5 defaults — so the last shard (seed → 1) was fully
+    // revealed at p = 0.75 and the final quarter of the leg was a static
+    // frame (the phosphor-peek dead-domain bug; flipped, a dead head on
+    // close). Collapse to one band per shard: `w` is the effective fade
+    // width the old composition produced at the defaults
+    // (spread × softness = 0.25), and seeding the thresholds over
+    // [0, 1 - w] tiles the bands so their union spans exactly [0, 1] for
+    // ANY dial values — the first shards start at p ≈ 0 and the last
+    // completes at exactly p = 1.
+    float w = clamp(p_revealSpread * p_shardSoftness, 1.0e-3, 1.0);
+    float thr = seed * (1.0 - w);
+    float reveal = smoothstep(thr, thr + w, p);
 
     return win * reveal;
 }


### PR DESCRIPTION
## Summary

Third occurrence of the dead-timeline bug (after the phosphor-peek drain in #782) triggered a catalog-wide audit: every animation pack was checked for visible work that starts late or finishes early inside the [0,1] progress domain. A dead tail becomes a visible hang under an eased progress curve, and a dead head on an open leg reads as launch lag.

## Fixes

**desktop-phosphor** (the reported bug): the signal-graph projection was scaled by a fixed 0.7071, sized for the diagonal only, so an axis-aligned switch compressed the activation ramp to [0.15, 0.85]; the flood was also over-provisioned, finishing the reveal by t ≈ 0.79. The projection is now L1-normalized (desktop-wipe's idiom) and the activation window re-budgeted so the slowest pixel clears at t ≈ 0.98.

**Six more packs from the audit:**
- **fadecolor**: default colorPhase 0.4 → 0.0. The niri original genuinely ships a 40% fully-invisible head (verified upstream, no colour fill exists); 0.4 on the dial reproduces niri exactly.
- **fade**: default revealEnd 0.8 → 1.0 (alpha saturated at p = 0.8 with only 1% of scale ease left).
- **broken-glass**: dropped BMW's +0.1 threshold bias, which emptied the shard atlas at p = 0.9.
- **voronoi-shatter**: niri's stacked smoothsteps saturated at mid-band (last shard done at p = 0.75); replaced with per-shard bands whose union tiles exactly [0,1] for any dial values.
- **inkwell-drop / ink-splash**: aspect-conditioned variant — fixed speed constants tuned for full-screen 16:9 finished a square window by p ≈ 0.6 / 0.72. Front travel is now normalized to the window's actual farthest corner; speed defaults 1.0, min 1.0 (wave-warp's early-hold contract).

## Deliberately unchanged

bounce (damped settle), incinerate (~8% soft head, faithful), soft-warp-fade / static-fade (exactly at tolerance), pixelfade-wave / polka-dots-curtain (defaults tuned precisely to the domain edge), ripple (an inverted smoothstep misread — it holds then fades to zero at exactly p = 1).

## Testing

- All 29 animation/shader tests pass (both pack bake tests cover assembly of every changed shader).
- Full suite: 289/289.

🤖 Generated with [Claude Code](https://claude.com/claude-code)