### PR TITLE
fix(shortcuts): keep the registry entry when a shortcut is cleared

### DIFF
--- a/libs/phosphor-shortcuts/include/PhosphorShortcuts/Registry.h
+++ b/libs/phosphor-shortcuts/include/PhosphorShortcuts/Registry.h
@@ -69,8 +69,9 @@ public:
     /**
      * Change the active binding for an already-registered id. Takes effect
      * after flush(). Unknown ids are logged and ignored. Passing an empty
-     * QKeySequence routes through unbind() — releasing the grab cleanly
-     * rather than leaving an empty sequence registered.
+     * QKeySequence releases the backend grab immediately (never leaves an
+     * empty sequence registered) but KEEPS the entry, so a later rebind()
+     * to a non-empty sequence re-registers it without a fresh bind().
      */
     void rebind(const QString& id, const QKeySequence& seq);
 

--- a/libs/phosphor-shortcuts/src/registry.cpp
+++ b/libs/phosphor-shortcuts/src/registry.cpp
@@ -71,10 +71,25 @@ void Registry::rebind(const QString& id, const QKeySequence& seq)
         return;
     }
     if (seq.isEmpty()) {
-        // An empty sequence would otherwise leave the grab registered with no
-        // key (the pre-library stale-Wayland-grab hazard from discussion #155).
-        // Route through unbind() so the backend drops the grab cleanly.
-        unbind(id);
+        // Clearing a shortcut must release the grab (an empty sequence left
+        // registered is the pre-library stale-Wayland-grab hazard from
+        // discussion #155) but must NOT forget the entry. Consumers rebind by
+        // id on every settings change (ShortcutManager::rebindAll walks its
+        // own table), so an evaporated entry turned every later rebind for
+        // the id into a warning no-op — a cleared shortcut could never be
+        // re-enabled until process restart (discussion #809). Drop the
+        // backend registration here, keep the entry, and reset the sent-state
+        // so a later non-empty rebind() re-registers through flush().
+        if (it->binding.currentSeq.isEmpty()) {
+            return;
+        }
+        it->binding.currentSeq = QKeySequence();
+        if (it->registered && m_backend) {
+            m_backend->unregisterShortcut(id);
+        }
+        it->registered = false;
+        it->lastSentDefault = QKeySequence();
+        it->lastSentCurrent = QKeySequence();
         return;
     }
     if (it->binding.currentSeq == seq) {

--- a/libs/phosphor-shortcuts/src/registry.cpp
+++ b/libs/phosphor-shortcuts/src/registry.cpp
@@ -87,9 +87,12 @@ void Registry::rebind(const QString& id, const QKeySequence& seq)
         if (it->registered && m_backend) {
             m_backend->unregisterShortcut(id);
         }
+        // Reset the full sent-state to match a fresh Entry — the backend has
+        // forgotten this id, so every lastSent field must say "nothing sent".
         it->registered = false;
         it->lastSentDefault = QKeySequence();
         it->lastSentCurrent = QKeySequence();
+        it->lastSentPersistent = true;
         return;
     }
     if (it->binding.currentSeq == seq) {

--- a/libs/phosphor-shortcuts/tests/test_registry.cpp
+++ b/libs/phosphor-shortcuts/tests/test_registry.cpp
@@ -224,7 +224,7 @@ private Q_SLOTS:
         QCOMPARE(backend.updates.size(), 0);
     }
 
-    void rebindEmptySequence_routesThroughUnbind()
+    void rebindEmptySequence_releasesGrabButKeepsEntry()
     {
         FakeBackend backend;
         Registry registry(&backend);
@@ -235,14 +235,71 @@ private Q_SLOTS:
         backend.updates.clear();
 
         // Rebind to an empty sequence should NOT leave the grab registered
-        // with an empty key (the pre-library stale-grab hazard). Route
-        // through unbind so the backend drops it cleanly.
+        // with an empty key (the pre-library stale-grab hazard) — the
+        // backend drops it immediately. But the entry must survive so a
+        // later rebind can re-enable the shortcut (discussion #809).
         registry.rebind(QStringLiteral("pz.a"), QKeySequence());
 
         QCOMPARE(backend.unregisters.size(), 1);
         QCOMPARE(backend.unregisters[0], QStringLiteral("pz.a"));
         QCOMPARE(backend.updates.size(), 0);
-        QCOMPARE(registry.bindings().size(), 0);
+        QCOMPARE(registry.bindings().size(), 1);
+        QCOMPARE(registry.shortcut(QStringLiteral("pz.a")), QKeySequence());
+    }
+
+    void rebindEmptySequence_whenNeverRegistered_skipsBackend()
+    {
+        FakeBackend backend;
+        Registry registry(&backend);
+
+        // bind + immediate clear BEFORE any flush — the backend never heard
+        // about this id, so clearing must not send it a spurious unregister
+        // (KGlobalAccel's unregister purges the persistent on-disk record).
+        registry.bind(QStringLiteral("pz.a"), QKeySequence(QStringLiteral("Meta+1")));
+        registry.rebind(QStringLiteral("pz.a"), QKeySequence());
+        registry.flush();
+
+        QCOMPARE(backend.registers.size(), 0);
+        QCOMPARE(backend.unregisters.size(), 0);
+        QCOMPARE(registry.bindings().size(), 1);
+    }
+
+    void rebindAfterClear_reRegistersWithBackend()
+    {
+        FakeBackend backend;
+        Registry registry(&backend);
+
+        registry.bind(QStringLiteral("pz.a"), QKeySequence(QStringLiteral("Meta+1")), QStringLiteral("A"));
+        registry.flush();
+
+        // Clear, then re-assign in the same session — the exact sequence a
+        // settings UI produces when the user empties a shortcut field and
+        // later types a new combo. Pre-fix the entry evaporated on clear and
+        // the re-assign was a warning no-op until process restart.
+        registry.rebind(QStringLiteral("pz.a"), QKeySequence());
+        registry.flush();
+
+        backend.registers.clear();
+        backend.updates.clear();
+
+        registry.rebind(QStringLiteral("pz.a"), QKeySequence(QStringLiteral("Meta+2")));
+        registry.flush();
+
+        // Fresh registerShortcut (not update) — the backend forgot the id on
+        // unregister, so it needs default + current + description again.
+        QCOMPARE(backend.registers.size(), 1);
+        QCOMPARE(backend.registers[0].id, QStringLiteral("pz.a"));
+        QCOMPARE(backend.registers[0].defaultSeq, QKeySequence(QStringLiteral("Meta+1")));
+        QCOMPARE(backend.registers[0].currentSeq, QKeySequence(QStringLiteral("Meta+2")));
+        QCOMPARE(backend.updates.size(), 0);
+
+        // The re-registered shortcut still activates.
+        int fired = 0;
+        registry.bind(QStringLiteral("pz.a"), QKeySequence(QStringLiteral("Meta+1")), QStringLiteral("A"), [&] {
+            ++fired;
+        });
+        backend.activate(QStringLiteral("pz.a"));
+        QCOMPARE(fired, 1);
     }
 
     void rebindUnknownId_isIgnored()

--- a/scripts/plasmazones-report.sh
+++ b/scripts/plasmazones-report.sh
@@ -57,6 +57,7 @@ while [[ $# -gt 0 ]]; do
             echo "  data/            User data (layouts, algorithms, shaders, animation profiles, etc.)"
             echo "  journal.log      Recent plasmazonesd journal entries"
             echo "  kwin-effect.log  Recent PlasmaZones KWin effect journal entries"
+            echo "  kglobalaccel.txt Effective KGlobalAccel bindings for the plasmazonesd component"
             exit 0
             ;;
         *)
@@ -172,7 +173,7 @@ if [[ -d "$CONFIG_DIR" ]]; then
         # journal logs below) or claimed by the DATA_DIR tree; a config-dir
         # entry with the same name must not fight them for the slot.
         case "$rel" in
-            report.md|journal.log|kwin-effect.log|data|data/*)
+            report.md|journal.log|kwin-effect.log|kglobalaccel.txt|data|data/*)
                 echo "Warning: skipping config entry '$rel' (name reserved by the archive layout)" >&2
                 continue ;;
         esac
@@ -295,6 +296,33 @@ if command -v journalctl &>/dev/null; then
         [[ -s "$STAGING/kwin-effect.log" ]] || rm -f "$STAGING/kwin-effect.log"
     fi
 fi
+
+# 5. Global shortcut state (KGlobalAccel)
+# The daemon registers shortcuts through KGlobalAccel with autoloading, so
+# what actually gets grabbed is the binding stored in kglobalshortcutsrc —
+# NOT the value in config.json, and the two can diverge (conflict prompts,
+# System Settings edits). Without this capture, "shortcut is set but nothing
+# happens" reports are untriageable from the archive alone (discussion #809).
+# Only the plasmazonesd component is included; the full file lists every
+# app's shortcuts, which the reporter did not agree to share.
+{
+    KGLOBAL_RC="${XDG_CONFIG_HOME:-$HOME/.config}/kglobalshortcutsrc"
+    if [[ -f "$KGLOBAL_RC" ]]; then
+        echo "── kglobalshortcutsrc [plasmazonesd] ──"
+        awk '/^\[/{keep=($0=="[plasmazonesd]")} keep' "$KGLOBAL_RC"
+        echo ""
+    fi
+    # Live registration state, best-effort: shows what KGlobalAccel is
+    # actually grabbing right now, which catches divergence between the
+    # on-disk rc and the running session.
+    if command -v busctl &>/dev/null; then
+        echo "── org.kde.kglobalaccel allShortcutInfos ──"
+        busctl --user call org.kde.kglobalaccel /component/plasmazonesd \
+            org.kde.kglobalaccel.Component allShortcutInfos 2>&1 || true
+    fi
+} | redact_home > "$STAGING/kglobalaccel.txt" || true
+# Nothing captured (no rc section, no busctl) → drop the blank file.
+[[ -s "$STAGING/kglobalaccel.txt" ]] || rm -f "$STAGING/kglobalaccel.txt"
 
 # ─── Create archive ──────────────────────────────────────────────────────────
 

--- a/src/dbus/windowdragadaptor.cpp
+++ b/src/dbus/windowdragadaptor.cpp
@@ -367,9 +367,9 @@ void WindowDragAdaptor::unregisterCancelOverlayShortcut()
     // unregisterAdhocShortcut() drops both the Registry entry and the
     // compositor-level key grab. Prior IShortcutBackend-era bug (discussion
     // #155) where setting an empty QKeySequence left a stale Wayland grab is
-    // no longer expressible: rebind() with an empty sequence now routes
-    // through unbind() inside the Registry, and the cancel path always uses
-    // the explicit unregister call below.
+    // no longer expressible: rebind() with an empty sequence releases the
+    // backend grab inside the Registry (keeping only the inert entry), and
+    // the cancel path always uses the explicit unregister call below.
     m_shortcutRegistrar->unregisterAdhocShortcut(kCancelOverlayId);
 }
 


### PR DESCRIPTION
## Summary

Surfaced by discussion #809. The reporter's journal showed `rebind(): unknown shortcut id "cycle_window_backward"` on every settings save, and the support tarball had no way to tell what KGlobalAccel was actually grabbing.

- **Clearing a shortcut no longer evaporates its registry entry.** `Registry::rebind()` with an empty sequence routed through `unbind()`, deleting the entry. Since `ShortcutManager::rebindAll()` rebinds by id on every settings change, a cleared shortcut turned every later rebind for that id into a warning no-op, and the shortcut could not be re-enabled until the daemon restarted. Clearing now releases the backend grab in place (skipping the backend entirely when the id was never registered, so KGlobalAccel's persistent on-disk record is not purged spuriously) and keeps the entry so a later non-empty rebind re-registers through the normal `flush()` path.
- **The support report now captures KGlobalAccel state.** The daemon registers shortcuts with the autoloading flag, so the binding stored in `kglobalshortcutsrc`, not `config.json`, is what actually gets grabbed, and the two can diverge. The archive now includes `kglobalaccel.txt` with the `[plasmazonesd]` section of `kglobalshortcutsrc` plus a best-effort `allShortcutInfos` D-Bus dump (home paths redacted, only our component, blank file dropped).

## Testing

- Two new regression tests: clear-then-reassign re-registers with the backend and still activates; clear-before-first-flush sends the backend nothing. Both mutation-verified: they fail against the pre-fix `registry.cpp`.
- Adapted `rebindEmptySequence_routesThroughUnbind` to the new contract (grab released, entry kept).
- `test_registry`: 33/33 pass. Report-script change syntax-checked and smoke-tested locally (captures the rc section + live D-Bus state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
