### PR TITLE
fix: float/restore regressions after the floating-cache and worktree-unify merges

### DIFF
--- a/libs/phosphor-engine/include/PhosphorEngine/PlacementEngineBase.h
+++ b/libs/phosphor-engine/include/PhosphorEngine/PlacementEngineBase.h
@@ -36,6 +36,22 @@ public:
     /// engines override and add their own pruning (then call the base).
     virtual int pruneStaleWindows(const QSet<QString>& aliveWindowIds);
 
+    /// The exact rect this engine last APPLIED to @p windowId while managing it
+    /// (its tile rect), remembered PAST the window's transition out of the
+    /// managed state. On a float toggle the engine flips its managed bit before
+    /// the compositor repositions the window, so state predicates
+    /// (isWindowTiled et al.) already answer "not managed" while the live frame
+    /// still IS the managed rect — the capture orchestrator compares against
+    /// this to refuse adopting such a frame as free/float geometry. Invalid
+    /// when the engine never applied a rect (the base default: engines whose
+    /// managed rects are resolvable from persisted state, like snap's zone
+    /// geometry, don't need it).
+    virtual QRect lastManagedRect(const QString& windowId) const
+    {
+        Q_UNUSED(windowId)
+        return {};
+    }
+
     // ═══════════════════════════════════════════════════════════════════════════
     // Settings — universal pattern for all engines
     //

--- a/libs/phosphor-engine/include/PhosphorEngine/WindowPlacementStore.h
+++ b/libs/phosphor-engine/include/PhosphorEngine/WindowPlacementStore.h
@@ -70,6 +70,17 @@ public:
     std::optional<WindowPlacement> peek(const QString& windowId, const QString& appId,
                                         const std::function<bool(const WindowPlacement&)>& accept = {}) const;
 
+    /// Exact-windowId peek: branch 1 of peek() only, never the appId-FIFO
+    /// fallback. For reads about a LIVE window mid-session (KWin uuids are
+    /// stable until logout), where a same-app sibling's record must not
+    /// answer for this window — the appId fallback exists for the relogin
+    /// re-bind paths (take()), not for live per-window state. An empty appId
+    /// disables peek's fallback branch structurally, so this cannot drift.
+    std::optional<WindowPlacement> peekExact(const QString& windowId) const
+    {
+        return peek(windowId, QString());
+    }
+
     /// True if a record exists for the exact windowId, or (if @p appId non-empty)
     /// any record in that appId bucket.
     bool contains(const QString& windowId, const QString& appId = QString()) const;

--- a/libs/phosphor-placement/src/WindowTrackingService.cpp
+++ b/libs/phosphor-placement/src/WindowTrackingService.cpp
@@ -386,6 +386,9 @@ std::optional<QRect> WindowTrackingService::validatedUnmanagedGeometry(const QSt
     // rect into float.) Free geometry is shared across modes, so snap and autotile
     // resolve the same value; prefer this screen's remembered spot, then any other
     // screen's (cross-screen validated).
+    // The non-exact default is DELIBERATE cross-instance float-back sharing
+    // (free positions only, never zone/tile slots — those reads are exact-only
+    // via peekExact); callers with a per-window contract pass exactOnly.
     const QString appId = exactOnly ? QString() : currentAppIdFor(windowId);
     const auto rec = m_placementStore.peek(windowId, appId);
     if (!rec) {
@@ -443,7 +446,11 @@ void WindowTrackingService::recordFreeGeometry(const QString& windowId, const QS
         return;
     }
     if (!overwrite) {
-        const auto existing = m_placementStore.peek(windowId, appId);
+        // First-capture-wins is a PER-WINDOW contract: only this window's own
+        // record may suppress the write. A same-app sibling's free geometry
+        // must not block recording this window's first genuine spot (it would
+        // never persist its own position while the sibling's record lives).
+        const auto existing = m_placementStore.peekExact(windowId);
         if (existing && existing->freeGeometryFor(screenId).isValid()) {
             return; // first-capture-wins
         }
@@ -485,7 +492,12 @@ void WindowTrackingService::recordFloatingClose(const QString& windowId, const Q
     // non-empty engine map is what makes the store merge adopt the new screenId
     // (a geometry-only partial, like recordFreeGeometry, would leave the stale
     // managed screen in place — exactly the bug this fixes).
-    if (const auto existing = m_placementStore.peek(windowId, appId)) {
+    // Exact record only: inheriting a same-app SIBLING's engine slots would
+    // graft its snapped/tiled placement under THIS windowId — a reopen then
+    // restores two windows into the sibling's zone and corrupts the per-app
+    // FIFO distribution. A window with no record of its own takes the
+    // synthesized-floating-slot branch below, which exists for exactly that.
+    if (const auto existing = m_placementStore.peekExact(windowId)) {
         p.virtualDesktop = existing->virtualDesktop;
         p.activity = existing->activity;
         p.kind = existing->kind;
@@ -823,7 +835,13 @@ QStringList WindowTrackingService::recordedSnapZones(const QString& windowId) co
     // Cold cache (post-restart, or after handoffRelease cleared the live map):
     // fall back to the DURABLE snap slot in the placement record. windowId is the
     // exact `appId|uuid`; KWin uuids are stable across a daemon restart, so peek's
-    // exact-id branch resolves the right window (the appId fallback is for relogin).
+    // exact-id branch resolves the right window. The appId fallback is DELIBERATE
+    // relogin support (pinned by testRecordedSnapZones_appIdFallbackAfterRelogin):
+    // a new-uuid window resolves its app's durable zone for the resnap /
+    // never-snapped consumers. Accepted tradeoff: a record-less LIVE window with
+    // no live zones reads the same app-level answer — indistinguishable from the
+    // relogin case at this layer, and a live-ASSIGNED sibling always resolves via
+    // its own live store first (see the sameAppInstancesEachKeepOwnZone test).
     const auto rec = m_placementStore.peek(windowId, currentAppIdFor(windowId));
     if (rec) {
         const PhosphorEngine::EngineSlot snapSlot = rec->slotFor(PhosphorEngine::WindowPlacement::snapEngineId());

--- a/libs/phosphor-snap-engine/src/float.cpp
+++ b/libs/phosphor-snap-engine/src/float.cpp
@@ -262,11 +262,33 @@ UnfloatResult SnapEngine::resolveUnfloatGeometry(const QString& windowId, const 
     UnfloatResult result;
 
     QStringList zoneIds = m_windowTracker->preFloatZones(windowId);
+    QString preFloatScreenId = m_windowTracker->preFloatScreen(windowId);
+    if (zoneIds.isEmpty()) {
+        // The in-memory pre-float capture does not survive a daemon restart, but
+        // the persisted placement record's snap slot does: a floating capture
+        // carries the pre-float zones in slot.zoneIds, and a stale snapped
+        // capture (daemon died before the float toggle was persisted) carries
+        // the zones the window occupied before it floated. Either is the
+        // window's home zone — without this fallback, unfloating after a
+        // restart dead-ends ("no pre-float zone, keeping floating") with no way
+        // out short of re-snapping by hand.
+        using PhosphorEngine::WindowPlacement;
+        const QString appId = m_windowTracker->currentAppIdFor(windowId);
+        if (const auto rec = m_windowTracker->placementStore().peek(windowId, appId)) {
+            const PhosphorEngine::EngineSlot slot = rec->slotFor(engineId());
+            if (!slot.zoneIds.isEmpty()
+                && (slot.state == WindowPlacement::stateFloating() || slot.state == WindowPlacement::stateSnapped())) {
+                zoneIds = slot.zoneIds;
+                preFloatScreenId = rec->screenId;
+                qCInfo(PhosphorSnapEngine::lcSnapEngine)
+                    << "resolveUnfloatGeometry:" << windowId << "no live pre-float capture — using placement record's"
+                    << slot.state << "slot zones" << zoneIds << "on" << preFloatScreenId;
+            }
+        }
+    }
     if (zoneIds.isEmpty()) {
         return result;
     }
-
-    const QString preFloatScreenId = m_windowTracker->preFloatScreen(windowId);
 
     // Cross-monitor restore is ALLOWED (Discussion #724 follow-up): unfloat returns
     // the window to its remembered home zone regardless of which monitor it is

--- a/libs/phosphor-snap-engine/src/float.cpp
+++ b/libs/phosphor-snap-engine/src/float.cpp
@@ -274,11 +274,27 @@ UnfloatResult SnapEngine::resolveUnfloatGeometry(const QString& windowId, const 
         // out short of re-snapping by hand.
         using PhosphorEngine::WindowPlacement;
         const QString appId = m_windowTracker->currentAppIdFor(windowId);
-        if (const auto rec = m_windowTracker->placementStore().peek(windowId, appId)) {
+        // Exact-windowId records ONLY: a daemon restart keeps KWin uuids, so the
+        // window's own record always exact-matches. Without the accept predicate,
+        // peek's appId-FIFO fallback would hand a record-less floating window a
+        // SIBLING's home zone (same app, different instance) and unfloat-snap it
+        // there — cross-window zone bleed. Logout/login (new uuids) restores
+        // through resolveWindowRestore's take(), never this path.
+        if (const auto rec = m_windowTracker->placementStore().peek(windowId, appId, [&](const WindowPlacement& p) {
+                return p.windowId == windowId;
+            })) {
             const PhosphorEngine::EngineSlot slot = rec->slotFor(engineId());
             if (!slot.zoneIds.isEmpty()
                 && (slot.state == WindowPlacement::stateFloating() || slot.state == WindowPlacement::stateSnapped())) {
                 zoneIds = slot.zoneIds;
+                // Home-screen hint. Exact for a stale SNAPPED slot (captured as the
+                // snap screen); an approximation for a FLOATING slot, whose record
+                // screen is the screen the window was floating on at capture time —
+                // after a cross-monitor drift while floating that is the drift
+                // monitor, not the pre-float home. resolveUnfloatScreen validates it
+                // and falls back to the caller's live screen, and cross-monitor
+                // unfloat-to-home is allowed anyway (#724), so the approximation is
+                // bounded.
                 preFloatScreenId = rec->screenId;
                 qCInfo(PhosphorSnapEngine::lcSnapEngine)
                     << "resolveUnfloatGeometry:" << windowId << "no live pre-float capture — using placement record's"

--- a/libs/phosphor-snap-engine/src/float.cpp
+++ b/libs/phosphor-snap-engine/src/float.cpp
@@ -185,6 +185,12 @@ bool SnapEngine::applyGeometryForFloat(const QString& windowId, const QString& s
     // not silently dropped on load by the disabled-context gate when the user has
     // toggled snapping off/on. The legacy store is consulted only as a fallback
     // for windows with no record yet (pre-migration / first float of the session).
+    //
+    // The appId-FIFO fallback here is DELIBERATE (unlike the exact-only pre-float
+    // zone read in resolveUnfloatGeometry): a record-less instance floating for
+    // the first time restores to where its app last floated — the cross-instance
+    // float-back share that collapsePureFloatSiblings manages. A shared free
+    // position is a sensible default; a shared ZONE assignment is not.
     if (m_windowTracker) {
         const QString appId = m_windowTracker->currentAppIdFor(windowId);
         auto rec = m_windowTracker->placementStore().peek(windowId, appId);
@@ -273,16 +279,13 @@ UnfloatResult SnapEngine::resolveUnfloatGeometry(const QString& windowId, const 
         // restart dead-ends ("no pre-float zone, keeping floating") with no way
         // out short of re-snapping by hand.
         using PhosphorEngine::WindowPlacement;
-        const QString appId = m_windowTracker->currentAppIdFor(windowId);
         // Exact-windowId records ONLY: a daemon restart keeps KWin uuids, so the
-        // window's own record always exact-matches. Without the accept predicate,
-        // peek's appId-FIFO fallback would hand a record-less floating window a
-        // SIBLING's home zone (same app, different instance) and unfloat-snap it
-        // there — cross-window zone bleed. Logout/login (new uuids) restores
-        // through resolveWindowRestore's take(), never this path.
-        if (const auto rec = m_windowTracker->placementStore().peek(windowId, appId, [&](const WindowPlacement& p) {
-                return p.windowId == windowId;
-            })) {
+        // window's own record always exact-matches. The appId-FIFO fallback
+        // would hand a record-less floating window a SIBLING's home zone (same
+        // app, different instance) and unfloat-snap it there — cross-window
+        // zone bleed. Logout/login (new uuids) restores through
+        // resolveWindowRestore's take(), never this path.
+        if (const auto rec = m_windowTracker->placementStore().peekExact(windowId)) {
             const PhosphorEngine::EngineSlot slot = rec->slotFor(engineId());
             if (!slot.zoneIds.isEmpty()
                 && (slot.state == WindowPlacement::stateFloating() || slot.state == WindowPlacement::stateSnapped())) {

--- a/libs/phosphor-snap-engine/src/lifecycle.cpp
+++ b/libs/phosphor-snap-engine/src/lifecycle.cpp
@@ -654,6 +654,20 @@ std::optional<PhosphorEngine::WindowPlacement> SnapEngine::capturePlacement(cons
         // orchestrator fills freeGeometryByScreen from the live frame; a contentless
         // capture (no frame) is dropped by hasRestorableContent() so geometry-less
         // floated residue never floods the per-app FIFO.
+        //
+        // But a window this engine does not track AT ALL is a different case: snap
+        // has NO knowledge of it — typically because a cross-engine handoffRelease
+        // just handed it to autotile, leaving the record's snap slot as the FROZEN
+        // per-mode memory that windowsReleased restores from on return to snapping.
+        // Fabricating a floated slot here overwrote that frozen memory (a window
+        // snapped in snap mode, mode-toggled through autotile, came back "floating"
+        // — the phantom snap-float restore). Return nullopt instead: the capture
+        // orchestrator's no-engine contract leaves the existing record intact, and
+        // a genuinely untracked window's close still persists via the
+        // recordFloatingClose fallback.
+        if (!isWindowTracked(windowId)) {
+            return std::nullopt;
+        }
         slot.state = WindowPlacement::stateFloating();
         p.screenId = screenForTrackedWindow(windowId);
     }

--- a/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
+++ b/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
@@ -1500,8 +1500,11 @@ private:
     // engine adoption) deliberately KEEPS the entry: the adopting engine's
     // capture runs right after the release, while the live frame can still
     // be the tile rect — exactly when the orchestrator's guard needs this
-    // memory. Used solely for an exact frame comparison, so a stale rect
-    // is harmless.
+    // memory. releaseScreenStateForTeardown (autotile toggled off on a
+    // screen / orphaned-context teardown) also leaves entries behind: its
+    // windows are still open, and the next stale-window prune reclaims any
+    // that go away. Used solely for an exact frame comparison, so a stale
+    // rect is harmless.
     QHash<QString, QRect> m_lastAppliedTileRect;
 
     // Instance id → first-seen canonical windowId.

--- a/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
+++ b/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
@@ -1495,16 +1495,19 @@ private:
     // Canonical windowId → tile rect last emitted for it by applyTiling.
     // Backs lastManagedRect(): deliberately NOT cleared when the window
     // leaves the tiled state (that survival is the point — see the base
-    // doc), only on full departure: close, a genuine cross-screen move off
-    // an autotile screen, and stale-window pruning. handoffRelease (cross-
-    // engine adoption) deliberately KEEPS the entry: the adopting engine's
-    // capture runs right after the release, while the live frame can still
-    // be the tile rect — exactly when the orchestrator's guard needs this
-    // memory. releaseScreenStateForTeardown (autotile toggled off on a
-    // screen / orphaned-context teardown) also leaves entries behind: its
-    // windows are still open, and the next stale-window prune reclaims any
-    // that go away. Used solely for an exact frame comparison, so a stale
-    // rect is harmless.
+    // doc). Cleared on exactly two events: a genuine cross-screen move off
+    // an autotile screen (the reposition has already moved the frame off
+    // the old tile rect) and stale-window pruning. Everything else KEEPS
+    // the entry — windowClosed (the effect notifies autotile before
+    // WindowTracking, so the orchestrator's close capture and its tile-rect
+    // guard run after this engine's teardown), handoffRelease (the adopting
+    // engine's capture runs right after the release), and
+    // releaseScreenStateForTeardown (windows still open) — because in each
+    // the live frame can still be the tile rect, exactly when the
+    // orchestrator's guard needs this memory. Closed windows' entries are
+    // reclaimed by pruneStaleWindows, whose sweep is independent of
+    // tracking. Used solely for an exact frame comparison, so a stale rect
+    // is harmless.
     QHash<QString, QRect> m_lastAppliedTileRect;
 
     // Instance id → first-seen canonical windowId.

--- a/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
+++ b/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
@@ -1496,8 +1496,12 @@ private:
     // Backs lastManagedRect(): deliberately NOT cleared when the window
     // leaves the tiled state (that survival is the point — see the base
     // doc), only on full departure: close, a genuine cross-screen move off
-    // an autotile screen, and stale-window pruning. Used solely for an
-    // exact frame comparison, so a stale rect is harmless.
+    // an autotile screen, and stale-window pruning. handoffRelease (cross-
+    // engine adoption) deliberately KEEPS the entry: the adopting engine's
+    // capture runs right after the release, while the live frame can still
+    // be the tile rect — exactly when the orchestrator's guard needs this
+    // memory. Used solely for an exact frame comparison, so a stale rect
+    // is harmless.
     QHash<QString, QRect> m_lastAppliedTileRect;
 
     // Instance id → first-seen canonical windowId.

--- a/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
+++ b/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
@@ -1116,6 +1116,14 @@ public:
 
     int pruneStaleWindows(const QSet<QString>& aliveWindowIds) override;
 
+    /// The tile rect this engine last emitted for @p rawWindowId via applyTiling,
+    /// remembered PAST the window's transition out of the tiled state (see the
+    /// base doc: on a float toggle the tiled bit clears before the compositor
+    /// repositions the window, and the capture orchestrator needs this rect to
+    /// recognise the still-tiled live frame). Invalid when the window was never
+    /// tiled here (or has closed).
+    QRect lastManagedRect(const QString& rawWindowId) const override;
+
 private Q_SLOTS:
     void onWindowZoneChanged(const QString& windowId, const QString& zoneId);
     void onWindowAdded(const QString& windowId);
@@ -1483,6 +1491,13 @@ private:
     QSet<PhosphorEngine::TilingStateKey> m_userTunedMasterCount;
 
     QHash<QString, QSize> m_windowMinSizes; // windowId -> minimum size from KWin
+
+    // Canonical windowId → tile rect last emitted for it by applyTiling.
+    // Backs lastManagedRect(): deliberately NOT cleared when the window
+    // leaves the tiled state (that survival is the point — see the base
+    // doc), only on close and stale-window pruning. Used solely for an
+    // exact frame comparison, so a stale rect is harmless.
+    QHash<QString, QRect> m_lastAppliedTileRect;
 
     // Instance id → first-seen canonical windowId.
     //

--- a/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
+++ b/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
@@ -1495,7 +1495,8 @@ private:
     // Canonical windowId → tile rect last emitted for it by applyTiling.
     // Backs lastManagedRect(): deliberately NOT cleared when the window
     // leaves the tiled state (that survival is the point — see the base
-    // doc), only on close and stale-window pruning. Used solely for an
+    // doc), only on full departure: close, a genuine cross-screen move off
+    // an autotile screen, and stale-window pruning. Used solely for an
     // exact frame comparison, so a stale rect is harmless.
     QHash<QString, QRect> m_lastAppliedTileRect;
 

--- a/libs/phosphor-tile-engine/src/AutotileEngine.cpp
+++ b/libs/phosphor-tile-engine/src/AutotileEngine.cpp
@@ -163,6 +163,11 @@ bool AutotileEngine::isAutotileFloated(const QString& rawWindowId) const
     return m_autotileFloatedWindows.contains(canonicalizeForLookup(rawWindowId));
 }
 
+QRect AutotileEngine::lastManagedRect(const QString& rawWindowId) const
+{
+    return m_lastAppliedTileRect.value(canonicalizeForLookup(rawWindowId));
+}
+
 int AutotileEngine::pruneStaleWindows(const QSet<QString>& aliveWindowIds)
 {
     int pruned = PlacementEngineBase::pruneStaleWindows(aliveWindowIds);
@@ -209,6 +214,14 @@ int AutotileEngine::pruneStaleWindows(const QSet<QString>& aliveWindowIds)
     for (auto it = m_windowMinSizes.begin(); it != m_windowMinSizes.end();) {
         if (!aliveWindowIds.contains(it.key())) {
             it = m_windowMinSizes.erase(it);
+        } else {
+            ++it;
+        }
+    }
+    // Same independent keying for the last-applied tile rects.
+    for (auto it = m_lastAppliedTileRect.begin(); it != m_lastAppliedTileRect.end();) {
+        if (!aliveWindowIds.contains(it.key())) {
+            it = m_lastAppliedTileRect.erase(it);
         } else {
             ++it;
         }
@@ -2411,6 +2424,7 @@ void AutotileEngine::windowClosed(const QString& rawWindowId)
     // (windowOpened only stores when minWidth/minHeight > 0), inflating
     // enforceMinSizes constraints with a stale value.
     m_windowMinSizes.remove(windowId);
+    m_lastAppliedTileRect.remove(windowId);
 
     onWindowRemoved(windowId);
     // Release the canonical translation last — downstream cleanup above may
@@ -4064,6 +4078,10 @@ void AutotileEngine::applyTiling(const QString& screenId)
         // (mirrors the snap side, DaemonGeometryResolver::snapBorderInset == 0).
         // Tile spacing comes from the zone gap/padding settings, not the border.
         const QRect& geo = zones[i];
+        // Remember the emitted rect for lastManagedRect(): the float-toggle
+        // capture path compares the live frame against it AFTER the tiled bit
+        // has already cleared (see the header doc on m_lastAppliedTileRect).
+        m_lastAppliedTileRect.insert(windows[i], geo);
         QJsonObject obj;
         obj[QLatin1String("windowId")] = windows[i];
         obj[QLatin1String("screenId")] = screenId;

--- a/libs/phosphor-tile-engine/src/AutotileEngine.cpp
+++ b/libs/phosphor-tile-engine/src/AutotileEngine.cpp
@@ -2426,7 +2426,14 @@ void AutotileEngine::windowClosed(const QString& rawWindowId)
     // (windowOpened only stores when minWidth/minHeight > 0), inflating
     // enforceMinSizes constraints with a stale value.
     m_windowMinSizes.remove(windowId);
-    m_lastAppliedTileRect.remove(windowId);
+    // m_lastAppliedTileRect is deliberately RETAINED here. The effect
+    // notifies autotile of a close BEFORE WindowTracking (two fire-and-forget
+    // calls on the same connection, delivered in order), so the orchestrator's
+    // captureWindowPlacement — and its close-path tile-rect guard — runs
+    // AFTER this teardown, on a live frame that is still the tile rect for a
+    // window that closed tiled. Erasing now would blind that guard and let
+    // the tile rect be recorded as the reopen float-back. pruneStaleWindows
+    // reclaims the entry (its sweep is independent of tracking).
 
     onWindowRemoved(windowId);
     // Release the canonical translation last — downstream cleanup above may

--- a/libs/phosphor-tile-engine/src/AutotileEngine.cpp
+++ b/libs/phosphor-tile-engine/src/AutotileEngine.cpp
@@ -735,9 +735,11 @@ void AutotileEngine::setAutotileScreens(const QSet<QString>& screens)
                         // of truth). Without this, windows added from pending orders lose
                         // their floating state because windowOpened's floating restore is
                         // skipped when the window already exists in the PhosphorTiles::TilingState.
+                        // Exact record only: pending orders are built from LIVE session
+                        // ids, so a same-app sibling's floating record must not float
+                        // this window (relogin restores go through insertWindow's take()).
                         if (m_windowTracker) {
-                            const auto rec = m_windowTracker->placementStore().peek(
-                                windowId, m_windowTracker->currentAppIdFor(windowId));
+                            const auto rec = m_windowTracker->placementStore().peekExact(windowId);
                             if (rec
                                 && rec->slotFor(engineId()).state == PhosphorEngine::WindowPlacement::stateFloating()) {
                                 ts->setFloating(windowId, true);

--- a/libs/phosphor-tile-engine/src/AutotileEngine.cpp
+++ b/libs/phosphor-tile-engine/src/AutotileEngine.cpp
@@ -2507,6 +2507,7 @@ void AutotileEngine::windowFocused(const QString& rawWindowId, const QString& sc
             m_states.removeWindow(windowId);
             m_windowMinSizes.remove(windowId);
             m_autotileFloatedWindows.remove(windowId);
+            m_lastAppliedTileRect.remove(windowId);
             if (!oldScreen.isEmpty()) {
                 migrateWindowBetweenKeys(windowId, oldKey, screenId);
             }

--- a/src/daemon/daemon/signals.cpp
+++ b/src/daemon/daemon/signals.cpp
@@ -136,7 +136,9 @@ void Daemon::initializeAutotile()
                             // last left snapping. No parallel saved-float set. Float state is set
                             // immediately; geometry restore is deferred to the batched resnap
                             // signal to avoid individual D-Bus signals queuing behind the resnap.
-                            const auto rec = wts->placementStore().peek(windowId, wts->currentAppIdFor(windowId));
+                            // Exact record only: this is a LIVE mid-session window (uuids stable),
+                            // so a same-app sibling's record must not float/zone-restore it.
+                            const auto rec = wts->placementStore().peekExact(windowId);
                             const PhosphorEngine::EngineSlot snapSlot = rec
                                 ? rec->slotFor(PhosphorEngine::WindowPlacement::snapEngineId())
                                 : PhosphorEngine::EngineSlot{};

--- a/src/dbus/windowtrackingadaptor.cpp
+++ b/src/dbus/windowtrackingadaptor.cpp
@@ -449,7 +449,14 @@ void WindowTrackingAdaptor::captureWindowPlacement(const QString& windowId, cons
     // above and returned) is never second-guessed.
     if (!authoritativeScreen.isEmpty() && m_service && !m_service->isWindowAutotileTiled(windowId)) {
         const QRect frame = m_frameGeometry.value(windowId);
-        if (frame.isValid()) {
+        // Same tile-rect poison guard as the primary capture path above: a
+        // window tiled by autotile, handed off, and closed before ever being
+        // repositioned still sits on its tile rect — recording that as the
+        // reopen float-back would restore it onto the tile, not a free spot.
+        // The engine's last-applied memory survives the handoff precisely for
+        // this comparison.
+        const bool stillOnTileRect = m_autotileEngine && m_autotileEngine->lastManagedRect(windowId) == frame;
+        if (frame.isValid() && !stillOnTileRect) {
             m_service->recordFloatingClose(windowId, authoritativeScreen, frame);
         }
     }

--- a/src/dbus/windowtrackingadaptor.cpp
+++ b/src/dbus/windowtrackingadaptor.cpp
@@ -369,23 +369,21 @@ void WindowTrackingAdaptor::captureWindowPlacement(const QString& windowId, cons
                         // user's next move while floating captures the real free spot.
                         const bool stillOnSnapRect =
                             !slot.zoneIds.isEmpty() && m_service->resolveZoneGeometry(slot.zoneIds, screenKey) == frame;
-                        // Tiled analogue of the same poison guard. The
-                        // isWindowAutotileTiled gate above cannot catch the
-                        // float-toggle edge: AutotileEngine::performToggleFloat
-                        // clears the tiled bit BEFORE the daemon's sync slot
-                        // reaches this capture, while the live frame is still
-                        // the tile rect (KWin has not applied the float-back
-                        // yet — applyGeometryForFloat runs AFTER this capture
-                        // and reads what it writes). Recording that frame
+                        // Tiled analogue of the same poison guard (see the
+                        // helper doc). The isWindowAutotileTiled gate above
+                        // cannot catch the float-toggle edge:
+                        // AutotileEngine::performToggleFloat clears the tiled
+                        // bit BEFORE the daemon's sync slot reaches this
+                        // capture, while the live frame is still the tile rect
+                        // (KWin has not applied the float-back yet —
+                        // applyGeometryForFloat runs AFTER this capture and
+                        // reads what it writes). Recording that frame
                         // overwrote the genuine float-back with the tile rect,
                         // so every float "restored" the window onto its own
-                        // tile. The engine remembers the exact rect it last
-                        // applied past the state flip; skip until the frame
-                        // moves off it — the next move while floating captures
-                        // the real free spot, exactly like the snap case.
-                        const bool stillOnTileRect =
-                            m_autotileEngine && m_autotileEngine->lastManagedRect(windowId) == frame;
-                        if (!stillOnSnapRect && !stillOnTileRect) {
+                        // tile. Skip until the frame moves off it — the next
+                        // move while floating captures the real free spot,
+                        // exactly like the snap case.
+                        if (!stillOnSnapRect && !isFrameStillOnTileRect(windowId, frame)) {
                             p->screenId = screenKey;
                             p->freeGeometryByScreen.insert(screenKey, frame);
                         }
@@ -449,17 +447,25 @@ void WindowTrackingAdaptor::captureWindowPlacement(const QString& windowId, cons
     // above and returned) is never second-guessed.
     if (!authoritativeScreen.isEmpty() && m_service && !m_service->isWindowAutotileTiled(windowId)) {
         const QRect frame = m_frameGeometry.value(windowId);
-        // Same tile-rect poison guard as the primary capture path above: a
-        // window tiled by autotile, handed off, and closed before ever being
-        // repositioned still sits on its tile rect — recording that as the
-        // reopen float-back would restore it onto the tile, not a free spot.
-        // The engine's last-applied memory survives the handoff precisely for
-        // this comparison.
-        const bool stillOnTileRect = m_autotileEngine && m_autotileEngine->lastManagedRect(windowId) == frame;
-        if (frame.isValid() && !stillOnTileRect) {
+        // Same tile-rect poison guard as the primary capture path (see the
+        // helper doc): a window tiled by autotile, handed off, and closed
+        // before ever being repositioned still sits on its tile rect —
+        // recording that as the reopen float-back would restore it onto the
+        // tile, not a free spot. Skipping deliberately forfeits this close's
+        // OTHER effects too (the screen adoption and pure-float sibling
+        // collapse recordFloatingClose bundles): the record keeps its prior
+        // screen and geometry, which is strictly better than adopting a
+        // poisoned one — recordFloatingClose has no geometry-less mode, and
+        // a genuine free frame at the next close records normally.
+        if (frame.isValid() && !isFrameStillOnTileRect(windowId, frame)) {
             m_service->recordFloatingClose(windowId, authoritativeScreen, frame);
         }
     }
+}
+
+bool WindowTrackingAdaptor::isFrameStillOnTileRect(const QString& windowId, const QRect& frame) const
+{
+    return m_autotileEngine && m_autotileEngine->lastManagedRect(windowId) == frame;
 }
 
 void WindowTrackingAdaptor::refreshOpenWindowPlacements()

--- a/src/dbus/windowtrackingadaptor.cpp
+++ b/src/dbus/windowtrackingadaptor.cpp
@@ -369,7 +369,23 @@ void WindowTrackingAdaptor::captureWindowPlacement(const QString& windowId, cons
                         // user's next move while floating captures the real free spot.
                         const bool stillOnSnapRect =
                             !slot.zoneIds.isEmpty() && m_service->resolveZoneGeometry(slot.zoneIds, screenKey) == frame;
-                        if (!stillOnSnapRect) {
+                        // Tiled analogue of the same poison guard. The
+                        // isWindowAutotileTiled gate above cannot catch the
+                        // float-toggle edge: AutotileEngine::performToggleFloat
+                        // clears the tiled bit BEFORE the daemon's sync slot
+                        // reaches this capture, while the live frame is still
+                        // the tile rect (KWin has not applied the float-back
+                        // yet — applyGeometryForFloat runs AFTER this capture
+                        // and reads what it writes). Recording that frame
+                        // overwrote the genuine float-back with the tile rect,
+                        // so every float "restored" the window onto its own
+                        // tile. The engine remembers the exact rect it last
+                        // applied past the state flip; skip until the frame
+                        // moves off it — the next move while floating captures
+                        // the real free spot, exactly like the snap case.
+                        const bool stillOnTileRect =
+                            m_autotileEngine && m_autotileEngine->lastManagedRect(windowId) == frame;
+                        if (!stillOnSnapRect && !stillOnTileRect) {
                             p->screenId = screenKey;
                             p->freeGeometryByScreen.insert(screenKey, frame);
                         }

--- a/src/dbus/windowtrackingadaptor.cpp
+++ b/src/dbus/windowtrackingadaptor.cpp
@@ -451,7 +451,13 @@ void WindowTrackingAdaptor::captureWindowPlacement(const QString& windowId, cons
         // helper doc): a window tiled by autotile, handed off, and closed
         // before ever being repositioned still sits on its tile rect —
         // recording that as the reopen float-back would restore it onto the
-        // tile, not a free spot. Skipping deliberately forfeits this close's
+        // tile, not a free spot. The same holds for a tiled close on the
+        // autotile screen itself: the effect's autotile-close relay has
+        // already untracked the window by the time this capture runs (relay
+        // before WindowTracking, in-order), so it lands here with its frame
+        // still the tile rect — only the engine's retained memory (kept
+        // through its windowClosed exactly for this read) lets the guard
+        // refuse it. Skipping deliberately forfeits this close's
         // OTHER effects too (the screen adoption and pure-float sibling
         // collapse recordFloatingClose bundles): the record keeps its prior
         // screen and geometry, which is strictly better than adopting a

--- a/src/dbus/windowtrackingadaptor.h
+++ b/src/dbus/windowtrackingadaptor.h
@@ -1108,21 +1108,25 @@ private:
     /// free-geometry write and its engine-miss close fallback: true when the
     /// live @p frame still equals the tile rect the autotile engine last
     /// applied to @p windowId (the engine remembers it PAST the tiled-bit
-    /// clear and past a cross-engine handoff — see
-    /// AutotileEngine::lastManagedRect). Such a frame is a managed rect, not
-    /// a genuine free position, and must never become the float-back. The
-    /// autotile analogue of the snap-side stillOnSnapRect zone comparison.
+    /// clear, past a cross-engine handoff, and past its own windowClosed
+    /// teardown — see AutotileEngine::lastManagedRect). Such a frame is a
+    /// managed rect, not a genuine free position, and must never become the
+    /// float-back. The autotile analogue of the snap-side stillOnSnapRect
+    /// zone comparison.
     ///
-    /// The memory this reads is conditional on the close/capture screen: a
-    /// window that closes ON an autotile screen has its entry erased by the
-    /// effect's autotile-close relay first — but such a window is still
-    /// autotile-tracked, so its capture takes the engine path and never
-    /// consults this guard. The guard therefore covers exactly the windows it
-    /// exists for: a float toggle in autotile mode (performToggleFloat clears
-    /// the tiled bit before this capture reaches it, window still on its
-    /// autotile screen — the primary regression), and a tiled window handed
-    /// off to a non-autotile screen and captured or closed there. In both,
-    /// the live frame has not yet moved off the tile rect.
+    /// The close ordering makes the engine's retention load-bearing: the
+    /// effect notifies autotile of a close BEFORE WindowTracking (same
+    /// connection, in-order delivery), so a window closing tiled on an
+    /// autotile screen reaches this capture already untracked — both
+    /// engines' capturePlacement decline and the isWindowAutotileTiled gate
+    /// reads false — and takes the close-path fallback with its live frame
+    /// still on the tile rect. Only the retained memory lets this guard
+    /// refuse that frame. The guard therefore covers: a float toggle in
+    /// autotile mode (performToggleFloat clears the tiled bit before this
+    /// capture reaches it — the primary regression), a tiled window handed
+    /// off to a non-autotile screen and captured or closed there, and a
+    /// tiled close on the autotile screen itself. In each, the live frame
+    /// has not yet moved off the tile rect.
     bool isFrameStillOnTileRect(const QString& windowId, const QRect& frame) const;
 
     // ═══════════════════════════════════════════════════════════════════════════════

--- a/src/dbus/windowtrackingadaptor.h
+++ b/src/dbus/windowtrackingadaptor.h
@@ -1104,6 +1104,24 @@ private:
     // windowFloatingClearedForSnap which the adaptor relays to its own
     // windowFloatingChanged D-Bus signal).
 
+    /// Tile-rect poison guard, shared by captureWindowPlacement's primary
+    /// free-geometry write and its engine-miss close fallback: true when the
+    /// live @p frame still equals the tile rect the autotile engine last
+    /// applied to @p windowId (the engine remembers it PAST the tiled-bit
+    /// clear and past a cross-engine handoff — see
+    /// AutotileEngine::lastManagedRect). Such a frame is a managed rect, not
+    /// a genuine free position, and must never become the float-back. The
+    /// autotile analogue of the snap-side stillOnSnapRect zone comparison.
+    ///
+    /// The memory this reads is conditional on the close/capture screen: a
+    /// window that closes ON an autotile screen has its entry erased by the
+    /// effect's autotile-close relay first — but such a window is still
+    /// autotile-tracked, so its capture takes the engine path and never
+    /// consults this guard. The guard therefore covers exactly the window it
+    /// exists for: tiled, handed off to a non-autotile screen, frame not yet
+    /// repositioned.
+    bool isFrameStillOnTileRect(const QString& windowId, const QRect& frame) const;
+
     // ═══════════════════════════════════════════════════════════════════════════════
     // Screen tracking (from KWin effect's D-Bus calls)
     // ═══════════════════════════════════════════════════════════════════════════════

--- a/src/dbus/windowtrackingadaptor.h
+++ b/src/dbus/windowtrackingadaptor.h
@@ -1117,9 +1117,12 @@ private:
     /// window that closes ON an autotile screen has its entry erased by the
     /// effect's autotile-close relay first — but such a window is still
     /// autotile-tracked, so its capture takes the engine path and never
-    /// consults this guard. The guard therefore covers exactly the window it
-    /// exists for: tiled, handed off to a non-autotile screen, frame not yet
-    /// repositioned.
+    /// consults this guard. The guard therefore covers exactly the windows it
+    /// exists for: a float toggle in autotile mode (performToggleFloat clears
+    /// the tiled bit before this capture reaches it, window still on its
+    /// autotile screen — the primary regression), and a tiled window handed
+    /// off to a non-autotile screen and captured or closed there. In both,
+    /// the live frame has not yet moved off the tile rect.
     bool isFrameStillOnTileRect(const QString& windowId, const QRect& frame) const;
 
     // ═══════════════════════════════════════════════════════════════════════════════

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -739,6 +739,12 @@ target_include_directories(test_wta_convenience PRIVATE ${CMAKE_SOURCE_DIR}/libs
 target_link_libraries(test_wta_convenience PRIVATE Qt6::Test Qt6::Core Qt6::DBus plasmazones_core)
 add_test(NAME test_wta_convenience COMMAND test_wta_convenience)
 
+add_executable(test_wta_capture_guards dbus/test_wta_capture_guards.cpp
+               ${CMAKE_SOURCE_DIR}/libs/phosphor-screens/tests/FakeScreenProvider.cpp)
+target_include_directories(test_wta_capture_guards PRIVATE ${CMAKE_SOURCE_DIR}/libs/phosphor-screens/tests)
+target_link_libraries(test_wta_capture_guards PRIVATE Qt6::Test Qt6::Core Qt6::DBus plasmazones_core)
+add_test(NAME test_wta_capture_guards COMMAND test_wta_capture_guards)
+
 add_executable(test_wta_reactive_metadata dbus/test_wta_reactive_metadata.cpp)
 target_link_libraries(test_wta_reactive_metadata PRIVATE Qt6::Test Qt6::Core Qt6::DBus plasmazones_core)
 add_test(NAME test_wta_reactive_metadata COMMAND test_wta_reactive_metadata)

--- a/tests/unit/autotile/test_autotile_engine_core.cpp
+++ b/tests/unit/autotile/test_autotile_engine_core.cpp
@@ -562,6 +562,71 @@ private Q_SLOTS:
         QVERIFY(tilingSpy.count() >= 1);
         QCOMPARE(tilingSpy.last().first().toString(), screenName);
     }
+
+    // =========================================================================
+    // lastManagedRect: the tile rect applyTiling last emitted for a window,
+    // remembered PAST the float flip. performToggleFloat clears the tiled bit
+    // before the compositor repositions the window, so the capture orchestrator
+    // needs this rect to recognise the still-tiled live frame and refuse it as
+    // float-back geometry (the "float restores onto its own tile" regression).
+    // =========================================================================
+
+    void testLastManagedRect_survivesFloatToggle_clearedOnClose()
+    {
+        AutotileEngine engine(nullptr, nullptr, nullptr, PlasmaZones::TestHelpers::testRegistry());
+        const QString screenName = QStringLiteral("DP-1");
+        engine.setAutotileScreens({screenName});
+
+        engine.windowOpened(QStringLiteral("win-1"), screenName);
+        engine.windowOpened(QStringLiteral("win-2"), screenName);
+        QCoreApplication::processEvents();
+
+        // Force zones directly — unit tests have no real screen geometry, so
+        // recalculateLayout() bails and applyTiling consumes what we set.
+        PhosphorTiles::TilingState* state = engine.tilingStateForScreen(screenName);
+        QVERIFY(state);
+        const QRect zoneA(10, 10, 950, 1060);
+        const QRect zoneB(960, 10, 950, 1060);
+        state->setCalculatedZones({zoneA, zoneB});
+        engine.retile(screenName);
+
+        const QStringList tiled = state->tiledWindows();
+        QCOMPARE(tiled.size(), 2);
+        QCOMPARE(engine.lastManagedRect(tiled.at(0)), zoneA);
+        QCOMPARE(engine.lastManagedRect(tiled.at(1)), zoneB);
+        QVERIFY(!engine.lastManagedRect(QStringLiteral("never-seen")).isValid());
+
+        // The regression pin: after the float toggle the tiled bit is gone,
+        // but the last-applied rect must still answer.
+        const QString floated = tiled.at(0);
+        engine.toggleWindowFloat(floated, screenName);
+        QVERIFY(state->isFloating(floated));
+        QCOMPARE(engine.lastManagedRect(floated), zoneA);
+
+        engine.windowClosed(floated);
+        QVERIFY(!engine.lastManagedRect(floated).isValid());
+    }
+
+    void testLastManagedRect_prunedWithStaleWindows()
+    {
+        AutotileEngine engine(nullptr, nullptr, nullptr, PlasmaZones::TestHelpers::testRegistry());
+        const QString screenName = QStringLiteral("DP-1");
+        engine.setAutotileScreens({screenName});
+
+        engine.windowOpened(QStringLiteral("win-1"), screenName);
+        engine.windowOpened(QStringLiteral("win-2"), screenName);
+        QCoreApplication::processEvents();
+
+        PhosphorTiles::TilingState* state = engine.tilingStateForScreen(screenName);
+        QVERIFY(state);
+        state->setCalculatedZones({QRect(10, 10, 950, 1060), QRect(960, 10, 950, 1060)});
+        engine.retile(screenName);
+        QVERIFY(engine.lastManagedRect(QStringLiteral("win-1")).isValid());
+
+        engine.pruneStaleWindows({QStringLiteral("win-2")});
+        QVERIFY(!engine.lastManagedRect(QStringLiteral("win-1")).isValid());
+        QVERIFY(engine.lastManagedRect(QStringLiteral("win-2")).isValid());
+    }
 };
 
 QTEST_MAIN(TestAutotileEngineCore)

--- a/tests/unit/autotile/test_autotile_engine_core.cpp
+++ b/tests/unit/autotile/test_autotile_engine_core.cpp
@@ -600,16 +600,22 @@ private Q_SLOTS:
 
         const QStringList tiled = state->tiledWindows();
         QCOMPARE(tiled.size(), 2);
-        QCOMPARE(engine.lastManagedRect(tiled.at(0)), zoneA);
-        QCOMPARE(engine.lastManagedRect(tiled.at(1)), zoneB);
+        // Assert per window id, not per tiling order: each tiled window owns
+        // exactly one of the two zone rects, and they differ.
+        const QRect rect0 = engine.lastManagedRect(tiled.at(0));
+        const QRect rect1 = engine.lastManagedRect(tiled.at(1));
+        QVERIFY(rect0 == zoneA || rect0 == zoneB);
+        QVERIFY(rect1 == zoneA || rect1 == zoneB);
+        QVERIFY(rect0 != rect1);
         QVERIFY(!engine.lastManagedRect(QStringLiteral("never-seen")).isValid());
 
         // The regression pin: after the float toggle the tiled bit is gone,
-        // but the last-applied rect must still answer.
+        // but the last-applied rect must still answer with the SAME rect the
+        // window was tiled at.
         const QString floated = tiled.at(0);
         engine.toggleWindowFloat(floated, screenName);
         QVERIFY(state->isFloating(floated));
-        QCOMPARE(engine.lastManagedRect(floated), zoneA);
+        QCOMPARE(engine.lastManagedRect(floated), rect0);
 
         engine.windowClosed(floated);
         QVERIFY(!engine.lastManagedRect(floated).isValid());
@@ -632,6 +638,32 @@ private Q_SLOTS:
         QVERIFY(engine.lastManagedRect(QStringLiteral("win-1")).isValid());
 
         engine.pruneStaleWindows({QStringLiteral("win-2")});
+        QVERIFY(!engine.lastManagedRect(QStringLiteral("win-1")).isValid());
+        QVERIFY(engine.lastManagedRect(QStringLiteral("win-2")).isValid());
+    }
+
+    // A genuine cross-screen focus move OFF the autotile screens is full
+    // departure: windowFocused drops the window's tracking, including its
+    // last-applied tile rect. The window left the engine's world entirely, so
+    // its tile-rect memory must not linger (the sibling stays untouched).
+    void testLastManagedRect_clearedOnCrossScreenFocusMove()
+    {
+        AutotileEngine engine(nullptr, nullptr, nullptr, PlasmaZones::TestHelpers::testRegistry());
+        const QString screenName = QStringLiteral("DP-1");
+        engine.setAutotileScreens({screenName});
+
+        engine.windowOpened(QStringLiteral("win-1"), screenName);
+        engine.windowOpened(QStringLiteral("win-2"), screenName);
+        QCoreApplication::processEvents();
+
+        PhosphorTiles::TilingState* state = engine.tilingStateForScreen(screenName);
+        QVERIFY(state);
+        state->setCalculatedZones({QRect(10, 10, 950, 1060), QRect(960, 10, 950, 1060)});
+        engine.retile(screenName);
+        QVERIFY(engine.lastManagedRect(QStringLiteral("win-1")).isValid());
+
+        // Focus reports win-1 on a non-autotile screen → tracking removed.
+        engine.windowFocused(QStringLiteral("win-1"), QStringLiteral("HDMI-1"));
         QVERIFY(!engine.lastManagedRect(QStringLiteral("win-1")).isValid());
         QVERIFY(engine.lastManagedRect(QStringLiteral("win-2")).isValid());
     }

--- a/tests/unit/autotile/test_autotile_engine_core.cpp
+++ b/tests/unit/autotile/test_autotile_engine_core.cpp
@@ -5,8 +5,16 @@
 #include <QCoreApplication>
 #include <QSignalSpy>
 
+#include <memory>
+
+#include <PhosphorEngine/WindowPlacement.h>
+#include <PhosphorPlacement/WindowTrackingService.h>
 #include <PhosphorTileEngine/AutotileEngine.h>
+#include <PhosphorZones/LayoutRegistry.h>
 #include "../helpers/AutotileTestHelpers.h"
+#include "../helpers/IsolatedConfigGuard.h"
+#include "../helpers/LayoutRegistryTestHelpers.h"
+#include "../helpers/StubZoneDetector.h"
 #include <PhosphorTileEngine/AutotileConfig.h>
 #include <PhosphorTiles/TilingState.h>
 #include <PhosphorTiles/TilingAlgorithm.h>
@@ -626,6 +634,55 @@ private Q_SLOTS:
         engine.pruneStaleWindows({QStringLiteral("win-2")});
         QVERIFY(!engine.lastManagedRect(QStringLiteral("win-1")).isValid());
         QVERIFY(engine.lastManagedRect(QStringLiteral("win-2")).isValid());
+    }
+
+    // =========================================================================
+    // Pending-order seed float restore: EXACT record only. Pending orders are
+    // built from live-session ids, so a same-app SIBLING's floating record
+    // must never float a record-less seeded window (relogin restores go
+    // through insertWindow's take(), not this path). The window's own exact
+    // floating record still restores its float.
+    // =========================================================================
+
+    void testPendingOrderSeed_floatRestoreIsExactRecordOnly()
+    {
+        PlasmaZones::TestHelpers::IsolatedConfigGuard guard;
+        std::unique_ptr<PhosphorZones::LayoutRegistry> layoutManager(
+            PlasmaZones::TestHelpers::makeLayoutRegistry(QStringLiteral("plasmazones/layouts")));
+        PlasmaZones::StubZoneDetector zoneDetector;
+        PhosphorPlacement::WindowTrackingService wts(layoutManager.get(), &zoneDetector, nullptr, nullptr);
+
+        AutotileEngine engine(nullptr, &wts, nullptr, PlasmaZones::TestHelpers::testRegistry());
+        const QString screenName = QStringLiteral("DP-1");
+
+        using PhosphorEngine::WindowPlacement;
+        PhosphorEngine::EngineSlot floatSlot;
+        floatSlot.state = QString(WindowPlacement::stateFloating());
+
+        // Sibling instance's durable floating record (same appId, other uuid).
+        WindowPlacement sib;
+        sib.windowId = QStringLiteral("app|sibling");
+        sib.appId = QStringLiteral("app");
+        sib.engines.insert(engine.engineId(), floatSlot);
+        QVERIFY(wts.placementStore().record(sib));
+
+        // The second seeded window's OWN exact floating record.
+        WindowPlacement own;
+        own.windowId = QStringLiteral("app|own");
+        own.appId = QStringLiteral("app");
+        own.engines.insert(engine.engineId(), floatSlot);
+        QVERIFY(wts.placementStore().record(own));
+
+        engine.setInitialWindowOrder(screenName, {QStringLiteral("app|fresh"), QStringLiteral("app|own")});
+        engine.setAutotileScreens({screenName});
+
+        PhosphorTiles::TilingState* state = engine.tilingStateForScreen(screenName);
+        QVERIFY(state);
+        QVERIFY(state->containsWindow(QStringLiteral("app|fresh")));
+        QVERIFY2(!state->isFloating(QStringLiteral("app|fresh")),
+                 "a same-app sibling's floating record must not float a record-less seeded window");
+        QVERIFY2(state->isFloating(QStringLiteral("app|own")),
+                 "the window's own exact floating record still restores its float");
     }
 };
 

--- a/tests/unit/autotile/test_autotile_engine_core.cpp
+++ b/tests/unit/autotile/test_autotile_engine_core.cpp
@@ -579,7 +579,7 @@ private Q_SLOTS:
     // float-back geometry (the "float restores onto its own tile" regression).
     // =========================================================================
 
-    void testLastManagedRect_survivesFloatToggle_clearedOnClose()
+    void testLastManagedRect_survivesFloatToggleAndClose()
     {
         AutotileEngine engine(nullptr, nullptr, nullptr, PlasmaZones::TestHelpers::testRegistry());
         const QString screenName = QStringLiteral("DP-1");
@@ -617,8 +617,15 @@ private Q_SLOTS:
         QVERIFY(state->isFloating(floated));
         QCOMPARE(engine.lastManagedRect(floated), rect0);
 
+        // Close is NOT a clearing site: the effect notifies autotile of a
+        // close before WindowTracking, so the orchestrator's close capture
+        // (and its tile-rect guard) runs after this teardown and still needs
+        // the memory. pruneStaleWindows is the reclaim path.
         engine.windowClosed(floated);
+        QCOMPARE(engine.lastManagedRect(floated), rect0);
+        engine.pruneStaleWindows({tiled.at(1)});
         QVERIFY(!engine.lastManagedRect(floated).isValid());
+        QVERIFY(engine.lastManagedRect(tiled.at(1)).isValid());
     }
 
     void testLastManagedRect_prunedWithStaleWindows()

--- a/tests/unit/core/test_snap_engine.cpp
+++ b/tests/unit/core/test_snap_engine.cpp
@@ -1595,7 +1595,8 @@ private Q_SLOTS:
     // Two-state model: snapping has only `snapped` / `floated` — no `free`.
     // =========================================================================
 
-    // capturePlacement of a window snap does not track AT ALL captures NOTHING.
+    // capturePlacement of a window that the snap engine does not track at all
+    // captures NOTHING.
     // It previously fabricated a FLOATING slot (the untracked window has no
     // effective screen, so the snap-mode gate was bypassed and it reached the
     // state if/else) — and that fabrication overwrote the record's frozen

--- a/tests/unit/core/test_snap_engine.cpp
+++ b/tests/unit/core/test_snap_engine.cpp
@@ -1595,17 +1595,27 @@ private Q_SLOTS:
     // Two-state model: snapping has only `snapped` / `floated` — no `free`.
     // =========================================================================
 
-    // capturePlacement of an unmanaged window (neither snapped nor floating in the
-    // runtime SnapState) records a FLOATING slot — the retired `free` state. An
-    // untracked window has no effective screen, so capturePlacement's snap-mode gate
-    // is bypassed and it reaches the state if/else.
-    void testCapturePlacement_unmanagedWindowRecordsFloating()
+    // capturePlacement of a window snap does not track AT ALL captures NOTHING.
+    // It previously fabricated a FLOATING slot (the untracked window has no
+    // effective screen, so the snap-mode gate was bypassed and it reached the
+    // state if/else) — and that fabrication overwrote the record's frozen
+    // snap-mode memory whenever a capture ran after a cross-engine
+    // handoffRelease (autotile adoption), which windowsReleased then read back
+    // and "restored" as a phantom float on return to snapping. A TRACKED
+    // window that is floating still captures a FLOATING slot — never the
+    // retired `free` state.
+    void testCapturePlacement_untrackedCapturesNothing_trackedFloatsAsFloating()
     {
         SnapEngine engine(m_layoutManager, m_wts, nullptr, nullptr, nullptr);
         engine.setEngineSettings(m_settings);
         m_wts->setSnapState(engine.snapState());
 
-        const auto p = engine.capturePlacement(QStringLiteral("app|unmanaged"));
+        QVERIFY2(!engine.capturePlacement(QStringLiteral("app|unmanaged")).has_value(),
+                 "an untracked window must capture nothing — fabricating a slot clobbers frozen per-mode memory");
+
+        const QString tracked = QStringLiteral("app|floaty");
+        engine.snapState()->setFloatingOnScreen(tracked, QStringLiteral("DP-1"), 0);
+        const auto p = engine.capturePlacement(tracked);
         QVERIFY(p.has_value());
         const PhosphorEngine::EngineSlot slot = p->slotFor(PhosphorEngine::WindowPlacement::snapEngineId());
         QCOMPARE(slot.state, QString(PhosphorEngine::WindowPlacement::stateFloating()));

--- a/tests/unit/core/test_snap_unfloat_fallback.cpp
+++ b/tests/unit/core/test_snap_unfloat_fallback.cpp
@@ -63,12 +63,12 @@ private:
     // Seed a placement record whose snap slot has @p state + @p zoneIds, as a
     // prior daemon session's capture would have persisted it.
     void seedSnapSlotRecord(SnapEngine& engine, const QString& windowId, const QString& state,
-                            const QStringList& zoneIds)
+                            const QStringList& zoneIds, const QString& screenId = QStringLiteral("DP-1"))
     {
         PhosphorEngine::WindowPlacement p;
         p.windowId = windowId;
         p.appId = m_wts->currentAppIdFor(windowId);
-        p.screenId = QStringLiteral("DP-1");
+        p.screenId = screenId;
         PhosphorEngine::EngineSlot slot;
         slot.state = state;
         slot.zoneIds = zoneIds;
@@ -470,6 +470,66 @@ private Q_SLOTS:
         const PhosphorEngine::UnfloatResult r = engine.resolveUnfloatGeometry(w, QStringLiteral("DP-1"));
         QVERIFY2(r.found, "a stale snapped slot still names the window's home zone — unfloat must use it");
         QCOMPARE(r.zoneIds, QStringList{homeZone});
+        QVERIFY(r.geometry.isValid());
+        m_wts->setSnapState(nullptr);
+    }
+
+    // The record's screenId is only a HINT: when it names a screen that no
+    // longer exists (monitor unplugged since the record was captured),
+    // resolveUnfloatScreen must reject it and degrade to the caller's live
+    // fallback screen — the restore still succeeds, on the fallback screen,
+    // instead of resolving against the missing monitor or failing outright.
+    void testResolveUnfloat_recordScreenGone_degradesToFallbackScreen()
+    {
+        SnapEngine engine(m_layoutManager, m_wts, nullptr, nullptr, nullptr);
+        engine.setEngineSettings(m_settings);
+        m_wts->setSnapState(engine.snapState());
+
+        auto* layout = installLayout(2);
+        const QString homeZone = layout->zones().first()->id().toString();
+        const QString w = QStringLiteral("app|unplugged");
+
+        engine.snapState()->setFloatingOnScreen(w, QStringLiteral("DP-1"), 0);
+        QVERIFY(m_wts->preFloatZones(w).isEmpty());
+        // Record captured on a screen no environment can have (a plausible
+        // name like DP-2 would resolve as a REAL monitor when the test binary
+        // is run directly on a developer's session instead of under ctest's
+        // offscreen QPA).
+        seedSnapSlotRecord(engine, w, QString(PhosphorEngine::WindowPlacement::stateSnapped()), {homeZone},
+                           QStringLiteral("PZTEST-UNPLUGGED-1"));
+
+        const PhosphorEngine::UnfloatResult r = engine.resolveUnfloatGeometry(w, QStringLiteral("DP-1"));
+        QVERIFY2(r.found, "a record naming a missing screen must still restore via the fallback screen");
+        QCOMPARE(r.zoneIds, QStringList{homeZone});
+        QCOMPARE(r.screenId, QStringLiteral("DP-1"));
+        QVERIFY(r.geometry.isValid());
+        m_wts->setSnapState(nullptr);
+    }
+
+    // Composed end-to-end join of the two resolvers through the public toggle:
+    // no live capture, no record, fallback setting ON → toggleWindowFloat's
+    // unfloat path falls from resolveUnfloatGeometry (not-found) through to
+    // resolveFallbackUnfloatGeometry and actually snaps the window into the
+    // fallback zone. Pins the caller-side chaining that the per-resolver unit
+    // tests above cover only in isolation.
+    void testToggleUnfloat_noCaptureNoRecord_snapsToFallbackZone()
+    {
+        SnapEngine engine(m_layoutManager, m_wts, nullptr, nullptr, nullptr);
+        engine.setEngineSettings(m_settings);
+        m_wts->setSnapState(engine.snapState());
+
+        auto* layout = installLayout(2);
+        const QString firstZone = layout->zones().first()->id().toString();
+        const QString w = QStringLiteral("app|composed");
+
+        engine.snapState()->setFloatingOnScreen(w, QStringLiteral("DP-1"), 0);
+        m_settings->setSnapUnfloatFallbackToZone(true);
+
+        engine.toggleWindowFloat(w, QStringLiteral("DP-1"));
+
+        QVERIFY2(!engine.snapState()->isFloating(w),
+                 "with the fallback setting on, the unfloat toggle must leave the floating state");
+        QCOMPARE(engine.snapState()->zoneForWindow(w), firstZone);
         m_wts->setSnapState(nullptr);
     }
 

--- a/tests/unit/core/test_snap_unfloat_fallback.cpp
+++ b/tests/unit/core/test_snap_unfloat_fallback.cpp
@@ -60,6 +60,22 @@ private:
         return layout;
     }
 
+    // Seed a placement record whose snap slot has @p state + @p zoneIds, as a
+    // prior daemon session's capture would have persisted it.
+    void seedSnapSlotRecord(SnapEngine& engine, const QString& windowId, const QString& state,
+                            const QStringList& zoneIds)
+    {
+        PhosphorEngine::WindowPlacement p;
+        p.windowId = windowId;
+        p.appId = m_wts->currentAppIdFor(windowId);
+        p.screenId = QStringLiteral("DP-1");
+        PhosphorEngine::EngineSlot slot;
+        slot.state = state;
+        slot.zoneIds = zoneIds;
+        p.engines.insert(engine.engineId(), slot);
+        QVERIFY(m_wts->placementStore().record(p));
+    }
+
 private Q_SLOTS:
     void init()
     {
@@ -401,6 +417,74 @@ private Q_SLOTS:
             engine.resolveWindowRestore(QStringLiteral("nomatch|win"), QStringLiteral("DP-1"), /*sticky*/ false);
 
         QVERIFY2(!result.shouldSnap, "no matching rule → the placement rule must not snap the window");
+        m_wts->setSnapState(nullptr);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // resolveUnfloatGeometry: placement-record fallback (daemon-restart path)
+    //
+    // The in-memory pre-float capture dies with the daemon. The persisted
+    // placement record's snap slot survives: a floating capture carries the
+    // pre-float zones, a stale snapped capture (daemon died before the float
+    // persisted) carries the zones the window occupied before it floated.
+    // Without the fallback, unfloating after a restart dead-ends ("no
+    // pre-float zone, keeping floating") with no way out.
+    // ═══════════════════════════════════════════════════════════════════════
+
+    void testResolveUnfloat_noLiveCapture_fallsBackToRecordFloatingSlot()
+    {
+        SnapEngine engine(m_layoutManager, m_wts, nullptr, nullptr, nullptr);
+        engine.setEngineSettings(m_settings);
+        m_wts->setSnapState(engine.snapState());
+
+        auto* layout = installLayout(2);
+        const QString homeZone = layout->zones().first()->id().toString();
+        const QString w = QStringLiteral("app|restarted");
+
+        // Live state after a daemon restart: the window is floating, but the
+        // in-memory pre-float capture is gone.
+        engine.snapState()->setFloatingOnScreen(w, QStringLiteral("DP-1"), 0);
+        QVERIFY(m_wts->preFloatZones(w).isEmpty());
+        seedSnapSlotRecord(engine, w, QString(PhosphorEngine::WindowPlacement::stateFloating()), {homeZone});
+
+        const PhosphorEngine::UnfloatResult r = engine.resolveUnfloatGeometry(w, QStringLiteral("DP-1"));
+        QVERIFY2(r.found, "record's floating slot carries the pre-float zones — unfloat must find them");
+        QCOMPARE(r.zoneIds, QStringList{homeZone});
+        QVERIFY(r.geometry.isValid());
+        m_wts->setSnapState(nullptr);
+    }
+
+    void testResolveUnfloat_noLiveCapture_fallsBackToRecordSnappedSlot()
+    {
+        SnapEngine engine(m_layoutManager, m_wts, nullptr, nullptr, nullptr);
+        engine.setEngineSettings(m_settings);
+        m_wts->setSnapState(engine.snapState());
+
+        auto* layout = installLayout(2);
+        const QString homeZone = layout->zones().last()->id().toString();
+        const QString w = QStringLiteral("app|stalerec");
+
+        engine.snapState()->setFloatingOnScreen(w, QStringLiteral("DP-1"), 0);
+        seedSnapSlotRecord(engine, w, QString(PhosphorEngine::WindowPlacement::stateSnapped()), {homeZone});
+
+        const PhosphorEngine::UnfloatResult r = engine.resolveUnfloatGeometry(w, QStringLiteral("DP-1"));
+        QVERIFY2(r.found, "a stale snapped slot still names the window's home zone — unfloat must use it");
+        QCOMPARE(r.zoneIds, QStringList{homeZone});
+        m_wts->setSnapState(nullptr);
+    }
+
+    void testResolveUnfloat_noLiveCapture_noRecord_staysNotFound()
+    {
+        SnapEngine engine(m_layoutManager, m_wts, nullptr, nullptr, nullptr);
+        engine.setEngineSettings(m_settings);
+        m_wts->setSnapState(engine.snapState());
+
+        installLayout(2);
+        engine.snapState()->setFloatingOnScreen(QStringLiteral("app|norec"), QStringLiteral("DP-1"), 0);
+
+        const PhosphorEngine::UnfloatResult r =
+            engine.resolveUnfloatGeometry(QStringLiteral("app|norec"), QStringLiteral("DP-1"));
+        QVERIFY2(!r.found, "no live capture and no record → not-found (caller falls to the fallback-zone path)");
         m_wts->setSnapState(nullptr);
     }
 };

--- a/tests/unit/core/test_snap_unfloat_fallback.cpp
+++ b/tests/unit/core/test_snap_unfloat_fallback.cpp
@@ -487,6 +487,32 @@ private Q_SLOTS:
         QVERIFY2(!r.found, "no live capture and no record → not-found (caller falls to the fallback-zone path)");
         m_wts->setSnapState(nullptr);
     }
+
+    // The record fallback consumes EXACT-windowId records only. A same-app
+    // SIBLING's record (different instance, same appId FIFO bucket) must never
+    // supply the unfloat target — without the accept predicate, peek's
+    // appId-FIFO branch would hand this record-less window the sibling's home
+    // zone and unfloat-snap it there (cross-window zone bleed).
+    void testResolveUnfloat_noLiveCaptureNoOwnRecord_ignoresAppIdSibling()
+    {
+        SnapEngine engine(m_layoutManager, m_wts, nullptr, nullptr, nullptr);
+        engine.setEngineSettings(m_settings);
+        m_wts->setSnapState(engine.snapState());
+
+        auto* layout = installLayout(2);
+        const QString siblingZone = layout->zones().first()->id().toString();
+
+        // The sibling instance persisted a snapped record; the window under
+        // test is floating with NO record of its own and no live capture.
+        seedSnapSlotRecord(engine, QStringLiteral("app|sibling"),
+                           QString(PhosphorEngine::WindowPlacement::stateSnapped()), {siblingZone});
+        engine.snapState()->setFloatingOnScreen(QStringLiteral("app|recordless"), QStringLiteral("DP-1"), 0);
+
+        const PhosphorEngine::UnfloatResult r =
+            engine.resolveUnfloatGeometry(QStringLiteral("app|recordless"), QStringLiteral("DP-1"));
+        QVERIFY2(!r.found, "a same-app sibling's record must not supply the unfloat target");
+        m_wts->setSnapState(nullptr);
+    }
 };
 
 QTEST_MAIN(TestSnapUnfloatFallback)

--- a/tests/unit/core/test_window_placement_store.cpp
+++ b/tests/unit/core/test_window_placement_store.cpp
@@ -603,7 +603,7 @@ private Q_SLOTS:
         store.record(make(QStringLiteral("dolphin|new"), QStringLiteral("dolphin"), WindowPlacement::stateFloating(),
                           WindowPlacement::snapEngineId(), QStringLiteral("S1")));
 
-        store.collapsePureFloatSiblings(QStringLiteral("dolphin"), QStringLiteral("dolphin|new"));
+        QVERIFY(store.collapsePureFloatSiblings(QStringLiteral("dolphin"), QStringLiteral("dolphin|new")));
 
         // Exact-windowId checks (no appId): contains(id, appId) would pass on any
         // surviving bucket record, so it can't prove the RIGHT record was kept.
@@ -626,7 +626,7 @@ private Q_SLOTS:
         store.record(make(QStringLiteral("dolphin|keep"), QStringLiteral("dolphin"), WindowPlacement::stateFloating(),
                           WindowPlacement::snapEngineId(), QStringLiteral("S1")));
 
-        store.collapsePureFloatSiblings(QStringLiteral("dolphin"), QStringLiteral("dolphin|keep"));
+        QVERIFY(store.collapsePureFloatSiblings(QStringLiteral("dolphin"), QStringLiteral("dolphin|keep")));
 
         QVERIFY(store.contains(QStringLiteral("dolphin|keep"))); // exact survival
         QVERIFY(store.contains(QStringLiteral("dolphin|snapped"))); // managed — kept
@@ -643,7 +643,8 @@ private Q_SLOTS:
         store.record(make(QStringLiteral("dolphin|snapped"), QStringLiteral("dolphin"), WindowPlacement::stateSnapped(),
                           WindowPlacement::snapEngineId(), QStringLiteral("S1")));
 
-        store.collapsePureFloatSiblings(QStringLiteral("dolphin"), QStringLiteral("dolphin|snapped"));
+        // A managed keep is a no-op: nothing pruned, so the store is unchanged.
+        QVERIFY(!store.collapsePureFloatSiblings(QStringLiteral("dolphin"), QStringLiteral("dolphin|snapped")));
 
         QVERIFY(store.contains(QStringLiteral("dolphin|float")));
         QVERIFY(store.contains(QStringLiteral("dolphin|snapped")));

--- a/tests/unit/core/test_window_placement_store.cpp
+++ b/tests/unit/core/test_window_placement_store.cpp
@@ -282,8 +282,8 @@ private Q_SLOTS:
     {
         // Regression: cross-screen snapped restore at login. A window snapped on
         // screen DP-1 reopens (new uuid) on screen DP-2 (KWin placed the session
-        // window on a different output). The appId bucket holds an OLDER contentless
-        // `free` record (empty screen) plus the NEWER `snapped` record on DP-1.
+        // window on a different output). The appId bucket holds an OLDER `free`
+        // record on an empty screen plus the NEWER `snapped` record on DP-1.
         // Without the `preferred` ranking, plain FIFO consumes the older free record
         // first and the window never returns to its zone. With it, the snapped
         // record wins even though it is newer AND on a different screen.
@@ -648,6 +648,36 @@ private Q_SLOTS:
 
         QVERIFY(store.contains(QStringLiteral("dolphin|float")));
         QVERIFY(store.contains(QStringLiteral("dolphin|snapped")));
+    }
+
+    void testCollapse_noopWhenKeptRecordHasNoGeometry()
+    {
+        // A pure-float keep with NO captured free position must not prune its
+        // siblings: with no shared-screen memory to converge on, collapsing
+        // would discard the sibling's only remembered spot. The managed-keep
+        // no-op above cannot pin this shape (a snapped keep trips the
+        // pure-float check first). The outcome is doubly enforced today (the
+        // empty-geometry early-out AND the geometry-keyed shares-screen scan);
+        // this pins the CONTRACT so it survives either check being refactored
+        // — e.g. a shares-screen scan that started counting the record's bare
+        // screenId as coverage would prune the sibling and fail here.
+        WindowPlacementStore store;
+        store.record(make(QStringLiteral("dolphin|sib"), QStringLiteral("dolphin"), WindowPlacement::stateFloating(),
+                          WindowPlacement::snapEngineId(), QStringLiteral("S1")));
+        WindowPlacement bareKeep;
+        bareKeep.windowId = QStringLiteral("dolphin|bare");
+        bareKeep.appId = QStringLiteral("dolphin");
+        bareKeep.screenId = QStringLiteral("S1");
+        EngineSlot floatSlot;
+        floatSlot.state = WindowPlacement::stateFloating();
+        floatSlot.zoneIds = QStringList{QStringLiteral("z1")}; // restorable, but no free geometry
+        bareKeep.engines.insert(WindowPlacement::snapEngineId(), floatSlot);
+        QVERIFY(store.record(bareKeep));
+
+        QVERIFY(!store.collapsePureFloatSiblings(QStringLiteral("dolphin"), QStringLiteral("dolphin|bare")));
+
+        QVERIFY(store.contains(QStringLiteral("dolphin|sib")));
+        QVERIFY(store.contains(QStringLiteral("dolphin|bare")));
     }
 
     void testCollapse_absorbsPrunedSiblingOtherScreenGeometry()

--- a/tests/unit/core/test_window_placement_store.cpp
+++ b/tests/unit/core/test_window_placement_store.cpp
@@ -243,6 +243,24 @@ private Q_SLOTS:
         QCOMPARE(store.size(), 2); // peek is non-consuming
     }
 
+    void testPeekExact_neverFallsBackToAppIdSibling()
+    {
+        // peekExact is the per-window read for LIVE windows: the exact-uuid
+        // branch only, never the appId-FIFO fallback — a same-app sibling's
+        // record must not answer for a record-less window (the sibling zone /
+        // float-state bleed the live-state readers were exposed to).
+        WindowPlacementStore store;
+        store.record(make(QStringLiteral("term|sibling"), QStringLiteral("term"), WindowPlacement::stateSnapped(),
+                          WindowPlacement::snapEngineId()));
+
+        QVERIFY(store.peek(QStringLiteral("term|other"), QStringLiteral("term")).has_value()); // fallback would bleed
+        QVERIFY(!store.peekExact(QStringLiteral("term|other")).has_value()); // exact-only refuses
+        const auto own = store.peekExact(QStringLiteral("term|sibling"));
+        QVERIFY(own.has_value());
+        QCOMPARE(own->windowId, QStringLiteral("term|sibling"));
+        QCOMPARE(store.size(), 1); // non-consuming
+    }
+
     void testTake_acceptPredicatePassesOnFifoCandidate()
     {
         // The accepting (not just rejecting) path: an appId-FIFO candidate that

--- a/tests/unit/core/test_window_placement_store.cpp
+++ b/tests/unit/core/test_window_placement_store.cpp
@@ -147,10 +147,12 @@ private Q_SLOTS:
         QVERIFY(p2.has_value());
         QCOMPARE(p2->slotFor(WindowPlacement::snapEngineId()).state, QString(WindowPlacement::stateFloating()));
 
-        // Remaining is term|1.
+        // No exact match for the unknown uuid → the appId fallback hands out the
+        // sole remaining record (term|1 — with one record left, ordering is not
+        // exercised here, only the fallback itself).
         auto p1 = store.take(QStringLiteral("term|unknown-uuid"), QStringLiteral("term"));
         QVERIFY(p1.has_value());
-        QCOMPARE(p1->windowId, QStringLiteral("term|1")); // FIFO fallback
+        QCOMPARE(p1->windowId, QStringLiteral("term|1"));
     }
 
     void testAcceptPredicate_rejectsWrongScreen()

--- a/tests/unit/core/test_wts_lifecycle.cpp
+++ b/tests/unit/core/test_wts_lifecycle.cpp
@@ -470,6 +470,52 @@ private Q_SLOTS:
         QCOMPARE(rec2->freeGeometryFor(screen), QRect(30, 30, 500, 400)); // overwrite replaces
     }
 
+    void testRecordFreeGeometry_firstCaptureWins_isPerWindow()
+    {
+        // First-capture-wins is a PER-WINDOW contract: a same-app sibling's
+        // recorded free geometry must not suppress this window's own first
+        // capture (it would never persist its own position while the sibling's
+        // record lives).
+        const QString screen = QStringLiteral("DP-1");
+        m_service->recordFreeGeometry(QStringLiteral("firefox|sibling-geo"), screen, QRect(10, 10, 400, 300),
+                                      /*overwrite=*/false);
+        m_service->recordFreeGeometry(QStringLiteral("firefox|self-geo"), screen, QRect(50, 60, 700, 500),
+                                      /*overwrite=*/false);
+        const auto rec = m_service->placementStore().peekExact(QStringLiteral("firefox|self-geo"));
+        QVERIFY2(rec.has_value(), "a sibling's record must not block this window's first capture");
+        QCOMPARE(rec->freeGeometryFor(screen), QRect(50, 60, 700, 500));
+    }
+
+    void testRecordFloatingClose_neverInheritsSiblingEngineSlots()
+    {
+        // A record-less window closing floating must take recordFloatingClose's
+        // synthesized-floating branch — grafting a same-app sibling's SNAPPED
+        // slot under this windowId would make a reopen restore two windows into
+        // the sibling's zone and corrupt the per-app FIFO distribution.
+        PhosphorEngine::WindowPlacement sib;
+        sib.windowId = QStringLiteral("firefox|sibling-close");
+        sib.appId = QStringLiteral("firefox");
+        PhosphorEngine::EngineSlot snap;
+        snap.state = QString(PhosphorEngine::WindowPlacement::stateSnapped());
+        snap.zoneIds = QStringList{m_zoneIds[0]};
+        sib.engines.insert(PhosphorEngine::WindowPlacement::snapEngineId(), snap);
+        QVERIFY(m_service->placementStore().record(sib));
+
+        m_service->recordFloatingClose(QStringLiteral("firefox|self-close"), QStringLiteral("DP-1"),
+                                       QRect(30, 40, 600, 400));
+
+        const auto rec = m_service->placementStore().peekExact(QStringLiteral("firefox|self-close"));
+        QVERIFY(rec.has_value());
+        const PhosphorEngine::EngineSlot slot = rec->slotFor(PhosphorEngine::WindowPlacement::snapEngineId());
+        QCOMPARE(slot.state, QString(PhosphorEngine::WindowPlacement::stateFloating()));
+        QVERIFY2(slot.zoneIds.isEmpty(), "the sibling's snapped slot must not be grafted under this windowId");
+        // The sibling's own record is untouched.
+        const auto sibRec = m_service->placementStore().peekExact(QStringLiteral("firefox|sibling-close"));
+        QVERIFY(sibRec.has_value());
+        QCOMPARE(sibRec->slotFor(PhosphorEngine::WindowPlacement::snapEngineId()).state,
+                 QString(PhosphorEngine::WindowPlacement::stateSnapped()));
+    }
+
     void testRecordedSnapZones_appIdFallbackAfterRelogin()
     {
         // After a relogin the window's uuid changes; the durable record stored under

--- a/tests/unit/dbus/test_wta_capture_guards.cpp
+++ b/tests/unit/dbus/test_wta_capture_guards.cpp
@@ -179,13 +179,18 @@ private Q_SLOTS:
             PhosphorScreens::ScreenManagerConfig{.screenProvider = &fake, .useGeometrySensors = false});
         screenMgr.start();
 
+        // Declared BEFORE parent (and therefore before wta) so the stub
+        // outlives the adaptor on EVERY exit path — an early QVERIFY failure
+        // skips the explicit setEngines detach below, and while the adaptor's
+        // engine ref is a self-nulling QPointer, outliving it makes the
+        // teardown safety structural rather than incidental.
+        StubTileRectEngine tileEngine;
         QObject parent;
         auto* wta = new WindowTrackingAdaptor(m_layoutManager, m_zoneDetector, &screenMgr, m_settings, nullptr, nullptr,
                                               &parent);
         auto* snap = new SnapEngine(m_layoutManager, wta->service(), m_zoneDetector, nullptr, nullptr);
         wta->service()->setSnapState(snap->snapState());
         wta->service()->setSnapEngine(snap);
-        StubTileRectEngine tileEngine;
         wta->setEngines(snap, &tileEngine);
 
         const QString windowId = QStringLiteral("ghostty|inst-tile");

--- a/tests/unit/dbus/test_wta_capture_guards.cpp
+++ b/tests/unit/dbus/test_wta_capture_guards.cpp
@@ -292,6 +292,60 @@ private Q_SLOTS:
         wta->service()->setSnapEngine(nullptr);
         delete snap;
     }
+
+    // The engine-miss CLOSE fallback carries the same tile-rect poison guard
+    // as the primary capture path: a window tiled by autotile, handed off
+    // (the tiled bit clears; the engine's last-applied rect memory
+    // deliberately survives), and closed before ever being repositioned
+    // still sits on its tile rect — recording that via recordFloatingClose
+    // would restore the reopened window onto the tile, not a free spot. A
+    // close frame OFF the tile rect records normally.
+    void testClosePathRefusesStillTiledFrame()
+    {
+        PhosphorScreens::FakeScreenProvider fake;
+        fake.addScreen(QStringLiteral("DP-1"), QRect(0, 0, 3072, 1728), QStringLiteral("DP-1"));
+        PhosphorScreens::ScreenManager screenMgr(
+            PhosphorScreens::ScreenManagerConfig{.screenProvider = &fake, .useGeometrySensors = false});
+        screenMgr.start();
+
+        // Same structural stub-before-parent ordering as the primary-path test.
+        StubTileRectEngine tileEngine;
+        QObject parent;
+        auto* wta = new WindowTrackingAdaptor(m_layoutManager, m_zoneDetector, &screenMgr, m_settings, nullptr, nullptr,
+                                              &parent);
+        auto* snap = new SnapEngine(m_layoutManager, wta->service(), m_zoneDetector, nullptr, nullptr);
+        wta->service()->setSnapState(snap->snapState());
+        wta->service()->setSnapEngine(snap);
+        wta->setEngines(snap, &tileEngine);
+
+        const QString windowId = QStringLiteral("app|closed-on-tile");
+        const QString screenId = QStringLiteral("DP-1");
+        const QString appId = wta->service()->currentAppIdFor(windowId);
+        const QRect tileRect(1540, 8, 1524, 829);
+
+        // Untracked by snap (no float/zone state) and the stub tile engine's
+        // capturePlacement default returns nullopt — the close capture takes
+        // the engine-miss fallback. The frame still equals the remembered
+        // tile rect, so the fallback must record NOTHING.
+        wta->setFrameGeometry(windowId, tileRect.x(), tileRect.y(), tileRect.width(), tileRect.height());
+        tileEngine.managedRect = tileRect;
+        wta->captureWindowPlacement(windowId, screenId);
+        QVERIFY2(!wta->service()->placementStore().peek(windowId, appId),
+                 "a close frame still on the tile rect must not become the reopen float-back");
+
+        // A close frame off the tile rect records the genuine free position.
+        const QRect freeFrame(600, 400, 900, 700);
+        wta->setFrameGeometry(windowId, freeFrame.x(), freeFrame.y(), freeFrame.width(), freeFrame.height());
+        wta->captureWindowPlacement(windowId, screenId);
+        const auto rec = wta->service()->placementStore().peek(windowId, appId);
+        QVERIFY(rec);
+        QCOMPARE(rec->freeGeometryFor(screenId), freeFrame);
+
+        wta->setEngines(snap, nullptr);
+        wta->service()->setSnapState(nullptr);
+        wta->service()->setSnapEngine(nullptr);
+        delete snap;
+    }
 };
 
 QTEST_MAIN(TestWtaCaptureGuards)

--- a/tests/unit/dbus/test_wta_capture_guards.cpp
+++ b/tests/unit/dbus/test_wta_capture_guards.cpp
@@ -1,0 +1,293 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_wta_capture_guards.cpp
+ * @brief Capture-orchestrator guards in WindowTrackingAdaptor::captureWindowPlacement:
+ *        the stillOnTileRect float-back poison guard and the untracked-window
+ *        no-engine contract (frozen per-mode snap slot preserved).
+ *
+ * Unlike test_wta_convenience's shared fixture, these tests wire a REAL
+ * ScreenManager (FakeScreenProvider): the untracked-window regression only
+ * reproduces when the orchestrator can resolve a screen for the live frame —
+ * with a null ScreenManager the fabricated slot has no geometry and
+ * hasRestorableContent() drops it before it can clobber the record, making the
+ * assertion vacuous.
+ */
+
+#include <QTest>
+#include <QRect>
+#include <QString>
+#include <QStringList>
+#include <QUuid>
+#include <memory>
+
+#include <PhosphorEngine/IPlacementState.h>
+#include <PhosphorEngine/PlacementEngineBase.h>
+#include <PhosphorEngine/WindowPlacement.h>
+#include <PhosphorPlacement/WindowTrackingService.h>
+#include <PhosphorScreens/Manager.h>
+#include <PhosphorSnapEngine/SnapEngine.h>
+#include <PhosphorSnapEngine/SnapState.h>
+#include <PhosphorZones/LayoutRegistry.h>
+#include "FakeScreenProvider.h"
+#include "dbus/windowtrackingadaptor.h"
+
+#include "../helpers/IsolatedConfigGuard.h"
+#include "../helpers/LayoutRegistryTestHelpers.h"
+#include "../helpers/StubSettings.h"
+#include "../helpers/StubZoneDetector.h"
+
+using namespace PlasmaZones;
+using namespace PhosphorSnapEngine;
+using PlasmaZones::TestHelpers::IsolatedConfigGuard;
+
+// =========================================================================
+// Stub autotile-side engine: only lastManagedRect() matters — it stands in
+// for AutotileEngine's last-applied tile rect memory in the capture guard
+// tests below. Everything else is a no-op.
+// =========================================================================
+
+class StubTileRectEngine : public PhosphorEngine::PlacementEngineBase
+{
+    Q_OBJECT
+public:
+    explicit StubTileRectEngine(QObject* parent = nullptr)
+        : PhosphorEngine::PlacementEngineBase(parent)
+    {
+    }
+
+    QRect managedRect; // returned for every window
+
+    QRect lastManagedRect(const QString&) const override
+    {
+        return managedRect;
+    }
+
+    bool isActiveOnScreen(const QString&) const override
+    {
+        return false;
+    }
+    void windowOpened(const QString&, const QString&, int, int) override
+    {
+    }
+    void windowClosed(const QString&) override
+    {
+    }
+    void windowFocused(const QString&, const QString&) override
+    {
+    }
+    void toggleWindowFloat(const QString&, const QString&) override
+    {
+    }
+    void setWindowFloat(const QString&, bool, const QString&) override
+    {
+    }
+    void focusInDirection(const QString&, const PhosphorEngine::NavigationContext&) override
+    {
+    }
+    void moveFocusedInDirection(const QString&, const PhosphorEngine::NavigationContext&) override
+    {
+    }
+    void swapFocusedInDirection(const QString&, const PhosphorEngine::NavigationContext&) override
+    {
+    }
+    void moveFocusedToPosition(int, const PhosphorEngine::NavigationContext&) override
+    {
+    }
+    void rotateWindows(bool, const PhosphorEngine::NavigationContext&) override
+    {
+    }
+    void reapplyLayout(const PhosphorEngine::NavigationContext&) override
+    {
+    }
+    void snapAllWindows(const PhosphorEngine::NavigationContext&) override
+    {
+    }
+    void cycleFocus(bool, const PhosphorEngine::NavigationContext&) override
+    {
+    }
+    void pushToEmptyZone(const PhosphorEngine::NavigationContext&) override
+    {
+    }
+    void restoreFocusedWindow(const PhosphorEngine::NavigationContext&) override
+    {
+    }
+    void toggleFocusedFloat(const PhosphorEngine::NavigationContext&) override
+    {
+    }
+    void saveState() override
+    {
+    }
+    void loadState() override
+    {
+    }
+    PhosphorEngine::IPlacementState* stateForScreen(const QString&) override
+    {
+        return nullptr;
+    }
+    const PhosphorEngine::IPlacementState* stateForScreen(const QString&) const override
+    {
+        return nullptr;
+    }
+};
+
+class TestWtaCaptureGuards : public QObject
+{
+    Q_OBJECT
+
+private:
+    std::unique_ptr<IsolatedConfigGuard> m_guard;
+    PhosphorZones::LayoutRegistry* m_layoutManager = nullptr;
+    StubSettings* m_settings = nullptr;
+    PlasmaZones::StubZoneDetector* m_zoneDetector = nullptr;
+
+private Q_SLOTS:
+    void init()
+    {
+        m_guard = std::make_unique<IsolatedConfigGuard>();
+        m_layoutManager = PlasmaZones::TestHelpers::makeLayoutRegistry(QStringLiteral("plasmazones/layouts"));
+        m_settings = new StubSettings(nullptr);
+        m_zoneDetector = new PlasmaZones::StubZoneDetector(nullptr);
+    }
+
+    void cleanup()
+    {
+        delete m_zoneDetector;
+        m_zoneDetector = nullptr;
+        delete m_settings;
+        m_settings = nullptr;
+        delete m_layoutManager;
+        m_layoutManager = nullptr;
+        m_guard.reset();
+    }
+
+    // Regression (float-restores-onto-its-own-tile): on a float-from-tiled
+    // toggle the autotile engine clears its tiled bit BEFORE the compositor
+    // repositions the window, so when captureWindowPlacement runs (from
+    // setWindowFloating) the live frame still IS the tile rect and the
+    // isWindowAutotileTiled gate no longer refuses it. The capture must
+    // compare against the engine's remembered last-applied rect and skip the
+    // free-geometry write, or applyGeometryForFloat (which runs AFTER the
+    // capture) reads the poisoned value back and "restores" the window onto
+    // its own tile — permanently overwriting the genuine float-back.
+    void testRefusesStillTiledFrameAsFloatBack()
+    {
+        PhosphorScreens::FakeScreenProvider fake;
+        fake.addScreen(QStringLiteral("DP-1"), QRect(0, 0, 3072, 1728), QStringLiteral("DP-1"));
+        PhosphorScreens::ScreenManager screenMgr(
+            PhosphorScreens::ScreenManagerConfig{.screenProvider = &fake, .useGeometrySensors = false});
+        screenMgr.start();
+
+        QObject parent;
+        auto* wta = new WindowTrackingAdaptor(m_layoutManager, m_zoneDetector, &screenMgr, m_settings, nullptr, nullptr,
+                                              &parent);
+        auto* snap = new SnapEngine(m_layoutManager, wta->service(), m_zoneDetector, nullptr, nullptr);
+        wta->service()->setSnapState(snap->snapState());
+        wta->service()->setSnapEngine(snap);
+        StubTileRectEngine tileEngine;
+        wta->setEngines(snap, &tileEngine);
+
+        const QString windowId = QStringLiteral("ghostty|inst-tile");
+        const QString screenId = QStringLiteral("DP-1");
+        const QString appId = wta->service()->currentAppIdFor(windowId);
+        const QRect tileRect(1540, 8, 1524, 829);
+        const QRect realFreeBack(1743, 795, 800, 628);
+
+        // The window's genuine float-back from an earlier session.
+        wta->service()->recordFreeGeometry(windowId, screenId, realFreeBack, true);
+
+        // Post-flip state: snap-side reports the window floating on DP-1 (the
+        // capture's owning-engine slot), the live frame still sits on the tile
+        // rect, and the autotile engine remembers having applied exactly it.
+        snap->snapState()->setFloatingOnScreen(windowId, screenId, 0);
+        wta->setFrameGeometry(windowId, tileRect.x(), tileRect.y(), tileRect.width(), tileRect.height());
+        tileEngine.managedRect = tileRect;
+
+        wta->captureWindowPlacement(windowId);
+
+        auto rec = wta->service()->placementStore().peek(windowId, appId);
+        QVERIFY(rec);
+        QCOMPARE(rec->freeGeometryFor(screenId), realFreeBack);
+
+        // Once the frame moves off the tile rect (the user repositioned the
+        // floating window), the capture adopts the genuine free frame.
+        const QRect movedFrame(600, 400, 900, 700);
+        wta->setFrameGeometry(windowId, movedFrame.x(), movedFrame.y(), movedFrame.width(), movedFrame.height());
+        wta->captureWindowPlacement(windowId);
+
+        rec = wta->service()->placementStore().peek(windowId, appId);
+        QVERIFY(rec);
+        QCOMPARE(rec->freeGeometryFor(screenId), movedFrame);
+
+        wta->setEngines(snap, nullptr);
+        wta->service()->setSnapState(nullptr);
+        wta->service()->setSnapEngine(nullptr);
+        delete snap;
+    }
+
+    // Regression (phantom snap-float after a mode round-trip): a snapped
+    // window adopted by autotile is handoff-released from snap, so snap
+    // tracks NOTHING for it — its record's snap slot is the frozen per-mode
+    // memory windowsReleased restores from on return to snapping. A capture
+    // running in that window (windowsReleased's own setWindowFloating(false)
+    // fires one) used to fabricate a "floating" snap slot for the untracked
+    // window; with a resolvable screen for the live frame the fabricated slot
+    // gains geometry, survives hasRestorableContent(), and the record merge
+    // overwrites the frozen snapped slot — which windowsReleased then read
+    // back and "restored" as a float the user never made. The capture must
+    // leave the record untouched instead.
+    void testUntrackedWindowPreservesFrozenSnapSlot()
+    {
+        PhosphorScreens::FakeScreenProvider fake;
+        fake.addScreen(QStringLiteral("DP-1"), QRect(0, 0, 3072, 1728), QStringLiteral("DP-1"));
+        PhosphorScreens::ScreenManager screenMgr(
+            PhosphorScreens::ScreenManagerConfig{.screenProvider = &fake, .useGeometrySensors = false});
+        screenMgr.start();
+
+        QObject parent;
+        auto* wta = new WindowTrackingAdaptor(m_layoutManager, m_zoneDetector, &screenMgr, m_settings, nullptr, nullptr,
+                                              &parent);
+        auto* snap = new SnapEngine(m_layoutManager, wta->service(), m_zoneDetector, nullptr, nullptr);
+        wta->service()->setSnapState(snap->snapState());
+        wta->service()->setSnapEngine(snap);
+        wta->setEngines(snap, nullptr);
+
+        const QString windowId = QStringLiteral("app|handoff");
+        const QString appId = wta->service()->currentAppIdFor(windowId);
+        const QString zoneId = QUuid::createUuid().toString();
+
+        // Frozen per-mode memory: the record's snap slot says snapped.
+        PhosphorEngine::WindowPlacement p;
+        p.windowId = windowId;
+        p.appId = appId;
+        p.screenId = QStringLiteral("DP-1");
+        PhosphorEngine::EngineSlot slot;
+        slot.state = QString(PhosphorEngine::WindowPlacement::stateSnapped());
+        slot.zoneIds = QStringList{zoneId};
+        p.engines.insert(snap->engineId(), slot);
+        QVERIFY(wta->service()->placementStore().record(p));
+
+        // Snap does not track the window (post-handoffRelease state), but the
+        // effect still reports a live frame for it — one whose centre resolves
+        // to DP-1, so a fabricated slot WOULD gain geometry and clobber the
+        // record if the untracked-capture guard were missing.
+        QVERIFY(!snap->isWindowTracked(windowId));
+        wta->setFrameGeometry(windowId, 619, 514, 1380, 907);
+
+        wta->captureWindowPlacement(windowId);
+
+        const auto rec = wta->service()->placementStore().peek(windowId, appId);
+        QVERIFY(rec);
+        const PhosphorEngine::EngineSlot after = rec->slotFor(snap->engineId());
+        QCOMPARE(after.state, QString(PhosphorEngine::WindowPlacement::stateSnapped()));
+        QCOMPARE(after.zoneIds, QStringList{zoneId});
+
+        wta->service()->setSnapState(nullptr);
+        wta->service()->setSnapEngine(nullptr);
+        delete snap;
+    }
+};
+
+QTEST_MAIN(TestWtaCaptureGuards)
+#include "test_wta_capture_guards.moc"

--- a/tests/unit/dbus/test_wta_convenience.cpp
+++ b/tests/unit/dbus/test_wta_convenience.cpp
@@ -30,9 +30,6 @@
 #include "dbus/snapadaptor.h"
 #include "dbus/windowtrackingadaptor.h"
 #include <PhosphorSnapEngine/SnapEngine.h>
-#include <PhosphorEngine/PlacementEngineBase.h>
-#include <PhosphorEngine/IPlacementState.h>
-#include <PhosphorEngine/WindowPlacement.h>
 #include <PhosphorEngine/WindowRegistry.h>
 #include <PhosphorRules/RuleStore.h>
 #include <PhosphorRules/RuleAction.h>
@@ -127,96 +124,6 @@ static PhosphorZones::Layout* createTestLayout(int zoneCount, QObject* parent)
     }
     return layout;
 }
-
-// =========================================================================
-// Stub autotile-side engine: only lastManagedRect() matters — it stands in
-// for AutotileEngine's last-applied tile rect memory in the capture guard
-// tests below. Everything else is a no-op.
-// =========================================================================
-
-class StubTileRectEngine : public PhosphorEngine::PlacementEngineBase
-{
-    Q_OBJECT
-public:
-    explicit StubTileRectEngine(QObject* parent = nullptr)
-        : PhosphorEngine::PlacementEngineBase(parent)
-    {
-    }
-
-    QRect managedRect; // returned for every window
-
-    QRect lastManagedRect(const QString&) const override
-    {
-        return managedRect;
-    }
-
-    bool isActiveOnScreen(const QString&) const override
-    {
-        return false;
-    }
-    void windowOpened(const QString&, const QString&, int, int) override
-    {
-    }
-    void windowClosed(const QString&) override
-    {
-    }
-    void windowFocused(const QString&, const QString&) override
-    {
-    }
-    void toggleWindowFloat(const QString&, const QString&) override
-    {
-    }
-    void setWindowFloat(const QString&, bool, const QString&) override
-    {
-    }
-    void focusInDirection(const QString&, const PhosphorEngine::NavigationContext&) override
-    {
-    }
-    void moveFocusedInDirection(const QString&, const PhosphorEngine::NavigationContext&) override
-    {
-    }
-    void swapFocusedInDirection(const QString&, const PhosphorEngine::NavigationContext&) override
-    {
-    }
-    void moveFocusedToPosition(int, const PhosphorEngine::NavigationContext&) override
-    {
-    }
-    void rotateWindows(bool, const PhosphorEngine::NavigationContext&) override
-    {
-    }
-    void reapplyLayout(const PhosphorEngine::NavigationContext&) override
-    {
-    }
-    void snapAllWindows(const PhosphorEngine::NavigationContext&) override
-    {
-    }
-    void cycleFocus(bool, const PhosphorEngine::NavigationContext&) override
-    {
-    }
-    void pushToEmptyZone(const PhosphorEngine::NavigationContext&) override
-    {
-    }
-    void restoreFocusedWindow(const PhosphorEngine::NavigationContext&) override
-    {
-    }
-    void toggleFocusedFloat(const PhosphorEngine::NavigationContext&) override
-    {
-    }
-    void saveState() override
-    {
-    }
-    void loadState() override
-    {
-    }
-    PhosphorEngine::IPlacementState* stateForScreen(const QString&) override
-    {
-        return nullptr;
-    }
-    const PhosphorEngine::IPlacementState* stateForScreen(const QString&) const override
-    {
-        return nullptr;
-    }
-};
 
 // =========================================================================
 // Test Class
@@ -1179,94 +1086,6 @@ private Q_SLOTS:
         m_wta->setWindowFloating(windowId, false);
         QCOMPARE(spy.count(), 2);
         QCOMPARE(spy.at(1).at(1).toBool(), false);
-    }
-
-    // Regression (float-restores-onto-its-own-tile): on a float-from-tiled
-    // toggle the autotile engine clears its tiled bit BEFORE the compositor
-    // repositions the window, so when captureWindowPlacement runs (from
-    // setWindowFloating) the live frame still IS the tile rect and the
-    // isWindowAutotileTiled gate no longer refuses it. The capture must
-    // compare against the engine's remembered last-applied rect and skip the
-    // free-geometry write, or applyGeometryForFloat (which runs AFTER the
-    // capture) reads the poisoned value back and "restores" the window onto
-    // its own tile — permanently overwriting the genuine float-back.
-    void testCaptureWindowPlacement_refusesStillTiledFrameAsFloatBack()
-    {
-        StubTileRectEngine tileEngine;
-        m_wta->setEngines(m_snapEngine, &tileEngine);
-
-        const QString windowId = QStringLiteral("ghostty|inst-tile");
-        const QString appId = m_wta->service()->currentAppIdFor(windowId);
-        const QRect tileRect(1540, 8, 1524, 829);
-        const QRect realFreeBack(1743, 795, 800, 628);
-
-        // The window's genuine float-back from an earlier session.
-        m_wta->service()->recordFreeGeometry(windowId, m_screenId, realFreeBack, true);
-
-        // Post-flip state: snap-side reports the window floating on DP-1 (the
-        // capture's owning-engine slot), the live frame still sits on the tile
-        // rect, and the autotile engine remembers having applied exactly it.
-        m_snapEngine->snapState()->setFloatingOnScreen(windowId, m_screenId, 0);
-        m_wta->setFrameGeometry(windowId, tileRect.x(), tileRect.y(), tileRect.width(), tileRect.height());
-        tileEngine.managedRect = tileRect;
-
-        m_wta->captureWindowPlacement(windowId);
-
-        auto rec = m_wta->service()->placementStore().peek(windowId, appId);
-        QVERIFY(rec);
-        QCOMPARE(rec->freeGeometryFor(m_screenId), realFreeBack);
-
-        // Once the frame moves off the tile rect (the user repositioned the
-        // floating window), the capture adopts the genuine free frame.
-        const QRect movedFrame(600, 400, 900, 700);
-        m_wta->setFrameGeometry(windowId, movedFrame.x(), movedFrame.y(), movedFrame.width(), movedFrame.height());
-        m_wta->captureWindowPlacement(windowId);
-
-        rec = m_wta->service()->placementStore().peek(windowId, appId);
-        QVERIFY(rec);
-        QCOMPARE(rec->freeGeometryFor(m_screenId), movedFrame);
-
-        m_wta->setEngines(m_snapEngine, nullptr);
-    }
-
-    // Regression (phantom snap-float after a mode round-trip): a snapped
-    // window adopted by autotile is handoff-released from snap, so snap
-    // tracks NOTHING for it — its record's snap slot is the frozen per-mode
-    // memory windowsReleased restores from on return to snapping. A capture
-    // running in that window (windowsReleased's own setWindowFloating(false)
-    // fires one) used to fabricate a "floating" snap slot for the untracked
-    // window, overwriting the frozen snapped slot — which windowsReleased
-    // then read back and "restored" as a float the user never made. The
-    // capture must leave the record untouched instead.
-    void testCaptureWindowPlacement_untrackedWindow_preservesFrozenSnapSlot()
-    {
-        const QString windowId = QStringLiteral("app|handoff");
-        const QString appId = m_wta->service()->currentAppIdFor(windowId);
-        const QString zoneId = m_zoneIds.first();
-
-        // Frozen per-mode memory: the record's snap slot says snapped.
-        PhosphorEngine::WindowPlacement p;
-        p.windowId = windowId;
-        p.appId = appId;
-        p.screenId = m_screenId;
-        PhosphorEngine::EngineSlot slot;
-        slot.state = QString(PhosphorEngine::WindowPlacement::stateSnapped());
-        slot.zoneIds = QStringList{zoneId};
-        p.engines.insert(m_snapEngine->engineId(), slot);
-        QVERIFY(m_wta->service()->placementStore().record(p));
-
-        // Snap does not track the window (post-handoffRelease state), but the
-        // effect still reports a live frame for it.
-        QVERIFY(!m_snapEngine->isWindowTracked(windowId));
-        m_wta->setFrameGeometry(windowId, 619, 514, 1380, 907);
-
-        m_wta->captureWindowPlacement(windowId);
-
-        const auto rec = m_wta->service()->placementStore().peek(windowId, appId);
-        QVERIFY(rec);
-        const PhosphorEngine::EngineSlot after = rec->slotFor(m_snapEngine->engineId());
-        QCOMPARE(after.state, QString(PhosphorEngine::WindowPlacement::stateSnapped()));
-        QCOMPARE(after.zoneIds, QStringList{zoneId});
     }
 
 private:

--- a/tests/unit/dbus/test_wta_convenience.cpp
+++ b/tests/unit/dbus/test_wta_convenience.cpp
@@ -30,6 +30,9 @@
 #include "dbus/snapadaptor.h"
 #include "dbus/windowtrackingadaptor.h"
 #include <PhosphorSnapEngine/SnapEngine.h>
+#include <PhosphorEngine/PlacementEngineBase.h>
+#include <PhosphorEngine/IPlacementState.h>
+#include <PhosphorEngine/WindowPlacement.h>
 #include <PhosphorEngine/WindowRegistry.h>
 #include <PhosphorRules/RuleStore.h>
 #include <PhosphorRules/RuleAction.h>
@@ -124,6 +127,96 @@ static PhosphorZones::Layout* createTestLayout(int zoneCount, QObject* parent)
     }
     return layout;
 }
+
+// =========================================================================
+// Stub autotile-side engine: only lastManagedRect() matters — it stands in
+// for AutotileEngine's last-applied tile rect memory in the capture guard
+// tests below. Everything else is a no-op.
+// =========================================================================
+
+class StubTileRectEngine : public PhosphorEngine::PlacementEngineBase
+{
+    Q_OBJECT
+public:
+    explicit StubTileRectEngine(QObject* parent = nullptr)
+        : PhosphorEngine::PlacementEngineBase(parent)
+    {
+    }
+
+    QRect managedRect; // returned for every window
+
+    QRect lastManagedRect(const QString&) const override
+    {
+        return managedRect;
+    }
+
+    bool isActiveOnScreen(const QString&) const override
+    {
+        return false;
+    }
+    void windowOpened(const QString&, const QString&, int, int) override
+    {
+    }
+    void windowClosed(const QString&) override
+    {
+    }
+    void windowFocused(const QString&, const QString&) override
+    {
+    }
+    void toggleWindowFloat(const QString&, const QString&) override
+    {
+    }
+    void setWindowFloat(const QString&, bool, const QString&) override
+    {
+    }
+    void focusInDirection(const QString&, const PhosphorEngine::NavigationContext&) override
+    {
+    }
+    void moveFocusedInDirection(const QString&, const PhosphorEngine::NavigationContext&) override
+    {
+    }
+    void swapFocusedInDirection(const QString&, const PhosphorEngine::NavigationContext&) override
+    {
+    }
+    void moveFocusedToPosition(int, const PhosphorEngine::NavigationContext&) override
+    {
+    }
+    void rotateWindows(bool, const PhosphorEngine::NavigationContext&) override
+    {
+    }
+    void reapplyLayout(const PhosphorEngine::NavigationContext&) override
+    {
+    }
+    void snapAllWindows(const PhosphorEngine::NavigationContext&) override
+    {
+    }
+    void cycleFocus(bool, const PhosphorEngine::NavigationContext&) override
+    {
+    }
+    void pushToEmptyZone(const PhosphorEngine::NavigationContext&) override
+    {
+    }
+    void restoreFocusedWindow(const PhosphorEngine::NavigationContext&) override
+    {
+    }
+    void toggleFocusedFloat(const PhosphorEngine::NavigationContext&) override
+    {
+    }
+    void saveState() override
+    {
+    }
+    void loadState() override
+    {
+    }
+    PhosphorEngine::IPlacementState* stateForScreen(const QString&) override
+    {
+        return nullptr;
+    }
+    const PhosphorEngine::IPlacementState* stateForScreen(const QString&) const override
+    {
+        return nullptr;
+    }
+};
 
 // =========================================================================
 // Test Class
@@ -1086,6 +1179,94 @@ private Q_SLOTS:
         m_wta->setWindowFloating(windowId, false);
         QCOMPARE(spy.count(), 2);
         QCOMPARE(spy.at(1).at(1).toBool(), false);
+    }
+
+    // Regression (float-restores-onto-its-own-tile): on a float-from-tiled
+    // toggle the autotile engine clears its tiled bit BEFORE the compositor
+    // repositions the window, so when captureWindowPlacement runs (from
+    // setWindowFloating) the live frame still IS the tile rect and the
+    // isWindowAutotileTiled gate no longer refuses it. The capture must
+    // compare against the engine's remembered last-applied rect and skip the
+    // free-geometry write, or applyGeometryForFloat (which runs AFTER the
+    // capture) reads the poisoned value back and "restores" the window onto
+    // its own tile — permanently overwriting the genuine float-back.
+    void testCaptureWindowPlacement_refusesStillTiledFrameAsFloatBack()
+    {
+        StubTileRectEngine tileEngine;
+        m_wta->setEngines(m_snapEngine, &tileEngine);
+
+        const QString windowId = QStringLiteral("ghostty|inst-tile");
+        const QString appId = m_wta->service()->currentAppIdFor(windowId);
+        const QRect tileRect(1540, 8, 1524, 829);
+        const QRect realFreeBack(1743, 795, 800, 628);
+
+        // The window's genuine float-back from an earlier session.
+        m_wta->service()->recordFreeGeometry(windowId, m_screenId, realFreeBack, true);
+
+        // Post-flip state: snap-side reports the window floating on DP-1 (the
+        // capture's owning-engine slot), the live frame still sits on the tile
+        // rect, and the autotile engine remembers having applied exactly it.
+        m_snapEngine->snapState()->setFloatingOnScreen(windowId, m_screenId, 0);
+        m_wta->setFrameGeometry(windowId, tileRect.x(), tileRect.y(), tileRect.width(), tileRect.height());
+        tileEngine.managedRect = tileRect;
+
+        m_wta->captureWindowPlacement(windowId);
+
+        auto rec = m_wta->service()->placementStore().peek(windowId, appId);
+        QVERIFY(rec);
+        QCOMPARE(rec->freeGeometryFor(m_screenId), realFreeBack);
+
+        // Once the frame moves off the tile rect (the user repositioned the
+        // floating window), the capture adopts the genuine free frame.
+        const QRect movedFrame(600, 400, 900, 700);
+        m_wta->setFrameGeometry(windowId, movedFrame.x(), movedFrame.y(), movedFrame.width(), movedFrame.height());
+        m_wta->captureWindowPlacement(windowId);
+
+        rec = m_wta->service()->placementStore().peek(windowId, appId);
+        QVERIFY(rec);
+        QCOMPARE(rec->freeGeometryFor(m_screenId), movedFrame);
+
+        m_wta->setEngines(m_snapEngine, nullptr);
+    }
+
+    // Regression (phantom snap-float after a mode round-trip): a snapped
+    // window adopted by autotile is handoff-released from snap, so snap
+    // tracks NOTHING for it — its record's snap slot is the frozen per-mode
+    // memory windowsReleased restores from on return to snapping. A capture
+    // running in that window (windowsReleased's own setWindowFloating(false)
+    // fires one) used to fabricate a "floating" snap slot for the untracked
+    // window, overwriting the frozen snapped slot — which windowsReleased
+    // then read back and "restored" as a float the user never made. The
+    // capture must leave the record untouched instead.
+    void testCaptureWindowPlacement_untrackedWindow_preservesFrozenSnapSlot()
+    {
+        const QString windowId = QStringLiteral("app|handoff");
+        const QString appId = m_wta->service()->currentAppIdFor(windowId);
+        const QString zoneId = m_zoneIds.first();
+
+        // Frozen per-mode memory: the record's snap slot says snapped.
+        PhosphorEngine::WindowPlacement p;
+        p.windowId = windowId;
+        p.appId = appId;
+        p.screenId = m_screenId;
+        PhosphorEngine::EngineSlot slot;
+        slot.state = QString(PhosphorEngine::WindowPlacement::stateSnapped());
+        slot.zoneIds = QStringList{zoneId};
+        p.engines.insert(m_snapEngine->engineId(), slot);
+        QVERIFY(m_wta->service()->placementStore().record(p));
+
+        // Snap does not track the window (post-handoffRelease state), but the
+        // effect still reports a live frame for it.
+        QVERIFY(!m_snapEngine->isWindowTracked(windowId));
+        m_wta->setFrameGeometry(windowId, 619, 514, 1380, 907);
+
+        m_wta->captureWindowPlacement(windowId);
+
+        const auto rec = m_wta->service()->placementStore().peek(windowId, appId);
+        QVERIFY(rec);
+        const PhosphorEngine::EngineSlot after = rec->slotFor(m_snapEngine->engineId());
+        QCOMPARE(after.state, QString(PhosphorEngine::WindowPlacement::stateSnapped()));
+        QCOMPARE(after.zoneIds, QStringList{zoneId});
     }
 
 private:


### PR DESCRIPTION
## Summary

Fixes three float/restore defects diagnosed from journal traces of live sessions after #814 and #815 landed. Two are long-latent bugs that those merges exposed; one is a restart-persistence gap.

### 1. Float-from-tiled restored the window onto its own tile rect

On Meta+F in autotile mode, `performToggleFloat` clears the tiled bit before KWin repositions the window. The float edge's placement capture then saw a live frame that was still the tile rect, with `isWindowAutotileTiled` no longer refusing it, and recorded it as the shared free geometry. `applyGeometryForFloat` runs after the capture and read the poisoned value straight back, so every float "restored" the window onto its own tile and destroyed the genuine float-back position (log-proven: a float landed at exactly the window's tile rect while its recorded free geometry was elsewhere).

Fix: a `lastManagedRect()` virtual on `PlacementEngineBase`, implemented by `AutotileEngine` as the rect `applyTiling` last emitted per window, deliberately surviving the float flip. The capture orchestrator refuses the free-geometry write while the frame still equals that rect, mirroring the existing `stillOnSnapRect` guard.

### 2. Unfloat dead-ended after a daemon restart

The in-memory pre-float capture dies with the daemon, so unfloating a window floated before a restart hit "no pre-float zone, keeping floating" forever. `resolveUnfloatGeometry` now falls back to the persisted placement record's snap slot: a floating capture carries the pre-float zones, and a stale snapped capture (daemon died before the float persisted) carries the zones the window occupied before floating. No record still falls through to the fallback-zone path.

### 3. Phantom snap-float after a mode round-trip

`SnapEngine::capturePlacement` fabricated a "floating" slot for windows it did not track at all (empty effective screen bypassed the autotile-mode gate into the unmanaged-equals-floating branch). After a cross-engine `handoffRelease`, any capture with snap primary overwrote the record's frozen snap-mode memory, and `windowsReleased` then "restored" a float the user never made (log-proven: unfloat in snap, toggle through autotile and back, window comes back floating). Latent since the two-state collapse; exposed by #814's broadcast-gate fix, which un-suppressed the `setWindowFloating(false)` capture inside `windowsReleased`. The capture now returns nullopt for untracked windows, honoring the orchestrator's leave-the-record-intact contract; untracked closes still persist via `recordFloatingClose`.

## Testing

- New regression tests at three layers: engine (`lastManagedRect` lifecycle across the float flip, untracked capture returns nothing), WTA capture orchestration (tile-rect frame refused as float-back, frozen snapped slot preserved for an untracked window), and snap resolver (record fallback for floating and stale-snapped slots).
- Each fix was mutation-verified: reverting the guard or fallback makes the new tests fail.
- Full suite passes: 291/291.
- Manually verified on a live session: floats restore to their real free positions, unfloat returns to the home zone, and snap/float state survives mode round-trips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Audit notes (resolved in ea33135ea)

A multi-pass audit enumerated the repo's other `peek(windowId, appId)` call sites for the appId-FIFO sibling-bleed shape fixed in `resolveUnfloatGeometry`. All are now resolved:

**Fixed (exact-windowId via the new `WindowPlacementStore::peekExact`, each mutation-verified by a new regression test):**
- `windowsReleased`'s snap-slot restore (signals.cpp): a sibling's record could float or zone-restore a record-less window on return to snapping.
- The pending-order seed's float restore (AutotileEngine): a sibling's floating record floated a record-less seeded window.
- `recordFreeGeometry`'s first-capture-wins probe: a sibling's geometry suppressed this window's own first capture.
- `recordFloatingClose`'s context inherit: a sibling's snapped slot could be grafted under this windowId, corrupting per-app FIFO distribution.

**Confirmed intentional (now documented in place):**
- `recordedSnapZones`' appId fallback is deliberate relogin support, pinned by its own regression test; a live-assigned sibling always resolves via its own live store first.
- `applyGeometryForFloat` and `validatedUnmanagedGeometry` deliberately share free float-back positions across same-app instances (managed by `collapsePureFloatSiblings`). Zone and tile slots are never app-shared; free positions deliberately are.
- The two predicate-carrying existence probes (snap deferral, autotile reciprocal defer) are app-scoped by design.


## Audit round 2 (commits 3a3d31139..8555a0359)

A five-pass multi-agent audit of the full PR scope found and fixed one production bug plus test/doc hardening:

- **Close-path guard was defeated in production (fixed in f37474a15).** The effect notifies autotile of a close before WindowTracking, so `AutotileEngine::windowClosed` erased the tile-rect memory and untracked the window before the orchestrator's close capture ran. Every tiled close on an autotile screen then recorded its tile rect as the reopen float-back with the guard blind. The engine now retains `m_lastAppliedTileRect` through `windowClosed` (mirroring the handoffRelease retention rationale) and `pruneStaleWindows` reclaims entries. Mutation-verified; guard docs rewritten to the real ordering.
- New regression tests: `windowFocused` cross-screen eviction of the tile rect, record screen-hint degradation to the caller's fallback screen, the composed no-capture/no-record unfloat into the fallback zone, and the bare-float collapse no-op contract.
- Doc/comment corrections and assertion tightening in the touched tests.

Two items deliberately left as-is: the pixel-exact reposition-onto-old-tile-rect coincidence (same accepted tradeoff as the snap-side `stillOnSnapRect` guard, self-correcting on the next move), and a cross-layer WTA+engine integration fixture (both seams are unit-pinned).
