### PR TITLE
fix(settings): keep the curve editor in simple mode's global defaults

### DIFF
--- a/src/settings/qml/AnimationProfileEditor.qml
+++ b/src/settings/qml/AnimationProfileEditor.qml
@@ -253,7 +253,8 @@ ColumnLayout {
         }
 
         // Simple-mode spring stand-in: with the timing-mode machinery hidden
-        // and a spring profile active (set via the global defaults editor or
+        // and a spring profile active (set in the Global animation defaults
+        // card, which keeps its full editor in simple mode, or on this event
         // in advanced mode), the Duration row below also hides — without this
         // hint the timing section would render silently empty.
         Label {
@@ -261,12 +262,12 @@ ColumnLayout {
             Layout.leftMargin: Kirigami.Units.largeSpacing
             Layout.rightMargin: Kirigami.Units.largeSpacing
             visible: root.simpleTiming && root.timingMode === CurvePresets.timingModeSpring
-            // Path-neutral wording. This editor is also hosted by
-            // GlobalTimingDefaultsCard, which is the ROOT of the inheritance
-            // tree and inherits from nothing, so "the inherited spring curve"
-            // was false there. It also has to say how to get out: in simple
-            // mode a stored spring makes duration genuinely unreachable.
-            text: i18n("A spring curve is set, so the duration has no effect. Switch to Advanced in the sidebar to change the curve.")
+            // Path-neutral wording: the spring can come from the Global
+            // defaults card or from an override this event owns, and the
+            // hint has to name a way out of both. The Global card is the
+            // first stop because it is right there on the same page, and
+            // Advanced covers the per-event override the card cannot show.
+            text: i18n("A spring curve is set, so the duration has no effect. Change the curve in Global animation defaults, or switch to Advanced in the sidebar to change it for this event.")
             font.italic: true
             color: Kirigami.Theme.disabledTextColor
             wrapMode: Text.WordWrap

--- a/src/settings/qml/AnimationsSimplePage.qml
+++ b/src/settings/qml/AnimationsSimplePage.qml
@@ -49,9 +49,12 @@ AnimationEventCardList {
     // The shared GlobalTimingDefaultsCard (curve summary + Customize,
     // Easing/Spring, Duration), the same component the advanced General page
     // hosts — without that page's sequencing / stagger / minimum-distance
-    // rows, which it appends as its own children. The editor drives the
-    // Global profile every card below inherits from; a per-card Duration
-    // overrides it for that event group.
+    // rows, which it appends as its own children. It keeps its FULL timing
+    // editor here even though the cards below are trimmed: the curve is
+    // chosen once, globally, and every grouped card inherits it, so this is
+    // the one place simple mode needs it. The editor drives the Global
+    // profile every card below inherits from; a per-card Duration overrides
+    // it for that event group.
     headerComponent: Component {
         ColumnLayout {
             spacing: Kirigami.Units.smallSpacing
@@ -60,9 +63,6 @@ AnimationEventCardList {
                 Layout.fillWidth: true
                 cardSettings: simplePage.globalSettings
                 collapsible: false
-                // Match the cards below: simple mode is duration-only, so the
-                // Global card must not be the one place Spring can be chosen.
-                simpleTiming: simplePage.simpleTiming
             }
 
             // The same animation window filter the advanced General page

--- a/src/settings/qml/GlobalTimingDefaultsCard.qml
+++ b/src/settings/qml/GlobalTimingDefaultsCard.qml
@@ -15,7 +15,11 @@ import org.kde.kirigami as Kirigami
  * Animations page, so the spring encode/parse round-trip and the
  * seed/commit guards exist once. Consumers append their own rows below the
  * editor as default children (the General page's sequencing / stagger /
- * minimum-distance rows); the simple page passes none.
+ * minimum-distance rows); the simple page passes none. The timing editor is
+ * the FULL one in both hosts (curve summary, Customize dialog,
+ * Easing/Spring, Duration) even though simple mode trims the per-event cards
+ * below it: the curve is a global choice every card inherits, so simple mode
+ * still needs one place to make it.
  *
  * Timing state is cached per axis (`_lastEasingCurve` vs
  * `_lastSpringOmega`/`_lastSpringZeta`) so toggling Easing ↔ Spring
@@ -29,13 +33,6 @@ SettingsCard {
 
     /// The ISettings object holding the global animation profile.
     required property QtObject cardSettings
-    /// Trims the timing editor to what simple mode exposes, matching the
-    /// AnimationEventCard.simpleTiming the cards below this one use. Without
-    /// it this card would still offer Easing/Spring and the curve editor while
-    /// every card under it hides them: picking Spring here seeds those cards to
-    /// spring, which hides their Duration row, leaving simple mode with no
-    /// reachable timing control at all until the user switches to Advanced.
-    property bool simpleTiming: false
     /// Extra rows appended below the timing editor. Aliased to `children`
     /// rather than `data` so it agrees with the empty-slot collapse below,
     /// which measures visual children: `data` also accepts non-Item objects
@@ -173,7 +170,6 @@ SettingsCard {
 
             Layout.fillWidth: true
             enabled: card.toggleChecked
-            simpleTiming: card.simpleTiming
             // The Global default has no shader leg in this UI — shader
             // overrides live on the per-event and Rules layers.
             shaderLegSupported: false


### PR DESCRIPTION
## Summary

Simple mode forwarded its duration-only timing trim to the **Global animation defaults** card as well as to the grouped event cards, so the curve thumbnail, the Customize dialog and the Easing/Spring choice were unreachable without switching to Advanced. The curve is a global choice every card inherits, so the Global card is exactly where simple mode still needs it.

- `AnimationsSimplePage.qml` no longer forwards `simpleTiming` to `GlobalTimingDefaultsCard`. The page still sets it, so the grouped event cards keep the duration + shader shape.
- `GlobalTimingDefaultsCard.qml` drops the `simpleTiming` property and its forward; the simple page was its only setter.
- The event cards' spring stand-in hint used to say "switch to Advanced" because a spring made duration unreachable there. It now points at the Global animation defaults card first, naming Advanced only for a per-event override.

## Test plan

- `cmake --build build` clean.
- `ctest` 300/300 passing (one GPU test skipped as usual).
- Settings → Animations in simple mode: Global animation defaults shows curve thumbnail, Customize…, Timing mode and Duration; the event cards below show Duration + shader only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)