### PR TITLE
fix(effect): report screen desktop before activation notifies on desktop switch

### DIFF
--- a/kwin-effect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect.h
@@ -620,6 +620,13 @@ private:
     /// only fires when the daemon service is registered.
     void reportScreenDesktop(const QString& screenId, int desktop);
     QString getWindowScreenId(KWin::EffectWindow* w) const;
+    /// Resolve the KWin output a window sits on by POSITION (the output whose
+    /// geometry contains the window centre), falling back to w->screen() only
+    /// when no output contains the centre. Never trust w->screen() first: KWin
+    /// can assign a window the wrong one of two identical-model outputs
+    /// (Discussion #724). Shared by getWindowScreenId and the activation-time
+    /// desktop report in notifyWindowActivated.
+    KWin::LogicalOutput* windowOutput(KWin::EffectWindow* w) const;
     AutotileHandler* autotileHandler() const
     {
         return m_autotileHandler.get();

--- a/kwin-effect/plasmazoneseffect/screens.cpp
+++ b/kwin-effect/plasmazoneseffect/screens.cpp
@@ -104,6 +104,25 @@ void PlasmaZonesEffect::reportScreenDesktop(const QString& screenId, int desktop
     }
 }
 
+// Resolve the monitor by the window's POSITION — the KWin output whose geometry
+// contains the window centre — NOT w->screen(). KWin can assign a window the
+// wrong one of two identical-model outputs, so trusting w->screen() made the
+// effect disagree with the daemon about which monitor a window sits on, which
+// then bounced a snapped window off to the other monitor (Discussion #724).
+// Mirrors the snap-assist path in snaphandler.cpp. The w->screen() fallback
+// only fires when no output contains the centre (window fully off-screen
+// mid-reconfigure).
+KWin::LogicalOutput* PlasmaZonesEffect::windowOutput(KWin::EffectWindow* w) const
+{
+    if (!w) {
+        return nullptr;
+    }
+    const QPointF cf = w->frameGeometry().center();
+    const QPoint c(qRound(cf.x()), qRound(cf.y()));
+    KWin::LogicalOutput* output = KWin::effects->screenAt(c);
+    return output ? output : w->screen();
+}
+
 QString PlasmaZonesEffect::getWindowScreenId(KWin::EffectWindow* w) const
 {
     if (!w) {
@@ -112,21 +131,13 @@ QString PlasmaZonesEffect::getWindowScreenId(KWin::EffectWindow* w) const
     const QPointF cf = w->frameGeometry().center();
     const QPoint c(qRound(cf.x()), qRound(cf.y()));
 
-    // Resolve the monitor by the window's POSITION — the KWin output whose geometry
-    // contains the window centre — NOT w->screen(). KWin can assign a window the
-    // wrong one of two identical-model outputs, so trusting w->screen() made the
-    // effect disagree with the daemon about which monitor a window sits on, which
-    // then bounced a snapped window off to the other monitor (Discussion #724).
-    // outputScreenId derives the id from the KWin output's OWN EDID (manufacturer /
-    // model / connector), which agrees with the daemon per-output — the bug was only
-    // the window→output trust. Mirrors the snap-assist path in snaphandler.cpp.
-    // (QScreen can't be used here: inside the compositor QScreen::manufacturer() /
-    // model() are empty, so a QScreen-derived id degrades to "::serial".)
-    const KWin::LogicalOutput* output = KWin::effects->screenAt(c);
-    if (!output) {
-        output = w->screen();
-    }
-    return resolveEffectiveScreenId(c, output);
+    // Position-resolved output (see windowOutput). outputScreenId derives the
+    // id from the KWin output's OWN EDID (manufacturer / model / connector),
+    // which agrees with the daemon per-output — the #724 bug was only the
+    // window→output trust. (QScreen can't be used here: inside the compositor
+    // QScreen::manufacturer() / model() are empty, so a QScreen-derived id
+    // degrades to "::serial".)
+    return resolveEffectiveScreenId(c, windowOutput(w));
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
+++ b/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
@@ -1362,20 +1362,12 @@ void PlasmaZonesEffect::notifyWindowActivated(KWin::EffectWindow* w)
     // activates the window its current desktop is already updated, and
     // fire-and-forget calls share one ordered D-Bus connection, so reporting
     // here guarantees the daemon switches context first. reportScreenDesktop
-    // dedups, so outside a desktop switch this is a no-op. Resolve the output
-    // by window position, mirroring getWindowScreenId (Discussion #724:
-    // w->screen() can disagree with the daemon on identical-model outputs).
-    {
-        const QPointF cf = w->frameGeometry().center();
-        const QPoint c(qRound(cf.x()), qRound(cf.y()));
-        KWin::LogicalOutput* output = KWin::effects->screenAt(c);
-        if (!output) {
-            output = w->screen();
-        }
-        if (output) {
-            if (auto* vd = KWin::effects->currentDesktop(output)) {
-                reportScreenDesktop(outputScreenId(output), static_cast<int>(vd->x11DesktopNumber()));
-            }
+    // dedups, so outside a desktop switch this is a no-op. windowOutput
+    // resolves by window position (Discussion #724: w->screen() can disagree
+    // with the daemon on identical-model outputs).
+    if (KWin::LogicalOutput* output = windowOutput(w)) {
+        if (auto* vd = KWin::effects->currentDesktop(output)) {
+            reportScreenDesktop(outputScreenId(output), static_cast<int>(vd->x11DesktopNumber()));
         }
     }
 

--- a/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
+++ b/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
@@ -1351,6 +1351,34 @@ void PlasmaZonesEffect::notifyWindowActivated(KWin::EffectWindow* w)
     QString windowId = getWindowId(w);
     QString screenId = getWindowScreenId(w);
 
+    // Push the output's current desktop BEFORE the activation notifies. On a
+    // virtual-desktop switch KWin activates the destination desktop's
+    // last-focused window before EffectsHandler::desktopChanged fires, so the
+    // daemon would otherwise process this focus event while its per-screen
+    // desktop context still points at the desktop the user just left — the
+    // autotile engine then sees a same-screen context mismatch and migrates
+    // the activated window into the WRONG desktop's tiling state (discussion
+    // #728: cross-desktop tile leak on rapid switching). By the time KWin
+    // activates the window its current desktop is already updated, and
+    // fire-and-forget calls share one ordered D-Bus connection, so reporting
+    // here guarantees the daemon switches context first. reportScreenDesktop
+    // dedups, so outside a desktop switch this is a no-op. Resolve the output
+    // by window position, mirroring getWindowScreenId (Discussion #724:
+    // w->screen() can disagree with the daemon on identical-model outputs).
+    {
+        const QPointF cf = w->frameGeometry().center();
+        const QPoint c(qRound(cf.x()), qRound(cf.y()));
+        KWin::LogicalOutput* output = KWin::effects->screenAt(c);
+        if (!output) {
+            output = w->screen();
+        }
+        if (output) {
+            if (auto* vd = KWin::effects->currentDesktop(output)) {
+                reportScreenDesktop(outputScreenId(output), static_cast<int>(vd->x11DesktopNumber()));
+            }
+        }
+    }
+
     qCDebug(lcEffect) << "Notifying daemon: windowActivated" << windowId << "on screen" << screenId;
     PhosphorProtocol::ClientHelpers::fireAndForget(this, PhosphorProtocol::Service::Interface::WindowTracking,
                                                    QStringLiteral("windowActivated"), {windowId, screenId});


### PR DESCRIPTION
## Summary

Fixes the v3.2.2 cross-desktop autotile leak re-reported in discussion #728 (windows jumping between tiled virtual desktops, overlapping / going floating on rapid switching).

## Root cause

On a virtual-desktop switch KWin activates the destination desktop's last-focused window **before** emitting `EffectsHandler::desktopChanged`. The effect forwards both as fire-and-forget D-Bus calls, so the daemon processed the focus event while the autotile engine's per-screen desktop context still pointed at the desktop the user just left.

The engine's deferred `revalidateWindowContext` (queued one event-loop pass to let an in-flight context push settle) cannot cover this: the `screenDesktopChanged` message had not even been sent by the effect yet, so the revalidate saw a persisting same-screen key mismatch and migrated the activated window into the **wrong desktop's** `TilingState`. The window becomes a ghost tile on one desktop and an untracked floater on the other, reflowing both desktops' layouts. It self-heals on the window's next focus, which is why users see churn rather than permanent loss.

The reporter's support-report journal shows the signature on every occurrence: `Window "X" moved from "S" to "S" - migrating` (identical screens) immediately before `Switching autotile context N -> M`.

## Fix

In `notifyWindowActivated`, report the activated window's output desktop via `reportScreenDesktop` **before** the `windowActivated` / `notifyWindowFocused` notifies:

- By activation time KWin's current desktop is already updated, so the report carries the new desktop.
- Fire-and-forget calls share one ordered D-Bus connection, so the daemon is guaranteed to switch the autotile context before processing the focus event, making `alreadyCorrect` true and skipping the bogus migration entirely.
- `reportScreenDesktop` dedups, so outside a desktop switch this is a no-op.
- The output is resolved by window position rather than `w->screen()`, mirroring `getWindowScreenId` (discussion #724).

## Testing

- Full build succeeds; all 290 ctest tests pass.
- Live verification needs a logout/login (KWin does not reload a rebuilt effect .so).

🤖 Generated with [Claude Code](https://claude.com/claude-code)