### PR TITLE
fix(daemon): stop effective float state from flipping silently across contexts

### DIFF
--- a/dbus/org.plasmazones.WindowTracking.xml
+++ b/dbus/org.plasmazones.WindowTracking.xml
@@ -384,7 +384,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
                 <annotation name="org.gtk.GDBus.DocString" value="PhosphorProtocol::WindowType underlying value; out-of-range values are clamped to Unknown."/>
             </arg>
             <arg name="extended" type="a{sv}" direction="in">
-                <annotation name="org.gtk.GDBus.DocString" value="Extended window-property snapshot (state flags, geometry, accessory flags, captionNormal) keyed by PhosphorProtocol::Service::WindowMetadataKey. A key is present only when the value is known, so absent keys leave the derived window-rule field disengaged. Lets the daemon's Float/RestorePosition resolvers match the same KWin-property fields the effect path resolves live."/>
+                <annotation name="org.gtk.GDBus.DocString" value="Extended window-property snapshot (state flags, geometry, accessory flags, captionNormal, multi-desktop span list) keyed by PhosphorProtocol::Service::WindowMetadataKey. A key is present only when the value is known, so absent keys leave the derived window-rule field disengaged. Lets the daemon's Float/RestorePosition resolvers match the same KWin-property fields the effect path resolves live."/>
             </arg>
         </method>
         <method name="windowClosed">

--- a/kwin-effect/plasmazoneseffect/window_identity.cpp
+++ b/kwin-effect/plasmazoneseffect/window_identity.cpp
@@ -118,20 +118,16 @@ void PlasmaZonesEffect::pushWindowMetadata(KWin::EffectWindow* w, bool includeEx
     // (but not all) desktops reports its first here and the FULL list via the
     // VirtualDesktops extended key below, so the daemon's per-window mode
     // resolution can prefer whichever spanned desktop the screen currently
-    // shows instead of pinning to the first.
+    // shows instead of pinning to the first. Null desktop entries are skipped
+    // on BOTH derivations, keeping the "virtualDesktop equals the span list's
+    // first entry" invariant even if KWin hands back a null pointer.
     int virtualDesktop = 0;
-    QList<int> spannedDesktops;
     if (window) {
         const QList<KWin::VirtualDesktop*> desktops = window->desktops();
-        if (!desktops.isEmpty() && desktops.first()) {
-            virtualDesktop = static_cast<int>(desktops.first()->x11DesktopNumber());
-        }
-        if (desktops.size() > 1) {
-            spannedDesktops.reserve(desktops.size());
-            for (const KWin::VirtualDesktop* vd : desktops) {
-                if (vd) {
-                    spannedDesktops.append(static_cast<int>(vd->x11DesktopNumber()));
-                }
+        for (const KWin::VirtualDesktop* vd : desktops) {
+            if (vd) {
+                virtualDesktop = static_cast<int>(vd->x11DesktopNumber());
+                break;
             }
         }
     }
@@ -230,13 +226,25 @@ void PlasmaZonesEffect::pushWindowMetadata(KWin::EffectWindow* w, bool includeEx
         if (props.captionNormal) {
             extended.insert(Key::CaptionNormal, *props.captionNormal);
         }
-        if (!spannedDesktops.isEmpty()) {
-            QVariantList desktopsList;
-            desktopsList.reserve(spannedDesktops.size());
-            for (int d : std::as_const(spannedDesktops)) {
-                desktopsList.append(d);
+        // Multi-desktop span list. Collected here (not with virtualDesktop
+        // above) so a caption-only refresh skips the walk along with the rest
+        // of the extended build. Built as an explicit QVariantList — a
+        // QVariant wrapping QList<int> would not survive the daemon's
+        // .toList() readback.
+        if (window) {
+            const QList<KWin::VirtualDesktop*> desktops = window->desktops();
+            if (desktops.size() > 1) {
+                QVariantList desktopsList;
+                desktopsList.reserve(desktops.size());
+                for (const KWin::VirtualDesktop* vd : desktops) {
+                    if (vd) {
+                        desktopsList.append(static_cast<int>(vd->x11DesktopNumber()));
+                    }
+                }
+                if (!desktopsList.isEmpty()) {
+                    extended.insert(Key::VirtualDesktops, desktopsList);
+                }
             }
-            extended.insert(Key::VirtualDesktops, desktopsList);
         }
     }
 

--- a/kwin-effect/plasmazoneseffect/window_identity.cpp
+++ b/kwin-effect/plasmazoneseffect/window_identity.cpp
@@ -115,12 +115,24 @@ void PlasmaZonesEffect::pushWindowMetadata(KWin::EffectWindow* w, bool includeEx
 
     // virtualDesktop: 0 = on all desktops / unknown; otherwise the 1-based x11
     // desktop number of the window's first desktop. A window spanning several
-    // (but not all) desktops reports its first — the registry stores one int.
+    // (but not all) desktops reports its first here and the FULL list via the
+    // VirtualDesktops extended key below, so the daemon's per-window mode
+    // resolution can prefer whichever spanned desktop the screen currently
+    // shows instead of pinning to the first.
     int virtualDesktop = 0;
+    QList<int> spannedDesktops;
     if (window) {
         const QList<KWin::VirtualDesktop*> desktops = window->desktops();
         if (!desktops.isEmpty() && desktops.first()) {
             virtualDesktop = static_cast<int>(desktops.first()->x11DesktopNumber());
+        }
+        if (desktops.size() > 1) {
+            spannedDesktops.reserve(desktops.size());
+            for (const KWin::VirtualDesktop* vd : desktops) {
+                if (vd) {
+                    spannedDesktops.append(static_cast<int>(vd->x11DesktopNumber()));
+                }
+            }
         }
     }
 
@@ -217,6 +229,14 @@ void PlasmaZonesEffect::pushWindowMetadata(KWin::EffectWindow* w, bool includeEx
         }
         if (props.captionNormal) {
             extended.insert(Key::CaptionNormal, *props.captionNormal);
+        }
+        if (!spannedDesktops.isEmpty()) {
+            QVariantList desktopsList;
+            desktopsList.reserve(spannedDesktops.size());
+            for (int d : std::as_const(spannedDesktops)) {
+                desktopsList.append(d);
+            }
+            extended.insert(Key::VirtualDesktops, desktopsList);
         }
     }
 

--- a/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
+++ b/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
@@ -467,15 +467,12 @@ void PlasmaZonesEffect::setupWindowConnections(KWin::EffectWindow* w)
 
     connect(w, &KWin::EffectWindow::windowDesktopsChanged, this, [this](KWin::EffectWindow* window) {
         updateWindowStickyState(window);
-        // Keep the registry's virtualDesktop fresh: the daemon's per-engine
-        // float resolver picks the owning engine by the mode at the WINDOW's
-        // own desktop, and metadata is otherwise pushed only at window-add /
-        // class rename. Without this, a window moved across desktops keeps
-        // resolving through its stale desktop's mode. Low-frequency signal
-        // (explicit desktop moves), and the daemon upsert is idempotent.
-        if (window && !window->isDeleted()) {
-            pushWindowMetadata(window);
-        }
+        // No metadata push here: the daemon's float resolver reads the
+        // window's own desktop/activity from the registry, but that is kept
+        // fresh by the KWin::Window::desktopsChanged → pushLatest connection
+        // below (this signal is KWin's EffectWindow relay of the same event,
+        // so a push here would build and marshal the extended snapshot twice
+        // per desktop move).
 
         // When a window is moved to a different desktop (e.g., "Move to Desktop 2"),
         // treat it as removed from the current desktop's tiling. The normal desktop-

--- a/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
+++ b/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
@@ -467,6 +467,15 @@ void PlasmaZonesEffect::setupWindowConnections(KWin::EffectWindow* w)
 
     connect(w, &KWin::EffectWindow::windowDesktopsChanged, this, [this](KWin::EffectWindow* window) {
         updateWindowStickyState(window);
+        // Keep the registry's virtualDesktop fresh: the daemon's per-engine
+        // float resolver picks the owning engine by the mode at the WINDOW's
+        // own desktop, and metadata is otherwise pushed only at window-add /
+        // class rename. Without this, a window moved across desktops keeps
+        // resolving through its stale desktop's mode. Low-frequency signal
+        // (explicit desktop moves), and the daemon upsert is idempotent.
+        if (window && !window->isDeleted()) {
+            pushWindowMetadata(window);
+        }
 
         // When a window is moved to a different desktop (e.g., "Move to Desktop 2"),
         // treat it as removed from the current desktop's tiling. The normal desktop-

--- a/kwin-effect/plasmazoneseffect/window_query.cpp
+++ b/kwin-effect/plasmazoneseffect/window_query.cpp
@@ -223,15 +223,18 @@ PhosphorRules::WindowQuery ruleQueryFor(KWin::EffectWindow* w, const QString& sc
     // Frame position — from the same frameGeometry() already read for the size.
     query.positionX = static_cast<int>(frame.x());
     query.positionY = static_cast<int>(frame.y());
-    // virtualDesktop: first desktop's 1-based x11 number (0 = all/unknown).
-    // activity: first activity UUID (empty = all/unknown). Both mirror the
-    // daemon-side setWindowMetadata derivation in window_identity.cpp so a
-    // window-domain rule pinning VirtualDesktop / Activity resolves the same
-    // way the context cascade does.
+    // virtualDesktop: first non-null desktop's 1-based x11 number (0 = all/
+    // unknown). activity: first activity UUID (empty = all/unknown). Both
+    // mirror the daemon-side setWindowMetadata derivation in
+    // window_identity.cpp so a window-domain rule pinning VirtualDesktop /
+    // Activity resolves the same way the context cascade does.
     if (kw) {
         const QList<KWin::VirtualDesktop*> desktops = kw->desktops();
-        if (!desktops.isEmpty() && desktops.first()) {
-            query.virtualDesktop = static_cast<int>(desktops.first()->x11DesktopNumber());
+        for (const KWin::VirtualDesktop* vd : desktops) {
+            if (vd) {
+                query.virtualDesktop = static_cast<int>(vd->x11DesktopNumber());
+                break;
+            }
         }
     }
     const QStringList activities = w->activities();

--- a/libs/phosphor-engine/include/PhosphorEngine/WindowRegistry.h
+++ b/libs/phosphor-engine/include/PhosphorEngine/WindowRegistry.h
@@ -107,6 +107,33 @@ public:
         int virtualDesktop = 0;
         QList<int> virtualDesktops;
         QString activity;
+
+        /// Effective desktop for per-window mode resolution: the window's own
+        /// desktop when known (virtualDesktop > 0), never the screen's current
+        /// one — reading through the screen's current desktop is what made the
+        /// effective float answer flip across per-output desktop switches.
+        /// EXCEPTION: a window spanning SEVERAL desktops resolves to
+        /// @p screenCurrentDesktop when that is one of them — the visible
+        /// spanned desktop is the live context governing the window, not the
+        /// arbitrary first entry virtualDesktop pins to. Sticky / unknown
+        /// (virtualDesktop 0) falls back to @p screenCurrentDesktop.
+        int effectiveDesktop(int screenCurrentDesktop) const
+        {
+            if (virtualDesktops.size() > 1 && virtualDesktops.contains(screenCurrentDesktop)) {
+                return screenCurrentDesktop;
+            }
+            return virtualDesktop > 0 ? virtualDesktop : screenCurrentDesktop;
+        }
+
+        /// Effective activity: the window's own when known, else
+        /// @p currentActivity. No span analogue to effectiveDesktop's
+        /// current-context preference exists here — the metadata carries only
+        /// the window's first activity, not a list, so there is nothing to
+        /// prefer against.
+        QString effectiveActivity(const QString& currentActivity) const
+        {
+            return activity.isEmpty() ? currentActivity : activity;
+        }
     };
     std::optional<WindowContext> windowContext(const QString& instanceId) const;
     Q_INVOKABLE QString appIdFor(const QString& instanceId) const override;

--- a/libs/phosphor-engine/include/PhosphorEngine/WindowRegistry.h
+++ b/libs/phosphor-engine/include/PhosphorEngine/WindowRegistry.h
@@ -24,6 +24,10 @@ struct WindowMetadata
     QString windowRole{}; ///< X11 WM_WINDOW_ROLE; empty for Wayland-native windows
     int pid = 0; ///< process id; 0 = unknown
     int virtualDesktop = 0; ///< 1-based x11 desktop number; 0 = all desktops / unknown
+    /// Full desktop list when the window spans SEVERAL (but not all) desktops;
+    /// empty for the common single-desktop / sticky / unknown cases. When
+    /// non-empty, virtualDesktop equals the first entry.
+    QList<int> virtualDesktops{};
     QString activity{}; ///< activity UUID; empty = all activities / unknown
     PhosphorProtocol::WindowType windowType = PhosphorProtocol::WindowType::Unknown;
 
@@ -65,9 +69,9 @@ struct WindowMetadata
     {
         return appId == other.appId && desktopFile == other.desktopFile && title == other.title
             && windowRole == other.windowRole && pid == other.pid && virtualDesktop == other.virtualDesktop
-            && activity == other.activity && windowType == other.windowType && isMinimized == other.isMinimized
-            && isFullscreen == other.isFullscreen && isSticky == other.isSticky && isMaximized == other.isMaximized
-            && isFocused == other.isFocused && isTransient == other.isTransient
+            && virtualDesktops == other.virtualDesktops && activity == other.activity && windowType == other.windowType
+            && isMinimized == other.isMinimized && isFullscreen == other.isFullscreen && isSticky == other.isSticky
+            && isMaximized == other.isMaximized && isFocused == other.isFocused && isTransient == other.isTransient
             && isNotification == other.isNotification && keepAbove == other.keepAbove && keepBelow == other.keepBelow
             && skipTaskbar == other.skipTaskbar && skipPager == other.skipPager && skipSwitcher == other.skipSwitcher
             && isModal == other.isModal && hasDecoration == other.hasDecoration && isResizable == other.isResizable
@@ -94,12 +98,14 @@ public:
 
     std::optional<WindowMetadata> metadata(const QString& instanceId) const;
     /// The window's own context for per-window mode resolution: its virtual
-    /// desktop (0 = all/unknown) and activity (empty = all/unknown), read
-    /// without copying the full ~30-field metadata record — this sits on the
+    /// desktop (0 = all/unknown), the full desktop list when it spans several
+    /// (empty otherwise), and activity (empty = all/unknown), read without
+    /// copying the full ~30-field metadata record — this sits on the
     /// per-query float-resolver path. nullopt when the instance is unknown.
     struct WindowContext
     {
         int virtualDesktop = 0;
+        QList<int> virtualDesktops;
         QString activity;
     };
     std::optional<WindowContext> windowContext(const QString& instanceId) const;

--- a/libs/phosphor-engine/include/PhosphorEngine/WindowRegistry.h
+++ b/libs/phosphor-engine/include/PhosphorEngine/WindowRegistry.h
@@ -93,6 +93,16 @@ public:
     void remove(const QString& instanceId);
 
     std::optional<WindowMetadata> metadata(const QString& instanceId) const;
+    /// The window's own context for per-window mode resolution: its virtual
+    /// desktop (0 = all/unknown) and activity (empty = all/unknown), read
+    /// without copying the full ~30-field metadata record — this sits on the
+    /// per-query float-resolver path. nullopt when the instance is unknown.
+    struct WindowContext
+    {
+        int virtualDesktop = 0;
+        QString activity;
+    };
+    std::optional<WindowContext> windowContext(const QString& instanceId) const;
     Q_INVOKABLE QString appIdFor(const QString& instanceId) const override;
     QStringList instancesWithAppId(const QString& appId) const;
     bool contains(const QString& instanceId) const;

--- a/libs/phosphor-engine/src/WindowRegistry.cpp
+++ b/libs/phosphor-engine/src/WindowRegistry.cpp
@@ -61,6 +61,15 @@ std::optional<WindowMetadata> WindowRegistry::metadata(const QString& instanceId
     return it.value();
 }
 
+std::optional<WindowRegistry::WindowContext> WindowRegistry::windowContext(const QString& instanceId) const
+{
+    auto it = m_records.constFind(instanceId);
+    if (it == m_records.constEnd()) {
+        return std::nullopt;
+    }
+    return WindowContext{it.value().virtualDesktop, it.value().activity};
+}
+
 QString WindowRegistry::appIdFor(const QString& instanceId) const
 {
     auto it = m_records.constFind(instanceId);

--- a/libs/phosphor-engine/src/WindowRegistry.cpp
+++ b/libs/phosphor-engine/src/WindowRegistry.cpp
@@ -67,7 +67,7 @@ std::optional<WindowRegistry::WindowContext> WindowRegistry::windowContext(const
     if (it == m_records.constEnd()) {
         return std::nullopt;
     }
-    return WindowContext{it.value().virtualDesktop, it.value().activity};
+    return WindowContext{it.value().virtualDesktop, it.value().virtualDesktops, it.value().activity};
 }
 
 QString WindowRegistry::appIdFor(const QString& instanceId) const

--- a/libs/phosphor-engine/tests/CMakeLists.txt
+++ b/libs/phosphor-engine/tests/CMakeLists.txt
@@ -21,3 +21,4 @@ endfunction()
 
 pe_add_test(test_engine_screencontexttracker test_screencontexttracker.cpp)
 pe_add_test(test_engine_perscreenstates test_perscreenstates.cpp)
+pe_add_test(test_engine_windowcontext test_windowcontext.cpp)

--- a/libs/phosphor-engine/tests/test_windowcontext.cpp
+++ b/libs/phosphor-engine/tests/test_windowcontext.cpp
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <PhosphorEngine/WindowRegistry.h>
+#include <QTest>
+
+using PhosphorEngine::WindowRegistry;
+
+/**
+ * Pins WindowContext's effective-context policy — the root-cause fix for the
+ * silent float-state flips: per-window mode resolution must read the WINDOW's
+ * own desktop/activity, not the screen's current ones, so a per-output desktop
+ * switch (or activity switch) crossing a mode boundary cannot flip the
+ * effective float answer without a broadcast.
+ */
+class TestWindowContext : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void effectiveDesktop_data();
+    void effectiveDesktop();
+    void effectiveActivity_data();
+    void effectiveActivity();
+    void windowContextLookup();
+};
+
+void TestWindowContext::effectiveDesktop_data()
+{
+    QTest::addColumn<int>("virtualDesktop");
+    QTest::addColumn<QList<int>>("virtualDesktops");
+    QTest::addColumn<int>("screenCurrent");
+    QTest::addColumn<int>("expected");
+
+    // The core fix: the window's own desktop wins over the screen's current
+    // one. Reverting to screen-current resolution fails this row.
+    QTest::newRow("own-desktop-beats-screen-current") << 3 << QList<int>{} << 1 << 3;
+    QTest::newRow("own-desktop-equals-screen-current") << 2 << QList<int>{} << 2 << 2;
+    // Sticky / unknown (0) falls back to the screen's current desktop.
+    QTest::newRow("sticky-falls-back-to-screen-current") << 0 << QList<int>{} << 4 << 4;
+    // Multi-desktop span: when the screen currently shows one of the spanned
+    // desktops, that one is the live context — preferred over the first entry.
+    QTest::newRow("span-prefers-visible-spanned-desktop") << 2 << QList<int>{2, 3} << 3 << 3;
+    QTest::newRow("span-first-entry-when-visible") << 2 << QList<int>{2, 3} << 2 << 2;
+    // Screen shows a desktop OUTSIDE the span: the window's first desktop wins.
+    QTest::newRow("span-offscreen-uses-first-entry") << 2 << QList<int>{2, 3} << 5 << 2;
+}
+
+void TestWindowContext::effectiveDesktop()
+{
+    QFETCH(int, virtualDesktop);
+    QFETCH(QList<int>, virtualDesktops);
+    QFETCH(int, screenCurrent);
+    QFETCH(int, expected);
+
+    WindowRegistry::WindowContext ctx;
+    ctx.virtualDesktop = virtualDesktop;
+    ctx.virtualDesktops = virtualDesktops;
+    QCOMPARE(ctx.effectiveDesktop(screenCurrent), expected);
+}
+
+void TestWindowContext::effectiveActivity_data()
+{
+    QTest::addColumn<QString>("activity");
+    QTest::addColumn<QString>("currentActivity");
+    QTest::addColumn<QString>("expected");
+
+    QTest::newRow("own-activity-beats-current")
+        << QStringLiteral("{aaaa}") << QStringLiteral("{bbbb}") << QStringLiteral("{aaaa}");
+    QTest::newRow("all-activities-falls-back-to-current")
+        << QString() << QStringLiteral("{bbbb}") << QStringLiteral("{bbbb}");
+}
+
+void TestWindowContext::effectiveActivity()
+{
+    QFETCH(QString, activity);
+    QFETCH(QString, currentActivity);
+    QFETCH(QString, expected);
+
+    WindowRegistry::WindowContext ctx;
+    ctx.activity = activity;
+    QCOMPARE(ctx.effectiveActivity(currentActivity), expected);
+}
+
+void TestWindowContext::windowContextLookup()
+{
+    // The registry hands the resolver exactly the upserted per-window context,
+    // and an unknown instance yields nullopt (resolver falls back to the
+    // screen's current context).
+    WindowRegistry registry;
+    PhosphorEngine::WindowMetadata meta;
+    meta.appId = QStringLiteral("org.example.app");
+    meta.virtualDesktop = 2;
+    meta.virtualDesktops = QList<int>{2, 3};
+    meta.activity = QStringLiteral("{aaaa}");
+    registry.upsert(QStringLiteral("instance-1"), meta);
+
+    const auto ctx = registry.windowContext(QStringLiteral("instance-1"));
+    QVERIFY(ctx.has_value());
+    QCOMPARE(ctx->virtualDesktop, 2);
+    QCOMPARE(ctx->virtualDesktops, (QList<int>{2, 3}));
+    QCOMPARE(ctx->activity, QStringLiteral("{aaaa}"));
+    QCOMPARE(ctx->effectiveDesktop(3), 3);
+
+    QVERIFY(!registry.windowContext(QStringLiteral("unknown")).has_value());
+}
+
+QTEST_APPLESS_MAIN(TestWindowContext)
+#include "test_windowcontext.moc"

--- a/libs/phosphor-protocol/include/PhosphorProtocol/ServiceConstants.h
+++ b/libs/phosphor-protocol/include/PhosphorProtocol/ServiceConstants.h
@@ -80,6 +80,10 @@ inline constexpr QLatin1String Height("height");
 inline constexpr QLatin1String PositionX("positionX");
 inline constexpr QLatin1String PositionY("positionY");
 inline constexpr QLatin1String CaptionNormal("captionNormal");
+/// Full 1-based desktop-number list for a window on SEVERAL (but not all)
+/// virtual desktops. Sent only when the window spans more than one desktop;
+/// the positional virtualDesktop arg stays the first entry for compatibility.
+inline constexpr QLatin1String VirtualDesktops("virtualDesktops");
 }
 
 /// Single-instance app identities. Each Phosphor sub-process (settings,

--- a/libs/phosphor-tile-engine/src/AutotileEngine.cpp
+++ b/libs/phosphor-tile-engine/src/AutotileEngine.cpp
@@ -2051,6 +2051,20 @@ void AutotileEngine::handoffReceive(const HandoffContext& ctx)
     }
     m_states.setKeyForWindow(windowId, destKey);
 
+    // Announce the received float bit on the passive channel (the snap twin
+    // emits from its handoffReceive too; this engine previously set the bit
+    // silently). A cross-mode move/swap of a floating window arrives with
+    // wasFloating=false after the source engine's handoffRelease cleared its
+    // bit without emitting — without this, subscribers that last heard
+    // "floating" (the effect's FloatingCache) stay stale until a daemon
+    // reconnect. Deliberately UNCONDITIONAL, not divergence-gated against
+    // the WTS resolver: mid-handoff the resolver already reads the cleared
+    // source bit, so it cannot tell what subscribers last heard — the
+    // adaptor's last-broadcast gate owns that dedup. Passive signal, not
+    // windowFloatingChanged: the window already has a valid position and
+    // must not ride the pre-tile geometry restore.
+    Q_EMIT windowFloatingStateSynced(windowId, ctx.wasFloating, ctx.toScreenId);
+
     // Trigger a retile so a non-floating arrival actually lands in a tile;
     // floating arrivals retile too because their displacement may free a
     // slot for the remaining tiled set.

--- a/libs/phosphor-tile-engine/src/AutotileEngine.cpp
+++ b/libs/phosphor-tile-engine/src/AutotileEngine.cpp
@@ -728,19 +728,18 @@ void AutotileEngine::setAutotileScreens(const QSet<QString>& screens)
                             if (rec
                                 && rec->slotFor(engineId()).state == PhosphorEngine::WindowPlacement::stateFloating()) {
                                 ts->setFloating(windowId, true);
-                                // Announce on the passive channel (mirrors
-                                // handoffReceive): the later windowOpened for
-                                // this already-present window is a tracked
-                                // no-op insert whose float sync is skipped,
-                                // so without this the seed restores a float
-                                // bit nothing ever broadcasts — subscribers
-                                // that believe the window not-floating (and
-                                // the adaptor's last-broadcast gate) stay
-                                // stale until a daemon reconnect. The gate
-                                // dedups when they already agree.
-                                Q_EMIT windowFloatingStateSynced(windowId, true, screenId);
                             }
                         }
+                        // Announce on the passive channel via the canonical
+                        // insert-time sync (both directions: restored-floating
+                        // OR seeded-tiled-over-a-stale-WTS-float-bit). The
+                        // later windowOpened for this already-present window
+                        // is a tracked no-op insert whose float sync is
+                        // skipped, so without this the seed's float state is
+                        // never broadcast — subscribers (and the adaptor's
+                        // last-broadcast gate) stay stale until a daemon
+                        // reconnect. The gate dedups when they already agree.
+                        emitInsertFloatStateSync(windowId, screenId);
                     }
                 }
             }
@@ -3119,7 +3118,8 @@ void AutotileEngine::emitInsertFloatStateSync(const QString& windowId, const QSt
 {
     // Read-only lookup — must NOT lazily materialize a state. tilingStateForScreen
     // would create one for a known-but-stateless screen; this method only reads
-    // isFloating right after a successful insertWindow, so the state already exists.
+    // isFloating right after a window lands in an existing state (insertWindow,
+    // or the strict-initial-order seed in setAutotileScreens), so it already exists.
     PhosphorTiles::TilingState* state = m_states.stateForKey(currentKeyForScreen(screenId));
     if (!state) {
         return;

--- a/libs/phosphor-tile-engine/src/AutotileEngine.cpp
+++ b/libs/phosphor-tile-engine/src/AutotileEngine.cpp
@@ -728,6 +728,17 @@ void AutotileEngine::setAutotileScreens(const QSet<QString>& screens)
                             if (rec
                                 && rec->slotFor(engineId()).state == PhosphorEngine::WindowPlacement::stateFloating()) {
                                 ts->setFloating(windowId, true);
+                                // Announce on the passive channel (mirrors
+                                // handoffReceive): the later windowOpened for
+                                // this already-present window is a tracked
+                                // no-op insert whose float sync is skipped,
+                                // so without this the seed restores a float
+                                // bit nothing ever broadcasts — subscribers
+                                // that believe the window not-floating (and
+                                // the adaptor's last-broadcast gate) stay
+                                // stale until a daemon reconnect. The gate
+                                // dedups when they already agree.
+                                Q_EMIT windowFloatingStateSynced(windowId, true, screenId);
                             }
                         }
                     }

--- a/libs/phosphor-tile-engine/src/AutotileEngine.cpp
+++ b/libs/phosphor-tile-engine/src/AutotileEngine.cpp
@@ -2003,7 +2003,10 @@ void AutotileEngine::handoffReceive(const HandoffContext& ctx)
     }
 
     // Already tracked on the destination screen — nothing to adopt; the float
-    // toggle path is what the caller probably wants instead.
+    // toggle path is what the caller probably wants instead. No float
+    // announcement needed on this return: the float bit is untouched (we
+    // return before setFloating), so what subscribers last heard remains
+    // accurate.
     const auto destKey = currentKeyForScreen(ctx.toScreenId);
     const auto trackedKeyIt = m_states.windowKeys().constFind(windowId);
     if (trackedKeyIt != m_states.windowKeys().constEnd() && trackedKeyIt.value() == destKey
@@ -2052,8 +2055,10 @@ void AutotileEngine::handoffReceive(const HandoffContext& ctx)
     m_states.setKeyForWindow(windowId, destKey);
 
     // Announce the received float bit on the passive channel (the snap twin
-    // emits from its handoffReceive too; this engine previously set the bit
-    // silently). A cross-mode move/swap of a floating window arrives with
+    // announces its float re-homes via windowFloatingChanged from its
+    // handoffReceive; this passive signal is autotile's position-preserving
+    // analogue — this engine previously set the bit silently). A cross-mode
+    // move/swap of a floating window arrives with
     // wasFloating=false after the source engine's handoffRelease cleared its
     // bit without emitting — without this, subscribers that last heard
     // "floating" (the effect's FloatingCache) stay stale until a daemon

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1673,19 +1673,13 @@ bool Daemon::init()
                 if (wts && wts->windowRegistry()) {
                     const auto ctx =
                         wts->windowRegistry()->windowContext(::PhosphorIdentity::WindowId::extractInstanceId(windowId));
-                    if (ctx && ctx->virtualDesktop > 0) {
-                        desktop = ctx->virtualDesktop;
-                    }
-                    // A window spanning SEVERAL desktops carries the full
-                    // list; when the screen currently shows one of them, that
-                    // one is the live context governing the window — prefer
-                    // it over the arbitrary first entry virtualDesktop pins
-                    // to. Single-desktop and sticky windows carry no list.
-                    if (ctx && ctx->virtualDesktops.size() > 1 && ctx->virtualDesktops.contains(screenCurrent)) {
-                        desktop = screenCurrent;
-                    }
-                    if (ctx && !ctx->activity.isEmpty()) {
-                        activity = ctx->activity;
+                    if (ctx) {
+                        // Own-desktop / multi-desktop-span / sticky policy
+                        // lives on WindowContext (see effectiveDesktop's doc);
+                        // this resolver just supplies the screen-current
+                        // fallbacks.
+                        desktop = ctx->effectiveDesktop(screenCurrent);
+                        activity = ctx->effectiveActivity(activity);
                     }
                 }
                 return m_layoutManager->modeForScreen(screenId, desktop, activity);

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1667,13 +1667,22 @@ bool Daemon::init()
                 screenId = wts->screenForWindow(windowId);
             }
             if (!screenId.isEmpty() && m_layoutManager) {
-                int desktop = currentDesktopForScreen(screenId);
+                const int screenCurrent = currentDesktopForScreen(screenId);
+                int desktop = screenCurrent;
                 QString activity = currentActivity();
                 if (wts && wts->windowRegistry()) {
                     const auto ctx =
                         wts->windowRegistry()->windowContext(::PhosphorIdentity::WindowId::extractInstanceId(windowId));
                     if (ctx && ctx->virtualDesktop > 0) {
                         desktop = ctx->virtualDesktop;
+                    }
+                    // A window spanning SEVERAL desktops carries the full
+                    // list; when the screen currently shows one of them, that
+                    // one is the live context governing the window — prefer
+                    // it over the arbitrary first entry virtualDesktop pins
+                    // to. Single-desktop and sticky windows carry no list.
+                    if (ctx && ctx->virtualDesktops.size() > 1 && ctx->virtualDesktops.contains(screenCurrent)) {
+                        desktop = screenCurrent;
                     }
                     if (ctx && !ctx->activity.isEmpty()) {
                         activity = ctx->activity;

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -48,6 +48,7 @@
 #include "rendering/zoneentryscaffold.h"
 #include "rendering/zoneshadernoderhi.h"
 #include <PhosphorIdentity/VirtualScreenId.h>
+#include <PhosphorIdentity/WindowId.h>
 #include <PhosphorZones/LayoutRegistry.h>
 #include "../config/configbackends.h"
 #include <PhosphorTiles/AlgorithmRegistry.h>
@@ -1641,15 +1642,35 @@ bool Daemon::init()
     // Mode resolution: the window's tracked screen (WTS screenForWindow, with
     // the autotile engine's own tracked screen as the fallback for windows snap
     // never saw) → LayoutRegistry::modeForScreen → the owning engine.
+    //
+    // Resolved at the WINDOW's OWN desktop (registry metadata), not the
+    // screen's current one. The window's desktop is per-window data, never
+    // the context key: reading through the screen's CURRENT desktop made the
+    // effective float answer flip when a per-output desktop switch crossed a
+    // snap↔autotile mode boundary — with no windowFloatingChanged broadcast,
+    // stranding every flat float mirror (the effect's FloatingCache) until a
+    // daemon reconnect. A window on the screen's current desktop (and the
+    // sticky / unknown-desktop case, virtualDesktop 0) resolves exactly as
+    // before via the fallback.
     {
         auto screenModeForWindow = [this, autotilePtr = QPointer(autotileEngine)](
                                        const QString& windowId) -> PhosphorZones::AssignmentEntry::Mode {
             QString screenId;
+            const PhosphorPlacement::WindowTrackingService* wts = nullptr;
             if (m_windowTrackingAdaptor && m_windowTrackingAdaptor->service()) {
-                screenId = m_windowTrackingAdaptor->service()->screenForWindow(windowId);
+                wts = m_windowTrackingAdaptor->service();
+                screenId = wts->screenForWindow(windowId);
             }
             if (!screenId.isEmpty() && m_layoutManager) {
-                return m_layoutManager->modeForScreen(screenId, currentDesktopForScreen(screenId), currentActivity());
+                int desktop = currentDesktopForScreen(screenId);
+                if (wts && wts->windowRegistry()) {
+                    const std::optional<PhosphorEngine::WindowMetadata> meta =
+                        wts->windowRegistry()->metadata(::PhosphorIdentity::WindowId::extractInstanceId(windowId));
+                    if (meta && meta->virtualDesktop > 0) {
+                        desktop = meta->virtualDesktop;
+                    }
+                }
+                return m_layoutManager->modeForScreen(screenId, desktop, currentActivity());
             }
             // No tracked screen in WTS (e.g. a window snap never saw): if the
             // autotile engine tracks it, its current mode is Autotile. Otherwise

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1653,7 +1653,10 @@ bool Daemon::init()
     // (the effect's FloatingCache) until a daemon reconnect. A window on the
     // screen's current desktop/activity (and the sticky / unknown cases:
     // virtualDesktop 0, empty activity) resolves exactly as before via the
-    // fallbacks.
+    // fallbacks. The shared lambda serves the float WRITER and the
+    // autotile-mode predicate too, so those routing decisions shift to the
+    // window's own context along with the reader — deliberate: all three
+    // answer "which engine owns this window", and that has one answer.
     {
         auto screenModeForWindow = [this, autotilePtr = QPointer(autotileEngine)](
                                        const QString& windowId) -> PhosphorZones::AssignmentEntry::Mode {

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1639,19 +1639,21 @@ bool Daemon::init()
     // window's CURRENT screen mode. This replaces the old single shared
     // m_floatingWindows + m_snapState bit that both engines read/wrote.
     //
-    // Mode resolution: the window's tracked screen (WTS screenForWindow, with
-    // the autotile engine's own tracked screen as the fallback for windows snap
-    // never saw) → LayoutRegistry::modeForScreen → the owning engine.
+    // Mode resolution: the window's tracked screen (WTS screenForWindow; for
+    // windows snap never saw, the no-screen fallback below resolves a MODE
+    // directly — Autotile when that engine tracks the window, else Snapping)
+    // → LayoutRegistry::modeForScreen → the owning engine.
     //
-    // Resolved at the WINDOW's OWN desktop (registry metadata), not the
-    // screen's current one. The window's desktop is per-window data, never
-    // the context key: reading through the screen's CURRENT desktop made the
-    // effective float answer flip when a per-output desktop switch crossed a
-    // snap↔autotile mode boundary — with no windowFloatingChanged broadcast,
-    // stranding every flat float mirror (the effect's FloatingCache) until a
-    // daemon reconnect. A window on the screen's current desktop (and the
-    // sticky / unknown-desktop case, virtualDesktop 0) resolves exactly as
-    // before via the fallback.
+    // Resolved at the WINDOW's OWN desktop and activity (registry context),
+    // not the screen's current ones. Those are per-window data, never the
+    // context key: reading through the screen's CURRENT desktop/activity
+    // made the effective float answer flip when a per-output desktop switch
+    // (or an activity switch) crossed a snap↔autotile mode boundary — with
+    // no windowFloatingChanged broadcast, stranding every flat float mirror
+    // (the effect's FloatingCache) until a daemon reconnect. A window on the
+    // screen's current desktop/activity (and the sticky / unknown cases:
+    // virtualDesktop 0, empty activity) resolves exactly as before via the
+    // fallbacks.
     {
         auto screenModeForWindow = [this, autotilePtr = QPointer(autotileEngine)](
                                        const QString& windowId) -> PhosphorZones::AssignmentEntry::Mode {
@@ -1663,14 +1665,18 @@ bool Daemon::init()
             }
             if (!screenId.isEmpty() && m_layoutManager) {
                 int desktop = currentDesktopForScreen(screenId);
+                QString activity = currentActivity();
                 if (wts && wts->windowRegistry()) {
-                    const std::optional<PhosphorEngine::WindowMetadata> meta =
-                        wts->windowRegistry()->metadata(::PhosphorIdentity::WindowId::extractInstanceId(windowId));
-                    if (meta && meta->virtualDesktop > 0) {
-                        desktop = meta->virtualDesktop;
+                    const auto ctx =
+                        wts->windowRegistry()->windowContext(::PhosphorIdentity::WindowId::extractInstanceId(windowId));
+                    if (ctx && ctx->virtualDesktop > 0) {
+                        desktop = ctx->virtualDesktop;
+                    }
+                    if (ctx && !ctx->activity.isEmpty()) {
+                        activity = ctx->activity;
                     }
                 }
-                return m_layoutManager->modeForScreen(screenId, desktop, currentActivity());
+                return m_layoutManager->modeForScreen(screenId, desktop, activity);
             }
             // No tracked screen in WTS (e.g. a window snap never saw): if the
             // autotile engine tracks it, its current mode is Autotile. Otherwise

--- a/src/daemon/daemon/signals.cpp
+++ b/src/daemon/daemon/signals.cpp
@@ -1069,11 +1069,14 @@ void Daemon::syncAutotileBatchFloatState(const QStringList& windowIds, const QSt
         // the next genuine unfloat broadcast hit false==false in the gate and
         // was suppressed — stranding the effect's float cache exactly like
         // the silent flips this contract exists to prevent. The relay's
-        // windowFloatingChanged emission is redundant for the effect (it
-        // already processed the float from the windowsTileRequested batch;
-        // the cache write is idempotent) and overflow floats are rare, so
-        // the spare signal is the price of keeping the last-broadcast
-        // contract single-owner and universal.
+        // windowFloatingChanged emission is redundant for the effect: its
+        // float-cache write no-ops (already floating from the
+        // windowsTileRequested batch) and the rest of its handler is
+        // convergent (coalesced rule reconcile re-resolving to the same
+        // state, idempotent snap-tracking clears, a raise of the already-
+        // floated window at most). Overflow floats are rare, so the spare
+        // signal is the price of keeping the last-broadcast contract
+        // single-owner and universal.
         wts->setWindowFloating(windowId, true);
         m_windowTrackingAdaptor->relayWindowFloatingChanged(windowId, true, screenId);
         m_autotileEngine->markModeSpecificFloated(windowId);

--- a/src/daemon/daemon/signals.cpp
+++ b/src/daemon/daemon/signals.cpp
@@ -1061,11 +1061,21 @@ void Daemon::syncAutotileBatchFloatState(const QStringList& windowIds, const QSt
     }
     PhosphorPlacement::WindowTrackingService* wts = m_windowTrackingAdaptor->service();
     for (const QString& windowId : windowIds) {
-        // Update WTS state directly — don't call setWindowFloating()
-        // on the adaptor since that emits a D-Bus windowFloatingChanged
-        // signal which the effect doesn't need (it already processed
-        // the float from the windowsTileRequested batch).
+        // Update WTS state directly (not adaptor setWindowFloating: its extra
+        // windowStateChanged/placement-capture side emissions are wrong for a
+        // batch the effect already applied), but DO route the broadcast
+        // bookkeeping through the relay chokepoint. Skipping it left
+        // m_broadcastFloating at not-floating for a batch-floated window, so
+        // the next genuine unfloat broadcast hit false==false in the gate and
+        // was suppressed — stranding the effect's float cache exactly like
+        // the silent flips this contract exists to prevent. The relay's
+        // windowFloatingChanged emission is redundant for the effect (it
+        // already processed the float from the windowsTileRequested batch;
+        // the cache write is idempotent) and overflow floats are rare, so
+        // the spare signal is the price of keeping the last-broadcast
+        // contract single-owner and universal.
         wts->setWindowFloating(windowId, true);
+        m_windowTrackingAdaptor->relayWindowFloatingChanged(windowId, true, screenId);
         m_autotileEngine->markModeSpecificFloated(windowId);
         // Same cross-VS preservation logic as the single-window handler
         const QString preFloatScreen = wts->preFloatScreen(windowId);

--- a/src/dbus/autotileadaptor.cpp
+++ b/src/dbus/autotileadaptor.cpp
@@ -56,6 +56,15 @@ AutotileAdaptor::AutotileAdaptor(PhosphorTileEngine::AutotileEngine* engine,
             [this](const QStringList& windowIds, const QSet<QString>& /*releasedScreenIds*/) {
                 Q_EMIT windowsReleasedFromTiling(windowIds);
             });
+    // Signal-to-signal relay WITHOUT a last-broadcast gate — deliberate, and
+    // safe only under the current invariant: this interface has exactly ONE
+    // producer (the autotile engine) whose windowFloatingChanged emissions
+    // are edge-triggered by construction (performToggleFloat and the
+    // overflow-recovery unfloat, both genuine flips). The WindowTracking
+    // interface's relayWindowFloatingChanged gate exists because FIVE
+    // producers with divergent bookkeeping feed one signal there. If another
+    // producer is ever wired into this relay, it needs the same
+    // last-broadcast dedup treatment.
     connect(m_engine, &PhosphorEngine::PlacementEngineBase::windowFloatingChanged, this,
             &AutotileAdaptor::windowFloatingChanged);
     qCDebug(lcDbusAutotile) << "AutotileAdaptor initialized";

--- a/src/dbus/snapadaptor.cpp
+++ b/src/dbus/snapadaptor.cpp
@@ -54,9 +54,11 @@ SnapAdaptor::SnapAdaptor(PhosphorSnapEngine::SnapEngine* engine, WindowTrackingA
     m_connections.append(connect(m_engine, &PhosphorSnapEngine::SnapEngine::navigationFeedback, adaptor,
                                  &WindowTrackingAdaptor::navigationFeedback));
 
-    // Float state changes
+    // Float state changes — through the relay chokepoint, never
+    // signal-to-signal: a direct emission bypasses m_broadcastFloating and
+    // desyncs the setWindowFloating dedup gate (see relayWindowFloatingChanged).
     m_connections.append(connect(m_engine, &PhosphorSnapEngine::SnapEngine::windowFloatingChanged, adaptor,
-                                 &WindowTrackingAdaptor::windowFloatingChanged));
+                                 &WindowTrackingAdaptor::relayWindowFloatingChanged));
 
     // Daemon-driven geometry application (used by autotile float restore via SnapEngine)
     m_connections.append(connect(m_engine, &PhosphorSnapEngine::SnapEngine::applyGeometryRequested, adaptor,

--- a/src/dbus/windowtrackingadaptor.cpp
+++ b/src/dbus/windowtrackingadaptor.cpp
@@ -829,6 +829,7 @@ void WindowTrackingAdaptor::setWindowMetadata(const QString& instanceId, const Q
             meta.positionX = existing->positionX;
             meta.positionY = existing->positionY;
             meta.captionNormal = existing->captionNormal;
+            meta.virtualDesktops = existing->virtualDesktops;
         }
     } else {
         namespace Key = PhosphorProtocol::Service::WindowMetadataKey;
@@ -866,6 +867,19 @@ void WindowTrackingAdaptor::setWindowMetadata(const QString& instanceId, const Q
         meta.positionX = optInt(Key::PositionX);
         meta.positionY = optInt(Key::PositionY);
         meta.captionNormal = optString(Key::CaptionNormal);
+        // Multi-desktop span list (absent for single-desktop / sticky windows,
+        // so an absent key correctly clears a previous span). Same lenient
+        // QVariant conversion policy as the fields above.
+        if (const auto it = extended.constFind(QString(Key::VirtualDesktops)); it != extended.constEnd()) {
+            const QVariantList list = it.value().toList();
+            meta.virtualDesktops.reserve(list.size());
+            for (const QVariant& v : list) {
+                const int d = v.toInt();
+                if (d > 0) {
+                    meta.virtualDesktops.append(d);
+                }
+            }
+        }
     }
 
     // Universal canonical seed. setWindowMetadata is the per-window choke point —

--- a/src/dbus/windowtrackingadaptor.cpp
+++ b/src/dbus/windowtrackingadaptor.cpp
@@ -444,8 +444,9 @@ void WindowTrackingAdaptor::refreshOpenWindowPlacements()
     // Re-capture EVERY open window into the unified store at save time. This is the
     // generic, engine-agnostic snapshot: captureWindowPlacement asks each engine's
     // capturePlacement() for the window's current state (snapped float-back, floated
-    // live geometry, autotiled position) and records it — or clears the record if no
-    // engine manages it. Saves are debounced and shutdown is guaranteed to run, so
+    // live geometry, autotiled position) and records it; when no engine manages a
+    // window its existing record is left intact — never cleared there (see the
+    // declaration doc). Saves are debounced and shutdown is guaranteed to run, so
     // this is the single point that makes open-window state (floating drag geometry,
     // autotile tile order) survive a daemon restart without any per-window capture
     // hook in the engines. m_frameGeometry holds every window the effect has

--- a/src/dbus/windowtrackingadaptor.h
+++ b/src/dbus/windowtrackingadaptor.h
@@ -946,9 +946,11 @@ public:
      * never a bare Q_EMIT): a direct emission leaves m_broadcastFloating
      * stale, and the setWindowFloating gate then suppresses the next genuine
      * change on the engine-sync channel (e.g. a cross-mode handoff's
-     * float-cleared sync after a snap-side float).
+     * float-cleared sync after a snap-side float). Returns whether a
+     * broadcast was actually emitted, so setWindowFloating (which delegates
+     * its gate here) can ride its extra side emissions on the same edge.
      */
-    void relayWindowFloatingChanged(const QString& windowId, bool floating, const QString& screenId);
+    bool relayWindowFloatingChanged(const QString& windowId, bool floating, const QString& screenId);
     /**
      * @brief Apply pre-snap/pre-autotile geometry for a floated window (call from daemon when autotile engine floats).
      * Gets validated geometry, emits applyGeometryRequested if found, clears stored geometry.

--- a/src/dbus/windowtrackingadaptor.h
+++ b/src/dbus/windowtrackingadaptor.h
@@ -247,7 +247,8 @@ public Q_SLOTS:
      *                       values are clamped to WindowType::Unknown
      * @param extended       Extended window-property snapshot keyed by
      *                       PhosphorProtocol::Service::WindowMetadataKey (state flags,
-     *                       geometry, accessory flags, captionNormal). A key is
+     *                       geometry, accessory flags, captionNormal, multi-desktop
+     *                       span list). A key is
      *                       present only when the value is known; absent keys leave
      *                       the corresponding WindowMetadata optional disengaged so a
      *                       window-rule predicate over it stays inert. Lets the

--- a/src/dbus/windowtrackingadaptor.h
+++ b/src/dbus/windowtrackingadaptor.h
@@ -633,7 +633,10 @@ public:
 
     /// Unified placement capture orchestrator: ask each engine for @p windowId's
     /// current placement, stamp it with the live frame geometry, and record it in
-    /// the WindowPlacementStore (or clear the record if no engine manages it).
+    /// the WindowPlacementStore. When NO engine manages the window, any existing
+    /// record is left intact (never cleared here — records are per-mode memory,
+    /// only merge-updated, consumed, or explicitly pruned); with an
+    /// @p authoritativeScreen it records a floating-close placement instead.
     /// Shadow-written in P1; the single funnel every state-change + close hook
     /// calls so the persisted record always reflects the window's live state.
     ///

--- a/src/dbus/windowtrackingadaptor.h
+++ b/src/dbus/windowtrackingadaptor.h
@@ -938,6 +938,18 @@ public:
     // `pruneExcludedPendingRestores` / `requestReapplyWindowGeometries`
     // pair above.
     /**
+     * @brief Single broadcast chokepoint for engine-relayed float changes.
+     *
+     * Updates m_broadcastFloating and emits windowFloatingChanged, deduped
+     * against the last value actually broadcast. Engine signal relays MUST
+     * route through this (never signal-to-signal into windowFloatingChanged,
+     * never a bare Q_EMIT): a direct emission leaves m_broadcastFloating
+     * stale, and the setWindowFloating gate then suppresses the next genuine
+     * change on the engine-sync channel (e.g. a cross-mode handoff's
+     * float-cleared sync after a snap-side float).
+     */
+    void relayWindowFloatingChanged(const QString& windowId, bool floating, const QString& screenId);
+    /**
      * @brief Apply pre-snap/pre-autotile geometry for a floated window (call from daemon when autotile engine floats).
      * Gets validated geometry, emits applyGeometryRequested if found, clears stored geometry.
      * @return true if geometry was applied, false if none stored

--- a/src/dbus/windowtrackingadaptor/enginewiring.cpp
+++ b/src/dbus/windowtrackingadaptor/enginewiring.cpp
@@ -931,6 +931,10 @@ void WindowTrackingAdaptor::handleCrossModeMove(const QString& windowId, const Q
         ctx.fromEngineId = sourceEngine->engineId();
         ctx.sourceZoneIds = landingZoneIds;
         ctx.wasFloating = false; // an explicit move always places, never floats
+        // An autotile target's handoffReceive also announces the arrival's
+        // tiled (non-floating) state on the passive float-sync channel —
+        // intended: the arrival IS tiled, and the relay's last-broadcast
+        // gate dedups when the bit already agrees.
         targetEngine->handoffReceive(ctx);
     }
 
@@ -1029,6 +1033,9 @@ void WindowTrackingAdaptor::handleCrossModeSwap(const QString& windowId, const Q
     targetEngine->handoffRelease(partner);
 
     // ── Place the focused window on the target, in the partner's slot. ──
+    // (Both placements below: an autotile receiver's handoffReceive also
+    // announces the arrival's tiled state on the passive float-sync channel —
+    // intended; the relay's last-broadcast gate dedups an agreeing bit.)
     {
         PhosphorEngine::IPlacementEngine::HandoffContext ctx;
         ctx.windowId = windowId;

--- a/src/dbus/windowtrackingadaptor/enginewiring.cpp
+++ b/src/dbus/windowtrackingadaptor/enginewiring.cpp
@@ -213,7 +213,9 @@ void WindowTrackingAdaptor::setEngines(PhosphorEngine::PlacementEngineBase* snap
                 &WindowTrackingAdaptor::windowStateChanged);
         connect(snap, &PhosphorSnapEngine::SnapEngine::windowFloatingClearedForSnap, this,
                 [this](const QString& windowId, const QString& screenId) {
-                    Q_EMIT windowFloatingChanged(windowId, false, screenId);
+                    // Through the relay chokepoint so m_broadcastFloating
+                    // tracks this emission too (see relayWindowFloatingChanged).
+                    relayWindowFloatingChanged(windowId, false, screenId);
                 });
         // Unified model: keep the live placement record current on every snap
         // state change (commit / uncommit) so the persisted state always matches

--- a/src/dbus/windowtrackingadaptor/float.cpp
+++ b/src/dbus/windowtrackingadaptor/float.cpp
@@ -223,6 +223,7 @@ void WindowTrackingAdaptor::setWindowFloatingForScreen(const QString& windowId, 
     //     rule/pre-float re-snap chance, and a window it cannot re-snap
     //     stays a free (unmanaged) window, which is what unfloating a
     //     window snap never tracked means.
+    bool recaptureAfterFloatWrite = false;
     if (dest && !dest->isWindowTracked(windowId)) {
         const bool sourceTracked = source && source->isWindowTracked(windowId);
         const bool destIsAutotile = m_autotileEngine && dest == m_autotileEngine.data();
@@ -243,6 +244,7 @@ void WindowTrackingAdaptor::setWindowFloatingForScreen(const QString& windowId, 
         } else if (sourceTracked) {
             source->handoffRelease(windowId);
             relayWindowFloatingChanged(windowId, false, screenId);
+            recaptureAfterFloatWrite = true;
         }
     }
 
@@ -253,6 +255,16 @@ void WindowTrackingAdaptor::setWindowFloatingForScreen(const QString& windowId, 
         // that drifted to another monitor while floating non-deterministically
         // teleports it back to its source-monitor zone (Discussion #724).
         dest->setWindowFloat(windowId, floating, screenId);
+    }
+    if (recaptureAfterFloatWrite) {
+        // Snap-dest unfloat: when unfloatToZone above re-snapped the window,
+        // the commitSnap wiring already refreshed the live placement record —
+        // this recapture is then an idempotent repeat. When it FAILED OPEN
+        // (no rule/pre-float zone) nothing else refreshes the record, and it
+        // would keep its prior floating slot while the broadcast above said
+        // not-floating; capture after the write so the persisted record
+        // matches what subscribers were told.
+        captureWindowPlacement(windowId);
     }
 }
 

--- a/src/dbus/windowtrackingadaptor/float.cpp
+++ b/src/dbus/windowtrackingadaptor/float.cpp
@@ -110,17 +110,16 @@ void WindowTrackingAdaptor::setWindowFloating(const QString& windowId, bool floa
     // value — the old `floating == wasFloating` gate then suppressed every
     // autotile float broadcast, leaving subscribers (the effect's float cache,
     // which the autotile FFM float-pause depends on) permanently stale.
-    // Tracking the last-broadcast value detects the real edge regardless of when
-    // the engine updated its bit, and still honours "only emit when changed".
-    if (m_broadcastFloating.value(windowId, false) == floating) {
+    // The gate itself lives in relayWindowFloatingChanged (the single owner of
+    // the last-broadcast contract); the unified state change and placement
+    // capture below ride the same edge.
+    // Use the window's tracked screen if available, otherwise fall back to last
+    // active screen.
+    const QString screen = m_service->screenForWindow(windowId, m_lastActiveScreenId);
+    if (!relayWindowFloatingChanged(windowId, floating, screen)) {
         return;
     }
-    m_broadcastFloating[windowId] = floating;
     qCInfo(lcDbusWindow) << "Window" << windowId << "is now" << (floating ? "floating" : "not floating");
-    // Notify effect so it can update its local cache (use full windowId for per-instance tracking).
-    // Use the window's tracked screen if available, otherwise fall back to last active screen.
-    QString screen = m_service->screenForWindow(windowId, m_lastActiveScreenId);
-    Q_EMIT windowFloatingChanged(windowId, floating, screen);
 
     // Emit unified state change
     Q_EMIT windowStateChanged(windowId,
@@ -165,17 +164,18 @@ bool WindowTrackingAdaptor::applyGeometryForFloat(const QString& windowId, const
 // windowFloatingClearedForSnap, which this adaptor relays to its own
 // windowFloatingChanged D-Bus signal in the constructor wiring.
 
-void WindowTrackingAdaptor::relayWindowFloatingChanged(const QString& windowId, bool floating, const QString& screenId)
+bool WindowTrackingAdaptor::relayWindowFloatingChanged(const QString& windowId, bool floating, const QString& screenId)
 {
-    // Same dedup key as the setWindowFloating gate — see the header doc:
-    // every emission channel must keep m_broadcastFloating equal to what
+    // The single owner of the last-broadcast dedup contract — see the header
+    // doc: every emission channel must keep m_broadcastFloating equal to what
     // subscribers last heard, or the gate turns from a dedup into a
-    // suppressor of genuine changes.
+    // suppressor of genuine changes. setWindowFloating delegates here too.
     if (m_broadcastFloating.value(windowId, false) == floating) {
-        return;
+        return false;
     }
     m_broadcastFloating[windowId] = floating;
     Q_EMIT windowFloatingChanged(windowId, floating, screenId);
+    return true;
 }
 
 void WindowTrackingAdaptor::setWindowFloatingForScreen(const QString& windowId, const QString& screenId, bool floating)
@@ -204,17 +204,29 @@ void WindowTrackingAdaptor::setWindowFloatingForScreen(const QString& windowId, 
     // dialog is a valid target — fromEngineId stays empty when neither side
     // tracks it, so receive-side reasoning that depends on the source mode
     // correctly degrades).
-    // Unfloat: adopt ONLY a window the OTHER engine still tracks. Without
-    // this, the unfloat dead-ends: setWindowFloat below targets the
+    // Unfloat of a window whose float bit lives in the OTHER engine: without
+    // handling, the unfloat dead-ends — setWindowFloat below targets the
     // destination engine, which doesn't track the window and early-returns,
-    // while the source engine's float bit stays set with no broadcast — the
-    // window reads floating through its own context's mode lens forever. The
-    // handoff releases the source (clearing its bit) and the receive tiles
-    // the arrival (wasFloating=false) and announces the new state on the
-    // passive sync channel.
+    // while the source engine's float bit stays set with no broadcast, so
+    // the window reads floating through its own context's mode lens forever.
+    // The two destinations need DIFFERENT handling:
+    //   - Autotile dest: adopt via the handoff (release source, receive with
+    //     wasFloating=false tiles the arrival and announces it on the
+    //     passive sync channel); the trailing relay dedups against that.
+    //   - Snap dest: NO adoption. Snap's handoffReceive floats an arrival
+    //     with no sourceZoneIds unconditionally (ignoring wasFloating) and
+    //     emits floating=true, and the setWindowFloat(false) below fails
+    //     open when no rule/pre-float zone resolves ("keeping floating") —
+    //     together that strands the snap store floating against a false
+    //     broadcast. Instead just release the source's bit and broadcast
+    //     the unfloat; the setWindowFloat below still gives snap its
+    //     rule/pre-float re-snap chance, and a window it cannot re-snap
+    //     stays a free (unmanaged) window, which is what unfloating a
+    //     window snap never tracked means.
     if (dest && !dest->isWindowTracked(windowId)) {
         const bool sourceTracked = source && source->isWindowTracked(windowId);
-        if (floating || sourceTracked) {
+        const bool destIsAutotile = m_autotileEngine && dest == m_autotileEngine.data();
+        if (floating || (sourceTracked && destIsAutotile)) {
             PhosphorEngine::IPlacementEngine::HandoffContext ctx;
             ctx.windowId = windowId;
             ctx.toScreenId = screenId;
@@ -226,14 +238,11 @@ void WindowTrackingAdaptor::setWindowFloatingForScreen(const QString& windowId, 
             }
             dest->handoffReceive(ctx);
             if (!floating) {
-                // The source's float bit was released silently and only the
-                // autotile receive announces a non-floating arrival on the
-                // passive channel (snap's handoffReceive announces float
-                // re-homes only) — relay the unfloat here so BOTH adoption
-                // directions broadcast it. The chokepoint dedups when the
-                // autotile passive sync already did.
                 relayWindowFloatingChanged(windowId, false, screenId);
             }
+        } else if (sourceTracked) {
+            source->handoffRelease(windowId);
+            relayWindowFloatingChanged(windowId, false, screenId);
         }
     }
 

--- a/src/dbus/windowtrackingadaptor/float.cpp
+++ b/src/dbus/windowtrackingadaptor/float.cpp
@@ -165,6 +165,19 @@ bool WindowTrackingAdaptor::applyGeometryForFloat(const QString& windowId, const
 // windowFloatingClearedForSnap, which this adaptor relays to its own
 // windowFloatingChanged D-Bus signal in the constructor wiring.
 
+void WindowTrackingAdaptor::relayWindowFloatingChanged(const QString& windowId, bool floating, const QString& screenId)
+{
+    // Same dedup key as the setWindowFloating gate — see the header doc:
+    // every emission channel must keep m_broadcastFloating equal to what
+    // subscribers last heard, or the gate turns from a dedup into a
+    // suppressor of genuine changes.
+    if (m_broadcastFloating.value(windowId, false) == floating) {
+        return;
+    }
+    m_broadcastFloating[windowId] = floating;
+    Q_EMIT windowFloatingChanged(windowId, floating, screenId);
+}
+
 void WindowTrackingAdaptor::setWindowFloatingForScreen(const QString& windowId, const QString& screenId, bool floating)
 {
     if (!validateWindowId(windowId, QStringLiteral("set float for screen"))) {
@@ -187,21 +200,41 @@ void WindowTrackingAdaptor::setWindowFloatingForScreen(const QString& windowId, 
         source = m_autotileEngine.data();
     }
 
-    if (dest && floating && !dest->isWindowTracked(windowId)) {
-        // Build the HandoffContext from whichever engine actually claims the
-        // window — fromEngineId stays empty when neither side tracks it (e.g.
-        // a brand-new floating dialog), so receive-side reasoning that depends
-        // on the source mode correctly degrades.
-        PhosphorEngine::IPlacementEngine::HandoffContext ctx;
-        ctx.windowId = windowId;
-        ctx.toScreenId = screenId;
-        ctx.wasFloating = true;
-        if (source && source->isWindowTracked(windowId)) {
-            ctx.fromEngineId = source->engineId();
-            ctx.sourceGeometry = m_frameGeometry.value(windowId);
-            source->handoffRelease(windowId);
+    // Float: adopt an untracked window unconditionally (a brand-new floating
+    // dialog is a valid target — fromEngineId stays empty when neither side
+    // tracks it, so receive-side reasoning that depends on the source mode
+    // correctly degrades).
+    // Unfloat: adopt ONLY a window the OTHER engine still tracks. Without
+    // this, the unfloat dead-ends: setWindowFloat below targets the
+    // destination engine, which doesn't track the window and early-returns,
+    // while the source engine's float bit stays set with no broadcast — the
+    // window reads floating through its own context's mode lens forever. The
+    // handoff releases the source (clearing its bit) and the receive tiles
+    // the arrival (wasFloating=false) and announces the new state on the
+    // passive sync channel.
+    if (dest && !dest->isWindowTracked(windowId)) {
+        const bool sourceTracked = source && source->isWindowTracked(windowId);
+        if (floating || sourceTracked) {
+            PhosphorEngine::IPlacementEngine::HandoffContext ctx;
+            ctx.windowId = windowId;
+            ctx.toScreenId = screenId;
+            ctx.wasFloating = floating;
+            if (sourceTracked) {
+                ctx.fromEngineId = source->engineId();
+                ctx.sourceGeometry = m_frameGeometry.value(windowId);
+                source->handoffRelease(windowId);
+            }
+            dest->handoffReceive(ctx);
+            if (!floating) {
+                // The source's float bit was released silently and only the
+                // autotile receive announces a non-floating arrival on the
+                // passive channel (snap's handoffReceive announces float
+                // re-homes only) — relay the unfloat here so BOTH adoption
+                // directions broadcast it. The chokepoint dedups when the
+                // autotile passive sync already did.
+                relayWindowFloatingChanged(windowId, false, screenId);
+            }
         }
-        dest->handoffReceive(ctx);
     }
 
     if (dest) {

--- a/src/dbus/windowtrackingadaptor/float.cpp
+++ b/src/dbus/windowtrackingadaptor/float.cpp
@@ -257,13 +257,19 @@ void WindowTrackingAdaptor::setWindowFloatingForScreen(const QString& windowId, 
         dest->setWindowFloat(windowId, floating, screenId);
     }
     if (recaptureAfterFloatWrite) {
-        // Snap-dest unfloat: when unfloatToZone above re-snapped the window,
-        // the commitSnap wiring already refreshed the live placement record —
-        // this recapture is then an idempotent repeat. When it FAILED OPEN
-        // (no rule/pre-float zone) nothing else refreshes the record, and it
-        // would keep its prior floating slot while the broadcast above said
-        // not-floating; capture after the write so the persisted record
-        // matches what subscribers were told.
+        // Snap-dest unfloat: re-anchor the live placement record after the
+        // float write. When unfloatToZone above re-snapped the window this is
+        // an idempotent repeat of the commitSnap-wired capture, kept so the
+        // record refresh doesn't silently depend on that wiring's ordering.
+        // When unfloatToZone FAILED OPEN (no rule/pre-float zone) the window
+        // is tracked by NEITHER engine, so this capture deliberately writes
+        // nothing and the persisted record keeps its floating-at-position
+        // slot from the source engine's float. That is the accepted outcome:
+        // a later restore of "floating at its position" and of "free window
+        // at its position" land the window identically, and the only writer
+        // that could record the free state has no engine placement to read.
+        // Live subscribers are unaffected either way — the broadcast above
+        // already told them not-floating.
         captureWindowPlacement(windowId);
     }
 }

--- a/tests/unit/autotile/test_autotile_handoff.cpp
+++ b/tests/unit/autotile/test_autotile_handoff.cpp
@@ -99,6 +99,43 @@ private Q_SLOTS:
         QCOMPARE(engine.screenForTrackedWindow(windowId), screen);
     }
 
+    void testHandoffReceive_announcesFloatBitOnPassiveChannel()
+    {
+        // handoffReceive must announce the received float bit via
+        // windowFloatingStateSynced (the passive channel) for BOTH arrival
+        // kinds. A cross-mode move of a floating window arrives with
+        // wasFloating=false after the source engine's handoffRelease cleared
+        // its bit silently — without this emission, subscribers that last
+        // heard "floating" (the effect's FloatingCache) stay stale until a
+        // daemon reconnect. The emission is deliberately unconditional; the
+        // adaptor's last-broadcast gate owns dedup.
+        AutotileEngine engine(nullptr, nullptr, nullptr, PlasmaZones::TestHelpers::testRegistry());
+        const QString screen = QLatin1String(Screen1);
+        engine.setAutotileScreens({screen});
+        QSignalSpy spy(&engine, &PhosphorEngine::PlacementEngineBase::windowFloatingStateSynced);
+        QVERIFY(spy.isValid());
+
+        PhosphorEngine::IPlacementEngine::HandoffContext tiled;
+        tiled.windowId = QStringLiteral("win-arrives-tiled");
+        tiled.toScreenId = screen;
+        tiled.wasFloating = false;
+        engine.handoffReceive(tiled);
+        QCOMPARE(spy.count(), 1);
+        QCOMPARE(spy.at(0).at(0).toString(), tiled.windowId);
+        QCOMPARE(spy.at(0).at(1).toBool(), false);
+        QCOMPARE(spy.at(0).at(2).toString(), screen);
+
+        PhosphorEngine::IPlacementEngine::HandoffContext floating;
+        floating.windowId = QStringLiteral("win-arrives-floating");
+        floating.toScreenId = screen;
+        floating.wasFloating = true;
+        engine.handoffReceive(floating);
+        QCOMPARE(spy.count(), 2);
+        QCOMPARE(spy.at(1).at(0).toString(), floating.windowId);
+        QCOMPARE(spy.at(1).at(1).toBool(), true);
+        QCOMPARE(spy.at(1).at(2).toString(), screen);
+    }
+
     void testHandoffReceive_insertIndex_placesAtPartnerSlot()
     {
         // A cross-mode SWAP arrival carries ctx.insertIndex so the focused window

--- a/tests/unit/autotile/test_autotile_handoff.cpp
+++ b/tests/unit/autotile/test_autotile_handoff.cpp
@@ -256,7 +256,10 @@ private Q_SLOTS:
         QCoreApplication::processEvents();
 
         // Idempotent receive: floating disposition shouldn't overwrite the
-        // existing tiled state.
+        // existing tiled state. Spy armed AFTER the seeding open so it only
+        // observes the no-op receive.
+        QSignalSpy floatSyncSpy(&engine, &PhosphorEngine::PlacementEngineBase::windowFloatingStateSynced);
+        QVERIFY(floatSyncSpy.isValid());
         PhosphorEngine::IPlacementEngine::HandoffContext ctx;
         ctx.windowId = windowId;
         ctx.toScreenId = screen;
@@ -267,6 +270,10 @@ private Q_SLOTS:
         QVERIFY(state);
         QVERIFY(state->containsWindow(windowId));
         QVERIFY(!state->isFloating(windowId));
+        // The early return must also stay SILENT on the passive float
+        // channel: the bit is untouched, so an announcement here would tell
+        // subscribers "floating" for a window that remains tiled.
+        QCOMPARE(floatSyncSpy.count(), 0);
     }
 
     void testHandoffReceive_crossScreenReleasesPreviousState()


### PR DESCRIPTION
Fixes the latent staleness of the effect's `FloatingCache` found while auditing the desktop-switch bug class from #808 (companion to #813, independent branches).

## Contract

The KWin effect mirrors per-window float state in a flat cache and relies on `windowFloatingChanged` reaching it for every effective change (plus a full re-seed on daemon reconnect). A full trace of the broadcast contract found four violations, one reliable and three narrow.

## Fixes

1. **Mode-lens keying (primary).** The per-engine float resolver picked the owning engine via the screen's *current* desktop, so a per-output desktop switch across a snap↔autotile mode boundary flipped a window's effective float answer with no broadcast — nothing about the window changed. The resolver now resolves at the window's own desktop (registry metadata, falling back to the screen's current for sticky/unknown windows), making the answer context-stable, which is what makes a flat mirror correct by design. The effect re-pushes metadata on `windowDesktopsChanged` so the registry desktop stays fresh; it was previously pushed only at window-add and class rename.

2. **Silent `handoffReceive`.** `AutotileEngine::handoffReceive` set the received float bit without emitting, while its snap twin emits. A cross-mode move of a floating window arrives as `wasFloating=false` after the source's `handoffRelease` cleared its bit silently, stranding subscribers at "floating" until reconnect. It now announces the received bit on the passive sync channel (`windowFloatingStateSynced`, so the arrival is never teleported through the pre-tile geometry restore). Unconditional by design: mid-handoff the resolver already reads the cleared source bit, so only the adaptor's last-broadcast gate can dedup correctly.

3. **Dead-ended cross-engine unfloat.** `setWindowFloatingForScreen` ran the cross-engine handoff only for floats. An unfloat whose destination engine did not track the window early-returned there while the source engine's bit stayed set, unannounced. The handoff now also runs for unfloat when the other engine tracks the window, and the unfloat is relayed for both adoption directions.

4. **Broadcast-gate desync.** `m_broadcastFloating` was updated only inside `setWindowFloating`, while the snap relays emitted the D-Bus signal directly (signal-to-signal wiring and a bare `Q_EMIT`). The stale gate could then suppress the next genuine change on the engine-sync channel — which is exactly what would have swallowed fix 2's emission. All engine relays now route through one chokepoint (`relayWindowFloatingChanged`) that keeps the gate equal to what subscribers last heard and dedups every channel.

## Testing

- Full suite: 290/290 pass.
- New regression test pins the `handoffReceive` emission for both arrival kinds (it fails if the emission is removed).
- The primary scenario (float on a snapping desktop, switch that output to an autotile desktop, watch `IsFloating` rules) needs a live session to observe; verified by code trace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Audit

A six-pass four-partition code audit ran over this PR (commits `fix(audit): pass 1` through `pass 5`). 17 findings were found and fixed: 4 MEDIUM (a snap-destination cross-mode unfloat that floated the arrival and could strand the snap store against a false broadcast; the activity axis missing from the mode-lens fix; a full-metadata copy on the per-query resolver path, replaced by a lightweight `WindowRegistry::windowContext` accessor; a redundant effect-side metadata double-push whose justifying comment was wrong), 11 LOW (including the batch-overflow float path bypassing the broadcast gate, and a placement recapture on the fail-open unfloat), and 2 NIT. Final pass came back clean across all partitions with the chokepoint invariant verified repo-wide.

Pre-existing observations recorded during the audit were subsequently fixed in this PR too (commit `fix(daemon): close the audit's descoped float-contract observations`):
- The strict pending-order seed in `AutotileEngine::setAutotileScreens` now announces its restored float bit on the passive sync channel, mirroring `handoffReceive` (the gate dedups when subscribers already agree).
- A window spanning several (but not all) virtual desktops now resolves its owning engine correctly: the effect sends the full desktop list via a `VirtualDesktops` extended metadata key, and the mode resolver prefers the screen's current desktop whenever it is among the spanned ones. Single-desktop and sticky windows are unchanged.
- The `org.plasmazones.Autotile` relay's deliberately ungated single-producer/edge-triggered invariant is now documented at the wiring site.

Only the standing file-size descopes remain (pre-existing, on the audit ledger).



**Audit descope (pass 2):** the extracted `WindowContext::effectiveDesktop`/`effectiveActivity` policy is unit-tested in `test_engine_windowcontext`, but no daemon-level test pins that `screenModeForWindow` calls it (that would need a full daemon fixture with a snap/autotile mode boundary across two desktops). The call site was verified by inspection in two independent review passes. Deliberately not built here.

**Audit descope (pass 3):** `WindowContext::effectiveDesktop`'s multi-desktop-span preference keeps one narrow screen-current-dependent path. A window pinned to two or more desktops whose assignments resolve to different modes can still flip its owning engine on a desktop switch between spanned desktops, with no float broadcast. This is documented on the method as a deliberate tradeoff, is strictly narrower than the pre-PR behavior (where every window could flip), and closing it would need per-window float rebroadcast on desktop switch. Accepted for this PR.
