### PR TITLE
fix: stop competing with KWin's minimize/maximize animations (discussion #816)

### DIFF
--- a/kwin-effect/autotilehandler.cpp
+++ b/kwin-effect/autotilehandler.cpp
@@ -756,9 +756,9 @@ void AutotileHandler::onDaemonReady()
     // setWindowFloatingForScreen against state the new daemon never had, and
     // a stale record would mis-route the next unminimize. Pending
     // cross-screen size-restore connections are likewise per-session.
-    // Pending deferred unminimize→unfloat commits need no explicit cancel
-    // here: their timeout bails when m_minimizeFloatedWindows.remove()
-    // misses, which the clear below guarantees.
+    // clearAllPendingMinimizeFloats() also cancels the pending deferred
+    // unminimize→unfloat timers; an escapee's timeout would bail anyway when
+    // m_minimizeFloatedWindows.remove() misses after the clear below.
     clearAllPendingMinimizeFloats();
     m_minimizeFloatedWindows.clear();
     for (auto connIt = m_pendingCrossScreenRestore.begin(); connIt != m_pendingCrossScreenRestore.end(); ++connIt) {

--- a/kwin-effect/autotilehandler.cpp
+++ b/kwin-effect/autotilehandler.cpp
@@ -608,6 +608,7 @@ void AutotileHandler::cleanupAutotileTracking(const QString& windowId, const QSt
         m_centeredWaylandZones, m_monocleMaximizedWindows, m_preAutotileGeometries};
     AutotileStateHelpers::cleanupClosedWindowState(windowId, m_border, windowState);
     cancelPendingMinimizeFloat(windowId);
+    cancelPendingUnminimizeUnfloat(windowId);
     // KWin-specific cleanup. NOTE: m_savedPreAutotileForDesktopMove is NOT cleared
     // here — the desktop-move path stashes it immediately before close (consume
     // site / clearDesktopMoveStash cover it). Also drop the unconsumed output-move

--- a/kwin-effect/autotilehandler.cpp
+++ b/kwin-effect/autotilehandler.cpp
@@ -756,6 +756,9 @@ void AutotileHandler::onDaemonReady()
     // setWindowFloatingForScreen against state the new daemon never had, and
     // a stale record would mis-route the next unminimize. Pending
     // cross-screen size-restore connections are likewise per-session.
+    // Pending deferred unminimize→unfloat commits need no explicit cancel
+    // here: their timeout bails when m_minimizeFloatedWindows.remove()
+    // misses, which the clear below guarantees.
     clearAllPendingMinimizeFloats();
     m_minimizeFloatedWindows.clear();
     for (auto connIt = m_pendingCrossScreenRestore.begin(); connIt != m_pendingCrossScreenRestore.end(); ++connIt) {

--- a/kwin-effect/autotilehandler.h
+++ b/kwin-effect/autotilehandler.h
@@ -280,9 +280,10 @@ private:
      * @brief Cancel a pending debounced minimize→float commit.
      *
      * No-op if no timer is pending for the window. Called from the
-     * unminimize path (to coalesce spurious cycles), from onWindowClosed
-     * (so pending timers never fire against destroyed windows), and from
-     * clearAllPendingMinimizeFloats (bulk teardown).
+     * unminimize path (to coalesce spurious cycles) and from onWindowClosed
+     * (so pending timers never fire against destroyed windows); bulk
+     * teardown goes through the helper's cancelAll in
+     * clearAllPendingMinimizeFloats instead.
      */
     void cancelPendingMinimizeFloat(const QString& windowId);
 
@@ -292,7 +293,9 @@ private:
      * No-op if no timer is pending for the window. Called from the minimize
      * path (a re-minimize during the grace must leave the window
      * minimize-floated), from cleanupAutotileTracking (window closed), and
-     * from clearAllPendingMinimizeFloats (bulk teardown / engine disable).
+     * from removeMinimizeFloated (authoritative external unfloat via the
+     * daemon's windowFloatingChanged echo); bulk teardown goes through the
+     * helper's cancelAll in clearAllPendingMinimizeFloats instead.
      */
     void cancelPendingUnminimizeUnfloat(const QString& windowId);
 

--- a/kwin-effect/autotilehandler.h
+++ b/kwin-effect/autotilehandler.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include "deferredwindowcommits.h"
+
 #include <PhosphorCompositor/AutotileState.h>
 #include <PhosphorProtocol/AutotileMarshalling.h>
 
@@ -108,6 +110,17 @@ public:
     /// daemon windowClosed call) and the cross-mode-move marker path (where the
     /// daemon already relinquished the window via handoffRelease).
     void cleanupAutotileTracking(const QString& windowId, const QString& screenId);
+    /// Drop @p windowId from the minimize-float set and cancel any deferred
+    /// unminimize→unfloat commit (mirrors SnapHandler::removeMinimizeFloated).
+    /// Returns true if the window was tracked. Called from the effect's
+    /// windowFloatingChanged handler: an authoritative external unfloat moots
+    /// the deferred commit — the daemon already unfloated the window, so a
+    /// later commit would re-send a redundant unfloat.
+    bool removeMinimizeFloated(const QString& windowId)
+    {
+        cancelPendingUnminimizeUnfloat(windowId);
+        return m_minimizeFloatedWindows.remove(windowId);
+    }
     /// Drop a destroyed window's desktop-move geometry stash. Separate from
     /// onWindowClosed because the desktop-MOVE path calls onWindowClosed
     /// right after creating the stash (the window must look "closed" to this
@@ -419,7 +432,7 @@ private:
     /// cancelled and no D-Bus float is issued. This absorbs spurious
     /// minimize/unminimize cycles that KWin emits on tiled windows when
     /// plasmashell notification popups transiently change stacking.
-    QHash<QString, QPointer<QTimer>> m_pendingMinimizeFloat;
+    DeferredWindowCommits m_pendingMinimizeFloat{this};
     /// Pending deferred unminimize→unfloat commits, keyed by windowId — the
     /// restore-side mirror of m_pendingMinimizeFloat, with a different reason:
     /// the unfloat triggers a retile whose applyWindowGeometry moveResize,
@@ -429,7 +442,7 @@ private:
     /// is deferred past the stock animation (Effect::animationTime-scaled
     /// grace) and revalidated at fire time; a re-minimize during the grace
     /// cancels it, leaving the window minimize-floated as before.
-    QHash<QString, QPointer<QTimer>> m_pendingUnminimizeUnfloat;
+    DeferredWindowCommits m_pendingUnminimizeUnfloat{this};
     /// Global stagger epoch, bumped on a desktop/screen switch (slotScreensChanged)
     /// to cancel EVERY in-flight staggered apply — geometry computed for the old
     /// context must never land in the new one.

--- a/kwin-effect/autotilehandler.h
+++ b/kwin-effect/autotilehandler.h
@@ -274,6 +274,16 @@ private:
     void cancelPendingMinimizeFloat(const QString& windowId);
 
     /**
+     * @brief Cancel a pending deferred unminimize→unfloat commit.
+     *
+     * No-op if no timer is pending for the window. Called from the minimize
+     * path (a re-minimize during the grace must leave the window
+     * minimize-floated), from cleanupAutotileTracking (window closed), and
+     * from clearAllPendingMinimizeFloats (bulk teardown / engine disable).
+     */
+    void cancelPendingUnminimizeUnfloat(const QString& windowId);
+
+    /**
      * @brief Cancel every pending debounced minimize→float commit.
      *
      * Called when autotile is disabled — in-flight timers should not
@@ -410,6 +420,16 @@ private:
     /// minimize/unminimize cycles that KWin emits on tiled windows when
     /// plasmashell notification popups transiently change stacking.
     QHash<QString, QPointer<QTimer>> m_pendingMinimizeFloat;
+    /// Pending deferred unminimize→unfloat commits, keyed by windowId — the
+    /// restore-side mirror of m_pendingMinimizeFloat, with a different reason:
+    /// the unfloat triggers a retile whose applyWindowGeometry moveResize,
+    /// landing mid-flight, CANCELS KWin's own unminimize animation (magic
+    /// lamp / squash; kwin's maximize script likewise self-cancels on a
+    /// mid-flight resize) — the discussion #816 restore stutter. The commit
+    /// is deferred past the stock animation (Effect::animationTime-scaled
+    /// grace) and revalidated at fire time; a re-minimize during the grace
+    /// cancels it, leaving the window minimize-floated as before.
+    QHash<QString, QPointer<QTimer>> m_pendingUnminimizeUnfloat;
     /// Global stagger epoch, bumped on a desktop/screen switch (slotScreensChanged)
     /// to cancel EVERY in-flight staggered apply — geometry computed for the old
     /// context must never land in the new one.

--- a/kwin-effect/autotilehandler/signals.cpp
+++ b/kwin-effect/autotilehandler/signals.cpp
@@ -71,44 +71,20 @@ void AutotileHandler::slotEnabledChanged(bool enabled)
 
 void AutotileHandler::cancelPendingMinimizeFloat(const QString& windowId)
 {
-    auto it = m_pendingMinimizeFloat.find(windowId);
-    if (it == m_pendingMinimizeFloat.end()) {
-        return;
-    }
-    if (QTimer* pending = it.value()) {
-        pending->stop();
-        pending->deleteLater();
-    }
-    m_pendingMinimizeFloat.erase(it);
+    m_pendingMinimizeFloat.cancel(windowId);
 }
 
 void AutotileHandler::cancelPendingUnminimizeUnfloat(const QString& windowId)
 {
-    auto it = m_pendingUnminimizeUnfloat.find(windowId);
-    if (it == m_pendingUnminimizeUnfloat.end()) {
-        return;
-    }
-    if (QTimer* pending = it.value()) {
-        pending->stop();
-        pending->deleteLater();
-    }
-    m_pendingUnminimizeUnfloat.erase(it);
+    m_pendingUnminimizeUnfloat.cancel(windowId);
 }
 
 void AutotileHandler::clearAllPendingMinimizeFloats()
 {
-    // Delegate per-entry so the cancel semantics (stop + deleteLater + erase)
-    // live in exactly one place. keys() snapshot: the delegate erases.
-    const QStringList ids = m_pendingMinimizeFloat.keys();
-    for (const QString& windowId : ids) {
-        cancelPendingMinimizeFloat(windowId);
-    }
+    m_pendingMinimizeFloat.cancelAll();
     // The restore-side timers must not fire against a disabled engine or a
     // torn-down handler either.
-    const QStringList unfloatIds = m_pendingUnminimizeUnfloat.keys();
-    for (const QString& windowId : unfloatIds) {
-        cancelPendingUnminimizeUnfloat(windowId);
-    }
+    m_pendingUnminimizeUnfloat.cancelAll();
 }
 
 void AutotileHandler::slotScreensChanged(const QStringList& screenIds, bool isDesktopSwitch)
@@ -710,23 +686,7 @@ void AutotileHandler::slotWindowMinimizedChanged(KWin::EffectWindow* w)
         // "100%" flash on every notification. By deferring we give the
         // unminimize path a chance to cancel the float entirely.
         QPointer<KWin::EffectWindow> wPtr(w);
-        auto* timer = new QTimer(this);
-        timer->setSingleShot(true);
-        timer->setInterval(kMinimizeFloatDebounceMs);
-        connect(timer, &QTimer::timeout, this, [this, windowId, screenId, wPtr]() {
-            // Consume the hash entry first. We take the timer out by value
-            // so we own its deleteLater regardless of which early-return
-            // branch we take below.
-            auto it = m_pendingMinimizeFloat.find(windowId);
-            if (it == m_pendingMinimizeFloat.end()) {
-                return; // Already cancelled by cancelPendingMinimizeFloat.
-            }
-            QPointer<QTimer> owned = it.value();
-            m_pendingMinimizeFloat.erase(it);
-            if (owned) {
-                owned->deleteLater();
-            }
-
+        m_pendingMinimizeFloat.schedule(windowId, kMinimizeFloatDebounceMs, [this, windowId, screenId, wPtr]() {
             // Re-validate the full entry predicate: the window may have been
             // destroyed, unminimized, moved, or had autotile disabled on its
             // screen during the debounce window. Mirrors the checks at entry
@@ -770,8 +730,6 @@ void AutotileHandler::slotWindowMinimizedChanged(KWin::EffectWindow* w)
                     QStringLiteral("setWindowFloatingForScreen"));
             }
         });
-        m_pendingMinimizeFloat.insert(windowId, timer);
-        timer->start();
         return;
     }
 
@@ -820,22 +778,7 @@ void AutotileHandler::slotWindowMinimizedChanged(KWin::EffectWindow* w)
     // exactly as it was.
     const int graceMs = int(KWin::Effect::animationTime(std::chrono::milliseconds(400)).count());
     QPointer<KWin::EffectWindow> wPtr(w);
-    auto* timer = new QTimer(this);
-    timer->setSingleShot(true);
-    timer->setInterval(graceMs);
-    connect(timer, &QTimer::timeout, this, [this, windowId, wPtr]() {
-        // Consume the hash entry first; we own the timer's deleteLater
-        // regardless of which early-return branch we take below.
-        auto it = m_pendingUnminimizeUnfloat.find(windowId);
-        if (it == m_pendingUnminimizeUnfloat.end()) {
-            return; // Already cancelled by cancelPendingUnminimizeUnfloat.
-        }
-        QPointer<QTimer> owned = it.value();
-        m_pendingUnminimizeUnfloat.erase(it);
-        if (owned) {
-            owned->deleteLater();
-        }
-
+    m_pendingUnminimizeUnfloat.schedule(windowId, graceMs, [this, windowId, wPtr]() {
         // Re-validate the entry predicate at commit time: the window may
         // have died, re-minimized (belt — the minimize path also cancels),
         // moved off an autotiled screen, or become unhandleable during the
@@ -875,8 +818,6 @@ void AutotileHandler::slotWindowMinimizedChanged(KWin::EffectWindow* w)
 
         notifyWindowAdded(fw);
     });
-    m_pendingUnminimizeUnfloat.insert(windowId, timer);
-    timer->start();
 }
 
 void AutotileHandler::slotWindowMaximizedStateChanged(KWin::EffectWindow* w, bool horizontal, bool vertical)

--- a/kwin-effect/autotilehandler/signals.cpp
+++ b/kwin-effect/autotilehandler/signals.cpp
@@ -11,6 +11,7 @@
 #include <PhosphorProtocol/ClientHelpers.h>
 #include <PhosphorIdentity/WindowId.h>
 
+#include <effect/effect.h> // Effect::animationTime, the deferred-unfloat grace
 #include <effect/effecthandler.h>
 #include <effect/effectwindow.h>
 #include <window.h>
@@ -25,6 +26,8 @@
 #include <QPointer>
 #include <QScopeGuard>
 #include <QTimer>
+
+#include <chrono> // std::chrono::milliseconds for Effect::animationTime
 
 namespace PlasmaZones {
 
@@ -79,6 +82,19 @@ void AutotileHandler::cancelPendingMinimizeFloat(const QString& windowId)
     m_pendingMinimizeFloat.erase(it);
 }
 
+void AutotileHandler::cancelPendingUnminimizeUnfloat(const QString& windowId)
+{
+    auto it = m_pendingUnminimizeUnfloat.find(windowId);
+    if (it == m_pendingUnminimizeUnfloat.end()) {
+        return;
+    }
+    if (QTimer* pending = it.value()) {
+        pending->stop();
+        pending->deleteLater();
+    }
+    m_pendingUnminimizeUnfloat.erase(it);
+}
+
 void AutotileHandler::clearAllPendingMinimizeFloats()
 {
     // Delegate per-entry so the cancel semantics (stop + deleteLater + erase)
@@ -86,6 +102,12 @@ void AutotileHandler::clearAllPendingMinimizeFloats()
     const QStringList ids = m_pendingMinimizeFloat.keys();
     for (const QString& windowId : ids) {
         cancelPendingMinimizeFloat(windowId);
+    }
+    // The restore-side timers must not fire against a disabled engine or a
+    // torn-down handler either.
+    const QStringList unfloatIds = m_pendingUnminimizeUnfloat.keys();
+    for (const QString& windowId : unfloatIds) {
+        cancelPendingUnminimizeUnfloat(windowId);
     }
 }
 
@@ -667,6 +689,10 @@ void AutotileHandler::slotWindowMinimizedChanged(KWin::EffectWindow* w)
     const bool minimized = w->isMinimized();
 
     if (minimized) {
+        // A re-minimize during the deferred unfloat grace cancels the pending
+        // commit: the window never unfloated, so it is still minimize-floated
+        // and the isWindowFloating skip below covers the rest.
+        cancelPendingUnminimizeUnfloat(windowId);
         if (m_effect->isWindowFloating(windowId)) {
             qCDebug(lcEffect) << "Autotile: minimized already-floating window, skipping floatWindow:" << windowId;
             return;
@@ -761,10 +787,14 @@ void AutotileHandler::slotWindowMinimizedChanged(KWin::EffectWindow* w)
         return;
     }
 
-    if (!m_minimizeFloatedWindows.remove(windowId)) {
+    if (!m_minimizeFloatedWindows.contains(windowId)) {
         qCDebug(lcEffect) << "Autotile: unminimized window was not minimize-floated, skipping unfloatWindow:"
                           << windowId;
         notifyWindowAdded(w);
+        return;
+    }
+    // A commit is already scheduled for this window — nothing new to do.
+    if (m_pendingUnminimizeUnfloat.contains(windowId)) {
         return;
     }
     // No pre-autotile geometry capture here: a minimize-floated window cannot
@@ -773,16 +803,80 @@ void AutotileHandler::slotWindowMinimizedChanged(KWin::EffectWindow* w)
     // entry (snap→autotile transitions), and a genuine entry already exists
     // from the original capture.
 
-    qCInfo(lcEffect) << "Autotile: window unminimized, unfloating:" << windowId << "on" << screenId;
+    // Defer the unfloat commit past KWin's unminimize animation. Committing
+    // immediately retiles the screen, and the retile's applyWindowGeometry
+    // moveResize lands mid-flight and CANCELS the stock animation (magic
+    // lamp / squash; kwin's maximize script likewise self-cancels on a
+    // mid-flight resize) — the discussion #816 restore stutter. There is no
+    // cross-effect API to observe the animation, so the grace is
+    // animationTime(400ms): stock minimize animations are 250ms base scaled
+    // by the user's global animation-speed factor, and animationTime applies
+    // that same factor, so the deferral tracks the user's actual animation
+    // length with margin. The window sits at its tiled rect meanwhile (it
+    // could not move while minimized), so the deferral only shifts the
+    // retile timing. All state mutation (m_minimizeFloatedWindows removal,
+    // D-Bus, notifyWindowAdded) happens at COMMIT, mirroring the minimize
+    // debounce, so a cancelled commit leaves the window minimize-floated
+    // exactly as it was.
+    const int graceMs = int(KWin::Effect::animationTime(std::chrono::milliseconds(400)).count());
+    QPointer<KWin::EffectWindow> wPtr(w);
+    auto* timer = new QTimer(this);
+    timer->setSingleShot(true);
+    timer->setInterval(graceMs);
+    connect(timer, &QTimer::timeout, this, [this, windowId, wPtr]() {
+        // Consume the hash entry first; we own the timer's deleteLater
+        // regardless of which early-return branch we take below.
+        auto it = m_pendingUnminimizeUnfloat.find(windowId);
+        if (it == m_pendingUnminimizeUnfloat.end()) {
+            return; // Already cancelled by cancelPendingUnminimizeUnfloat.
+        }
+        QPointer<QTimer> owned = it.value();
+        m_pendingUnminimizeUnfloat.erase(it);
+        if (owned) {
+            owned->deleteLater();
+        }
 
-    if (m_effect->m_daemonServiceRegistered) {
-        PhosphorProtocol::ClientHelpers::fireAndForget(m_effect, PhosphorProtocol::Service::Interface::WindowTracking,
-                                                       QStringLiteral("setWindowFloatingForScreen"),
-                                                       {windowId, screenId, false},
-                                                       QStringLiteral("setWindowFloatingForScreen"));
-    }
+        // Re-validate the entry predicate at commit time: the window may
+        // have died, re-minimized (belt — the minimize path also cancels),
+        // moved off an autotiled screen, or become unhandleable during the
+        // grace. Every bail leaves the window minimize-floated, which the
+        // next unminimize edge picks up again.
+        if (!wPtr) {
+            qCDebug(lcEffect) << "Autotile: deferred unfloat window destroyed, skipping:" << windowId;
+            return;
+        }
+        KWin::EffectWindow* fw = wPtr.data();
+        if (fw->isMinimized()) {
+            qCDebug(lcEffect) << "Autotile: deferred unfloat window re-minimized, skipping:" << windowId;
+            return;
+        }
+        if (!m_effect->shouldHandleWindow(fw) || !m_effect->isTileableWindow(fw)) {
+            qCDebug(lcEffect) << "Autotile: deferred unfloat no longer handleable, skipping:" << windowId;
+            return;
+        }
+        const QString currentScreenId = m_effect->getWindowScreenId(fw);
+        if (!m_autotileScreens.contains(currentScreenId)) {
+            qCDebug(lcEffect) << "Autotile: deferred unfloat screen no longer autotiled, skipping:" << windowId;
+            return;
+        }
+        if (!m_minimizeFloatedWindows.remove(windowId)) {
+            return; // State moved under us (e.g. bulk cleanup); nothing to commit.
+        }
 
-    notifyWindowAdded(w);
+        qCInfo(lcEffect) << "Autotile: window unminimized, unfloating (after animation grace):" << windowId << "on"
+                         << currentScreenId;
+
+        if (m_effect->m_daemonServiceRegistered) {
+            PhosphorProtocol::ClientHelpers::fireAndForget(
+                m_effect, PhosphorProtocol::Service::Interface::WindowTracking,
+                QStringLiteral("setWindowFloatingForScreen"), {windowId, currentScreenId, false},
+                QStringLiteral("setWindowFloatingForScreen"));
+        }
+
+        notifyWindowAdded(fw);
+    });
+    m_pendingUnminimizeUnfloat.insert(windowId, timer);
+    timer->start();
 }
 
 void AutotileHandler::slotWindowMaximizedStateChanged(KWin::EffectWindow* w, bool horizontal, bool vertical)

--- a/kwin-effect/deferredwindowcommits.h
+++ b/kwin-effect/deferredwindowcommits.h
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <QHash>
+#include <QObject>
+#include <QPointer>
+#include <QString>
+#include <QTimer>
+
+#include <functional>
+#include <utility>
+
+namespace PlasmaZones {
+
+/**
+ * @brief Per-window deferred single-shot commits with consume-erase semantics.
+ *
+ * The shared plumbing behind the tiling handlers' debounced/deferred
+ * per-window state machines (AutotileHandler's minimize→float debounce and
+ * both engines' unminimize→unfloat grace): one pending single-shot QTimer
+ * per windowId, cancellable until it fires. What stays engine-specific is
+ * the @c fire callback — every revalidation and commit decision lives with
+ * the caller; this class only owns the timer bookkeeping.
+ *
+ * Lifetime: timers are parented to @p owner and their timeouts use @p owner
+ * as the connection context, so destroying the owner (which also destroys
+ * this member) cancels everything in flight — no callback ever runs against
+ * a torn-down handler. The timeout consumes the pending entry BEFORE
+ * invoking @c fire, so a commit that re-schedules for the same window (or a
+ * cancel() called from inside the callback) never touches a stale entry.
+ */
+class DeferredWindowCommits
+{
+public:
+    /// @param owner Timer parent and timeout connection context — the
+    ///        handler that owns this member.
+    explicit DeferredWindowCommits(QObject* owner)
+        : m_owner(owner)
+    {
+    }
+
+    DeferredWindowCommits(const DeferredWindowCommits&) = delete;
+    DeferredWindowCommits& operator=(const DeferredWindowCommits&) = delete;
+
+    /// True while a commit is pending for @p windowId.
+    bool contains(const QString& windowId) const
+    {
+        return m_pending.contains(windowId);
+    }
+
+    /// Schedule @p fire to run after @p intervalMs, replacing nothing —
+    /// callers gate on contains() when an existing pending commit should
+    /// win. The pending entry is consumed (erased, timer released) before
+    /// @p fire runs, so every early-return inside the callback leaves no
+    /// bookkeeping behind.
+    void schedule(const QString& windowId, int intervalMs, std::function<void()> fire)
+    {
+        auto* timer = new QTimer(m_owner);
+        timer->setSingleShot(true);
+        timer->setInterval(intervalMs);
+        QObject::connect(timer, &QTimer::timeout, m_owner, [this, windowId, fire = std::move(fire)]() {
+            // Consume the hash entry first; we own the timer's deleteLater
+            // regardless of which branch the callback takes.
+            auto it = m_pending.find(windowId);
+            if (it == m_pending.end()) {
+                return; // Already cancelled.
+            }
+            QPointer<QTimer> owned = it.value();
+            m_pending.erase(it);
+            if (owned) {
+                owned->deleteLater();
+            }
+            fire();
+        });
+        m_pending.insert(windowId, timer);
+        timer->start();
+    }
+
+    /// Cancel the pending commit for @p windowId. No-op if none is pending.
+    void cancel(const QString& windowId)
+    {
+        auto it = m_pending.find(windowId);
+        if (it == m_pending.end()) {
+            return;
+        }
+        if (QTimer* pending = it.value()) {
+            pending->stop();
+            pending->deleteLater();
+        }
+        m_pending.erase(it);
+    }
+
+    /// Cancel every pending commit (bulk teardown / engine disable).
+    void cancelAll()
+    {
+        // keys() snapshot: cancel() erases while we iterate.
+        const QStringList ids = m_pending.keys();
+        for (const QString& windowId : ids) {
+            cancel(windowId);
+        }
+    }
+
+private:
+    QObject* m_owner;
+    QHash<QString, QPointer<QTimer>> m_pending;
+};
+
+} // namespace PlasmaZones

--- a/kwin-effect/desktoptransitionmanager.cpp
+++ b/kwin-effect/desktoptransitionmanager.cpp
@@ -516,7 +516,7 @@ void DesktopTransitionManager::beginPeek(bool showing, const QString& effectId, 
     // still-visible windows. Releasing at settle would fire it a second time.
     // This is also why windowaperture/eyeonscreen never pass fullScreen: true.
     // Nothing is lost by not claiming: the show-desktop script effects ignore
-    // the claim anyway (syncShowDesktopEffectSuppression unloads them), and
+    // the claim anyway (syncStockEffectSuppression unloads them), and
     // contention with Overview/Cube is handled by the bow-out check at the top.
     KWin::effects->addRepaintFull();
 }

--- a/kwin-effect/desktoptransitionmanager.h
+++ b/kwin-effect/desktoptransitionmanager.h
@@ -63,7 +63,7 @@ class PlasmaZonesEffect;
 /// windows don't hide" bug). beginPeek instead bows out if another effect
 /// already holds the screen. Suppressing KWin's show-desktop script effects
 /// doesn't need the claim either (windowaperture / eyeonscreen never consult
-/// it) — those are unloaded by syncShowDesktopEffectSuppression while a peek
+/// it) — those are unloaded by syncStockEffectSuppression while a peek
 /// pack is assigned, which also keeps the peek captures free of their
 /// transforms.
 class DesktopTransitionManager

--- a/kwin-effect/plasmazoneseffect.cpp
+++ b/kwin-effect/plasmazoneseffect.cpp
@@ -55,8 +55,9 @@ void PlasmaZonesEffect::reconfigure(ReconfigureFlags flags)
     // Called when KWin wants effects to reload or when daemon notifies of settings change
     qCDebug(lcEffect) << "reconfigure() called";
     // A KWin effects reconfigure (any Desktop Effects KCM apply) reconciles
-    // the loaded-effects list against kwinrc, which RE-LOADS windowaperture /
-    // eyeonscreen — the suppression never writes kwinrc, so this is the one
+    // the loaded-effects list against kwinrc, which RE-LOADS every suppressed
+    // stock effect (windowaperture / eyeonscreen / magiclamp / squash /
+    // maximize) — the suppression never writes kwinrc, so this is the one
     // path that undoes the unload without any of the other sync triggers
     // (tree load, registry commit, animations toggle) firing. Re-assert on the
     // NEXT event-loop turn only, never synchronously: this reconfigure runs
@@ -66,15 +67,16 @@ void PlasmaZonesEffect::reconfigure(ReconfigureFlags flags)
     // just coalesces to cheap no-ops. `this` as context cancels the callback if
     // we unload first.
     //
-    // Whether the deferred pass lands after the KCM's own re-load of
-    // windowaperture/eyeonscreen is NOT guaranteed here — it depends on
+    // Whether the deferred pass lands after the KCM's own re-load of the
+    // stock effects is NOT guaranteed here — it depends on
     // EffectsHandler's internal ordering between queueing those loads and
     // driving our reconfigure(). Lose the race and the sync sees them still
-    // unloaded, no-ops, and they come back live alongside an assigned peek
-    // pack. That is self-correcting rather than sticky: any later trigger (a
+    // unloaded, no-ops, and they come back live alongside an assigned pack.
+    // That is self-correcting rather than sticky: any later trigger (a
     // pack change, the animations toggle, the next reconfigure) re-asserts,
     // and the cost until then is that a peek capture can bake in their
-    // transform. Re-asserting from the showingDesktopChanged handler would
+    // transform, or a minimize/maximize double-animates alongside our
+    // shader. Re-asserting from the showingDesktopChanged handler would
     // close it, but that handler runs inside KWin's own emission over its
     // effects list, which is the one place an unload must not happen.
     QTimer::singleShot(0, this, [this]() {

--- a/kwin-effect/plasmazoneseffect.cpp
+++ b/kwin-effect/plasmazoneseffect.cpp
@@ -78,7 +78,7 @@ void PlasmaZonesEffect::reconfigure(ReconfigureFlags flags)
     // close it, but that handler runs inside KWin's own emission over its
     // effects list, which is the one place an unload must not happen.
     QTimer::singleShot(0, this, [this]() {
-        syncShowDesktopEffectSuppression();
+        syncStockEffectSuppression();
     });
 }
 

--- a/kwin-effect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect.h
@@ -929,12 +929,14 @@ private:
     // can read fresh geometry without a round-trip.
     //
     // The window pointer rides along so the debounced flush can run the
-    // shouldHandleWindow exclusion gate and the decoration resync ONCE per
-    // flush instead of on every geometry tick — during animated geometry
-    // (retiles, morphs, interactive resize) the per-tick gate was an uncached
-    // rule resolve plus a full ruleQuery build, hundreds of times per second
-    // (discussion #816). QPointer auto-nulls if the window dies before the
-    // flush; the flush skips those entries.
+    // shouldHandleWindow exclusion gate ONCE per flush instead of on every
+    // geometry tick — during animated geometry (retiles, morphs, interactive
+    // resize) the per-tick gate was an uncached rule resolve plus a full
+    // ruleQuery build, hundreds of times per second (discussion #816). The
+    // decoration resync deliberately stays PER TICK in the stash lambda (see
+    // window_lifecycle.cpp): it is cheap, and deferring it let a re-decorated
+    // title bar flash for the throttle window. QPointer auto-nulls if the
+    // window dies before the flush; the flush skips those entries.
     struct PendingFrameGeometry
     {
         QRect geometry;

--- a/kwin-effect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect.h
@@ -967,6 +967,23 @@ private:
     void notifyWindowResized(KWin::EffectWindow* w, const QRect& oldGeometry);
 
     void updateWindowDecoration(const QString& windowId, KWin::EffectWindow* w);
+
+    /// Poll-defer a decorated, minimized window's teardown while an animation
+    /// still paints it. A minimized window is only isVisible() while some
+    /// effect holds an EffectWindowVisibleRef on it — KWin's magic lamp /
+    /// squash minimize animations, or our own minimize transition. Tearing
+    /// the decoration down at that moment (updateWindowDecoration's
+    /// isMinimized() gate) yanks the OffscreenEffect redirect and its GL
+    /// working set out from under the in-flight animation: the mid-lamp
+    /// freeze and unbound-sampler black smears of discussion #816. The poll
+    /// re-enters updateWindowDecoration; once the animation drops its ref the
+    /// window stops being visible and the normal undecorate proceeds (or, if
+    /// the window unminimized meanwhile, the normal refresh path re-resolves).
+    /// Keyed set prevents timer pileup when decoration sweeps re-enter while
+    /// a poll is already armed. Defined in decorations.cpp.
+    void deferDecorationTeardownWhileAnimated(const QString& windowId);
+    QSet<QString> m_animatedDecoTeardownPending;
+
     /// windowHint: the EffectWindow when the caller still holds it and the
     /// window is already deleted (close / delete paths) — findWindowById
     /// cannot resolve a deleted id, and without the pointer the GL release

--- a/kwin-effect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect.h
@@ -1443,8 +1443,10 @@ private:
     bool m_enableAudioVisualizer = false;
     PhosphorAudio::SpectrumOptions m_audioOptions;
 
-    /// KWin show-desktop script effects syncShowDesktopEffectSuppression
-    /// unloaded because a `desktop.peek` pack is assigned. Only names WE
+    /// KWin stock effects syncStockEffectSuppression unloaded because one of
+    /// OUR packs owns the event they animate: windowaperture/eyeonscreen for
+    /// a `desktop.peek` pack, magiclamp/squash for a window.minimize pack,
+    /// maximize for a window.maximize pack. Only names WE
     /// unloaded are recorded, so clearing the pack (or unloading this effect)
     /// loads back exactly what the user had — never an effect KWin left
     /// disabled in kwinrc. Accepted edge: disabling a builtin in the Desktop
@@ -1454,7 +1456,7 @@ private:
     /// session honours kwinrc, which the suppression never writes. Querying
     /// kwinrc from the effect to close this would add a config dependency the
     /// plugin doesn't otherwise need.
-    QStringList m_suppressedShowDesktopEffects;
+    QStringList m_suppressedStockEffects;
     /// Set by the aboutToQuit latch (constructor): distinguishes a runtime
     /// unload of this effect from compositor shutdown in the destructor's
     /// suppressed-effect restore. See ~PlasmaZonesEffect.
@@ -1487,22 +1489,27 @@ private:
     /// the compositor thread never blocks on cava stop()+respawn mid-refresh.
     void scheduleEffectAudioSync();
 
-    /// Unload KWin's show-desktop script effects (windowaperture / eyeonscreen)
-    /// while the peek would actually run — a `desktop.peek` pack is assigned,
-    /// installed, desktop-contract, AND animations are enabled — and load back
-    /// exactly the ones WE unloaded when any of that stops holding. Unloading
-    /// is the only suppression that works: they never consult
-    /// activeFullScreenEffect() (and the peek deliberately takes no fullscreen
-    /// claim anyway, see DesktopTransitionManager) — left loaded they would
-    /// animate invisibly under our blend AND leak their transforms into the
-    /// peek captures (the capture paths continue down the effect chain).
+    /// Unload the KWin stock effects whose event one of OUR packs owns, and
+    /// load back exactly the ones WE unloaded when that stops holding. Three
+    /// groups share one predicate shape (pack assigned in the tree, installed,
+    /// event-contract match, animations enabled):
+    ///   desktop.peek       → windowaperture / eyeonscreen
+    ///   window.minimize    → magiclamp / squash
+    ///   window.maximize    → maximize
+    /// Unloading is the only suppression that works for all three: the
+    /// show-desktop scripts never consult activeFullScreenEffect() (and the
+    /// peek deliberately takes no fullscreen claim anyway, see
+    /// DesktopTransitionManager), and the minimize/maximize stock effects
+    /// honor no per-window grab role the way the open/close builtins honor
+    /// WindowAddedGrabRole / WindowClosedGrabRole — left loaded they animate
+    /// the same surface concurrently with our shader (discussion #816).
     /// Idempotent; re-asserted from every path that can change the predicate
     /// or the loaded-effects list: the shader-profile-tree load, the animation
     /// registry commit (bringup + pack install/uninstall), the animationsEnabled
     /// setting, and reconfigure() (a Desktop Effects KCM apply re-loads the
     /// scripts from kwinrc). The destructor restores them on a runtime unload
     /// but skips during compositor shutdown (m_compositorShuttingDown).
-    void syncShowDesktopEffectSuppression();
+    void syncStockEffectSuppression();
 
     /// True when any decorated window's resolved chain carries an audio-reactive
     /// pack (SurfaceShaderEffect::audio). Read from pack METADATA (no compile

--- a/kwin-effect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect.h
@@ -927,7 +927,20 @@ private:
     // WindowTracking::setFrameGeometry. Populates the daemon's frame-geometry
     // shadow used by daemon-local shortcut handlers (float toggle, etc.) so they
     // can read fresh geometry without a round-trip.
-    QHash<QString, QRect> m_pendingFrameGeometry;
+    //
+    // The window pointer rides along so the debounced flush can run the
+    // shouldHandleWindow exclusion gate and the decoration resync ONCE per
+    // flush instead of on every geometry tick — during animated geometry
+    // (retiles, morphs, interactive resize) the per-tick gate was an uncached
+    // rule resolve plus a full ruleQuery build, hundreds of times per second
+    // (discussion #816). QPointer auto-nulls if the window dies before the
+    // flush; the flush skips those entries.
+    struct PendingFrameGeometry
+    {
+        QRect geometry;
+        QPointer<KWin::EffectWindow> window;
+    };
+    QHash<QString, PendingFrameGeometry> m_pendingFrameGeometry;
     QTimer* m_frameGeometryFlushTimer = nullptr;
     void flushPendingFrameGeometry();
 

--- a/kwin-effect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect.h
@@ -979,8 +979,17 @@ private:
     /// re-enters updateWindowDecoration; once the animation drops its ref the
     /// window stops being visible and the normal undecorate proceeds (or, if
     /// the window unminimized meanwhile, the normal refresh path re-resolves).
-    /// Keyed set prevents timer pileup when decoration sweeps re-enter while
-    /// a poll is already armed. Defined in decorations.cpp.
+    /// The deferral's lifetime is bounded by WHOEVER holds a visible ref, not
+    /// only minimize animations: a thumbnail / overview effect keeping a
+    /// minimized window visible extends the poll (and the kept decoration)
+    /// for the ref's whole lifetime, which is the correct trade — the window
+    /// is being painted, so its decoration staying live is consistent, and
+    /// each poll tick is a lookup plus an early return. Keyed set prevents
+    /// timer pileup when decoration sweeps re-enter while a poll is already
+    /// armed; stale entries self-drain (the timer removes its own entry, and
+    /// a re-entry against a since-cleared decoration map is a no-op that does
+    /// not re-arm), so bulk teardown paths need no explicit clear. Defined in
+    /// decorations.cpp.
     void deferDecorationTeardownWhileAnimated(const QString& windowId);
     QSet<QString> m_animatedDecoTeardownPending;
 

--- a/kwin-effect/plasmazoneseffect/daemon_apply.cpp
+++ b/kwin-effect/plasmazoneseffect/daemon_apply.cpp
@@ -489,6 +489,17 @@ void PlasmaZonesEffect::slotWindowFloatingChanged(const QString& windowId, bool 
     // because m_dragFloatedWindowIds still has the entry from the original drag.
     if (!isFloating) {
         m_dragFloatedWindowIds.remove(windowId);
+        // An authoritative external unfloat moots any deferred
+        // unminimize→unfloat commit in either engine: the daemon has already
+        // unfloated (and re-snapped/retiled) the window — a user float toggle
+        // or rule action landing inside the animation grace — so the pending
+        // commit's unfloat would be redundant and snap's restore net would
+        // misread the post-unfloat daemon state as an orphaned window. Both
+        // engines' own commits consume their pending entry and minimize-float
+        // tracking BEFORE dispatching the unfloat, so this can never cancel
+        // the commit whose echo delivered this signal.
+        m_autotileHandler->removeMinimizeFloated(windowId);
+        m_snapHandler->removeMinimizeFloated(windowId);
     } else {
         // Backstop: a window that becomes floating is no longer snap-managed.
         // Covers float paths that don't emit applyGeometryRequested with an

--- a/kwin-effect/plasmazoneseffect/daemon_bringup.cpp
+++ b/kwin-effect/plasmazoneseffect/daemon_bringup.cpp
@@ -935,10 +935,10 @@ void PlasmaZonesEffect::loadCachedSettings()
             return;
         }
         m_windowAnimator->setEnabled(v.toBool());
-        // The animations master toggle is part of the suppression predicate:
-        // with animations off the peek never runs, so KWin's own show-desktop
-        // effects must come back rather than leave the user with no
-        // show-desktop animation at all.
+        // The animations master toggle is part of the suppression predicate
+        // for every group: with animations off none of our packs run, so
+        // KWin's own minimize / maximize / show-desktop effects must come
+        // back rather than leave the user with no animation at all.
         syncStockEffectSuppression();
     });
     loadSettingAsync(QStringLiteral("animationDuration"), [this](const QVariant& v) {

--- a/kwin-effect/plasmazoneseffect/daemon_bringup.cpp
+++ b/kwin-effect/plasmazoneseffect/daemon_bringup.cpp
@@ -939,7 +939,7 @@ void PlasmaZonesEffect::loadCachedSettings()
         // with animations off the peek never runs, so KWin's own show-desktop
         // effects must come back rather than leave the user with no
         // show-desktop animation at all.
-        syncShowDesktopEffectSuppression();
+        syncStockEffectSuppression();
     });
     loadSettingAsync(QStringLiteral("animationDuration"), [this](const QVariant& v) {
         // Clamp against the canonical settings-UI bounds. The earlier

--- a/kwin-effect/plasmazoneseffect/daemon_bringup.cpp
+++ b/kwin-effect/plasmazoneseffect/daemon_bringup.cpp
@@ -929,8 +929,8 @@ void PlasmaZonesEffect::loadCachedSettings()
         // fallback) coerces through toBool() to false, and m_enabled defaults
         // to TRUE (windowanimator.h) — so an unguarded read INVERTS the default
         // and silently disables every animation. It would drag the suppression
-        // sync below with it too, reloading KWin's show-desktop effects as a
-        // side effect of a malformed reply.
+        // sync below with it too, reloading KWin's stock minimize / maximize /
+        // show-desktop effects as a side effect of a malformed reply.
         if (v.typeId() != QMetaType::Bool) {
             return;
         }

--- a/kwin-effect/plasmazoneseffect/decorations.cpp
+++ b/kwin-effect/plasmazoneseffect/decorations.cpp
@@ -29,6 +29,7 @@
 #include <QGuiApplication>
 #include <QPalette>
 #include <QtMath> // qCeil, resolving the chain's outer padding
+#include <QTimer> // deferDecorationTeardownWhileAnimated poll
 #include <QVariantMap>
 
 #include <optional>
@@ -130,8 +131,62 @@ void PlasmaZonesEffect::reconcileDecorationOnPlacementFlip(const QString& window
     }
 }
 
+void PlasmaZonesEffect::deferDecorationTeardownWhileAnimated(const QString& windowId)
+{
+    // Poll cadence. Coarse on purpose: the poll only decides WHEN the
+    // teardown happens (the animation holds the visuals meanwhile), so the
+    // sole cost of a late tick is a border lingering a few extra frames on a
+    // window that just finished minimizing. Stock minimize animations run
+    // ~250ms scaled by the user's global animation speed, so a handful of
+    // ticks covers the common case.
+    constexpr int kAnimatedTeardownPollMs = 120;
+    if (m_animatedDecoTeardownPending.contains(windowId)) {
+        return; // a poll is already armed; decoration sweeps re-enter freely
+    }
+    m_animatedDecoTeardownPending.insert(windowId);
+    // `this` as context cancels the poll on effect teardown (clearAllDecorations
+    // handles the windows themselves there).
+    QTimer::singleShot(kAnimatedTeardownPollMs, this, [this, windowId] {
+        m_animatedDecoTeardownPending.remove(windowId);
+        // Exact-id re-check, same discipline as the windowDecorationRestored
+        // handler: findWindowById's fuzzy appId fallback must not resolve a
+        // same-app sibling and refresh IT under the dead window's id.
+        KWin::EffectWindow* w = findWindowById(windowId);
+        if (w && getWindowId(w) == windowId) {
+            // Re-resolve: still animation-held → defers again; fully
+            // minimized (ref dropped, no longer visible) → normal
+            // undecorate; unminimized meanwhile → normal refresh.
+            updateWindowDecoration(windowId, w);
+        } else {
+            // Window died during the deferral. The delete/close paths
+            // already released its GL with the corpse pointer in hand;
+            // this just drops any bookkeeping left under the id.
+            removeWindowDecoration(windowId);
+        }
+    });
+}
+
 void PlasmaZonesEffect::updateWindowDecoration(const QString& windowId, KWin::EffectWindow* w)
 {
+    // ANIMATION-HELD MINIMIZED WINDOW — defer, and defer BEFORE the remove-first
+    // below touches any state. A minimized window is only isVisible() while an
+    // effect holds an EffectWindowVisibleRef on it: KWin's magic lamp / squash
+    // minimize animation (or our own minimize transition) is mid-flight and
+    // still painting the window — through this very decoration's redirect. The
+    // isMinimized() gate further down would tear the redirect and GL working
+    // set out from under that animation (the discussion #816 mid-lamp freeze +
+    // unbound-sampler black), and a plain early-return AFTER the remove-first
+    // would orphan the kept redirect instead. So the decision is made here, at
+    // entry, while the decoration entry is still intact: keep it untouched and
+    // poll until the animation drops its ref (fully minimized → no longer
+    // visible → normal undecorate) or the window unminimizes (normal refresh).
+    // Gated on an existing decoration: with nothing to tear down there is
+    // nothing to defer.
+    if (w && w->isMinimized() && w->isVisible() && m_windowDecorations.contains(windowId)) {
+        deferDecorationTeardownWhileAnimated(windowId);
+        return;
+    }
+
     // Did this window already have a decoration? Read LIVE, and read BEFORE the
     // remove-first below, so the focus cross-fade can tell a genuine undecorated→decorated
     // transition (must SNAP to the current focus) from a plain refresh (focus change, snap

--- a/kwin-effect/plasmazoneseffect/lifecycle.cpp
+++ b/kwin-effect/plasmazoneseffect/lifecycle.cpp
@@ -72,7 +72,7 @@ PlasmaZonesEffect::PlasmaZonesEffect()
     PhosphorProtocol::registerWireTypes();
 
     // Latch compositor shutdown so the destructor can tell a runtime unload
-    // (KCM toggle — restore the suppressed show-desktop effects) from session
+    // (KCM toggle — restore the suppressed stock effects) from session
     // teardown (do NOT call loadEffect into the list KWin is unloading).
     // aboutToQuit fires when the event loop exits, before destructors run.
     connect(QCoreApplication::instance(), &QCoreApplication::aboutToQuit, this, [this]() {
@@ -1323,7 +1323,7 @@ PlasmaZonesEffect::~PlasmaZonesEffect()
             // instance re-unloads during its daemon bringup (a few sequential
             // D-Bus round trips plus the registry rescan, sub-second in
             // practice; indefinitely if no daemon is running, in which case no
-            // peek pack resolves either), a window where both animations could
+            // pack resolves either), a window where both animations could
             // race.
             for (const QString& name : toRestore) {
                 // Already loaded (a KCM reconcile beat us to it) is satisfied,

--- a/kwin-effect/plasmazoneseffect/lifecycle.cpp
+++ b/kwin-effect/plasmazoneseffect/lifecycle.cpp
@@ -1249,20 +1249,30 @@ void PlasmaZonesEffect::syncStockEffectSuppression()
     // apply re-loads scripts from kwinrc behind our back while the predicate
     // still holds, and this loop re-unloads them (the contains() check keeps
     // the record entry unique).
+    // Snapshot the minimize pair's loaded state BEFORE the unload loop: the
+    // sibling eviction below must judge "was the sibling genuinely loaded
+    // this sync?" against pre-unload reality, not against a state this very
+    // loop already mutated (processing magiclamp first would otherwise make
+    // squash's check see the sibling as unloaded and evict a live record).
+    const bool magiclampWasLoaded = KWin::effects->isEffectLoaded(QStringLiteral("magiclamp"));
+    const bool squashWasLoaded = KWin::effects->isEffectLoaded(QStringLiteral("squash"));
     for (const QString& name : std::as_const(wanted)) {
         if (KWin::effects->isEffectLoaded(name)) {
             if (!m_suppressedStockEffects.contains(name)) {
                 m_suppressedStockEffects.append(name);
             }
-            // magiclamp/squash are an exclusive KCM group: seeing one loaded
-            // means the user's pick is THIS one, so a sibling recorded by an
-            // earlier sync (user switched picks while suppressed — KWin's
-            // reconcile loaded the new pick behind our back) is stale. Drop
-            // it, or the restore path would force-load BOTH minimize
-            // animations, including the one the user just switched away from.
-            if (name == QLatin1String("magiclamp")) {
+            // magiclamp/squash form the Desktop Effects KCM's exclusive
+            // minimize group: recording one while its sibling is NOT loaded
+            // means any sibling record is stale — the user switched picks
+            // while suppressed (KWin's reconcile loaded the new pick behind
+            // our back) and the old pick is now disabled in kwinrc. Drop it,
+            // or the restore path would force-load BOTH minimize animations.
+            // A sibling that IS loaded this sync (a hand-edited kwinrc
+            // enabling both) keeps its record: both are genuinely owed
+            // restoring, exactly as configured.
+            if (name == QLatin1String("magiclamp") && !squashWasLoaded) {
                 m_suppressedStockEffects.removeAll(QStringLiteral("squash"));
-            } else if (name == QLatin1String("squash")) {
+            } else if (name == QLatin1String("squash") && !magiclampWasLoaded) {
                 m_suppressedStockEffects.removeAll(QStringLiteral("magiclamp"));
             }
             KWin::effects->unloadEffect(name);

--- a/kwin-effect/plasmazoneseffect/lifecycle.cpp
+++ b/kwin-effect/plasmazoneseffect/lifecycle.cpp
@@ -1177,8 +1177,12 @@ void PlasmaZonesEffect::syncStockEffectSuppression()
         return;
     }
     // A pack owns an event only when it would actually RUN: animations
-    // enabled, a pack resolved for the event's path (built-in defaults
-    // included), installed, AND applying to the event's contract class.
+    // enabled, a pack resolved for the event's path, installed, AND applying
+    // to the event's contract class. Resolution goes through
+    // resolveShaderWithDefault, so a built-in per-event default would count
+    // as ownership too — though none of the three current event paths
+    // carries one (defaultShaderEffectIdForPath covers only the snap /
+    // layout-switch geometry legs and the daemon overlay surfaces).
     // For the peek this mirrors the whole peek path's runnability gates, not
     // just the showingDesktopChanged handler's: the handler itself only
     // checks the animations toggle and a non-empty id, while the
@@ -1281,9 +1285,10 @@ PlasmaZonesEffect::~PlasmaZonesEffect()
 {
     // Give KWin back the stock effects the suppression unloaded (show-desktop
     // scripts for the peek, magiclamp/squash/maximize for window packs) — a
-    // runtime unload of THIS effect (KCM toggle) must not leave
-    // the user with no minimize/maximize/show-desktop animation. First, while everything is
-    // still alive. Skipped during compositor shutdown (the aboutToQuit latch):
+    // runtime unload of THIS effect (KCM toggle) must not leave the user
+    // with no minimize/maximize/show-desktop animation. First, while
+    // everything is still alive.
+    // Skipped during compositor shutdown (the aboutToQuit latch):
     // there the destructor runs from EffectsHandler's own unload-everything
     // sequence, and loadEffect would re-instantiate a script effect into the
     // list KWin is tearing down mid-iteration. Nothing is lost by skipping —

--- a/kwin-effect/plasmazoneseffect/lifecycle.cpp
+++ b/kwin-effect/plasmazoneseffect/lifecycle.cpp
@@ -238,14 +238,15 @@ PlasmaZonesEffect::PlasmaZonesEffect()
                 // feeds the cava run gate via hasAudioReactiveAnimation().
                 scheduleEffectAudioSync();
                 // The registry commit is also the FIRST moment (bringup) and
-                // the ONLY moment (pack install/uninstall) the desktop.peek
-                // pack's validity can change without a tree edit: the profile
+                // the ONLY moment (pack install/uninstall) a suppression-owning
+                // pack's validity (peek / minimize / maximize) can change
+                // without a tree edit: the profile
                 // tree arrives on an EARLIER D-Bus reply than the registry
                 // scan, so the tree-load sync at loadShaderProfileFromDbus
                 // resolves against an empty registry on session start, and
                 // deleting the assigned pack from disk never touches the tree
-                // at all. Re-run the suppression sync here so KWin's
-                // show-desktop effects are unloaded exactly when the peek pack
+                // at all. Re-run the suppression sync here so KWin's stock
+                // effects are unloaded exactly when our pack
                 // becomes runnable and restored the moment it stops being.
                 syncStockEffectSuppression();
             });

--- a/kwin-effect/plasmazoneseffect/lifecycle.cpp
+++ b/kwin-effect/plasmazoneseffect/lifecycle.cpp
@@ -247,7 +247,7 @@ PlasmaZonesEffect::PlasmaZonesEffect()
                 // at all. Re-run the suppression sync here so KWin's
                 // show-desktop effects are unloaded exactly when the peek pack
                 // becomes runnable and restored the moment it stops being.
-                syncShowDesktopEffectSuppression();
+                syncStockEffectSuppression();
             });
 
     // Surface shader pack hot-reload: when a data/surface pack changes on disk,
@@ -683,7 +683,7 @@ PlasmaZonesEffect::PlasmaZonesEffect()
     // resolve is a no-op, so KWin's default show-desktop behaviour proceeds
     // untouched.
     // While a pack IS assigned, KWin's windowaperture / eyeonscreen script
-    // effects are unloaded (syncShowDesktopEffectSuppression) — they ignore
+    // effects are unloaded (syncStockEffectSuppression) — they ignore
     // the fullscreen claim, and left loaded they would leak their transforms
     // into the peek captures.
     connect(KWin::effects, &KWin::EffectsHandler::showingDesktopChanged, this, [this](bool showing) {
@@ -1171,83 +1171,118 @@ void PlasmaZonesEffect::clearDaemonCompositorState()
                                                 QStringLiteral("hideOverlay"));
 }
 
-void PlasmaZonesEffect::syncShowDesktopEffectSuppression()
+void PlasmaZonesEffect::syncStockEffectSuppression()
 {
     if (!KWin::effects) {
         return;
     }
-    // Our peek owns the show-desktop animation only when the resolved pack
-    // would actually RUN: animations enabled, installed, AND a desktop-contract
-    // pack. Mirrors the whole peek path's runnability gates, not just the
-    // showingDesktopChanged handler's: the handler itself only checks the
-    // animations toggle and a non-empty id, while the isValid/appliesTo pair
-    // lives downstream in DesktopTransitionManager::prepareTransitionPrototype.
-    // This has to be the stricter of the two — a stale or inherited non-desktop
-    // override (or a pack assigned while the animations master toggle is off)
-    // must not unload KWin's effects and then bail at the signal, leaving the
-    // user with no show-desktop animation at all.
+    // A pack owns an event only when it would actually RUN: animations
+    // enabled, a pack resolved for the event's path (built-in defaults
+    // included), installed, AND applying to the event's contract class.
+    // For the peek this mirrors the whole peek path's runnability gates, not
+    // just the showingDesktopChanged handler's: the handler itself only
+    // checks the animations toggle and a non-empty id, while the
+    // isValid/appliesTo pair lives downstream in
+    // DesktopTransitionManager::prepareTransitionPrototype. The gate has to
+    // be the stricter of the two — a stale or inherited wrong-contract
+    // override (or a pack assigned while the animations master toggle is
+    // off) must not unload KWin's effects and then bail at the signal,
+    // leaving the user with no animation at all.
     //
     // The gate covers ASSIGNMENT and CONTRACT, not COMPILE. Compilation happens
     // on the GL thread at paint time, so a pack whose metadata is valid but
     // whose .frag fails to compile still unloads the builtins here and then
     // draws nothing (compiledShader's null sentinel abandons the leg). That
-    // leaves no show-desktop animation for as long as the pack stays assigned.
+    // leaves no animation for the event for as long as the pack stays assigned.
     // Accepted rather than plumbed: routing a paint-thread compile result back
     // into this predicate would make the suppression depend on frame timing,
     // and a bundled pack that fails to compile is a build-time bug the shader
     // validator catches, not a runtime state to design around.
-    bool wantOurs = false;
-    const PhosphorAnimationShaders::ShaderProfile profile = PhosphorAnimationShaders::resolveShaderWithDefault(
-        m_shaderManager.profileTree(), PhosphorAnimation::ProfilePaths::DesktopPeek);
-    const QString effectId = profile.effectiveEffectId();
-    if (!effectId.isEmpty() && m_windowAnimator->isEnabled()) {
-        const PhosphorAnimationShaders::AnimationShaderEffect eff = m_shaderManager.shaderRegistry().effect(effectId);
-        wantOurs = eff.isValid()
-            && PhosphorAnimationShaders::shaderEffectAppliesToEventPath(eff,
-                                                                        PhosphorAnimation::ProfilePaths::DesktopPeek);
-    }
-    static const QString kBuiltinShowDesktopEffects[] = {QStringLiteral("windowaperture"),
-                                                         QStringLiteral("eyeonscreen")};
-    if (wantOurs) {
-        for (const QString& name : kBuiltinShowDesktopEffects) {
-            // Record then unload only what is actually loaded, so the restore
-            // path re-loads exactly the user's own configuration and never
-            // force-loads an effect they had disabled.
-            if (KWin::effects->isEffectLoaded(name)) {
-                if (!m_suppressedShowDesktopEffects.contains(name)) {
-                    m_suppressedShowDesktopEffects.append(name);
-                }
-                KWin::effects->unloadEffect(name);
-            }
+    const auto packOwnsEvent = [this](const QString& path) {
+        const PhosphorAnimationShaders::ShaderProfile profile =
+            PhosphorAnimationShaders::resolveShaderWithDefault(m_shaderManager.profileTree(), path);
+        const QString effectId = profile.effectiveEffectId();
+        if (effectId.isEmpty() || !m_windowAnimator->isEnabled()) {
+            return false;
         }
-        return;
+        const PhosphorAnimationShaders::AnimationShaderEffect eff = m_shaderManager.shaderRegistry().effect(effectId);
+        return eff.isValid() && PhosphorAnimationShaders::shaderEffectAppliesToEventPath(eff, path);
+    };
+
+    // Suppression groups — each KWin stock effect is owed unloading exactly
+    // while OUR pack owns the event it animates (discussion #816: with both
+    // running, two effects animate the same surface concurrently — stutter,
+    // ghost trails, or a cancelled stock leg). The minimize/maximize stock
+    // effects honor no grab role (unlike the open/close builtins, which the
+    // WindowAddedGrabRole / WindowClosedGrabRole path already handles
+    // per-window), so unloading is the only suppression that works — the same
+    // conclusion the peek reached for windowaperture/eyeonscreen.
+    //
+    // TREE-resolved assignment only, deliberately: a per-app animation RULE
+    // carrying a minimize/maximize shader cannot drive a global unload — it
+    // would strip the stock animation from every other window for one app's
+    // override. A rule-scoped pack therefore still double-animates its
+    // matches; the tree (the global assignment surface) is the opt-in that
+    // makes the exchange whole-session coherent.
+    QStringList wanted;
+    if (packOwnsEvent(PhosphorAnimation::ProfilePaths::DesktopPeek)) {
+        wanted << QStringLiteral("windowaperture") << QStringLiteral("eyeonscreen");
     }
-    // Keep names whose re-load failed: the wantOurs=false branch re-runs on
-    // every later sync (see the four trigger sites on the header decl), so a
-    // transient loader failure gets a free retry instead of permanently
+    if (packOwnsEvent(PhosphorAnimation::ProfilePaths::WindowMinimize)) {
+        // Both stock minimize animations: KWin loads whichever the user
+        // picked in the exclusive minimize-animations group, and unloading
+        // the one that is not loaded is a recorded no-op.
+        wanted << QStringLiteral("magiclamp") << QStringLiteral("squash");
+    }
+    if (packOwnsEvent(PhosphorAnimation::ProfilePaths::WindowMaximize)) {
+        wanted << QStringLiteral("maximize");
+    }
+
+    // Record then unload only what is actually loaded, so the restore path
+    // re-loads exactly the user's own configuration and never force-loads an
+    // effect they had disabled. Re-asserted every sync: a Desktop Effects KCM
+    // apply re-loads scripts from kwinrc behind our back while the predicate
+    // still holds, and this loop re-unloads them (the contains() check keeps
+    // the record entry unique).
+    for (const QString& name : std::as_const(wanted)) {
+        if (KWin::effects->isEffectLoaded(name)) {
+            if (!m_suppressedStockEffects.contains(name)) {
+                m_suppressedStockEffects.append(name);
+            }
+            KWin::effects->unloadEffect(name);
+        }
+    }
+    // Restore recorded names whose group predicate stopped holding. Keep
+    // names whose re-load failed: the sync re-runs from every trigger site,
+    // so a transient loader failure gets a free retry instead of permanently
     // dropping the restore obligation for the session. Already-loaded names
     // are satisfied as-is (a KCM reconcile can re-load them behind our back,
     // and loadEffect returns false for a loaded effect — treating that as a
     // failure would pin the name in the retry list forever, warning on every
     // sync for an effect that is in fact running).
-    QStringList failed;
-    for (const QString& name : std::as_const(m_suppressedShowDesktopEffects)) {
+    QStringList keep;
+    for (const QString& name : std::as_const(m_suppressedStockEffects)) {
+        if (wanted.contains(name)) {
+            keep.append(name); // still suppressed; restore is owed later
+            continue;
+        }
         if (KWin::effects->isEffectLoaded(name)) {
             continue;
         }
         if (!KWin::effects->loadEffect(name)) {
-            qCWarning(lcEffect) << "failed to restore show-desktop effect" << name << "— will retry on next sync";
-            failed.append(name);
+            qCWarning(lcEffect) << "failed to restore stock effect" << name << "— will retry on next sync";
+            keep.append(name);
         }
     }
-    m_suppressedShowDesktopEffects = failed;
+    m_suppressedStockEffects = keep;
 }
 
 PlasmaZonesEffect::~PlasmaZonesEffect()
 {
-    // Give KWin back the show-desktop script effects the peek suppression
-    // unloaded — a runtime unload of THIS effect (KCM toggle) must not leave
-    // the user with no show-desktop animation. First, while everything is
+    // Give KWin back the stock effects the suppression unloaded (show-desktop
+    // scripts for the peek, magiclamp/squash/maximize for window packs) — a
+    // runtime unload of THIS effect (KCM toggle) must not leave
+    // the user with no minimize/maximize/show-desktop animation. First, while everything is
     // still alive. Skipped during compositor shutdown (the aboutToQuit latch):
     // there the destructor runs from EffectsHandler's own unload-everything
     // sequence, and loadEffect would re-instantiate a script effect into the
@@ -1268,7 +1303,7 @@ PlasmaZonesEffect::~PlasmaZonesEffect()
         // originated from a KCM-apply reconcile iterating the loaded-effects
         // list, a synchronous loadEffect here would mutate the container
         // mid-iteration — the same hazard reconfigure() defers around.
-        const QStringList toRestore = m_suppressedShowDesktopEffects;
+        const QStringList toRestore = m_suppressedStockEffects;
         QTimer::singleShot(0, [toRestore]() {
             if (!KWin::effects) {
                 return;
@@ -1288,11 +1323,11 @@ PlasmaZonesEffect::~PlasmaZonesEffect()
                 // Already loaded (a KCM reconcile beat us to it) is satisfied,
                 // not a failure — loadEffect returns false for a loaded effect.
                 if (!KWin::effects->isEffectLoaded(name) && !KWin::effects->loadEffect(name)) {
-                    qCWarning(lcEffect) << "failed to restore show-desktop effect" << name;
+                    qCWarning(lcEffect) << "failed to restore stock effect" << name;
                 }
             }
         });
-        m_suppressedShowDesktopEffects.clear();
+        m_suppressedStockEffects.clear();
     }
 
     // Sever the registry's `effectsChanged` connection BEFORE any shader or

--- a/kwin-effect/plasmazoneseffect/lifecycle.cpp
+++ b/kwin-effect/plasmazoneseffect/lifecycle.cpp
@@ -1254,6 +1254,17 @@ void PlasmaZonesEffect::syncStockEffectSuppression()
             if (!m_suppressedStockEffects.contains(name)) {
                 m_suppressedStockEffects.append(name);
             }
+            // magiclamp/squash are an exclusive KCM group: seeing one loaded
+            // means the user's pick is THIS one, so a sibling recorded by an
+            // earlier sync (user switched picks while suppressed — KWin's
+            // reconcile loaded the new pick behind our back) is stale. Drop
+            // it, or the restore path would force-load BOTH minimize
+            // animations, including the one the user just switched away from.
+            if (name == QLatin1String("magiclamp")) {
+                m_suppressedStockEffects.removeAll(QStringLiteral("squash"));
+            } else if (name == QLatin1String("squash")) {
+                m_suppressedStockEffects.removeAll(QStringLiteral("magiclamp"));
+            }
             KWin::effects->unloadEffect(name);
         }
     }

--- a/kwin-effect/plasmazoneseffect/shader_transitions.cpp
+++ b/kwin-effect/plasmazoneseffect/shader_transitions.cpp
@@ -2116,7 +2116,7 @@ void PlasmaZonesEffect::loadShaderProfileFromDbus()
                                     // It can also assign or clear the `desktop.peek` pack;
                                     // keep KWin's own show-desktop effects unloaded exactly
                                     // while ours owns that animation.
-                                    syncShowDesktopEffectSuppression();
+                                    syncStockEffectSuppression();
                                 },
                                 /*arraySink=*/{});
         });

--- a/kwin-effect/plasmazoneseffect/shader_transitions.cpp
+++ b/kwin-effect/plasmazoneseffect/shader_transitions.cpp
@@ -2113,9 +2113,10 @@ void PlasmaZonesEffect::loadShaderProfileFromDbus()
                                     // animation pack; re-evaluate the cava run gate so the
                                     // provider is warm before the first transition needs it.
                                     scheduleEffectAudioSync();
-                                    // It can also assign or clear the `desktop.peek` pack;
-                                    // keep KWin's own show-desktop effects unloaded exactly
-                                    // while ours owns that animation.
+                                    // It can also assign or clear any suppression-owning pack
+                                    // (`desktop.peek`, `window.minimize`, `window.maximize`);
+                                    // keep KWin's own stock effects unloaded exactly while
+                                    // ours owns the event.
                                     syncStockEffectSuppression();
                                 },
                                 /*arraySink=*/{});

--- a/kwin-effect/plasmazoneseffect/window_identity.cpp
+++ b/kwin-effect/plasmazoneseffect/window_identity.cpp
@@ -264,7 +264,28 @@ void PlasmaZonesEffect::flushPendingFrameGeometry()
     // disturb the iteration.
     const auto batch = std::exchange(m_pendingFrameGeometry, {});
     for (auto it = batch.constBegin(); it != batch.constEnd(); ++it) {
-        const QRect& geo = it.value();
+        // The exclusion gate and the decoration resync run HERE, once per
+        // debounced flush, rather than on every windowFrameGeometryChanged
+        // tick — the gate is an uncached rule resolve over a freshly built
+        // ruleQuery, and animated geometry fired it hundreds of times per
+        // second (discussion #816). QPointer nulls if the window died since
+        // the stash; a dead or excluded window contributes no daemon push.
+        KWin::EffectWindow* w = it.value().window.data();
+        if (!w || w->isDeleted() || !shouldHandleWindow(w)) {
+            continue;
+        }
+        // Self-heal a noBorder reset KWin issues asynchronously after a
+        // cross-OUTPUT move. For a rule-owned (title-bar-hidden) window
+        // the manager already believes it hidden, so the synchronous
+        // resync in updateAllDecorations bails ("still suppressed") when it
+        // runs before KWin re-evaluates the decoration. KWin grows the
+        // frame by the title-bar height when it re-decorates, firing the
+        // frame-geometry signal that stashed this entry: resyncWindow
+        // re-hides exactly the windows the manager owns and believes hidden
+        // whose decoration drifted back, and is a self-guarding no-op
+        // otherwise.
+        m_decorationManager->resyncWindow(it.key());
+        const QRect& geo = it.value().geometry;
         PhosphorProtocol::ClientHelpers::fireAndForget(
             this, PhosphorProtocol::Service::Interface::WindowTracking, QStringLiteral("setFrameGeometry"),
             {it.key(), geo.x(), geo.y(), geo.width(), geo.height()}, QStringLiteral("setFrameGeometry"));

--- a/kwin-effect/plasmazoneseffect/window_identity.cpp
+++ b/kwin-effect/plasmazoneseffect/window_identity.cpp
@@ -264,27 +264,19 @@ void PlasmaZonesEffect::flushPendingFrameGeometry()
     // disturb the iteration.
     const auto batch = std::exchange(m_pendingFrameGeometry, {});
     for (auto it = batch.constBegin(); it != batch.constEnd(); ++it) {
-        // The exclusion gate and the decoration resync run HERE, once per
-        // debounced flush, rather than on every windowFrameGeometryChanged
-        // tick — the gate is an uncached rule resolve over a freshly built
-        // ruleQuery, and animated geometry fired it hundreds of times per
-        // second (discussion #816). QPointer nulls if the window died since
-        // the stash; a dead or excluded window contributes no daemon push.
+        // The shouldHandleWindow exclusion gate runs HERE, once per debounced
+        // flush, rather than on every windowFrameGeometryChanged tick — it is
+        // an uncached rule resolve over a freshly built ruleQuery, and
+        // animated geometry fired it hundreds of times per second
+        // (discussion #816). The decoration resync deliberately stayed per
+        // tick in the stash lambda (window_lifecycle.cpp): it is cheap and
+        // deferring it let a re-decorated title bar flash for the throttle
+        // window. QPointer nulls if the window died since the stash; a dead
+        // or excluded window contributes no daemon push.
         KWin::EffectWindow* w = it.value().window.data();
         if (!w || w->isDeleted() || !shouldHandleWindow(w)) {
             continue;
         }
-        // Self-heal a noBorder reset KWin issues asynchronously after a
-        // cross-OUTPUT move. For a rule-owned (title-bar-hidden) window
-        // the manager already believes it hidden, so the synchronous
-        // resync in updateAllDecorations bails ("still suppressed") when it
-        // runs before KWin re-evaluates the decoration. KWin grows the
-        // frame by the title-bar height when it re-decorates, firing the
-        // frame-geometry signal that stashed this entry: resyncWindow
-        // re-hides exactly the windows the manager owns and believes hidden
-        // whose decoration drifted back, and is a self-guarding no-op
-        // otherwise.
-        m_decorationManager->resyncWindow(it.key());
         const QRect& geo = it.value().geometry;
         PhosphorProtocol::ClientHelpers::fireAndForget(
             this, PhosphorProtocol::Service::Interface::WindowTracking, QStringLiteral("setFrameGeometry"),

--- a/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
+++ b/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
@@ -1147,18 +1147,34 @@ void PlasmaZonesEffect::setupWindowConnections(KWin::EffectWindow* w)
                     && it->targetGeometry.isValid() && safeW->frameGeometry() != it->spawnGeometry) {
                     endRestoreSuppression(safeW.data());
                 }
-                // Body 2 — debounced daemon shadow. Per tick this ONLY stashes
-                // the latest geometry: the shouldHandleWindow exclusion gate
-                // (an uncached rule resolve over a freshly built ruleQuery) and
-                // the decoration resync both moved into
-                // flushPendingFrameGeometry, so they run once per 50ms flush
+                // Body 2 — debounced daemon shadow. Per tick this stashes the
+                // latest geometry and runs ONLY the cheap decoration resync:
+                // the shouldHandleWindow exclusion gate (an uncached rule
+                // resolve over a freshly built ruleQuery) moved into
+                // flushPendingFrameGeometry, so it runs once per 50ms flush
                 // per window instead of on every geometry tick — animated
-                // geometry (retiles, morphs, interactive resize) fired them
+                // geometry (retiles, morphs, interactive resize) fired it
                 // hundreds of times per second (discussion #816).
                 const QString windowId = getWindowId(safeW);
                 if (windowId.isEmpty()) {
                     return;
                 }
+                // Self-heal a noBorder reset KWin issues asynchronously after
+                // a cross-OUTPUT move. For a rule-owned (title-bar-hidden)
+                // window the manager already believes it hidden, so the
+                // synchronous resync in updateAllDecorations bails ("still
+                // suppressed") when it runs before KWin re-evaluates the
+                // decoration. KWin grows the frame by the title-bar height
+                // when it re-decorates, firing this very signal: resyncWindow
+                // re-hides exactly the windows the manager owns and believes
+                // hidden whose decoration drifted back, and is a self-guarding
+                // no-op otherwise. Kept PER TICK, not behind the flush: it is
+                // a hash lookup plus two flag checks for the untracked common
+                // case, and deferring it to the flush let the re-decorated
+                // title bar flash for up to the 50ms throttle window. No
+                // shouldHandleWindow gate needed — the manager only ever owns
+                // windows that passed it.
+                m_decorationManager->resyncWindow(windowId);
                 const QRect geo = safeW->frameGeometry().toRect();
                 if (geo.width() <= 0 || geo.height() <= 0) {
                     return;

--- a/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
+++ b/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
@@ -1147,29 +1147,23 @@ void PlasmaZonesEffect::setupWindowConnections(KWin::EffectWindow* w)
                     && it->targetGeometry.isValid() && safeW->frameGeometry() != it->spawnGeometry) {
                     endRestoreSuppression(safeW.data());
                 }
-                // Body 2 — debounced daemon shadow
-                if (!shouldHandleWindow(safeW)) {
-                    return;
-                }
+                // Body 2 — debounced daemon shadow. Per tick this ONLY stashes
+                // the latest geometry: the shouldHandleWindow exclusion gate
+                // (an uncached rule resolve over a freshly built ruleQuery) and
+                // the decoration resync both moved into
+                // flushPendingFrameGeometry, so they run once per 50ms flush
+                // per window instead of on every geometry tick — animated
+                // geometry (retiles, morphs, interactive resize) fired them
+                // hundreds of times per second (discussion #816).
                 const QString windowId = getWindowId(safeW);
                 if (windowId.isEmpty()) {
                     return;
                 }
-                // Self-heal a noBorder reset KWin issues asynchronously after a
-                // cross-OUTPUT move. For a rule-owned (title-bar-hidden) window
-                // the manager already believes it hidden, so the synchronous
-                // resync in updateAllDecorations bails ("still suppressed") when it
-                // runs before KWin re-evaluates the decoration. KWin grows the
-                // frame by the title-bar height when it re-decorates, firing this
-                // very signal: resyncWindow re-hides exactly the windows the
-                // manager owns and believes hidden whose decoration drifted back,
-                // and is a self-guarding no-op otherwise.
-                m_decorationManager->resyncWindow(windowId);
                 const QRect geo = safeW->frameGeometry().toRect();
                 if (geo.width() <= 0 || geo.height() <= 0) {
                     return;
                 }
-                m_pendingFrameGeometry[windowId] = geo;
+                m_pendingFrameGeometry[windowId] = {geo, safeW};
                 if (!m_frameGeometryFlushTimer->isActive()) {
                     m_frameGeometryFlushTimer->start();
                 }

--- a/kwin-effect/snaphandler.cpp
+++ b/kwin-effect/snaphandler.cpp
@@ -14,6 +14,7 @@
 #include <PhosphorProtocol/ServiceConstants.h>
 #include <PhosphorProtocol/WindowMarshalling.h>
 
+#include <effect/effect.h> // Effect::animationTime, the deferred-unfloat grace
 #include <effect/effecthandler.h>
 #include <effect/effectwindow.h>
 #include <window.h>
@@ -25,7 +26,9 @@
 #include <QPointer>
 #include <QSet>
 #include <QStringList>
+#include <QTimer>
 
+#include <chrono> // std::chrono::milliseconds for Effect::animationTime
 #include <memory>
 
 namespace PlasmaZones {
@@ -328,105 +331,179 @@ void SnapHandler::handleMinimizeChanged(KWin::EffectWindow* window, const QStrin
     }
 
     if (minimized) {
+        // A re-minimize during the deferred unfloat grace cancels the pending
+        // commit: the window never unfloated, so it is still minimize-floated
+        // and the isWindowFloating skip below covers the rest.
+        cancelPendingUnminimizeUnfloat(windowId);
         if (m_effect->isWindowFloating(windowId)) {
             qCDebug(lcEffect) << "Snap: minimized already-floating window, skipping float:" << windowId;
             return;
         }
         m_minimizeFloatedWindows.insert(windowId);
     } else {
-        if (!m_minimizeFloatedWindows.remove(windowId)) {
+        if (!m_minimizeFloatedWindows.contains(windowId)) {
             qCDebug(lcEffect) << "Snap: unminimized window was not minimize-floated, skipping unfloat:" << windowId;
             return;
         }
-        // Restore net for a snap-tracked window minimized across a daemon
-        // restart: every restore pass (slotDaemonReady's untracked sweep,
-        // slotPendingRestoresAvailable) deliberately skips minimized windows,
-        // and the unfloat sent below only flips a floating flag the daemon
-        // applies to windows it already tracks — the new daemon session tracks
-        // this window as neither snapped nor floating, so the unfloat no-ops
-        // and the window never rejoins its zone.
-        //
-        // Discriminating "orphaned by a restart" from a NORMAL minimize cycle
-        // needs both daemon states: minimize-float UNSNAPS the window
-        // (SnapEngine::setWindowFloat(true) → unsnapForFloat), so in a normal
-        // cycle it is absent from getSnappedWindows too — but it IS in the
-        // daemon's floating set, and the unfloat below re-snaps it. Only a
-        // window in NEITHER set is orphaned. Both queries are dispatched HERE,
-        // before the unfloat fireAndForget below enters the same D-Bus send
-        // queue, so the daemon answers them against the pre-unfloat state.
-        //
-        // The restore-on-orphan is deliberately scoped to windows this effect
-        // session minimize-floated (the remove() above succeeded): an
-        // unconditional net would fire resolveWindowRestore on every
-        // unminimize of any never-tracked window, re-running its open-time
-        // placement routing (RouteToDesktop) and churning the placement
-        // store's per-app FIFO on a path that is not an open.
-        //
-        // Tracked-ness MUST be checked, not resolved blindly:
-        // resolveWindowRestore consumes the single-shot FIFO pending-restore
-        // entry for the window's appId, and burning it on a window the daemon
-        // still owns robs a sibling window's restore. A failed query counts
-        // as tracked for the same reason.
-        if (window && m_effect->isDaemonReady("unminimize restore check")) {
-            struct QueryJoin
-            {
-                int pending = 2;
-                bool trackedOrFailed = false;
-            };
-            auto join = std::make_shared<QueryJoin>();
-            QPointer<KWin::EffectWindow> safeWindow = window;
-            const auto onReplyDone = [this, join, safeWindow, windowId]() {
-                if (--join->pending > 0 || join->trackedOrFailed) {
-                    return;
-                }
-                // Same eligibility guards as slotPendingRestoresAvailable's
-                // sweep, re-checked post-await: the window may have closed,
-                // re-minimized, or left the current desktop/activity while
-                // the queries were in flight (restoring an off-desktop window
-                // would snap it through the wrong desktop's snap state).
-                if (!safeWindow || safeWindow->isDeleted() || safeWindow->isMinimized()
-                    || !safeWindow->isOnCurrentDesktop() || !safeWindow->isOnCurrentActivity()) {
-                    return;
-                }
-                qCInfo(lcEffect) << "Snap: unminimized window is untracked by daemon — retrying restore:" << windowId;
-                callResolveWindowRestore(safeWindow.data());
-            };
-            auto* snappedWatcher = new QDBusPendingCallWatcher(
-                PhosphorProtocol::ClientHelpers::asyncCall(PhosphorProtocol::Service::Interface::WindowTracking,
-                                                           QStringLiteral("getSnappedWindows")),
-                this);
-            connect(snappedWatcher, &QDBusPendingCallWatcher::finished, this,
-                    [join, windowId, onReplyDone](QDBusPendingCallWatcher* w) {
-                        w->deleteLater();
-                        QDBusPendingReply<QStringList> reply = *w;
-                        if (!reply.isValid() || reply.value().contains(windowId)) {
-                            join->trackedOrFailed = true;
-                        }
-                        onReplyDone();
-                    });
-            auto* floatingWatcher = new QDBusPendingCallWatcher(
-                PhosphorProtocol::ClientHelpers::asyncCall(PhosphorProtocol::Service::Interface::WindowTracking,
-                                                           QStringLiteral("queryWindowFloating"), {windowId}),
-                this);
-            connect(floatingWatcher, &QDBusPendingCallWatcher::finished, this,
-                    [join, onReplyDone](QDBusPendingCallWatcher* w) {
-                        w->deleteLater();
-                        QDBusPendingReply<bool> reply = *w;
-                        if (!reply.isValid() || reply.value()) {
-                            join->trackedOrFailed = true;
-                        }
-                        onReplyDone();
-                    });
+        // A commit is already scheduled for this window — nothing new to do.
+        if (m_pendingUnminimizeUnfloat.contains(windowId)) {
+            return;
         }
+        // Defer the whole unfloat commit (restore-net queries included) past
+        // KWin's unminimize animation, mirroring AutotileHandler's deferred
+        // unfloat and for the same reason: the unfloat re-snaps the window,
+        // the daemon applies its zone geometry, and a moveResize landing
+        // mid-flight cancels the stock animation (discussion #816). There is
+        // no cross-effect API to observe the animation, so the grace is
+        // animationTime(400ms) — stock minimize animations are 250ms base
+        // scaled by the user's global animation-speed factor, which
+        // animationTime applies too. All state mutation
+        // (m_minimizeFloatedWindows removal, queries, D-Bus) happens at
+        // COMMIT, so a cancelled commit (re-minimize, close) leaves the
+        // window minimize-floated exactly as it was.
+        const int graceMs = int(KWin::Effect::animationTime(std::chrono::milliseconds(400)).count());
+        QPointer<KWin::EffectWindow> wPtr(window);
+        auto* timer = new QTimer(this);
+        timer->setSingleShot(true);
+        timer->setInterval(graceMs);
+        connect(timer, &QTimer::timeout, this, [this, windowId, wPtr]() {
+            // Consume the hash entry first; we own the timer's deleteLater
+            // regardless of which early-return branch we take below.
+            auto it = m_pendingUnminimizeUnfloat.find(windowId);
+            if (it == m_pendingUnminimizeUnfloat.end()) {
+                return; // Already cancelled by cancelPendingUnminimizeUnfloat.
+            }
+            QPointer<QTimer> owned = it.value();
+            m_pendingUnminimizeUnfloat.erase(it);
+            if (owned) {
+                owned->deleteLater();
+            }
+            // Re-validate at commit time. Every bail leaves the window
+            // minimize-floated, which the next unminimize edge picks up.
+            if (!wPtr) {
+                qCDebug(lcEffect) << "Snap: deferred unfloat window destroyed, skipping:" << windowId;
+                return;
+            }
+            KWin::EffectWindow* fw = wPtr.data();
+            if (fw->isMinimized()) {
+                qCDebug(lcEffect) << "Snap: deferred unfloat window re-minimized, skipping:" << windowId;
+                return;
+            }
+            const QString currentScreenId = m_effect->getWindowScreenId(fw);
+            if (m_effect->autotileHandler()->isAutotileScreen(currentScreenId)) {
+                // The screen flipped to autotile during the grace; that
+                // engine's own minimize-float machine owns the window now.
+                qCDebug(lcEffect) << "Snap: deferred unfloat screen became autotile, skipping:" << windowId;
+                return;
+            }
+            m_minimizeFloatedWindows.remove(windowId);
+            commitUnminimizeUnfloat(fw, windowId, currentScreenId);
+        });
+        m_pendingUnminimizeUnfloat.insert(windowId, timer);
+        timer->start();
+        return;
     }
 
-    qCInfo(lcEffect) << "Snap: window" << (minimized ? "minimized, floating:" : "unminimized, unfloating:") << windowId
-                     << "on" << screenId;
+    qCInfo(lcEffect) << "Snap: window minimized, floating:" << windowId << "on" << screenId;
 
     if (m_effect->isDaemonReady("snap minimize float")) {
         PhosphorProtocol::ClientHelpers::fireAndForget(m_effect, PhosphorProtocol::Service::Interface::WindowTracking,
                                                        QStringLiteral("setWindowFloatingForScreen"),
-                                                       {windowId, screenId, minimized},
+                                                       {windowId, screenId, true},
+                                                       QStringLiteral("setWindowFloatingForScreen"));
+    }
+}
+
+void SnapHandler::commitUnminimizeUnfloat(KWin::EffectWindow* window, const QString& windowId, const QString& screenId)
+{
+    // Restore net for a snap-tracked window minimized across a daemon
+    // restart: every restore pass (slotDaemonReady's untracked sweep,
+    // slotPendingRestoresAvailable) deliberately skips minimized windows,
+    // and the unfloat sent below only flips a floating flag the daemon
+    // applies to windows it already tracks — the new daemon session tracks
+    // this window as neither snapped nor floating, so the unfloat no-ops
+    // and the window never rejoins its zone.
+    //
+    // Discriminating "orphaned by a restart" from a NORMAL minimize cycle
+    // needs both daemon states: minimize-float UNSNAPS the window
+    // (SnapEngine::setWindowFloat(true) → unsnapForFloat), so in a normal
+    // cycle it is absent from getSnappedWindows too — but it IS in the
+    // daemon's floating set, and the unfloat below re-snaps it. Only a
+    // window in NEITHER set is orphaned. Both queries are dispatched HERE,
+    // before the unfloat fireAndForget below enters the same D-Bus send
+    // queue, so the daemon answers them against the pre-unfloat state.
+    //
+    // The restore-on-orphan is deliberately scoped to windows this effect
+    // session minimize-floated (the caller removed the entry from
+    // m_minimizeFloatedWindows just before committing): an
+    // unconditional net would fire resolveWindowRestore on every
+    // unminimize of any never-tracked window, re-running its open-time
+    // placement routing (RouteToDesktop) and churning the placement
+    // store's per-app FIFO on a path that is not an open.
+    //
+    // Tracked-ness MUST be checked, not resolved blindly:
+    // resolveWindowRestore consumes the single-shot FIFO pending-restore
+    // entry for the window's appId, and burning it on a window the daemon
+    // still owns robs a sibling window's restore. A failed query counts
+    // as tracked for the same reason.
+    if (window && m_effect->isDaemonReady("unminimize restore check")) {
+        struct QueryJoin
+        {
+            int pending = 2;
+            bool trackedOrFailed = false;
+        };
+        auto join = std::make_shared<QueryJoin>();
+        QPointer<KWin::EffectWindow> safeWindow = window;
+        const auto onReplyDone = [this, join, safeWindow, windowId]() {
+            if (--join->pending > 0 || join->trackedOrFailed) {
+                return;
+            }
+            // Same eligibility guards as slotPendingRestoresAvailable's
+            // sweep, re-checked post-await: the window may have closed,
+            // re-minimized, or left the current desktop/activity while
+            // the queries were in flight (restoring an off-desktop window
+            // would snap it through the wrong desktop's snap state).
+            if (!safeWindow || safeWindow->isDeleted() || safeWindow->isMinimized() || !safeWindow->isOnCurrentDesktop()
+                || !safeWindow->isOnCurrentActivity()) {
+                return;
+            }
+            qCInfo(lcEffect) << "Snap: unminimized window is untracked by daemon — retrying restore:" << windowId;
+            callResolveWindowRestore(safeWindow.data());
+        };
+        auto* snappedWatcher = new QDBusPendingCallWatcher(
+            PhosphorProtocol::ClientHelpers::asyncCall(PhosphorProtocol::Service::Interface::WindowTracking,
+                                                       QStringLiteral("getSnappedWindows")),
+            this);
+        connect(snappedWatcher, &QDBusPendingCallWatcher::finished, this,
+                [join, windowId, onReplyDone](QDBusPendingCallWatcher* w) {
+                    w->deleteLater();
+                    QDBusPendingReply<QStringList> reply = *w;
+                    if (!reply.isValid() || reply.value().contains(windowId)) {
+                        join->trackedOrFailed = true;
+                    }
+                    onReplyDone();
+                });
+        auto* floatingWatcher = new QDBusPendingCallWatcher(
+            PhosphorProtocol::ClientHelpers::asyncCall(PhosphorProtocol::Service::Interface::WindowTracking,
+                                                       QStringLiteral("queryWindowFloating"), {windowId}),
+            this);
+        connect(floatingWatcher, &QDBusPendingCallWatcher::finished, this,
+                [join, onReplyDone](QDBusPendingCallWatcher* w) {
+                    w->deleteLater();
+                    QDBusPendingReply<bool> reply = *w;
+                    if (!reply.isValid() || reply.value()) {
+                        join->trackedOrFailed = true;
+                    }
+                    onReplyDone();
+                });
+    }
+
+    qCInfo(lcEffect) << "Snap: window unminimized, unfloating (after animation grace):" << windowId << "on" << screenId;
+
+    if (m_effect->isDaemonReady("snap minimize float")) {
+        PhosphorProtocol::ClientHelpers::fireAndForget(m_effect, PhosphorProtocol::Service::Interface::WindowTracking,
+                                                       QStringLiteral("setWindowFloatingForScreen"),
+                                                       {windowId, screenId, false},
                                                        QStringLiteral("setWindowFloatingForScreen"));
     }
 }

--- a/kwin-effect/snaphandler.cpp
+++ b/kwin-effect/snaphandler.cpp
@@ -389,6 +389,14 @@ void SnapHandler::handleMinimizeChanged(KWin::EffectWindow* window, const QStrin
                 qCDebug(lcEffect) << "Snap: deferred unfloat window re-minimized, skipping:" << windowId;
                 return;
             }
+            // Mirror the caller-side gate (slotWindowMinimizedChanged only
+            // forwards handleable tileable windows) and the autotile twin's
+            // commit revalidation: the window may have become excluded or
+            // non-tileable during the grace.
+            if (!m_effect->shouldHandleWindow(fw) || !m_effect->isTileableWindow(fw)) {
+                qCDebug(lcEffect) << "Snap: deferred unfloat no longer handleable, skipping:" << windowId;
+                return;
+            }
             const QString currentScreenId = m_effect->getWindowScreenId(fw);
             if (m_effect->autotileHandler()->isAutotileScreen(currentScreenId)) {
                 // The screen flipped to autotile during the grace; that

--- a/kwin-effect/snaphandler.cpp
+++ b/kwin-effect/snaphandler.cpp
@@ -363,21 +363,7 @@ void SnapHandler::handleMinimizeChanged(KWin::EffectWindow* window, const QStrin
         // window minimize-floated exactly as it was.
         const int graceMs = int(KWin::Effect::animationTime(std::chrono::milliseconds(400)).count());
         QPointer<KWin::EffectWindow> wPtr(window);
-        auto* timer = new QTimer(this);
-        timer->setSingleShot(true);
-        timer->setInterval(graceMs);
-        connect(timer, &QTimer::timeout, this, [this, windowId, wPtr]() {
-            // Consume the hash entry first; we own the timer's deleteLater
-            // regardless of which early-return branch we take below.
-            auto it = m_pendingUnminimizeUnfloat.find(windowId);
-            if (it == m_pendingUnminimizeUnfloat.end()) {
-                return; // Already cancelled by cancelPendingUnminimizeUnfloat.
-            }
-            QPointer<QTimer> owned = it.value();
-            m_pendingUnminimizeUnfloat.erase(it);
-            if (owned) {
-                owned->deleteLater();
-            }
+        m_pendingUnminimizeUnfloat.schedule(windowId, graceMs, [this, windowId, wPtr]() {
             // Re-validate at commit time. Every bail leaves the window
             // minimize-floated, which the next unminimize edge picks up.
             if (!wPtr) {
@@ -413,8 +399,6 @@ void SnapHandler::handleMinimizeChanged(KWin::EffectWindow* window, const QStrin
             }
             commitUnminimizeUnfloat(fw, windowId, currentScreenId);
         });
-        m_pendingUnminimizeUnfloat.insert(windowId, timer);
-        timer->start();
         return;
     }
 

--- a/kwin-effect/snaphandler.cpp
+++ b/kwin-effect/snaphandler.cpp
@@ -393,10 +393,16 @@ void SnapHandler::handleMinimizeChanged(KWin::EffectWindow* window, const QStrin
             if (m_effect->autotileHandler()->isAutotileScreen(currentScreenId)) {
                 // The screen flipped to autotile during the grace; that
                 // engine's own minimize-float machine owns the window now.
+                // The m_minimizeFloatedWindows entry is deliberately LEFT in
+                // place (mirroring the autotile twin's symmetric bail): the
+                // window is still floating daemon-side, and the entry drains
+                // on close via removeMinimizeFloated.
                 qCDebug(lcEffect) << "Snap: deferred unfloat screen became autotile, skipping:" << windowId;
                 return;
             }
-            m_minimizeFloatedWindows.remove(windowId);
+            if (!m_minimizeFloatedWindows.remove(windowId)) {
+                return; // State moved under us (e.g. bulk cleanup); nothing to commit.
+            }
             commitUnminimizeUnfloat(fw, windowId, currentScreenId);
         });
         m_pendingUnminimizeUnfloat.insert(windowId, timer);

--- a/kwin-effect/snaphandler.h
+++ b/kwin-effect/snaphandler.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include "deferredwindowcommits.h"
+
 #include <PhosphorCompositor/AutotileState.h>
 #include <PhosphorProtocol/ZoneTypes.h>
 
@@ -187,15 +189,7 @@ public:
     /// removeMinimizeFloated (window closed).
     void cancelPendingUnminimizeUnfloat(const QString& windowId)
     {
-        auto it = m_pendingUnminimizeUnfloat.find(windowId);
-        if (it == m_pendingUnminimizeUnfloat.end()) {
-            return;
-        }
-        if (QTimer* pending = it.value()) {
-            pending->stop();
-            pending->deleteLater();
-        }
-        m_pendingUnminimizeUnfloat.erase(it);
+        m_pendingUnminimizeUnfloat.cancel(windowId);
     }
 
     // ── Tiled-membership accessor — delegates to shared AutotileStateHelpers ──
@@ -263,8 +257,10 @@ private:
     // zone geometry), and a moveResize landing mid-flight cancels KWin's own
     // unminimize animation (discussion #816). Deferred by an
     // Effect::animationTime-scaled grace and revalidated at fire time; a
-    // re-minimize during the grace cancels it.
-    QHash<QString, QPointer<QTimer>> m_pendingUnminimizeUnfloat;
+    // re-minimize during the grace cancels it, and an authoritative external
+    // unfloat (the daemon's windowFloatingChanged echo) cancels it via
+    // removeMinimizeFloated.
+    DeferredWindowCommits m_pendingUnminimizeUnfloat{this};
 };
 
 } // namespace PlasmaZones

--- a/kwin-effect/snaphandler.h
+++ b/kwin-effect/snaphandler.h
@@ -174,9 +174,12 @@ public:
     void handleMinimizeChanged(KWin::EffectWindow* window, const QString& windowId, const QString& screenId,
                                bool minimized);
 
-    /// Drop @p windowId from the minimize-float set (window closed). Returns
-    /// true if it was present. Also cancels any deferred unfloat commit so a
-    /// grace timer never fires against a destroyed window.
+    /// Drop @p windowId from the minimize-float set and cancel any deferred
+    /// unfloat commit. Returns true if it was present. Two callers, two
+    /// reasons (mirrors AutotileHandler::removeMinimizeFloated): the close
+    /// path (a grace timer must never fire against a destroyed window) and
+    /// the daemon's windowFloatingChanged(false) echo (an authoritative
+    /// external unfloat moots the deferred commit).
     bool removeMinimizeFloated(const QString& windowId)
     {
         cancelPendingUnminimizeUnfloat(windowId);
@@ -186,7 +189,8 @@ public:
     /// Cancel a pending deferred unminimize→unfloat commit. No-op if no timer
     /// is pending for the window. Called from the minimize edge (a re-minimize
     /// during the grace must leave the window minimize-floated) and from
-    /// removeMinimizeFloated (window closed).
+    /// removeMinimizeFloated (window closed, or an authoritative external
+    /// unfloat via the daemon's windowFloatingChanged echo).
     void cancelPendingUnminimizeUnfloat(const QString& windowId)
     {
         m_pendingUnminimizeUnfloat.cancel(windowId);

--- a/kwin-effect/snaphandler.h
+++ b/kwin-effect/snaphandler.h
@@ -172,13 +172,6 @@ public:
     void handleMinimizeChanged(KWin::EffectWindow* window, const QString& windowId, const QString& screenId,
                                bool minimized);
 
-    /// Deferred-commit body of the unminimize→unfloat edge: the restore-net
-    /// queries (dispatched before the unfloat enters the same D-Bus send
-    /// queue, so the daemon answers against pre-unfloat state) plus the
-    /// unfloat itself. Called only from the grace timer in
-    /// handleMinimizeChanged after revalidation; @p window is alive,
-    /// unminimized, and on a snap-mode screen.
-    void commitUnminimizeUnfloat(KWin::EffectWindow* window, const QString& windowId, const QString& screenId);
     /// Drop @p windowId from the minimize-float set (window closed). Returns
     /// true if it was present. Also cancels any deferred unfloat commit so a
     /// grace timer never fires against a destroyed window.
@@ -225,6 +218,14 @@ public Q_SLOTS:
                              const PhosphorProtocol::EmptyZoneList& emptyZones);
 
 private:
+    /// Deferred-commit body of the unminimize→unfloat edge: the restore-net
+    /// queries (dispatched before the unfloat enters the same D-Bus send
+    /// queue, so the daemon answers against pre-unfloat state) plus the
+    /// unfloat itself. Called only from the grace timer in
+    /// handleMinimizeChanged after revalidation; @p window is alive,
+    /// unminimized, handleable, and on a snap-mode screen.
+    void commitUnminimizeUnfloat(KWin::EffectWindow* window, const QString& windowId, const QString& screenId);
+
     PlasmaZonesEffect* m_effect;
     // Snapping focus-follows-mouse (Snapping.Behavior.FocusFollowsMouse). When
     // on, moving the cursor over a snapped window activates it. Mirrors autotile
@@ -250,6 +251,11 @@ private:
     QHash<QString, CachedSnapRestore> m_restoreCache;
     // Snap-mode windows floated because they were minimized (mirrors
     // AutotileHandler::m_minimizeFloatedWindows). Removed on unminimize / close.
+    // Deliberately NOT cleared on daemon restart, unlike the autotile twin
+    // (AutotileHandler::onDaemonReady): the restore net in
+    // commitUnminimizeUnfloat is snap's restart-recovery path, and it only
+    // fires for windows still in this set — clearing on daemon-ready would
+    // strand exactly the windows the net exists to recover.
     QSet<QString> m_minimizeFloatedWindows;
     // Pending deferred unminimize→unfloat commits, keyed by windowId — the
     // snap-mode mirror of AutotileHandler::m_pendingUnminimizeUnfloat, for the

--- a/kwin-effect/snaphandler.h
+++ b/kwin-effect/snaphandler.h
@@ -9,10 +9,12 @@
 #include <QHash>
 #include <QObject>
 #include <QPointF>
+#include <QPointer>
 #include <QRect>
 #include <QRectF>
 #include <QSet>
 #include <QString>
+#include <QTimer>
 
 #include <functional>
 #include <optional>
@@ -163,13 +165,44 @@ public:
     /// the net inert and the plain unfloat re-snaps as before. Called from
     /// PlasmaZonesEffect::slotWindowMinimizedChanged after the shared minimize
     /// shader event.
+    /// The unfloat side does NOT commit synchronously: it is deferred by an
+    /// Effect::animationTime-scaled grace so the re-snap's geometry apply
+    /// cannot land mid-flight and cancel KWin's own unminimize animation
+    /// (discussion #816); see m_pendingUnminimizeUnfloat.
     void handleMinimizeChanged(KWin::EffectWindow* window, const QString& windowId, const QString& screenId,
                                bool minimized);
+
+    /// Deferred-commit body of the unminimize→unfloat edge: the restore-net
+    /// queries (dispatched before the unfloat enters the same D-Bus send
+    /// queue, so the daemon answers against pre-unfloat state) plus the
+    /// unfloat itself. Called only from the grace timer in
+    /// handleMinimizeChanged after revalidation; @p window is alive,
+    /// unminimized, and on a snap-mode screen.
+    void commitUnminimizeUnfloat(KWin::EffectWindow* window, const QString& windowId, const QString& screenId);
     /// Drop @p windowId from the minimize-float set (window closed). Returns
-    /// true if it was present.
+    /// true if it was present. Also cancels any deferred unfloat commit so a
+    /// grace timer never fires against a destroyed window.
     bool removeMinimizeFloated(const QString& windowId)
     {
+        cancelPendingUnminimizeUnfloat(windowId);
         return m_minimizeFloatedWindows.remove(windowId);
+    }
+
+    /// Cancel a pending deferred unminimize→unfloat commit. No-op if no timer
+    /// is pending for the window. Called from the minimize edge (a re-minimize
+    /// during the grace must leave the window minimize-floated) and from
+    /// removeMinimizeFloated (window closed).
+    void cancelPendingUnminimizeUnfloat(const QString& windowId)
+    {
+        auto it = m_pendingUnminimizeUnfloat.find(windowId);
+        if (it == m_pendingUnminimizeUnfloat.end()) {
+            return;
+        }
+        if (QTimer* pending = it.value()) {
+            pending->stop();
+            pending->deleteLater();
+        }
+        m_pendingUnminimizeUnfloat.erase(it);
     }
 
     // ── Tiled-membership accessor — delegates to shared AutotileStateHelpers ──
@@ -218,6 +251,14 @@ private:
     // Snap-mode windows floated because they were minimized (mirrors
     // AutotileHandler::m_minimizeFloatedWindows). Removed on unminimize / close.
     QSet<QString> m_minimizeFloatedWindows;
+    // Pending deferred unminimize→unfloat commits, keyed by windowId — the
+    // snap-mode mirror of AutotileHandler::m_pendingUnminimizeUnfloat, for the
+    // same reason: the unfloat re-snaps the window (the daemon applies its
+    // zone geometry), and a moveResize landing mid-flight cancels KWin's own
+    // unminimize animation (discussion #816). Deferred by an
+    // Effect::animationTime-scaled grace and revalidated at fire time; a
+    // re-minimize during the grace cancels it.
+    QHash<QString, QPointer<QTimer>> m_pendingUnminimizeUnfloat;
 };
 
 } // namespace PlasmaZones

--- a/src/settings/CMakeLists.txt
+++ b/src/settings/CMakeLists.txt
@@ -305,6 +305,7 @@ qt_add_qml_module(plasmazones-settings
         qml/MatchLeafEditor.qml
         qml/ActionListEditor.qml
         qml/ActionRow.qml
+        qml/StockAnimationConflictChip.qml
         qml/AboutPage.qml
         qml/WhatsNewPage.qml
         qml/MonitorStatePage.qml

--- a/src/settings/animationspagecontroller.cpp
+++ b/src/settings/animationspagecontroller.cpp
@@ -173,6 +173,10 @@ AnimationsPageController::AnimationsPageController(PhosphorAnimationShaders::Ani
     if (m_shaderRegistry) {
         connect(m_shaderRegistry, &PhosphorAnimationShaders::AnimationShaderRegistry::effectsChanged, this,
                 &AnimationsPageController::shaderEffectsChanged);
+        // A registry rescan can flip a pack's validity / contract class,
+        // which is one of the stock-suppression gate's inputs.
+        connect(m_shaderRegistry, &PhosphorAnimationShaders::AnimationShaderRegistry::effectsChanged, this,
+                &AnimationsPageController::stockSuppressedEventsChanged);
     }
     if (m_settings) {
         // Sole emitter of pendingChangesChanged for shader-tree edits: EVERY
@@ -195,11 +199,19 @@ AnimationsPageController::AnimationsPageController(PhosphorAnimationShaders::Ani
                 // can't tell which path moved without diffing. QML pages refresh
                 // every visible event card on this signal which is cheap enough.
                 Q_EMIT shaderProfileChanged(QString());
+                // Tree assignment is the primary input of the stock-suppression
+                // gate (see stockSuppressedEvents).
+                Q_EMIT stockSuppressedEventsChanged();
                 if (m_asyncRevertInFlight)
                     return;
                 Q_EMIT pendingChangesChanged();
             },
             Qt::DirectConnection);
+        // The animations master toggle gates the whole suppression predicate:
+        // with animations off no pack owns any event and every stock effect
+        // is (re)loaded, so the conflict chip must come back.
+        connect(m_settings, &ISettings::animationsEnabledChanged, this,
+                &AnimationsPageController::stockSuppressedEventsChanged);
     }
 }
 

--- a/src/settings/animationspagecontroller.h
+++ b/src/settings/animationspagecontroller.h
@@ -74,6 +74,14 @@ class AnimationsPageController : public PhosphorControl::PageController
     /// The motion-set store, bound by AnimationsMotionSetsPage as its `bridge`.
     Q_PROPERTY(PlasmaZones::ShaderSetStore* setsBridge READ setsBridge CONSTANT)
 
+    /// Animation event paths whose stock KWin effect the compositor
+    /// suppresses session-wide because a tree-assigned pack owns the event
+    /// (the settings-side mirror of the effect's syncStockEffectSuppression
+    /// gate). The rule editor's stock-animation conflict chip hides for
+    /// these events: with the stock effect unloaded there is no
+    /// double-animation for a rule shader to conflict with.
+    Q_PROPERTY(QStringList stockSuppressedEvents READ stockSuppressedEvents NOTIFY stockSuppressedEventsChanged)
+
 public:
     /// @param shaderRegistry Optional — when null, all `*ShaderEffects()` /
     ///        `*ShaderProfile()` Q_INVOKABLEs return empty results so unit
@@ -361,6 +369,13 @@ public:
     /// overrides count, mirroring the existing tree-walk semantics.
     Q_INVOKABLE QVariantList shaderEffectUsages(const QString& effectId) const;
 
+    /// See the stockSuppressedEvents Q_PROPERTY. Evaluates the effect's
+    /// per-event ownership gate (animations enabled, tree-resolved effectId
+    /// non-empty, pack applies to the event's contract class) for the
+    /// minimize and maximize events — the two whose stock KWin effects the
+    /// compositor unloads while a tree pack owns them.
+    QStringList stockSuppressedEvents() const;
+
     /// Test hook: redirect file I/O to @p dir instead of the XDG default.
     /// Pass an empty string to restore the default. Not Q_INVOKABLE — QML
     /// callers must not redirect persistence.
@@ -384,6 +399,11 @@ Q_SIGNALS:
     /// Re-emit of `AnimationShaderRegistry::effectsChanged` so QML can
     /// rebind without poking at the registry directly.
     void shaderEffectsChanged();
+
+    /// Emitted whenever stockSuppressedEvents may have changed: on any
+    /// shader-tree change, registry rescan, or a flip of the animations
+    /// master toggle — the three inputs of the ownership gate.
+    void stockSuppressedEventsChanged();
 
     /// Emitted whenever `hasPendingChanges()` may have flipped. The
     /// SettingsController's slot calls `setNeedsSave(true)` when there

--- a/src/settings/animationspagecontroller_shaders.cpp
+++ b/src/settings/animationspagecontroller_shaders.cpp
@@ -229,9 +229,11 @@ QStringList AnimationsPageController::stockSuppressedEvents() const
         if (effectId.isEmpty()) {
             return false;
         }
-        if (m_shaderRegistry && m_shaderRegistry->hasEffect(effectId)
-            && !shaderEffectAppliesToEventPath(m_shaderRegistry->effect(effectId), path)) {
-            return false;
+        if (m_shaderRegistry && m_shaderRegistry->hasEffect(effectId)) {
+            const AnimationShaderEffect eff = m_shaderRegistry->effect(effectId);
+            if (!eff.isValid() || !shaderEffectAppliesToEventPath(eff, path)) {
+                return false;
+            }
         }
         return true;
     };

--- a/src/settings/animationspagecontroller_shaders.cpp
+++ b/src/settings/animationspagecontroller_shaders.cpp
@@ -36,6 +36,7 @@
 // struct" errors. The sibling animationspagecontroller.cpp picks the
 // same path.
 #include <PhosphorAnimation/AnimationShaderRegistry.h>
+#include <PhosphorAnimation/ProfilePaths.h>
 
 #include <QDesktopServices>
 #include <QDir>
@@ -205,6 +206,42 @@ QVariantMap AnimationsPageController::resolvedShaderProfile(const QString& path)
         resolved.effectId.reset();
     }
     return shaderProfileToMap(resolved);
+}
+
+QStringList AnimationsPageController::stockSuppressedEvents() const
+{
+    using namespace PhosphorAnimationShaders;
+    QStringList owned;
+    if (!m_settings || !m_settings->animationsEnabled()) {
+        return owned;
+    }
+    const ShaderProfileTree tree = m_settings->shaderProfileTree();
+    // Mirrors the compositor's packOwnsEvent gate (syncStockEffectSuppression
+    // in the kwin effect): tree-resolved effectId non-empty AND the pack
+    // applies to the event's contract class. One deliberate divergence: an
+    // effectId the registry does not know yet (a user pack still scanning at
+    // startup) counts as owned here — resolvedShaderProfile grants unknown
+    // ids the same warm-up grace, and flashing the conflict chip for a pack
+    // that will suppress once scanned would be a false alarm.
+    const auto packOwns = [this, &tree](const QString& path) {
+        const ShaderProfile resolved = resolveShaderWithDefault(tree, path);
+        const QString effectId = resolved.effectiveEffectId();
+        if (effectId.isEmpty()) {
+            return false;
+        }
+        if (m_shaderRegistry && m_shaderRegistry->hasEffect(effectId)
+            && !shaderEffectAppliesToEventPath(m_shaderRegistry->effect(effectId), path)) {
+            return false;
+        }
+        return true;
+    };
+    for (const QString& path :
+         {PhosphorAnimation::ProfilePaths::WindowMinimize, PhosphorAnimation::ProfilePaths::WindowMaximize}) {
+        if (packOwns(path)) {
+            owned.append(path);
+        }
+    }
+    return owned;
 }
 
 bool AnimationsPageController::setShaderOverride(const QString& path, const QString& effectId,

--- a/src/settings/qml/ActionListView.qml
+++ b/src/settings/qml/ActionListView.qml
@@ -444,6 +444,15 @@ ColumnLayout {
                     }
                 }
 
+                // Stock-animation conflict chip — same shared component (and
+                // therefore the same predicate and tree-suppression hide
+                // condition) as the rule editor's action row, so the saved-rule
+                // summary flags the conflict too, not just the editor.
+                StockAnimationConflictChip {
+                    action: actionDelegate._action
+                    animationsController: root.appSettings ? root.appSettings.animationsController : null
+                }
+
                 Item {
                     Layout.fillWidth: true
                 }

--- a/src/settings/qml/ActionRow.qml
+++ b/src/settings/qml/ActionRow.qml
@@ -479,7 +479,7 @@ ColumnLayout {
             Accessible.name: i18n("May run alongside the KDE animation for this event")
             ToolTip.visible: stockConflictHover.hovered
             ToolTip.delay: Kirigami.Units.toolTipDelay
-            ToolTip.text: row.action.event === "window.movement.maximize" ? i18n("A rule cannot turn off the KDE Maximize animation for matched windows. If it is enabled in System Settings → Desktop Effects, both animations will play together.") : i18n("A rule cannot turn off the KDE minimize animation (Magic Lamp or Squash) for matched windows. If one is enabled in System Settings → Desktop Effects, both animations will play together.")
+            ToolTip.text: row.action.event === "window.movement.maximize" ? i18n("A rule cannot turn off the KDE maximize animation for matched windows. If it is enabled in System Settings → Desktop Effects, both animations will play together.") : i18n("A rule cannot turn off the KDE minimize animation (Magic Lamp or Squash) for matched windows. If one is enabled in System Settings → Desktop Effects, both animations will play together.")
 
             HoverHandler {
                 id: stockConflictHover

--- a/src/settings/qml/ActionRow.qml
+++ b/src/settings/qml/ActionRow.qml
@@ -469,7 +469,15 @@ ColumnLayout {
         // warning above. Gated on a non-empty effectId: an empty override is
         // the "no shader" sentinel and removes the conflict instead.
         Kirigami.Icon {
-            readonly property bool _stockAnimationConflict: row.action.type === "overrideAnimationShader" && (row.action.effectId || "") !== "" && (row.action.event === "window.appearance.minimize" || row.action.event === "window.movement.maximize")
+            readonly property bool _stockAnimationConflict: {
+                if (row.action.type !== "overrideAnimationShader")
+                    return false;
+
+                if ((row.action.effectId || "") === "")
+                    return false;
+
+                return row.action.event === "window.appearance.minimize" || row.action.event === "window.movement.maximize";
+            }
 
             visible: _stockAnimationConflict
             Layout.alignment: Qt.AlignVCenter

--- a/src/settings/qml/ActionRow.qml
+++ b/src/settings/qml/ActionRow.qml
@@ -461,37 +461,13 @@ ColumnLayout {
         }
 
         // Stock-animation conflict chip — a per-window shader on the minimize
-        // or maximize event cannot suppress KDE's own effect for that event
-        // (unloading it is global, so the runtime only does that for packs
-        // assigned in the animation tree, never for rules). Both animations
-        // play for matched windows unless the user disables the stock effect
-        // themselves. Same chip-plus-tooltip shape as the incompatibility
-        // warning above. Gated on a non-empty effectId: an empty override is
-        // the "no shader" sentinel and removes the conflict instead.
-        Kirigami.Icon {
-            readonly property bool _stockAnimationConflict: {
-                if (row.action.type !== "overrideAnimationShader")
-                    return false;
-
-                if ((row.action.effectId || "") === "")
-                    return false;
-
-                return row.action.event === "window.appearance.minimize" || row.action.event === "window.movement.maximize";
-            }
-
-            visible: _stockAnimationConflict
-            Layout.alignment: Qt.AlignVCenter
-            Layout.preferredWidth: Kirigami.Units.iconSizes.small
-            Layout.preferredHeight: Kirigami.Units.iconSizes.small
-            source: "dialog-information"
-            Accessible.name: i18n("May run alongside the KDE animation for this event")
-            ToolTip.visible: stockConflictHover.hovered
-            ToolTip.delay: Kirigami.Units.toolTipDelay
-            ToolTip.text: row.action.event === "window.movement.maximize" ? i18n("A rule cannot turn off the KDE maximize animation for matched windows. If it is enabled in System Settings → Desktop Effects, both animations will play together.") : i18n("A rule cannot turn off the KDE minimize animation (Magic Lamp or Squash) for matched windows. If one is enabled in System Settings → Desktop Effects, both animations will play together.")
-
-            HoverHandler {
-                id: stockConflictHover
-            }
+        // or maximize event cannot suppress KDE's own effect for that event.
+        // Predicate, tooltip, and the tree-suppression hide condition all
+        // live in the shared component (also used by the read-only rule
+        // summary, ActionListView).
+        StockAnimationConflictChip {
+            action: row.action
+            animationsController: row.appSettings ? row.appSettings.animationsController : null
         }
 
         // One editor per parameter — the shape comes from the param `kind`,

--- a/src/settings/qml/ActionRow.qml
+++ b/src/settings/qml/ActionRow.qml
@@ -460,6 +460,32 @@ ColumnLayout {
             }
         }
 
+        // Stock-animation conflict chip — a per-window shader on the minimize
+        // or maximize event cannot suppress KDE's own effect for that event
+        // (unloading it is global, so the runtime only does that for packs
+        // assigned in the animation tree, never for rules). Both animations
+        // play for matched windows unless the user disables the stock effect
+        // themselves. Same chip-plus-tooltip shape as the incompatibility
+        // warning above. Gated on a non-empty effectId: an empty override is
+        // the "no shader" sentinel and removes the conflict instead.
+        Kirigami.Icon {
+            readonly property bool _stockAnimationConflict: row.action.type === "overrideAnimationShader" && (row.action.effectId || "") !== "" && (row.action.event === "window.appearance.minimize" || row.action.event === "window.movement.maximize")
+
+            visible: _stockAnimationConflict
+            Layout.alignment: Qt.AlignVCenter
+            Layout.preferredWidth: Kirigami.Units.iconSizes.small
+            Layout.preferredHeight: Kirigami.Units.iconSizes.small
+            source: "dialog-information"
+            Accessible.name: i18n("May run alongside the KDE animation for this event")
+            ToolTip.visible: stockConflictHover.hovered
+            ToolTip.delay: Kirigami.Units.toolTipDelay
+            ToolTip.text: row.action.event === "window.movement.maximize" ? i18n("A rule cannot turn off the KDE Maximize animation for matched windows. If it is enabled in System Settings → Desktop Effects, both animations will play together.") : i18n("A rule cannot turn off the KDE minimize animation (Magic Lamp or Squash) for matched windows. If one is enabled in System Settings → Desktop Effects, both animations will play together.")
+
+            HoverHandler {
+                id: stockConflictHover
+            }
+        }
+
         // One editor per parameter — the shape comes from the param `kind`,
         // never an action-type ladder. The param-editor Components are
         // declared as `property Component` on `row` (below) so the Loader

--- a/src/settings/qml/StockAnimationConflictChip.qml
+++ b/src/settings/qml/StockAnimationConflictChip.qml
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import org.kde.kirigami as Kirigami
+
+/**
+ * @brief Stock-animation conflict chip for rule actions.
+ *
+ * Shown next to an `overrideAnimationShader` action targeting the minimize
+ * or maximize event when KDE's own effect for that event will run alongside
+ * the rule's shader: a per-window rule cannot suppress the stock effect
+ * (unloading it is global, so the runtime only does that for packs assigned
+ * in the animation tree, never for rules). The chip therefore HIDES when a
+ * tree-assigned pack already owns the event — the stock effect is unloaded
+ * session-wide then, and there is no double-animation left to warn about
+ * (`AnimationsPageController.stockSuppressedEvents` mirrors the compositor's
+ * suppression gate and notifies on tree / registry / master-toggle changes).
+ * With no controller available the chip falls back to warning on the basic
+ * predicate alone. Gated on a non-empty effectId: an empty override is the
+ * "no shader" sentinel and removes the conflict instead.
+ *
+ * Shared by the rule editor's action row and the read-only rule summary so
+ * the two surfaces cannot drift. Same chip-plus-tooltip shape as the
+ * editor's type-incompatibility warning.
+ */
+Kirigami.Icon {
+    id: chip
+
+    /// The action JSON — `{ type, event, effectId, ... }`.
+    required property var action
+    /// AnimationsPageController, or null while the page is still wiring up.
+    property var animationsController: null
+
+    readonly property bool _conflict: {
+        if (!chip.action || chip.action.type !== "overrideAnimationShader")
+            return false;
+
+        if ((chip.action.effectId || "") === "")
+            return false;
+
+        if (chip.action.event !== "window.appearance.minimize" && chip.action.event !== "window.movement.maximize")
+            return false;
+
+        var suppressed = chip.animationsController ? chip.animationsController.stockSuppressedEvents : [];
+        return suppressed.indexOf(chip.action.event) === -1;
+    }
+
+    visible: _conflict
+    Layout.alignment: Qt.AlignVCenter
+    Layout.preferredWidth: Kirigami.Units.iconSizes.small
+    Layout.preferredHeight: Kirigami.Units.iconSizes.small
+    source: "dialog-information"
+    Accessible.name: i18n("May run alongside the KDE animation for this event")
+    ToolTip.visible: conflictHover.hovered
+    ToolTip.delay: Kirigami.Units.toolTipDelay
+    ToolTip.text: chip.action && chip.action.event === "window.movement.maximize" ? i18n("A rule cannot turn off the KDE maximize animation for matched windows. If it is enabled in System Settings → Desktop Effects, both animations will play together.") : i18n("A rule cannot turn off the KDE minimize animation (Magic Lamp or Squash) for matched windows. If one is enabled in System Settings → Desktop Effects, both animations will play together.")
+
+    HoverHandler {
+        id: conflictHover
+    }
+}

--- a/tests/unit/settings/test_animations_page_controller.cpp
+++ b/tests/unit/settings/test_animations_page_controller.cpp
@@ -29,10 +29,15 @@
 
 #include <PhosphorAnimation/Profile.h>
 #include <PhosphorAnimation/ProfilePaths.h>
+#include <PhosphorAnimation/ShaderProfile.h>
+#include <PhosphorAnimation/ShaderProfileTree.h>
 
+#include "../helpers/IsolatedConfigGuard.h"
+#include "config/settings.h"
 #include "settings/animationspagecontroller.h"
 
 using namespace PlasmaZones;
+using PlasmaZones::TestHelpers::IsolatedConfigGuard;
 
 namespace {
 
@@ -625,6 +630,63 @@ private Q_SLOTS:
         // Empty path / nonsense path.
         QVERIFY(!c.supportsShaderLeg(QString()));
         QVERIFY(!c.supportsShaderLeg(QStringLiteral("../etc/passwd")));
+    }
+
+    // ─── Stock-animation suppression mirror ───────────────────────────────
+
+    /// `stockSuppressedEvents` is the settings-side mirror of the
+    /// compositor's syncStockEffectSuppression ownership gate; the rule
+    /// editor's stock-animation conflict chip hides for listed events. Pin
+    /// the gate's three inputs: tree assignment (a tree-resolved effectId
+    /// on the minimize/maximize path lists the event; with a null registry
+    /// the unknown id gets the warm-up grace and counts as owned), the
+    /// animations master toggle (off collapses the list to empty), and the
+    /// NOTIFY wiring (both inputs fire stockSuppressedEventsChanged so the
+    /// chip bindings re-evaluate).
+    void stockSuppressedEvents_reflectsTreeAndMasterToggle()
+    {
+        IsolatedConfigGuard guard;
+        Settings s;
+        s.setAnimationsEnabled(true);
+        AnimationsPageController c(nullptr, &s);
+
+        // No tree assignment: nothing suppressed, no conflict-free events.
+        QVERIFY(c.stockSuppressedEvents().isEmpty());
+
+        QSignalSpy spy(&c, &AnimationsPageController::stockSuppressedEventsChanged);
+
+        // Tree-assign a minimize pack. The controller was built with a null
+        // registry, so the effectId is unknown and the warm-up grace counts
+        // it as owned (mirroring resolvedShaderProfile's grace).
+        PhosphorAnimationShaders::ShaderProfileTree tree;
+        PhosphorAnimationShaders::ShaderProfile profile;
+        profile.effectId = QStringLiteral("genie");
+        tree.setOverride(PhosphorAnimation::ProfilePaths::WindowMinimize, profile);
+        s.setShaderProfileTree(tree);
+
+        QVERIFY2(spy.count() >= 1, "tree change must notify the chip bindings");
+        // Minimize is owned; maximize (unassigned) is not.
+        QCOMPARE(c.stockSuppressedEvents(), QStringList{PhosphorAnimation::ProfilePaths::WindowMinimize});
+
+        // Assigning the maximize path too lists both events.
+        tree.setOverride(PhosphorAnimation::ProfilePaths::WindowMaximize, profile);
+        s.setShaderProfileTree(tree);
+        QCOMPARE(c.stockSuppressedEvents(),
+                 (QStringList{PhosphorAnimation::ProfilePaths::WindowMinimize,
+                              PhosphorAnimation::ProfilePaths::WindowMaximize}));
+
+        // Master toggle off gates the whole predicate: nothing is owned and
+        // the change is notified, so every chip comes back.
+        const int beforeToggle = spy.count();
+        s.setAnimationsEnabled(false);
+        QVERIFY2(spy.count() > beforeToggle, "master-toggle flip must notify the chip bindings");
+        QVERIFY(c.stockSuppressedEvents().isEmpty());
+
+        // Toggle back on: ownership returns.
+        s.setAnimationsEnabled(true);
+        QCOMPARE(c.stockSuppressedEvents(),
+                 (QStringList{PhosphorAnimation::ProfilePaths::WindowMinimize,
+                              PhosphorAnimation::ProfilePaths::WindowMaximize}));
     }
 };
 

--- a/tests/unit/settings/test_animations_page_controller.cpp
+++ b/tests/unit/settings/test_animations_page_controller.cpp
@@ -3,14 +3,20 @@
 
 /**
  * @file test_animations_page_controller.cpp
- * @brief Path-discovery + override-CRUD tests for AnimationsPageController.
+ * @brief AnimationsPageController behaviour pins: path discovery,
+ *        override CRUD, the shader-leg support gate, and the
+ *        stock-animation suppression mirror.
  *
  * Pins the file-per-path persistence model: setOverride writes one JSON
  * file under `<userProfilesDir>/<path>.json`, clearOverride deletes it,
  * resolvedProfile walks the parent chain and fills library defaults.
+ * The suppression-mirror slots pin `stockSuppressedEvents` (the
+ * settings-side twin of the compositor's syncStockEffectSuppression
+ * ownership gate) and its NOTIFY inputs.
  *
- * Uses `setUserProfilesDirOverride()` to redirect file I/O into a
- * tmpdir so the test never touches the real user XDG dir.
+ * Uses `setUserProfilesDirOverride()` to redirect override-file I/O into
+ * a tmpdir, and `IsolatedConfigGuard` where a real Settings is needed, so
+ * the test never touches the real user XDG dirs.
  *
  * Companion test files:
  *   - test_animations_motion_sets.cpp      — preset / motion-set / pending
@@ -24,9 +30,11 @@
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
+#include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
 
+#include <PhosphorAnimation/AnimationShaderRegistry.h>
 #include <PhosphorAnimation/Profile.h>
 #include <PhosphorAnimation/ProfilePaths.h>
 #include <PhosphorAnimation/ShaderProfile.h>
@@ -47,6 +55,29 @@ QString readFile(const QString& path)
     if (!f.open(QIODevice::ReadOnly))
         return {};
     return QString::fromUtf8(f.readAll());
+}
+
+/// Author a minimal animation pack `<root>/<subdir>/metadata.json` plus an
+/// effect.frag stub so the registry's scan accepts it (mirrors the
+/// decoration-page test fixture). An empty @p appliesTo omits the field,
+/// which loads the pack as universal (applies to every single-surface
+/// class); a non-empty array constrains it to the listed event classes.
+bool writeAnimationPack(const QString& root, const QString& subdir, const QJsonArray& appliesTo)
+{
+    const QString packDir = root + QLatin1Char('/') + subdir;
+    if (!QDir().mkpath(packDir))
+        return false;
+    QJsonObject metadata{{QLatin1String("id"), subdir},
+                         {QLatin1String("name"), subdir},
+                         {QLatin1String("fragmentShader"), QStringLiteral("effect.frag")},
+                         {QLatin1String("parameters"), QJsonArray{}}};
+    if (!appliesTo.isEmpty())
+        metadata.insert(QLatin1String("appliesTo"), appliesTo);
+    QFile meta(packDir + QStringLiteral("/metadata.json"));
+    if (!meta.open(QIODevice::WriteOnly | QIODevice::Truncate) || meta.write(QJsonDocument(metadata).toJson()) < 0)
+        return false;
+    QFile frag(packDir + QStringLiteral("/effect.frag"));
+    return frag.open(QIODevice::WriteOnly | QIODevice::Truncate) && frag.write(QByteArrayLiteral("// stub\n")) > 0;
 }
 
 } // namespace
@@ -687,6 +718,53 @@ private Q_SLOTS:
         QCOMPARE(c.stockSuppressedEvents(),
                  (QStringList{PhosphorAnimation::ProfilePaths::WindowMinimize,
                               PhosphorAnimation::ProfilePaths::WindowMaximize}));
+    }
+
+    /// Registry-backed half of the gate: a KNOWN pack is owned only when its
+    /// contract class applies to the event (the compositor refuses to run a
+    /// mismatched pack, so the stock effect stays loaded and the conflict
+    /// chip must show), and a committed registry rescan fires the third
+    /// NOTIFY input so the chip bindings re-evaluate.
+    void stockSuppressedEvents_registryContractGateAndNotify()
+    {
+        IsolatedConfigGuard guard;
+        QTemporaryDir tmp;
+        QVERIFY(tmp.isValid());
+        // Universal pack (no appliesTo) applies to the appearance-class
+        // minimize path; the desktop-only pack is a two-texture contract
+        // that never runs on a single-surface window event.
+        QVERIFY(writeAnimationPack(tmp.path(), QStringLiteral("universal-pack"), {}));
+        QVERIFY(writeAnimationPack(tmp.path(), QStringLiteral("desktop-pack"), QJsonArray{QStringLiteral("desktop")}));
+        PhosphorAnimationShaders::AnimationShaderRegistry registry;
+        registry.addSearchPaths(QStringList{tmp.path()}, PhosphorFsLoader::LiveReload::Off);
+        QVERIFY(registry.hasEffect(QStringLiteral("universal-pack")));
+        QVERIFY(registry.hasEffect(QStringLiteral("desktop-pack")));
+
+        Settings s;
+        s.setAnimationsEnabled(true);
+        AnimationsPageController c(&registry, &s);
+        QSignalSpy spy(&c, &AnimationsPageController::stockSuppressedEventsChanged);
+
+        // Known, class-compatible pack: owned.
+        PhosphorAnimationShaders::ShaderProfileTree tree;
+        PhosphorAnimationShaders::ShaderProfile profile;
+        profile.effectId = QStringLiteral("universal-pack");
+        tree.setOverride(PhosphorAnimation::ProfilePaths::WindowMinimize, profile);
+        s.setShaderProfileTree(tree);
+        QCOMPARE(c.stockSuppressedEvents(), QStringList{PhosphorAnimation::ProfilePaths::WindowMinimize});
+
+        // Known, class-INCOMPATIBLE pack: not owned, chip stays visible.
+        profile.effectId = QStringLiteral("desktop-pack");
+        tree.setOverride(PhosphorAnimation::ProfilePaths::WindowMinimize, profile);
+        s.setShaderProfileTree(tree);
+        QVERIFY(c.stockSuppressedEvents().isEmpty());
+
+        // Third NOTIFY input: a committed rescan (a new pack changes the
+        // scan fingerprint) re-fires the chip rebind signal.
+        const int beforeRescan = spy.count();
+        QVERIFY(writeAnimationPack(tmp.path(), QStringLiteral("late-pack"), {}));
+        registry.refresh();
+        QTRY_VERIFY2(spy.count() > beforeRescan, "registry rescan must notify the chip bindings");
     }
 };
 


### PR DESCRIPTION
## Summary

Discussion #816 reported frozen and corrupted KDE minimize/restore animations on PlasmaZones 3.2.5. Investigation (support report + frame-by-frame recording analysis + a three-agent code audit) pinned two independent defects plus a coexistence gap, all fixed here.

### Root cause fixes (the reported bug — no PZ packs assigned)

- **Frozen magic lamp + black smears on minimize**: the debounced minimize-float placement flip re-resolved the window's decoration while KWin's magic lamp was still painting it, and `updateWindowDecoration`'s `isMinimized()` gate tore the OffscreenEffect redirect and its GL working set out from under the in-flight animation (the teardown guard only recognizes our own transitions). A minimized window is only `isVisible()` while some effect holds an `EffectWindowVisibleRef` on it, so the teardown now defers at function entry (before the remove-first touches state) and polls until the animation drops its ref or the window unminimizes.
- **Cancelled/stuttering restore animation**: the unminimize path committed the unfloat immediately, and the resulting retile's `applyWindowGeometry` moveResize landed mid-flight and cancelled the stock unminimize animation (KWin's maximize script self-cancels on a mid-flight resize the same way). The commit is now deferred by an `Effect::animationTime`-scaled grace, revalidated at fire time, and cancelled by a re-minimize, with all state mutation moved to the commit. Implemented for **both engines**: autotile (`AutotileHandler`) and snapping (`SnapHandler`, where the restore-net queries keep their dispatch-before-unfloat ordering inside the deferred commit).

### Coexistence for PZ minimize/maximize packs

PZ's own minimize transition holds only a paint-enable `EffectWindowVisibleRef` (which keeps the surface alive for *both* renderers) and maximize held nothing, while KWin's magic lamp / squash / maximize honor no per-window grab role (unlike the open/close builtins). The desktop-peek stock-effect suppression is generalized into `syncStockEffectSuppression` with three groups behind one runnability gate:

| PZ event with a pack assigned | KWin stock effects unloaded |
|---|---|
| `desktop.peek` (existing) | `windowaperture`, `eyeonscreen` |
| `window.minimize` | `magiclamp`, `squash` |
| `window.maximize` | `maximize` |

Only effects we unloaded are recorded and restored; tree-assigned packs only (a per-app rule cannot drive a global unload). The rule editor now shows an info chip when a rule assigns a minimize/maximize shader, explaining that the stock effect will run alongside it unless disabled in System Settings.

### Performance

The `windowFrameGeometryChanged` handler ran the `shouldHandleWindow` exclusion gate (an uncached rule resolve over a freshly built ~30-accessor query) plus the decoration resync on every geometry tick before the 50ms debounce. The user's log showed 400-500 resolves/s against a 13-rule slice on the compositor thread during animations. Both now run once per debounced flush.

## Testing

- Full build clean, 291/291 ctest pass (the one skip is the opt-in GPU orientation test).
- Runtime verification of the animation interplay needs an installed effect + relogin (effect .so does not hot-reload); please verify the #816 repro: autotile + borders (tiled scope) + magic lamp, minimize/restore with 2+ tiled windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)