### PR TITLE
fix(tests): opt-in GPU orientation test and private-bus isolation for ctest

### DIFF
--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -1206,19 +1206,20 @@ add_test(NAME test_zone_zorder COMMAND test_zone_zorder)
 # ReplyMessage, which EditorController::saveLayout then treats as a landed write
 # (clean undo stack, no unsaved-changes prompt, work lost on close). The client
 # hard-binds the daemon's bus name, so the stub registry has to claim it — the
-# test skips itself when a real daemon already owns the name, hence the
-# dbus-run-session wrapper. DBusLayoutService lives in the editor executable
-# rather than a library, so its TU is compiled into the test directly.
-# ILayoutService.h declares its Q_OBJECT base entirely in the header, so it is
-# listed explicitly: AUTOMOC has to see it to emit the base's metaobject.
+# shared TEST_LAUNCHER's private bus (see the D-Bus isolation block at the
+# bottom) guarantees the name is unowned; when the launcher is unavailable the
+# test skips itself if a real daemon already owns the name. DBusLayoutService
+# lives in the editor executable rather than a library, so its TU is compiled
+# into the test directly. ILayoutService.h declares its Q_OBJECT base entirely
+# in the header, so it is listed explicitly: AUTOMOC has to see it to emit the
+# base's metaobject.
 add_executable(test_dbus_layout_service_replies editor/test_dbus_layout_service_replies.cpp
                ${CMAKE_SOURCE_DIR}/src/editor/services/DBusLayoutService.cpp
                ${CMAKE_SOURCE_DIR}/src/editor/services/ILayoutService.h)
 target_link_libraries(test_dbus_layout_service_replies
                       PRIVATE Qt6::Test Qt6::Core Qt6::DBus plasmazones_core
                               PhosphorProtocol::PhosphorProtocol)
-add_test(NAME test_dbus_layout_service_replies
-         COMMAND dbus-run-session -- $<TARGET_FILE:test_dbus_layout_service_replies>)
+add_test(NAME test_dbus_layout_service_replies COMMAND test_dbus_layout_service_replies)
 
 # Decoration page→root scoping helpers (decorationpagescope.{h,cpp}): the pure
 # dispatch/prefix/diff logic behind SettingsController's per-page decoration

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -1237,10 +1237,13 @@ add_test(NAME test_decoration_page_scope COMMAND test_decoration_page_scope)
 # GPU-gated orientation guard for the per-render-target NDC Y-flip: renders a
 # two-stage surface-decoration chain (border + shadow via ShaderEffectSource
 # taps, mirroring SurfaceDecoration.qml) on a forced OpenGL scene graph and
-# asserts the sampled card content is upright. Skips itself cleanly when no
-# display server or GL context is available (its custom main drops the forced
-# offscreen QPA — an offscreen GL grab returns a uniform placeholder and
-# proves nothing).
+# asserts the sampled card content is upright. OPT-IN: it only runs with
+# PLASMAZONES_GPU_TESTS=1 in the environment, because it must present on the
+# LIVE session (its custom main drops the forced offscreen QPA — an offscreen
+# GL grab returns a uniform placeholder and proves nothing) and mapping a real
+# window D-Bus-activates the installed plasmazonesd via the KWin effect on a
+# developer machine, while CI containers pass the display/GL gates yet never
+# get a ready shader pipeline. Without the opt-in it exits as Skipped.
 add_executable(test_surface_decoration_orientation
     rendering/test_surface_decoration_orientation.cpp
 )
@@ -1256,7 +1259,7 @@ target_link_libraries(test_surface_decoration_orientation
         PhosphorSurface::PhosphorSurface
 )
 add_test(NAME test_surface_decoration_orientation COMMAND test_surface_decoration_orientation)
-# Headless runs exit with 77 from the test's custom main (no display server),
+# Non-opted-in and headless runs exit with 77 from the test's custom main,
 # which ctest reports as SKIPPED rather than Passed — honest status for the
 # GPU gate. In-test QSKIPs still exit 0 via qExec (green, Qt's contract).
 set_tests_properties(test_surface_decoration_orientation PROPERTIES SKIP_RETURN_CODE 77)
@@ -1287,4 +1290,37 @@ file(MAKE_DIRECTORY
 get_property(_all_tests DIRECTORY . PROPERTY TESTS)
 set_tests_properties(${_all_tests} PROPERTIES ENVIRONMENT
     "QT_QPA_PLATFORM=offscreen;XDG_CONFIG_HOME=${_pz_test_home}/config;XDG_DATA_HOME=${_pz_test_home}/data;XDG_STATE_HOME=${_pz_test_home}/state;XDG_CACHE_HOME=${_pz_test_home}/cache")
+
+# D-Bus isolation: run every test on its own PRIVATE session bus. Several
+# tests compile client sources whose async calls target the daemon's real
+# well-known name (org.plasmazones) with QDBus's default auto-start flag —
+# on a developer machine the installed org.plasmazones.service activation
+# file turns each such call into a spawn of the installed plasmazonesd,
+# left running after ctest exits. The custom bus config is essential: a
+# stock dbus-run-session bus still reads /usr/share/dbus-1/services, so the
+# installed daemon would be activated on the private bus too (as a child of
+# the private dbus-daemon — it then leaks into the session AND holds the
+# test's stdout pipe open, hanging ctest after the test passes). The config
+# declares no service directories, so activation is impossible and daemon
+# calls fail fast with ServiceUnknown; tests that register their own bus
+# names (adaptor routing, layout-service replies) get a clean bus where the
+# name is never already owned. Uses the TEST_LAUNCHER target property
+# (CMake 3.29+); when dbus-run-session or the CMake version is missing,
+# tests run directly on whatever bus the environment provides — the
+# pre-isolation status quo.
+find_program(_pz_dbus_run_session dbus-run-session)
+if(_pz_dbus_run_session AND CMAKE_VERSION VERSION_GREATER_EQUAL 3.29)
+    foreach(_pz_test IN LISTS _all_tests)
+        # Every add_test in this directory uses NAME == target; the guard
+        # keeps a future non-target test entry from breaking the configure.
+        if(TARGET ${_pz_test})
+            set_target_properties(${_pz_test} PROPERTIES
+                TEST_LAUNCHER
+                "${_pz_dbus_run_session};--config-file=${CMAKE_CURRENT_SOURCE_DIR}/test-session-bus.conf;--")
+        endif()
+    endforeach()
+else()
+    message(STATUS "PlasmaZones: dbus-run-session or CMake >= 3.29 unavailable — "
+                   "tests will use the ambient session bus")
+endif()
 # ─── ABOVE THIS LINE: ADD NEW TESTS — BELOW THIS LINE: env wiring only ───

--- a/tests/unit/rendering/test_surface_decoration_orientation.cpp
+++ b/tests/unit/rendering/test_surface_decoration_orientation.cpp
@@ -15,12 +15,21 @@
  * asserts the gradient is upright: a wrong per-target flip on either pass
  * (the tap's texture render or the final direct draw) lands blue on top.
  *
- * GPU-gated: OpenGL context creation is probed BEFORE any QQuickView exists
- * (a failed scene-graph init is fatal inside Qt, not catchable). Headless
- * environments exit with the ctest SKIP_RETURN_CODE before QGuiApplication;
- * in-test gates (no GL context, wrong backend, no grab) QSKIP, which qExec
- * reports as a green run — either way CI without a GPU stays green without
- * pretending to cover this.
+ * OPT-IN: this test connects to the LIVE session (it must — an offscreen GL
+ * grab returns a uniform placeholder and proves nothing), and mapping a real
+ * window has side effects on a developer machine: the installed KWin effect
+ * reacts to the new window with D-Bus calls to org.plasmazones, whose
+ * activation service file spawns the installed plasmazonesd (and from there
+ * the daemon can launch plasmazones-settings) — processes a test run must
+ * never leave behind. CI containers have the inverse problem: a display and
+ * a GL context exist, so every environment gate passes, but the shader
+ * pipeline never becomes ready and the grab stays a uniform placeholder,
+ * failing the assert without testing anything. So the live run requires
+ * PLASMAZONES_GPU_TESTS=1; without it the test exits with the ctest
+ * SKIP_RETURN_CODE before QGuiApplication. When opted in, in-test gates
+ * (no GL context, wrong backend, no grab, chain never renders in either
+ * orientation) QSKIP, which qExec reports as a green run — a regression is
+ * only declared on the flip's actual signature (blue on top).
  */
 
 #include <QElapsedTimer>
@@ -35,6 +44,8 @@
 #include <QTemporaryDir>
 #include <QTest>
 #include <QUrl>
+
+#include <utility>
 
 #include <PhosphorSurface/SurfaceShaderRegistry.h>
 
@@ -207,54 +218,86 @@ private Q_SLOTS:
         if (view.rendererInterface()->graphicsApi() != QSGRendererInterface::OpenGLRhi)
             QSKIP("Scene graph is not running on the OpenGL RHI backend");
 
-        // Upright gradient: red dominates the top of the card, blue the
-        // bottom. Channel-dominance beats exact colors — the border pack
-        // rounds corners and the sample points sit well inside the card.
-        const auto upright = [](const QImage& frame) {
-            if (frame.isNull())
-                return false;
-            const QColor top = frame.pixelColor(frame.width() / 2, frame.height() / 4);
-            const QColor bottom = frame.pixelColor(frame.width() / 2, frame.height() * 3 / 4);
-            return top.red() > 150 && top.blue() < 100 && bottom.blue() > 150 && bottom.red() < 100;
+        // Channel-dominance beats exact colors — the border pack rounds
+        // corners and the sample points sit well inside the card. Upright:
+        // red on top, blue on the bottom. Flipped (the regression's exact
+        // signature): blue on top, red on the bottom. A frame matching
+        // NEITHER means the chain hasn't rendered — still settling, or an
+        // environment whose shader pipeline never becomes ready and leaves
+        // the placeholder gray in place (observed in CI containers, where a
+        // display and GL context exist but shader compilation never
+        // completes). Only the flipped signature is a verdict.
+        const auto samples = [](const QImage& frame) {
+            return std::pair{frame.pixelColor(frame.width() / 2, frame.height() / 4),
+                             frame.pixelColor(frame.width() / 2, frame.height() * 3 / 4)};
+        };
+        const auto redDominant = [](const QColor& c) {
+            return c.red() > 150 && c.blue() < 100;
+        };
+        const auto blueDominant = [](const QColor& c) {
+            return c.blue() > 150 && c.red() < 100;
         };
 
         // Poll-grab until the async pack load and the two live capture folds
         // settle, instead of one grab after a magic fixed wait — a slow or
         // loaded GPU just takes more iterations. A genuinely flipped chain
-        // never satisfies the predicate, so the regression still times out
-        // into the failure assert below carrying the last frame's samples.
+        // (mutation-verified: reverting the per-target flip fix) presents the
+        // flipped signature within a frame or two of the upright timing, so
+        // the regression is caught as a hard failure, while a chain that
+        // never renders at all skips as an environment gate.
         QImage frame;
         bool sawUpright = false;
+        bool sawFlipped = false;
         QElapsedTimer settle;
         settle.start();
         while (settle.elapsed() < 5000) {
             QTest::qWait(150);
             frame = view.grabWindow();
-            if (upright(frame)) {
+            if (frame.isNull())
+                continue;
+            const auto [top, bottom] = samples(frame);
+            if (redDominant(top) && blueDominant(bottom)) {
                 sawUpright = true;
+                break;
+            }
+            if (blueDominant(top) && redDominant(bottom)) {
+                sawFlipped = true;
                 break;
             }
         }
         if (frame.isNull())
             QSKIP("grabWindow returned no image in this environment");
-        const QColor top = frame.pixelColor(frame.width() / 2, frame.height() / 4);
-        const QColor bottom = frame.pixelColor(frame.width() / 2, frame.height() * 3 / 4);
-        QVERIFY2(sawUpright,
-                 qPrintable(QStringLiteral("card never rendered upright (top %1, bottom %2) — a flipped chain "
-                                           "renders blue on top")
+        const auto [top, bottom] = samples(frame);
+        QVERIFY2(!sawFlipped,
+                 qPrintable(QStringLiteral("card rendered UPSIDE DOWN (top %1, bottom %2) — the per-target "
+                                           "NDC Y-flip regressed")
                                 .arg(top.name(), bottom.name())));
+        if (!sawUpright)
+            QSKIP(qPrintable(QStringLiteral("chain never rendered in either orientation (top %1, bottom %2) — "
+                                            "shader pipeline unavailable in this environment")
+                                 .arg(top.name(), bottom.name())));
     }
 };
 
 int main(int argc, char** argv)
 {
+    // Live-session runs are OPT-IN (see the header comment): mapping a real
+    // window makes the installed KWin effect D-Bus-activate the installed
+    // plasmazonesd on a developer machine, and CI containers pass every
+    // display/GL gate yet never compile the shaders. Exit with the ctest
+    // SKIP_RETURN_CODE (see the target's test property) unless the developer
+    // explicitly asked for the live run.
+    if (!qEnvironmentVariableIsSet("PLASMAZONES_GPU_TESTS")) {
+        fprintf(stderr, "SKIP: live-session GPU test — set PLASMAZONES_GPU_TESTS=1 to run it\n");
+        return 77;
+    }
     // A GL scene graph needs a real display server: under the offscreen QPA
     // (which the shared ctest environment forces for isolation) the window
     // renders nothing and grabWindow returns a uniform placeholder — the
     // asserts would fail without testing anything. Exit with the ctest
-    // SKIP_RETURN_CODE (see the target's test property) before
-    // QGuiApplication when headless; otherwise drop the forced offscreen
-    // platform so the scene graph presents on the session's compositor.
+    // SKIP_RETURN_CODE before QGuiApplication when headless; otherwise drop
+    // the forced offscreen platform so the scene graph presents on the
+    // session's compositor.
     // Assumption: a NON-empty display variable points at a live server — a
     // stale value would abort inside the QGuiApplication constructor (a QPA
     // connection failure is fatal, not catchable), which only a dead-socket

--- a/tests/unit/rendering/test_surface_decoration_orientation.cpp
+++ b/tests/unit/rendering/test_surface_decoration_orientation.cpp
@@ -287,7 +287,7 @@ int main(int argc, char** argv)
     // display/GL gate yet never compile the shaders. Exit with the ctest
     // SKIP_RETURN_CODE (see the target's test property) unless the developer
     // explicitly asked for the live run.
-    if (!qEnvironmentVariableIsSet("PLASMAZONES_GPU_TESTS")) {
+    if (qEnvironmentVariableIntValue("PLASMAZONES_GPU_TESTS") == 0) {
         fprintf(stderr, "SKIP: live-session GPU test — set PLASMAZONES_GPU_TESTS=1 to run it\n");
         return 77;
     }

--- a/tests/unit/test-session-bus.conf
+++ b/tests/unit/test-session-bus.conf
@@ -1,0 +1,30 @@
+<!--
+SPDX-FileCopyrightText: 2026 fuddlesworth
+SPDX-License-Identifier: GPL-3.0-or-later
+
+Private session-bus configuration for the unit-test TEST_LAUNCHER
+(dbus-run-session, wired in tests/unit/CMakeLists.txt).
+
+Deliberately declares NO <servicedir> and NO <standard_session_servicedirs/>:
+a stock dbus-run-session bus still reads /usr/share/dbus-1/services, where an
+installed PlasmaZones provides org.plasmazones.service — so a test's
+auto-start D-Bus call would activate the INSTALLED plasmazonesd as a child of
+the private dbus-daemon. That daemon outlives the test (it reparents to the
+user manager when the bus dies), leaks into the developer's session, and
+holds the test's stdout pipe open, hanging ctest after the test has passed.
+With no service directories, activation is impossible: such calls fail fast
+with ServiceUnknown, which is exactly what the tests expect from a bus
+without a daemon.
+-->
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-Bus Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+  <type>session</type>
+  <listen>unix:tmpdir=/tmp</listen>
+  <!-- Same permissive default policy as the stock session bus. -->
+  <policy context="default">
+    <allow send_destination="*" eavesdrop="true"/>
+    <allow eavesdrop="true"/>
+    <allow own="*"/>
+  </policy>
+</busconfig>


### PR DESCRIPTION
## Problem

`test_surface_decoration_orientation` (added on #798) broke two ways at once:

1. **CI red on main and every PR branch.** The CI container passes every environment gate the test has (display variable set, GL context creates, window exposes, OpenGL RHI backend) — but the shader pipeline never becomes ready, the grab stays the uniform placeholder (`top #a0a0a4, bottom #a0a0a4`), and the upright assert failed without testing anything.
2. **Leaked processes locally.** The test drops the forced offscreen QPA and maps a real window on the live compositor. The installed KWin effect reacts with D-Bus calls to `org.plasmazones`, and the activation service file spawns the installed `plasmazonesd`, left running after ctest exits. Independently, tests that compile settings client sources (e.g. `test_rule_controller`) async-call the daemon's well-known name with QDBus's default auto-start flag, which activates the installed daemon on every run.

## Fix

**Orientation test is now opt-in** (`PLASMAZONES_GPU_TESTS=1`; otherwise the custom main exits with the ctest SKIP_RETURN_CODE, reported as Skipped). When opted in, the verdict is three-valued: only the flip regression's actual signature (blue on top, red on the bottom) fails; a chain that never renders in either orientation skips as an environment gate. The mutation-verified regression still fails hard.

**Every unit-test target gets a `TEST_LAUNCHER`** running it under `dbus-run-session` with a custom bus config (`tests/unit/test-session-bus.conf`) that declares **no service directories**. The custom config is load-bearing: a stock private bus still reads `/usr/share/dbus-1/services`, so the installed daemon was activated on the private bus too — it leaked into the session as a child of the private `dbus-daemon` and held the test's stdout pipe open, hanging ctest after the test had passed. With no servicedirs, activation is impossible and daemon calls fail fast with ServiceUnknown, which is what the tests expect from a bus with no daemon. Degrades gracefully (with a configure-time notice) when `dbus-run-session` or CMake >= 3.29 is unavailable.

## Verification

- Default `ctest`: 289/289 pass in ~31s (no measurable launcher overhead), orientation test Skipped.
- `PLASMAZONES_GPU_TESTS=1`: orientation test passes on a live session in 1.1s.
- Before/after process diff across a full suite run (covering `plasmazonesd`, `plasmazones-settings`, `dbus-daemon`): no new processes.
- Launcher confirmed in `ctest -V` output; a daemon spawned by the pre-config-file launcher carried `DBUS_STARTER_ADDRESS` pointing at the private bus socket, confirming the activation path the bus config now closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)