### PR TITLE
fix(autotile): title bars flash on outgoing desktop's windows during desktop-switch animation

### DIFF
--- a/kwin-effect/autotilehandler/tiling.cpp
+++ b/kwin-effect/autotilehandler/tiling.cpp
@@ -337,26 +337,25 @@ void AutotileHandler::slotWindowsTileRequested(const PhosphorProtocol::TileReque
             const QSet<QString> previous = AutotileStateHelpers::tiledOnScreen(m_border, screenId);
             const QSet<QString> untiled = previous - newSet;
             for (const QString& wid : untiled) {
-                KWin::EffectWindow* win = m_effect->findWindowById(wid);
-                // Exact-id re-check: findWindowById's appId fuzzy fallback can
-                // resolve a same-app SIBLING for a gone id, and the desktop
-                // gate below must read the REAL window's desktop (a vanished
-                // window still falls through and clears).
-                if (win && m_effect->getWindowId(win) != wid) {
-                    win = nullptr;
-                }
-                // A retile batch describes ONE (screen, desktop) TilingState —
-                // the screen's CURRENT desktop. A tracked window sitting on
-                // another desktop is absent from `newSet` because it belongs
-                // to a sibling desktop's state, not because it was untiled,
-                // and this batch has no jurisdiction over it. Clearing it
-                // anyway flipped IsTiled, dropped the tiled appearance scope,
-                // and restored the title bar on the outgoing desktop's
-                // windows for the whole desktop-switch animation (#808). Its
-                // own desktop's retile decides its fate; genuine untiles
-                // while off-desktop (float, close) flow through funnels that
-                // clear all screens regardless.
-                if (win && !win->isOnCurrentDesktop()) {
+                // Exact resolve only: findWindowById's appId fuzzy fallback
+                // could hand back a same-app SIBLING for a gone id, and the
+                // jurisdiction gate below must read the REAL window's
+                // desktop/activity (a vanished window resolves null and still
+                // falls through and clears).
+                KWin::EffectWindow* win = m_effect->findWindowByIdExact(wid);
+                // A retile batch describes ONE (screen, desktop, activity)
+                // TilingState — the screen's CURRENT context. A tracked window
+                // sitting on another desktop or activity is absent from
+                // `newSet` because it belongs to a sibling context's state,
+                // not because it was untiled, and this batch has no
+                // jurisdiction over it. Clearing it anyway flipped IsTiled,
+                // dropped the tiled appearance scope, and restored the title
+                // bar on the outgoing desktop's windows for the whole
+                // desktop-switch animation (#808) — and identically for an
+                // activity switch. Its own context's retile decides its fate;
+                // genuine untiles while off-context (float, close) flow
+                // through funnels that clear all screens regardless.
+                if (win && (!win->isOnCurrentDesktop() || !win->isOnCurrentActivity())) {
                     continue;
                 }
                 // Every untiled window drops its per-screen tiled tracking,

--- a/kwin-effect/autotilehandler/tiling.cpp
+++ b/kwin-effect/autotilehandler/tiling.cpp
@@ -338,6 +338,27 @@ void AutotileHandler::slotWindowsTileRequested(const PhosphorProtocol::TileReque
             const QSet<QString> untiled = previous - newSet;
             for (const QString& wid : untiled) {
                 KWin::EffectWindow* win = m_effect->findWindowById(wid);
+                // Exact-id re-check: findWindowById's appId fuzzy fallback can
+                // resolve a same-app SIBLING for a gone id, and the desktop
+                // gate below must read the REAL window's desktop (a vanished
+                // window still falls through and clears).
+                if (win && m_effect->getWindowId(win) != wid) {
+                    win = nullptr;
+                }
+                // A retile batch describes ONE (screen, desktop) TilingState —
+                // the screen's CURRENT desktop. A tracked window sitting on
+                // another desktop is absent from `newSet` because it belongs
+                // to a sibling desktop's state, not because it was untiled,
+                // and this batch has no jurisdiction over it. Clearing it
+                // anyway flipped IsTiled, dropped the tiled appearance scope,
+                // and restored the title bar on the outgoing desktop's
+                // windows for the whole desktop-switch animation (#808). Its
+                // own desktop's retile decides its fate; genuine untiles
+                // while off-desktop (float, close) flow through funnels that
+                // clear all screens regardless.
+                if (win && !win->isOnCurrentDesktop()) {
+                    continue;
+                }
                 // Every untiled window drops its per-screen tiled tracking,
                 // minimized/unresolvable or not — hoisted so the branch below
                 // reads as what it actually gates: the centering-target
@@ -349,9 +370,9 @@ void AutotileHandler::slotWindowsTileRequested(const PhosphorProtocol::TileReque
                     continue;
                 }
                 // A daemon-initiated untile that is not a float/fullscreen/
-                // close/desktop-switch (e.g. a rule change dropping the
-                // window from the layout) must not leave a stale centering
-                // target that teleport-centers the window on its next
+                // close (e.g. a rule change dropping the window from the
+                // layout) must not leave a stale centering target that
+                // teleport-centers the window on its next
                 // frameGeometryChanged. Cross-screen transfers are safe: the
                 // apply lambda wrote a fresh entry only for windows in
                 // toApply, which are never in `untiled` for their new screen.

--- a/kwin-effect/snaphandler.h
+++ b/kwin-effect/snaphandler.h
@@ -205,11 +205,12 @@ private:
     // is per-(screen, desktop, activity). It stays correct ONLY because every
     // mutation is per-window (mark/clear at commit funnels) — there is no
     // batch diff. Never add an "untile whatever is absent from this batch"
-    // cleanup here without gating on isOnCurrentDesktop: a window absent from
-    // the current desktop's batch is usually snapped in a SIBLING desktop's
-    // state, and clearing it flips the tiled appearance scope and restores
-    // its title bar mid-desktop-switch (the autotile #808 bug; see the gated
-    // diff in autotilehandler/tiling.cpp onComplete).
+    // cleanup here without gating on isOnCurrentDesktop AND
+    // isOnCurrentActivity: a window absent from the current context's batch
+    // is usually snapped in a SIBLING desktop's or activity's state, and
+    // clearing it flips the tiled appearance scope and restores its title
+    // bar mid-switch (the autotile #808 bug; see the gated diff in
+    // autotilehandler/tiling.cpp onComplete).
     BorderState m_border;
     // Single-shot instant-restore latency cache (appId → saved zone geometry +
     // screen), populated on daemon-ready and consumed on window-open.

--- a/kwin-effect/snaphandler.h
+++ b/kwin-effect/snaphandler.h
@@ -200,6 +200,16 @@ private:
     // Snapping's own managed-window border state, parallel to
     // AutotileHandler::m_border. Populated at snap commit, cleared on
     // float / unsnap / close.
+    //
+    // KEYING WARNING: this set is per-SCREEN, but the daemon's snap membership
+    // is per-(screen, desktop, activity). It stays correct ONLY because every
+    // mutation is per-window (mark/clear at commit funnels) — there is no
+    // batch diff. Never add an "untile whatever is absent from this batch"
+    // cleanup here without gating on isOnCurrentDesktop: a window absent from
+    // the current desktop's batch is usually snapped in a SIBLING desktop's
+    // state, and clearing it flips the tiled appearance scope and restores
+    // its title bar mid-desktop-switch (the autotile #808 bug; see the gated
+    // diff in autotilehandler/tiling.cpp onComplete).
     BorderState m_border;
     // Single-shot instant-restore latency cache (appId → saved zone geometry +
     // screen), populated on daemon-ready and consumed on window-open.


### PR DESCRIPTION
Fixes #808.

## Bug

With **Hide title bars** on (scope: tiled windows) and a desktop-switch animation enabled, the outgoing desktop's autotiled windows showed their title bars for the whole animation.

## Root cause

On a desktop switch the daemon retiles the new desktop and the effect receives a tile batch containing only that desktop's windows. The batch's `onComplete` cleanup computed `untiled = previous - newSet` per screen, but the effect's tiled tracking is keyed per screen while the daemon's TilingState is per (screen, desktop). Every window on the outgoing desktop therefore landed in the diff and had its tracking cleared. That flipped `IsTiled`, dropped the tiled appearance scope, released the DecorationManager's rule owner, and called `setNoBorder(false)`. KWin re-decorated the windows right as the switch animation rendered them, and they stayed decorated until switching back retiled them.

## Fix

Gate the clear on `isOnCurrentDesktop`, after an exact-id re-check so the appId fuzzy fallback cannot read a sibling window's desktop. A retile batch only has jurisdiction over the screen's current desktop; a tracked window sitting on another desktop belongs to a sibling desktop's TilingState, and that desktop's own retile decides its fate. Vanished windows still fall through and clear, and genuine off-desktop untiles (float, close) already flow through funnels that clear all screens.

Timing note: retile batches arrive via the event loop after KWin's desktop flip commits, including on the activation-driven switch path from #728, so the predicate always reads post-switch state. The change also composes with the `slotScreensChanged` assignment-change path, which already skips sticky and multi-desktop windows for the same reason.

Also documents the keying hazard on `SnapHandler::m_border`, the snap side's structural twin: it is correct today only because all of its mutations are per-window, and a future batch-diff cleanup there must copy this gate. An audit of the remaining effect-side caches found no other unguarded absent-means-untiled diff.

## Testing

- Full suite: 290/290 pass.
- The gated path is effect-side and not reachable from ctest; live verification needs the rebuilt effect loaded (logout/login) with the reporter's setup: title bars hidden for tiled windows, desktop-switch animation on, switch between two autotiled desktops. Not yet run — root cause and timing were verified by code trace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)