### PR TITLE
fix(settings): layout context menu, listing-page scroll jumps, duplicate layout refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - **Shortcut cheatsheet overlay**: a new overlay that lists every PlasmaZones global shortcut with the keys you actually have bound, grouped by category. Open it with Meta+Alt+/ (rebindable in System Settings) and dismiss it with Escape, a backdrop click, or the shortcut again. The sheet is mode aware. Shortcuts that do nothing in the current tiling mode are hidden, and it updates live when you switch modes or rebind a key. Shortcuts you have unbound stay listed as unassigned so you can discover them ([#810](https://github.com/fuddlesworth/PlasmaZones/pull/810)).
 
+### Fixed
+
+- **The layout right-click menu works again**: right-clicking a layout and choosing "Set as Default" or "Hide from Zone Selector" did nothing, because the menu never received the settings it needed to act on ([#827](https://github.com/fuddlesworth/PlasmaZones/pull/827)).
+- **Editing a layout no longer scrolls the page back to the top**: hiding a layout, changing its auto-assign, or picking an aspect ratio while scrolled down threw the Layouts page back to the top. The page now holds its position while the cards rebuild. The Shaders pages keep their position across a group or sort change for the same reason ([#827](https://github.com/fuddlesworth/PlasmaZones/pull/827)).
+- **Layout cards no longer flicker when you change one**: toggling a layout's visibility or auto-assign briefly redrew every card without its badges, and the one you just changed snapped back before it took. Each change now refreshes the list once, with everything in place ([#827](https://github.com/fuddlesworth/PlasmaZones/pull/827)).
+- **Overlay shaders with a depth buffer render cleanly**: the Neon City and Voxel Terrain overlays asked the graphics driver to read and write the same depth texture in one drawing pass, which it refused ([#827](https://github.com/fuddlesworth/PlasmaZones/pull/827)).
+
 ## [3.2.7] - 2026-07-21
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1710,6 +1710,13 @@ Initial packaged release. Wayland-only (X11 support removed). Requires KDE Plasm
 - Session restoration and rotation after login ([#66])
 - Window tracking: snap/restore behavior, zone clearing, startup timing, rotation zone ID matching, floating window exclusion ([#67])
 
+[3.2.7]: https://github.com/fuddlesworth/PlasmaZones/compare/v3.2.6...v3.2.7
+[3.2.6]: https://github.com/fuddlesworth/PlasmaZones/compare/v3.2.5...v3.2.6
+[3.2.5]: https://github.com/fuddlesworth/PlasmaZones/compare/v3.2.4...v3.2.5
+[3.2.4]: https://github.com/fuddlesworth/PlasmaZones/compare/v3.2.3...v3.2.4
+[3.2.3]: https://github.com/fuddlesworth/PlasmaZones/compare/v3.2.2...v3.2.3
+[3.2.2]: https://github.com/fuddlesworth/PlasmaZones/compare/v3.2.1...v3.2.2
+[3.2.1]: https://github.com/fuddlesworth/PlasmaZones/compare/v3.2.0...v3.2.1
 [3.2.0]: https://github.com/fuddlesworth/PlasmaZones/compare/v3.1.3...v3.2.0
 [3.1.3]: https://github.com/fuddlesworth/PlasmaZones/compare/v3.1.2...v3.1.3
 [3.1.2]: https://github.com/fuddlesworth/PlasmaZones/compare/v3.1.1...v3.1.2
@@ -1733,6 +1740,12 @@ Initial packaged release. Wayland-only (X11 support removed). Requires KDE Plasm
 [3.0.2]: https://github.com/fuddlesworth/PlasmaZones/compare/v3.0.1...v3.0.2
 [3.0.1]: https://github.com/fuddlesworth/PlasmaZones/compare/v3.0.0...v3.0.1
 [3.0.0]: https://github.com/fuddlesworth/PlasmaZones/compare/v2.8.7...v3.0.0
+[2.8.8]: https://github.com/fuddlesworth/PlasmaZones/compare/v2.8.7...v2.8.8
+[2.8.7]: https://github.com/fuddlesworth/PlasmaZones/compare/v2.8.6...v2.8.7
+[2.8.6]: https://github.com/fuddlesworth/PlasmaZones/compare/v2.8.5...v2.8.6
+[2.8.5]: https://github.com/fuddlesworth/PlasmaZones/compare/v2.8.4...v2.8.5
+[2.8.4]: https://github.com/fuddlesworth/PlasmaZones/compare/v2.8.3...v2.8.4
+[2.8.3]: https://github.com/fuddlesworth/PlasmaZones/compare/v2.8.2...v2.8.3
 [2.8.2]: https://github.com/fuddlesworth/PlasmaZones/compare/v2.8.1...v2.8.2
 [2.8.1]: https://github.com/fuddlesworth/PlasmaZones/compare/v2.8.0...v2.8.1
 [2.8.0]: https://github.com/fuddlesworth/PlasmaZones/compare/v2.7.1...v2.8.0

--- a/libs/phosphor-rendering/include/PhosphorRendering/ShaderNodeRhi.h
+++ b/libs/phosphor-rendering/include/PhosphorRendering/ShaderNodeRhi.h
@@ -359,14 +359,33 @@ private:
     void releaseRhiResources();
     void appendUserTextureBindings(QVector<QRhiShaderResourceBinding>& bindings) const;
     void appendWallpaperBinding(QVector<QRhiShaderResourceBinding>& bindings) const;
-    void appendDepthBinding(QVector<QRhiShaderResourceBinding>& bindings) const;
+    /// How the pass an SRB belongs to touches the depth texture.
+    ///
+    /// Every buffer render target carries the depth texture as its second
+    /// colour attachment (ensureBufferResources), so a buffer pass WRITES it.
+    /// Binding it as a sampled texture in that same pass's SRB is a read and a
+    /// write of one texture inside a single render pass, which QRhi rejects
+    /// ("Texture ... used with different accesses within the same pass, this is
+    /// not allowed") — it showed up on the overlay packs that pair `multipass`
+    /// with `depthBuffer` (neon-city, voxel-terrain). Those buffer shaders only
+    /// ever write depth (`layout(location = 1) out float oDepth`); reading it
+    /// back is the image pass's job, and the depth.glsl helper lives on the
+    /// image side. So a writing pass gets the dummy texture at binding 12 —
+    /// a valid binding for a shader that includes depth.glsl anyway, rather
+    /// than a missing one.
+    enum class DepthAccess {
+        Sampled, ///< Image pass: binds the real depth texture.
+        WrittenThisPass ///< Buffer pass: depth is an attachment, bind the dummy.
+    };
+    void appendDepthBinding(QVector<QRhiShaderResourceBinding>& bindings, DepthAccess access) const;
     void appendExtraBindings(QVector<QRhiShaderResourceBinding>& bindings) const;
     void appendAudioBinding(QVector<QRhiShaderResourceBinding>& bindings) const;
     /// UBO at binding 0 + consumer-managed extra bindings (e.g. binding 1).
     void appendUboAndExtraBindings(QVector<QRhiShaderResourceBinding>& bindings) const;
     /// Bindings 6 (audio), 7-10 (user textures), 11 (wallpaper), 12 (depth) —
-    /// shared trailer between buffer-pass and image-pass SRBs.
-    void appendCommonTrailerBindings(QVector<QRhiShaderResourceBinding>& bindings) const;
+    /// shared trailer between buffer-pass and image-pass SRBs. @p depthAccess
+    /// is the one thing the two differ on; see DepthAccess.
+    void appendCommonTrailerBindings(QVector<QRhiShaderResourceBinding>& bindings, DepthAccess depthAccess) const;
     void resetAllBindingsAndPipelines();
     void bakeBufferShaders();
     QString loadAndExpandShader(const QString& path, QString* outError);

--- a/libs/phosphor-rendering/include/PhosphorRendering/ShaderNodeRhi.h
+++ b/libs/phosphor-rendering/include/PhosphorRendering/ShaderNodeRhi.h
@@ -362,7 +362,7 @@ private:
     /// How the pass an SRB belongs to touches the depth texture.
     ///
     /// Every buffer render target carries the depth texture as its second
-    /// colour attachment (ensureBufferResources), so a buffer pass WRITES it.
+    /// colour attachment (ensureBufferTarget), so a buffer pass WRITES it.
     /// Binding it as a sampled texture in that same pass's SRB is a read and a
     /// write of one texture inside a single render pass, which QRhi rejects
     /// ("Texture ... used with different accesses within the same pass, this is

--- a/libs/phosphor-rendering/src/shadernoderhipipeline.cpp
+++ b/libs/phosphor-rendering/src/shadernoderhipipeline.cpp
@@ -310,7 +310,7 @@ bool ShaderNodeRhi::ensureBufferPipeline()
                             2 + j, QRhiShaderResourceBinding::FragmentStage, tex, sam));
                     }
                 }
-                appendCommonTrailerBindings(bindings);
+                appendCommonTrailerBindings(bindings, DepthAccess::WrittenThisPass);
                 srb->setBindings(bindings.begin(), bindings.end());
                 if (!srb->create()) {
                     m_shaderError = QStringLiteral("Failed to create multi-buffer pass SRB ") + QString::number(i);
@@ -373,7 +373,7 @@ bool ShaderNodeRhi::ensureBufferPipeline()
                     2 + ch, QRhiShaderResourceBinding::FragmentStage, tex, sam));
             }
         }
-        appendCommonTrailerBindings(bindings);
+        appendCommonTrailerBindings(bindings, DepthAccess::WrittenThisPass);
         srb->setBindings(bindings.begin(), bindings.end());
         return srb->create() ? std::move(srb) : nullptr;
     };
@@ -452,7 +452,7 @@ bool ShaderNodeRhi::ensurePipeline()
                     2 + ch, QRhiShaderResourceBinding::FragmentStage, tex, sam));
             }
         }
-        appendCommonTrailerBindings(bindings);
+        appendCommonTrailerBindings(bindings, DepthAccess::Sampled);
         srb->setBindings(bindings.begin(), bindings.end());
         return srb->create() ? std::move(srb) : nullptr;
     };
@@ -471,7 +471,7 @@ bool ShaderNodeRhi::ensurePipeline()
                     2 + i, QRhiShaderResourceBinding::FragmentStage, tex, sam));
             }
         }
-        appendCommonTrailerBindings(bindings);
+        appendCommonTrailerBindings(bindings, DepthAccess::Sampled);
         srb->setBindings(bindings.begin(), bindings.end());
         return srb->create() ? std::move(srb) : nullptr;
     };
@@ -612,12 +612,13 @@ void ShaderNodeRhi::appendUboAndExtraBindings(QVector<QRhiShaderResourceBinding>
     appendExtraBindings(bindings);
 }
 
-void ShaderNodeRhi::appendCommonTrailerBindings(QVector<QRhiShaderResourceBinding>& bindings) const
+void ShaderNodeRhi::appendCommonTrailerBindings(QVector<QRhiShaderResourceBinding>& bindings,
+                                                DepthAccess depthAccess) const
 {
     appendAudioBinding(bindings);
     appendUserTextureBindings(bindings);
     appendWallpaperBinding(bindings);
-    appendDepthBinding(bindings);
+    appendDepthBinding(bindings, depthAccess);
 }
 
 void ShaderNodeRhi::appendWallpaperBinding(QVector<QRhiShaderResourceBinding>& bindings) const
@@ -628,12 +629,21 @@ void ShaderNodeRhi::appendWallpaperBinding(QVector<QRhiShaderResourceBinding>& b
     }
 }
 
-void ShaderNodeRhi::appendDepthBinding(QVector<QRhiShaderResourceBinding>& bindings) const
+void ShaderNodeRhi::appendDepthBinding(QVector<QRhiShaderResourceBinding>& bindings, DepthAccess access) const
 {
-    if (m_useDepthBuffer && m_depthTexture && m_depthSampler) {
-        bindings.append(QRhiShaderResourceBinding::sampledTexture(12, QRhiShaderResourceBinding::FragmentStage,
-                                                                  m_depthTexture.get(), m_depthSampler.get()));
+    if (!m_useDepthBuffer || !m_depthTexture || !m_depthSampler) {
+        return;
     }
+    // A pass that writes the depth attachment must not also sample it — see
+    // DepthAccess. Substitute the dummy so binding 12 stays populated for a
+    // buffer shader that pulls in depth.glsl regardless.
+    const bool writes = access == DepthAccess::WrittenThisPass;
+    QRhiTexture* tex = writes ? m_dummyChannelTexture.get() : m_depthTexture.get();
+    QRhiSampler* sam = writes ? m_dummyChannelSampler.get() : m_depthSampler.get();
+    if (!tex || !sam) {
+        return;
+    }
+    bindings.append(QRhiShaderResourceBinding::sampledTexture(12, QRhiShaderResourceBinding::FragmentStage, tex, sam));
 }
 
 void ShaderNodeRhi::appendExtraBindings(QVector<QRhiShaderResourceBinding>& bindings) const

--- a/src/settings/qml/LayoutsPage.qml
+++ b/src/settings/qml/LayoutsPage.qml
@@ -131,6 +131,10 @@ SettingsFlickable {
     }
 
     function rebuildModel() {
+        // Hold the current height across the delegate teardown the model swap
+        // below causes, or the page snaps to the top whenever a layout is
+        // edited while scrolled down.
+        root.holdContentHeight();
         let allLayouts = settingsController.layouts;
         let filtered = [];
         for (let i = 0; i < allLayouts.length; i++) {
@@ -242,7 +246,10 @@ SettingsFlickable {
         return Core.ungrouped(filtered, i18n("All layouts"));
     }
 
-    contentHeight: content.implicitHeight
+    // `naturalContentHeight`, not `contentHeight`: rebuildModel() swaps the
+    // whole group model, which tears every card down for a few frames. See the
+    // model-swap scroll guard in SettingsFlickable.
+    naturalContentHeight: content.implicitHeight
     clip: true
 
     Component.onCompleted: {

--- a/src/settings/qml/Main.qml
+++ b/src/settings/qml/Main.qml
@@ -23,6 +23,15 @@ PhosphorUi.SettingsAppWindow {
     id: window
 
     // ── Public API used by per-page QML files ───────────────────────
+    // The `settingsController` / `appSettings` context properties from
+    // main.cpp, re-exposed under distinct names. A child that declares a
+    // required property of the SAME name cannot be wired with
+    // `Foo { appSettings: appSettings }`: the right-hand side resolves
+    // against Foo's own scope first, so the binding points the property at
+    // itself and it stays undefined (context properties sit at the bottom
+    // of the lookup order). Wire such children from these names instead.
+    readonly property var controllerContext: settingsController
+    readonly property var appSettingsContext: appSettings
     // Pages reach the layout-context popup via window.layoutContextMenu.
     readonly property alias layoutContextMenu: layoutContextMenu
     // GeneralPage's "Reset to Defaults" button reaches the chrome-owned
@@ -660,8 +669,8 @@ PhosphorUi.SettingsAppWindow {
     LayoutContextMenu {
         id: layoutContextMenu
 
-        settingsController: settingsController
-        appSettings: appSettings
+        settingsController: window.controllerContext
+        appSettings: window.appSettingsContext
         aspectRatioLabels: window.aspectRatioLabels
     }
 
@@ -729,10 +738,10 @@ PhosphorUi.SettingsAppWindow {
     // ── Keyboard-shortcut overlay ───────────────────────────────────
     KeyboardShortcutOverlay {
         parent: window.contentItem
-        // `appSettings` is the context property exposed by main.cpp;
-        // pass it explicitly through the new required property so the
-        // overlay no longer relies on the implicit context-name match.
-        appSettings: appSettings
+        // `appSettings` is the context property exposed by main.cpp,
+        // reached through window.appSettingsContext because the overlay's
+        // own required property of that name shadows the context one.
+        appSettings: window.appSettingsContext
         shown: window._showShortcuts
         onDismiss: window._showShortcuts = false
     }

--- a/src/settings/qml/Main.qml
+++ b/src/settings/qml/Main.qml
@@ -30,8 +30,11 @@ PhosphorUi.SettingsAppWindow {
     // against Foo's own scope first, so the binding points the property at
     // itself and it stays undefined (context properties sit at the bottom
     // of the lookup order). Wire such children from these names instead.
-    readonly property var controllerContext: settingsController
-    readonly property var appSettingsContext: appSettings
+    // Same two names every page already uses for the same capture (see
+    // LayoutsPage / GeneralPage / TilingAlgorithmPage…), so there is one
+    // spelling for one idea across the settings tree.
+    readonly property var controllerBridge: settingsController
+    readonly property var settingsBridge: appSettings
     // Pages reach the layout-context popup via window.layoutContextMenu.
     readonly property alias layoutContextMenu: layoutContextMenu
     // GeneralPage's "Reset to Defaults" button reaches the chrome-owned
@@ -669,8 +672,8 @@ PhosphorUi.SettingsAppWindow {
     LayoutContextMenu {
         id: layoutContextMenu
 
-        settingsController: window.controllerContext
-        appSettings: window.appSettingsContext
+        settingsController: window.controllerBridge
+        appSettings: window.settingsBridge
         aspectRatioLabels: window.aspectRatioLabels
     }
 
@@ -739,9 +742,9 @@ PhosphorUi.SettingsAppWindow {
     KeyboardShortcutOverlay {
         parent: window.contentItem
         // `appSettings` is the context property exposed by main.cpp,
-        // reached through window.appSettingsContext because the overlay's
+        // reached through window.settingsBridge because the overlay's
         // own required property of that name shadows the context one.
-        appSettings: window.appSettingsContext
+        appSettings: window.settingsBridge
         shown: window._showShortcuts
         onDismiss: window._showShortcuts = false
     }

--- a/src/settings/qml/SettingsFlickable.qml
+++ b/src/settings/qml/SettingsFlickable.qml
@@ -48,10 +48,14 @@ import "SearchAnchorHelpers.js" as SearchAnchors
  * inherits Flickable's whole property surface unchanged. Each
  * consumer is responsible for:
  *
- *   - Binding `contentHeight` (and `contentWidth` if scrolling
+ *   - Binding the content height (and `contentWidth` if scrolling
  *     horizontally — not the typical settings-page case). Without it
  *     `WheelHandler` sees a zero scrollable range and silently
- *     refuses to move.
+ *     refuses to move. A page whose content is a fixed tree binds
+ *     `contentHeight` directly; a listing page that swaps a group model
+ *     binds `naturalContentHeight` instead and calls
+ *     `holdContentHeight()` before each swap, so the rebuild cannot
+ *     throw the scroll position away (see the model-swap scroll guard).
  *   - Avoiding nested Flickable / ListView / TextArea scroll surfaces
  *     unless they are intentionally height-clamped to their content
  *     (the `LayoutsPage.qml` pattern). Nested independent scrollers

--- a/src/settings/qml/SettingsFlickable.qml
+++ b/src/settings/qml/SettingsFlickable.qml
@@ -126,11 +126,11 @@ Flickable {
             settingsFlickable._contentHeightFloor = 0;
             return;
         }
-        // Still climbing (cards materialise one per step, and a single toggle
-        // triggers two rebuilds because the daemon announces the reload twice).
-        // Restart rather than let a fixed timeout expire mid-rebuild, which
-        // would drop the floor at exactly the collapsed height this exists to
-        // paper over.
+        // Still climbing: the cards materialise a step at a time, and a page can
+        // start a second swap (a filter or sort change landing on the heels of a
+        // model refresh) before the first has finished. Restart rather than let
+        // a fixed timeout expire mid-rebuild, which would drop the floor at
+        // exactly the collapsed height this exists to paper over.
         contentHeightFloorSettle.restart();
     }
 

--- a/src/settings/qml/SettingsFlickable.qml
+++ b/src/settings/qml/SettingsFlickable.qml
@@ -82,6 +82,66 @@ Flickable {
     /// top border never fully shows on hover.
     topMargin: Kirigami.Units.smallSpacing
 
+    // ── Model-swap scroll guard ──────────────────────────────────────────
+    // A listing page that swaps its group model (LayoutsPage.rebuildModel and
+    // friends) destroys every card delegate and rebuilds them over the
+    // following frames. For that window the page's natural height collapses to
+    // the chrome alone — measured on the Layouts page: 4091 → 671 with a 694 px
+    // viewport — so Flickable sees nothing scrollable, clamps `contentY` to the
+    // top, and the cards then re-materialise around a scroll offset that is
+    // gone for good. Any edit made while scrolled down (toggling a layout's
+    // zone-selector visibility, auto-assign, aspect ratio…) threw the user back
+    // to the top of the page.
+    //
+    // Consumers opt in by setting `naturalContentHeight` instead of
+    // `contentHeight` and calling `holdContentHeight()` immediately before the
+    // model swap. The floor keeps the scrollable range alive across the gap, so
+    // there is nothing to clamp and the offset survives untouched.
+    //
+    // Pages that bind `contentHeight` directly are unaffected — that assignment
+    // simply replaces the binding below.
+    property real naturalContentHeight: 0
+    /// Lower bound held over an in-flight rebuild. Zero means no hold.
+    property real _contentHeightFloor: 0
+
+    contentHeight: Math.max(settingsFlickable.naturalContentHeight, settingsFlickable._contentHeightFloor)
+
+    function holdContentHeight() {
+        settingsFlickable._contentHeightFloor = settingsFlickable.contentHeight;
+        contentHeightFloorSettle.restart();
+    }
+
+    onNaturalContentHeightChanged: {
+        if (settingsFlickable._contentHeightFloor <= 0)
+            return;
+        // Rebuilt to at least the height we were holding — the hold has done
+        // its job and must end now, or a page that genuinely grew would be
+        // capped for the rest of the settle window.
+        if (settingsFlickable.naturalContentHeight >= settingsFlickable._contentHeightFloor) {
+            contentHeightFloorSettle.stop();
+            settingsFlickable._contentHeightFloor = 0;
+            return;
+        }
+        // Still climbing (cards materialise one per step, and a single toggle
+        // triggers two rebuilds because the daemon announces the reload twice).
+        // Restart rather than let a fixed timeout expire mid-rebuild, which
+        // would drop the floor at exactly the collapsed height this exists to
+        // paper over.
+        contentHeightFloorSettle.restart();
+    }
+
+    // Ends a hold whose rebuild finished genuinely shorter than before (a
+    // layout deleted, a filter narrowed). Without it the page would keep the
+    // old height as dead scrollable space forever. Restarted on every height
+    // step, so the interval only has to outlast the gap between two steps, not
+    // the whole rebuild.
+    Timer {
+        id: contentHeightFloorSettle
+
+        interval: Kirigami.Units.shortDuration
+        onTriggered: settingsFlickable._contentHeightFloor = 0
+    }
+
     // ── Deep-link reveal (global search / `--setting`) ───────────────────
     // Rows and cards self-register here by anchor id (see SettingsRow /
     // SettingsCard `searchAnchor`). PageHost duck-calls `revealAnchor()` once

--- a/src/settings/qml/ShaderBrowserPage.qml
+++ b/src/settings/qml/ShaderBrowserPage.qml
@@ -388,8 +388,16 @@ SettingsFlickable {
     // re-evaluates against this tick whenever any usage source mutates.
     property int _usagesRev: 0
 
-    contentHeight: content.implicitHeight
+    // `naturalContentHeight`, not `contentHeight`: re-evaluating _displayGroups
+    // swaps the section Repeater's model, which tears every card down for a few
+    // frames. See the model-swap scroll guard in SettingsFlickable.
+    naturalContentHeight: content.implicitHeight
     clip: true
+
+    // Hold the current height across that teardown. Layout runs on polish, so
+    // this handler still sees the pre-swap height even though _displayGroups
+    // has already been re-evaluated.
+    on_DisplayGroupsChanged: root.holdContentHeight()
 
     Connections {
         function onShaderEffectsChanged() {

--- a/src/settings/settingscontroller.cpp
+++ b/src/settings/settingscontroller.cpp
@@ -276,20 +276,22 @@ SettingsController::SettingsController(QObject* parent)
         // path guarded on `!localLayouts.isEmpty()`, which left stale
         // entries in m_layouts after a wipe when the daemon was down.
         SettingsController::sortMergedLayoutList(localLayouts);
-        // Skip when the disk view matches what we already have — a daemon
-        // save batch fires a reload per layout write, and identical
-        // payloads would re-emit the model on each one.
-        const bool actuallyChanged = m_layouts != localLayouts;
-        if (actuallyChanged) {
-            m_layouts = std::move(localLayouts);
+        // Withhold the local view while a D-Bus getLayoutList call is in
+        // flight. It carries no daemon-side enrichment (hasSystemOrigin /
+        // hiddenFromSelector / defaultOrder / allow-lists), so publishing it
+        // now would drop that off every entry for the length of the round trip
+        // and force a second full model rebuild when the reply lands. The reply
+        // adopts what is held here only if the daemon turns out to be
+        // unreachable.
+        if (m_awaitingDaemonLayouts) {
+            m_withheldLocalLayouts = std::move(localLayouts);
+            return;
         }
-        // Suppress the local-path emit while a D-Bus getLayoutList
-        // call is in flight — the async reply lambda will emit once
-        // it replaces m_layouts with the daemon-enriched view. If the
-        // daemon is unreachable or the call errors, the gate is
-        // cleared in the reply lambda's head and subsequent local
-        // emits run normally (fallback behaviour).
-        if (actuallyChanged && !m_awaitingDaemonLayouts) {
+        // Skip when the disk view matches what we already have — a daemon save
+        // batch fires a reload per layout write, and identical payloads would
+        // re-emit the model on each one.
+        if (m_layouts != localLayouts) {
+            m_layouts = std::move(localLayouts);
             Q_EMIT layoutsChanged();
         }
     });

--- a/src/settings/settingscontroller.cpp
+++ b/src/settings/settingscontroller.cpp
@@ -271,19 +271,19 @@ SettingsController::SettingsController(QObject* parent)
     connect(m_localLayoutManager.get(), &PhosphorZones::LayoutRegistry::layoutsChanged, this, [this]() {
         recalcLocalLayouts();
         QVariantList localLayouts = localLayoutPreviews();
-        // Assign unconditionally: when the user deletes every layout we
-        // want m_layouts to reflect the empty state. Previously this
-        // path guarded on `!localLayouts.isEmpty()`, which left stale
-        // entries in m_layouts after a wipe when the daemon was down.
+        // An empty disk view is published like any other: when the user deletes
+        // every layout we want m_layouts to reflect the empty state. This path
+        // once guarded on `!localLayouts.isEmpty()`, which left stale entries in
+        // m_layouts after a wipe when the daemon was down.
         SettingsController::sortMergedLayoutList(localLayouts);
         // Withhold the local view while a D-Bus getLayoutList call is in
         // flight. It carries no daemon-side enrichment (hasSystemOrigin /
         // hiddenFromSelector / defaultOrder / allow-lists), so publishing it
         // now would drop that off every entry for the length of the round trip
-        // and force a second full model rebuild when the reply lands. The reply
-        // adopts what is held here only if the daemon turns out to be
+        // and force a second full model rebuild when the reply lands. The last
+        // reply adopts what is held here only if the daemon turns out to be
         // unreachable.
-        if (m_awaitingDaemonLayouts) {
+        if (m_pendingDaemonLayoutCalls > 0) {
             m_withheldLocalLayouts = std::move(localLayouts);
             return;
         }

--- a/src/settings/settingscontroller.h
+++ b/src/settings/settingscontroller.h
@@ -986,27 +986,32 @@ private:
     QTimer m_layoutLoadTimer;
     QString m_pendingSelectLayoutId;
 
-    // Suppresses the local-path layoutsChanged emit while a D-Bus
-    // getLayoutList round-trip is in flight.
+    // Holds back the local-path layout view while a D-Bus getLayoutList
+    // round-trip is in flight.
     //
-    // This does NOT collapse loadLayoutsAsync()'s own two emits: that call
-    // reloads the local manager (emitting synchronously through the
-    // PhosphorZones::LayoutRegistry::layoutsChanged lambda) BEFORE this gate is
-    // set, and the reply lambda emits again with the daemon-enriched list. That
-    // pair is the deliberate Step-1 instant-paint / Step-2 enrichment design.
+    // The local composite is built from LayoutPreview, which carries no
+    // daemon-side enrichment (hasSystemOrigin / hiddenFromSelector /
+    // defaultOrder / allow-lists). Publishing it mid-flight would strip that
+    // enrichment off every entry until the reply lands, so a hidden/auto-assign
+    // toggle visibly reverted on the card that was just toggled, and every
+    // listing page rebuilt its whole model twice per mutation.
     //
-    // What the gate suppresses is a local emit that lands BETWEEN the dispatch
-    // and the reply. A second daemon layout signal arriving in that window
-    // restarts the scheduleLayoutLoad() debounce, and its loadLayoutsAsync()
-    // calls loadLayouts() on the local registry, which drives that lambda
-    // synchronously. Ungated it would repaint the page from the un-enriched
-    // local composite only for the in-flight reply to immediately replace it.
-    // Set true right before the D-Bus asyncCall dispatch;
-    // cleared at the reply lambda's entry (before any early-return on error, so
-    // the local fallback emit resumes if the daemon is unreachable). Only
-    // relevant when the daemon is available — when the D-Bus call errors out, the
-    // local path's emit remains the authoritative refresh.
+    // So loadLayoutsAsync() arms this BEFORE reloading the local registry,
+    // covering both its own synchronous local emit and any that lands between
+    // the dispatch and the reply (a second daemon signal restarts the
+    // scheduleLayoutLoad() debounce, whose loadLayoutsAsync() drives the
+    // registry lambda synchronously). The reply is then the single refresh.
+    //
+    // Cleared at the reply lambda's entry, before any early-return on error, so
+    // the local path resumes emitting when the daemon is unreachable. Startup's
+    // direct loadLayouts() call runs ungated and paints immediately as before.
     bool m_awaitingDaemonLayouts = false;
+    /// The local view withheld under that gate, kept as the fallback the reply
+    /// adopts when the daemon turns out to be unreachable — otherwise a failed
+    /// round-trip would leave the page painted from before the change. Engaged
+    /// (not merely non-empty) is what marks a withheld view, so a genuine wipe
+    /// to zero layouts is still adopted on error.
+    std::optional<QVariantList> m_withheldLocalLayouts;
 
     // Daemon-independent layout source — see localLayoutPreviews() doc.
     // PhosphorZones::LayoutRegistry opens its own assignments backend + scans the standard

--- a/src/settings/settingscontroller.h
+++ b/src/settings/settingscontroller.h
@@ -986,8 +986,8 @@ private:
     QTimer m_layoutLoadTimer;
     QString m_pendingSelectLayoutId;
 
-    // Holds back the local-path layout view while a D-Bus getLayoutList
-    // round-trip is in flight.
+    // Number of getLayoutList round-trips currently in flight. Non-zero holds
+    // back the local-path layout view.
     //
     // The local composite is built from LayoutPreview, which carries no
     // daemon-side enrichment (hasSystemOrigin / hiddenFromSelector /
@@ -996,21 +996,30 @@ private:
     // toggle visibly reverted on the card that was just toggled, and every
     // listing page rebuilt its whole model twice per mutation.
     //
-    // So loadLayoutsAsync() arms this BEFORE reloading the local registry,
-    // covering both its own synchronous local emit and any that lands between
-    // the dispatch and the reply (a second daemon signal restarts the
+    // So loadLayoutsAsync() increments this BEFORE reloading the local
+    // registry, covering both its own synchronous local emit and any that lands
+    // between the dispatch and the reply (a second daemon signal restarts the
     // scheduleLayoutLoad() debounce, whose loadLayoutsAsync() drives the
-    // registry lambda synchronously). The reply is then the single refresh.
+    // registry lambda synchronously). The replies are then the only refresh.
     //
-    // Cleared at the reply lambda's entry, before any early-return on error, so
-    // the local path resumes emitting when the daemon is unreachable. Startup's
-    // direct loadLayouts() call runs ungated and paints immediately as before.
-    bool m_awaitingDaemonLayouts = false;
-    /// The local view withheld under that gate, kept as the fallback the reply
-    /// adopts when the daemon turns out to be unreachable — otherwise a failed
-    /// round-trip would leave the page painted from before the change. Engaged
-    /// (not merely non-empty) is what marks a withheld view, so a genuine wipe
-    /// to zero layouts is still adopted on error.
+    // A COUNT, not a flag: the debounce is 50 ms and a reply costs the daemon a
+    // full layout rescan, so a burst of mutations readily puts two calls in
+    // flight at once. A flag would be cleared by the first reply while the
+    // second was still pending, reopening exactly the un-enriched-publish window
+    // this exists to close.
+    //
+    // Decremented at the reply lambda's entry, before any early-return on
+    // error, so the local path resumes emitting once the last call settles and
+    // the daemon is unreachable. Startup's direct loadLayouts() call runs
+    // ungated and paints immediately as before.
+    int m_pendingDaemonLayoutCalls = 0;
+    /// The local view withheld under that gate, kept as the fallback the last
+    /// reply adopts when the daemon turns out to be unreachable — otherwise a
+    /// failed round-trip would leave the page painted from before the change.
+    /// Engaged (not merely non-empty) is what marks a withheld view, so a
+    /// genuine wipe to zero layouts is still adopted on error. Any SUCCESSFUL
+    /// reply clears it: enriched data supersedes the local view, and a later
+    /// error in the same burst must not downgrade the page back to it.
     std::optional<QVariantList> m_withheldLocalLayouts;
 
     // Daemon-independent layout source — see localLayoutPreviews() doc.

--- a/src/settings/settingscontroller.h
+++ b/src/settings/settingscontroller.h
@@ -360,9 +360,9 @@ public:
     // Loads the on-disk layouts via an in-process LayoutRegistry +
     // ZonesLayoutSource so QML preview paths render even when the daemon
     // is down (early launch, crash). Paints directly at startup, before the
-    // first getLayoutList is dispatched. From then on loadLayoutsAsync holds
-    // this view back (m_withheldLocalLayouts) and publishes it only when the
-    // daemon cannot answer, because it lacks the enrichment described below.
+    // first getLayoutList goes out; after that loadLayoutsAsync holds it back
+    // (m_withheldLocalLayouts) and publishes it only when the daemon cannot
+    // answer, because it lacks the enrichment described below.
     //
     // Returns the projection produced by PlasmaZones::toVariantMap. That is
     // the SAME projection, key for key, that the D-Bus side emits via toJson
@@ -988,40 +988,28 @@ private:
     QTimer m_layoutLoadTimer;
     QString m_pendingSelectLayoutId;
 
-    // Number of getLayoutList round-trips currently in flight. Non-zero holds
-    // back the local-path layout view.
-    //
-    // The local composite is built from LayoutPreview, which carries no
+    // Number of getLayoutList round-trips in flight. Non-zero holds back the
+    // local-path layout view, which is built from LayoutPreview and carries no
     // daemon-side enrichment (hasSystemOrigin / hiddenFromSelector /
-    // defaultOrder / allow-lists). Publishing it mid-flight would strip that
-    // enrichment off every entry until the reply lands, so a hidden/auto-assign
-    // toggle visibly reverted on the card that was just toggled, and every
-    // listing page rebuilt its whole model twice per mutation.
+    // defaultOrder / allow-lists). Publishing it mid-flight stripped that off
+    // every entry for the length of the round trip, so a hidden/auto-assign
+    // toggle visibly reverted on the card just toggled and every listing page
+    // rebuilt its whole model twice per mutation.
     //
-    // So loadLayoutsAsync() increments this BEFORE reloading the local
-    // registry, covering both its own synchronous local emit and any that lands
-    // between the dispatch and the reply (a second daemon signal restarts the
-    // scheduleLayoutLoad() debounce, whose loadLayoutsAsync() drives the
-    // registry lambda synchronously). The replies are then the only refresh.
-    //
-    // A COUNT, not a flag: the debounce is 50 ms and a reply costs the daemon a
-    // full layout rescan, so a burst of mutations readily puts two calls in
-    // flight at once. A flag would be cleared by the first reply while the
-    // second was still pending, reopening exactly the un-enriched-publish window
-    // this exists to close.
-    //
-    // Decremented at the reply lambda's entry, before any early-return on
-    // error, so the local path resumes emitting once the last call settles and
-    // the daemon is unreachable. Startup's direct loadLayouts() call runs
-    // ungated and paints immediately as before.
+    // loadLayoutsAsync() increments it BEFORE reloading the local registry, so
+    // the gate covers that reload's synchronous emit as well as any landing
+    // before the reply. A COUNT, not a flag: the debounce is 50 ms and a reply
+    // costs the daemon a full rescan, so a burst readily puts two calls in
+    // flight, and a flag would be cleared by the first reply while the second
+    // was still pending. Decremented at the reply lambda's entry, ahead of any
+    // early-return. Startup's direct loadLayouts() runs ungated.
     int m_pendingDaemonLayoutCalls = 0;
-    /// The local view withheld under that gate, kept as the fallback the last
-    /// reply adopts when the daemon turns out to be unreachable — otherwise a
-    /// failed round-trip would leave the page painted from before the change.
-    /// Engaged (not merely non-empty) is what marks a withheld view, so a
-    /// genuine wipe to zero layouts is still adopted on error. Any SUCCESSFUL
-    /// reply clears it: enriched data supersedes the local view, and a later
-    /// error in the same burst must not downgrade the page back to it.
+    /// The local view withheld under that gate, adopted by the last reply when
+    /// the daemon turns out to be unreachable, so a failed round trip does not
+    /// leave the page painted from before the change. Engaged (not merely
+    /// non-empty) marks a withheld view, so a genuine wipe to zero layouts is
+    /// still adopted. Any SUCCESSFUL reply clears it: enriched data supersedes
+    /// it, and a later error must not downgrade the page back to it.
     std::optional<QVariantList> m_withheldLocalLayouts;
 
     // Daemon-independent layout source — see localLayoutPreviews() doc.

--- a/src/settings/settingscontroller.h
+++ b/src/settings/settingscontroller.h
@@ -359,8 +359,10 @@ public:
     // ─── Daemon-independent layout previews (PhosphorZones::ILayoutSource) ───
     // Loads the on-disk layouts via an in-process LayoutRegistry +
     // ZonesLayoutSource so QML preview paths render even when the daemon
-    // is down (early launch, crash). Drives the Step-1 instant paint in
-    // loadLayoutsAsync, which the daemon's enriched reply then replaces.
+    // is down (early launch, crash). Paints directly at startup, before the
+    // first getLayoutList is dispatched. From then on loadLayoutsAsync holds
+    // this view back (m_withheldLocalLayouts) and publishes it only when the
+    // daemon cannot answer, because it lacks the enrichment described below.
     //
     // Returns the projection produced by PlasmaZones::toVariantMap. That is
     // the SAME projection, key for key, that the D-Bus side emits via toJson
@@ -368,7 +370,7 @@ public:
     // What differs is the daemon's LayoutAdaptor::getLayoutList, which adds an
     // enrichment layer on top (hasSystemOrigin / hiddenFromSelector /
     // defaultOrder / allow-lists) from Layout state that LayoutPreview does not
-    // carry. So the list this returns is a strict SUBSET of the Step-2 D-Bus
+    // carry. So the list this returns is a strict SUBSET of the D-Bus
     // list: any consumer reading an enrichment-only key off these previews
     // gets `undefined`, not `false`. See src/common/layoutpreviewserialize.h.
     //

--- a/src/settings/settingscontroller_layouts.cpp
+++ b/src/settings/settingscontroller_layouts.cpp
@@ -56,28 +56,26 @@ void SettingsController::loadLayoutsAsync()
     // layoutListChanged — see
     // settingscontroller_dbuswire.cpp::wireDaemonSubscriptions) relies on it.
     // It is not a redundant backup for a file watcher.
+    // Arm the gate BEFORE the local reload, not after: loadLayouts() drives the
+    // PhosphorZones::LayoutRegistry::layoutsChanged lambda wired in
+    // settingscontroller.cpp's ctor synchronously, and that lambda's view of the
+    // world is the in-process composite, which carries none of the daemon-side
+    // enrichment (hasSystemOrigin / hiddenFromSelector / defaultOrder /
+    // allow-lists) the reply below brings back. Publishing it first painted
+    // every card without its enrichment for the length of the round trip — a
+    // hidden or auto-assign toggle visibly snapped back before it took — and
+    // made every listing page tear down and rebuild its entire model twice for
+    // one mutation. The lambda holds that view in m_withheldLocalLayouts
+    // instead, and the reply adopts it only if the daemon is unreachable.
+    m_awaitingDaemonLayouts = true;
+    m_withheldLocalLayouts.reset();
     if (m_localLayoutManager) {
         m_localLayoutManager->loadLayouts();
     }
 
-    // Step 1: instant paint from the in-process composite source is handled
-    // by the PhosphorZones::LayoutRegistry::layoutsChanged lambda wired in
-    // settingscontroller.cpp's ctor
-    // (it calls recalcLocalLayouts() + swaps m_layouts from localLayoutPreviews()
-    // and emits layoutsChanged). loadLayouts() above emits that signal
-    // synchronously on every call, so the instant-paint path runs without a
-    // duplicate recalc/emit here.
-
-    // Step 2: async D-Bus call to pick up daemon-side enrichment
-    // (hasSystemOrigin / hiddenFromSelector / defaultOrder / allow-lists)
-    // that the local composite can't know about. On reply the enriched
-    // list replaces m_layouts; if the call errors we keep the local
-    // previews from Step 1 visible rather than blanking the page.
-    // Gate the local-path layoutsChanged emit (see the ctor-wired lambda
-    // on PhosphorZones::LayoutRegistry::layoutsChanged). The reply lambda clears this
-    // unconditionally so any subsequent local-only refresh (daemon down)
-    // emits as usual.
-    m_awaitingDaemonLayouts = true;
+    // Pick up the daemon-side enrichment the local composite can't know about.
+    // On reply the enriched list replaces m_layouts; if the call errors we fall
+    // back to the local view withheld above rather than blanking the page.
     auto* watcher = new QDBusPendingCallWatcher(
         PhosphorProtocol::ClientHelpers::asyncCall(PhosphorProtocol::Service::Interface::LayoutRegistry,
                                                    QStringLiteral("getLayoutList")),
@@ -88,21 +86,31 @@ void SettingsController::loadLayoutsAsync()
         // Clear the gate first so any local-path emit that arrives after
         // an error reply (or after a successful one) runs normally.
         m_awaitingDaemonLayouts = false;
+        // Take ownership of whatever the local path held back, whichever way
+        // the reply goes: leaving it engaged would let a later error branch
+        // adopt a view from a round trip that has long since finished.
+        std::optional<QVariantList> withheldLocal;
+        withheldLocal.swap(m_withheldLocalLayouts);
 
         QDBusPendingReply<QStringList> reply = *w;
         if (reply.isError()) {
             qCWarning(lcCore) << "Failed to load layouts (D-Bus):" << reply.error().message()
-                              << "— keeping local manual-layout previews from Step 1.";
+                              << "— falling back to the local manual-layout previews.";
+            // Adopt the withheld local view. It is the only refresh the user
+            // gets on this path, and it is newer than m_layouts by definition:
+            // the reload that produced it is what this call was answering.
+            if (withheldLocal && m_layouts != *withheldLocal) {
+                m_layouts = std::move(*withheldLocal);
+            }
             // Drop any pending select-after-create id so a future successful
             // reload doesn't emit layoutAdded() for a stale id that the user
             // has already navigated away from (or that was deleted from
             // another session).
             m_pendingSelectLayoutId.clear();
-            // Re-emit the local view: the file-watcher emit that ran
-            // while m_awaitingDaemonLayouts was true was suppressed
-            // (see settingscontroller.cpp's connect lambda). Without
-            // this re-emit, an immediate user-visible refresh after a
-            // daemon error waits for the next disk change.
+            // Emit unconditionally, even when the withheld view matched what we
+            // already had: local emits that landed inside the gate window were
+            // held back too (see settingscontroller.cpp's connect lambda), and
+            // without this the page waits for the next disk change to refresh.
             Q_EMIT layoutsChanged();
             return;
         }

--- a/src/settings/settingscontroller_layouts.cpp
+++ b/src/settings/settingscontroller_layouts.cpp
@@ -56,8 +56,8 @@ void SettingsController::loadLayoutsAsync()
     // layoutListChanged — see
     // settingscontroller_dbuswire.cpp::wireDaemonSubscriptions) relies on it.
     // It is not a redundant backup for a file watcher.
-    // Count this call in BEFORE the local reload, not after: loadLayouts() drives the
-    // PhosphorZones::LayoutRegistry::layoutsChanged lambda wired in
+    // Count this call in BEFORE the local reload, not after: loadLayouts()
+    // drives the PhosphorZones::LayoutRegistry::layoutsChanged lambda wired in
     // settingscontroller.cpp's ctor synchronously, and that lambda's view of the
     // world is the in-process composite, which carries none of the daemon-side
     // enrichment (hasSystemOrigin / hiddenFromSelector / defaultOrder /
@@ -66,7 +66,8 @@ void SettingsController::loadLayoutsAsync()
     // hidden or auto-assign toggle visibly snapped back before it took — and
     // made every listing page tear down and rebuild its entire model twice for
     // one mutation. The lambda holds that view in m_withheldLocalLayouts
-    // instead, and the reply adopts it only if the daemon is unreachable.
+    // instead, and the last reply in flight adopts it only if the daemon turns
+    // out to be unreachable.
     ++m_pendingDaemonLayoutCalls;
     // Whatever an earlier cycle held back is superseded by the reload below,
     // which re-stashes the freshly-scanned view through the same lambda.
@@ -76,8 +77,9 @@ void SettingsController::loadLayoutsAsync()
     }
 
     // Pick up the daemon-side enrichment the local composite can't know about.
-    // On reply the enriched list replaces m_layouts; if the call errors we fall
-    // back to the local view withheld above rather than blanking the page.
+    // On reply the enriched list replaces m_layouts. If the call errors and no
+    // newer one is in flight, the local view withheld above is adopted rather
+    // than leaving the page as it was before the change.
     auto* watcher = new QDBusPendingCallWatcher(
         PhosphorProtocol::ClientHelpers::asyncCall(PhosphorProtocol::Service::Interface::LayoutRegistry,
                                                    QStringLiteral("getLayoutList")),
@@ -96,15 +98,17 @@ void SettingsController::loadLayoutsAsync()
 
         QDBusPendingReply<QStringList> reply = *w;
         if (reply.isError()) {
-            qCWarning(lcCore) << "Failed to load layouts (D-Bus):" << reply.error().message()
-                              << "— falling back to the local manual-layout previews.";
             if (!lastInFlight) {
                 // A newer getLayoutList is still in flight and owns the refresh.
                 // Publishing the withheld local view here would strip the
                 // enrichment off every card for the rest of that round trip,
                 // which is the whole failure this withholding exists to avoid.
+                qCWarning(lcCore) << "Failed to load layouts (D-Bus):" << reply.error().message()
+                                  << "— a newer request is still in flight, leaving the refresh to it.";
                 return;
             }
+            qCWarning(lcCore) << "Failed to load layouts (D-Bus):" << reply.error().message()
+                              << "— falling back to the local manual-layout previews.";
             // Adopt the withheld local view. It is the only refresh the user
             // gets on this path, and it is newer than m_layouts by definition:
             // the reload that produced it is what this call was answering. It

--- a/src/settings/settingscontroller_layouts.cpp
+++ b/src/settings/settingscontroller_layouts.cpp
@@ -56,7 +56,7 @@ void SettingsController::loadLayoutsAsync()
     // layoutListChanged — see
     // settingscontroller_dbuswire.cpp::wireDaemonSubscriptions) relies on it.
     // It is not a redundant backup for a file watcher.
-    // Arm the gate BEFORE the local reload, not after: loadLayouts() drives the
+    // Count this call in BEFORE the local reload, not after: loadLayouts() drives the
     // PhosphorZones::LayoutRegistry::layoutsChanged lambda wired in
     // settingscontroller.cpp's ctor synchronously, and that lambda's view of the
     // world is the in-process composite, which carries none of the daemon-side
@@ -67,7 +67,9 @@ void SettingsController::loadLayoutsAsync()
     // made every listing page tear down and rebuild its entire model twice for
     // one mutation. The lambda holds that view in m_withheldLocalLayouts
     // instead, and the reply adopts it only if the daemon is unreachable.
-    m_awaitingDaemonLayouts = true;
+    ++m_pendingDaemonLayoutCalls;
+    // Whatever an earlier cycle held back is superseded by the reload below,
+    // which re-stashes the freshly-scanned view through the same lambda.
     m_withheldLocalLayouts.reset();
     if (m_localLayoutManager) {
         m_localLayoutManager->loadLayouts();
@@ -83,22 +85,34 @@ void SettingsController::loadLayoutsAsync()
 
     connect(watcher, &QDBusPendingCallWatcher::finished, this, [this](QDBusPendingCallWatcher* w) {
         w->deleteLater();
-        // Clear the gate first so any local-path emit that arrives after
-        // an error reply (or after a successful one) runs normally.
-        m_awaitingDaemonLayouts = false;
-        // Take ownership of whatever the local path held back, whichever way
-        // the reply goes: leaving it engaged would let a later error branch
-        // adopt a view from a round trip that has long since finished.
-        std::optional<QVariantList> withheldLocal;
-        withheldLocal.swap(m_withheldLocalLayouts);
+        // Count this reply out first, before any early-return, so the local
+        // path resumes emitting once nothing is in flight. Guarded rather than
+        // a bare decrement: a stray second finished() must not drive the count
+        // negative and un-gate the local path while a call is still pending.
+        if (m_pendingDaemonLayoutCalls > 0) {
+            --m_pendingDaemonLayoutCalls;
+        }
+        const bool lastInFlight = m_pendingDaemonLayoutCalls == 0;
 
         QDBusPendingReply<QStringList> reply = *w;
         if (reply.isError()) {
             qCWarning(lcCore) << "Failed to load layouts (D-Bus):" << reply.error().message()
                               << "— falling back to the local manual-layout previews.";
+            if (!lastInFlight) {
+                // A newer getLayoutList is still in flight and owns the refresh.
+                // Publishing the withheld local view here would strip the
+                // enrichment off every card for the rest of that round trip,
+                // which is the whole failure this withholding exists to avoid.
+                return;
+            }
             // Adopt the withheld local view. It is the only refresh the user
             // gets on this path, and it is newer than m_layouts by definition:
-            // the reload that produced it is what this call was answering.
+            // the reload that produced it is what this call was answering. It
+            // is absent when a successful reply already published enriched data
+            // for this burst, in which case the page is current and there is
+            // nothing to fall back to.
+            std::optional<QVariantList> withheldLocal;
+            withheldLocal.swap(m_withheldLocalLayouts);
             if (withheldLocal && m_layouts != *withheldLocal) {
                 m_layouts = std::move(*withheldLocal);
             }
@@ -114,6 +128,11 @@ void SettingsController::loadLayoutsAsync()
             Q_EMIT layoutsChanged();
             return;
         }
+
+        // Enriched data supersedes anything the local path held back, so a
+        // later error in this burst cannot downgrade the page to the
+        // un-enriched view.
+        m_withheldLocalLayouts.reset();
 
         QVariantList newLayouts;
         const QStringList layoutJsonList = reply.value();
@@ -133,6 +152,13 @@ void SettingsController::loadLayoutsAsync()
         // monitor overview, picker dialogs) to recompute. Skipping
         // the emit also avoids re-firing the pending-select path
         // for an already-loaded id.
+        //
+        // Safe even when a local emit was withheld during the round trip: the
+        // daemon is the authority on the layout list, and every trigger of this
+        // reload is either a daemon broadcast or a mutation that went through
+        // the daemon, so a reply identical to m_layouts means nothing changed
+        // for the user to see. Publishing the withheld view instead would only
+        // repaint the same entries minus their enrichment.
         if (m_layouts != newLayouts) {
             m_layouts = newLayouts;
             Q_EMIT layoutsChanged();


### PR DESCRIPTION
Four fixes that came out of one report: right-clicking a layout and choosing **Hide from Zone Selector** did nothing.

## The context menu was wired to itself

`LayoutContextMenu { settingsController: settingsController }` in `Main.qml` bound each required property to itself. In QML the right-hand side resolves against the menu's own scope first, and context properties sit at the bottom of the lookup order, so both `settingsController` and `appSettings` stayed `undefined`:

```
LayoutContextMenu.qml:305: TypeError: Cannot read property 'defaultAutotileAlgorithm' of undefined
LayoutContextMenu.qml:320: TypeError: Cannot call method 'setLayoutHidden' of undefined
```

The two context properties are now re-exposed at window scope under distinct names and the menu is wired from those. `KeyboardShortcutOverlay` had the identical self-binding and is repointed the same way. A sweep found no other context-property cases (the remaining `foo: foo` hits pass `id`s, which resolve through the component's id table).

## Listing pages jumped to the top on any edit

With that fixed, toggling visibility worked but threw the page back to the top. Not menu-specific — the eye icon did it too. Traced live:

```
rebuildModel exit   contentY 956   contentHeight 4091
contentY -4         contentHeight 671    height 694      ← every group card torn down
contentHeight 671 → 903 → 1795 → … → 4091, contentY stays -4
```

Swapping the group model destroys every card delegate and rebuilds them over the following frames. In between, the natural content height collapses to the page chrome alone, Flickable has nothing scrollable and clamps `contentY` to the top, and the cards re-materialise around a scroll offset that is gone.

`SettingsFlickable` gains a model-swap scroll guard. A page sets `naturalContentHeight` instead of `contentHeight` and calls `holdContentHeight()` before the swap, which floors the content height for the length of the rebuild so there is no zero range to clamp against. The floor drops as soon as the rebuilt content reaches it, and a settle timer restarted on every height step releases it when a rebuild genuinely ends shorter (a deleted layout, a narrowed filter), so real shrinks still behave normally.

Adopted by `LayoutsPage` (from `rebuildModel`) and `ShaderBrowserPage` (from the `_displayGroups` re-evaluation that swaps its section model). `RulesPage` still binds `contentHeight` directly and is likely to jump the same way, left for a follow-up.

## Every layout mutation refreshed twice, un-enriched

The trace also showed two full rebuilds per toggle. `loadLayoutsAsync()` reloaded the in-process registry *before* arming `m_awaitingDaemonLayouts`, so the registry's synchronous `layoutsChanged` published the local composite view. That view is built from `LayoutPreview` and carries none of the daemon-side enrichment (`hasSystemOrigin`, `hiddenFromSelector`, `defaultOrder`, allow-lists), so for the length of the D-Bus round trip every card lost its state and the layout just toggled visibly snapped back before the reply corrected it.

The gate is now armed before the local reload, and the local path holds its view in `m_withheldLocalLayouts` rather than publishing it. The reply takes ownership either way: on success the enriched list is the single refresh, and on error it adopts the withheld view so a daemon-down refresh still shows local previews instead of pre-change data. Startup is unchanged, since the constructor's direct `loadLayouts()` runs ungated.

## Depth texture read and written in one pass

Verifying the shader browser surfaced an unrelated RHI error on the overlay shaders page:

```
Texture 0x55afe8b2f380 () used with different accesses within the same pass, this is not allowed.
```

Every buffer render target attaches the depth texture as its second colour attachment, so a buffer pass writes it, while the shared SRB trailer also bound that same texture as a sampled texture at binding 12. It fires on the overlay packs that pair `multipass` with `depthBuffer` (`neon-city`, `voxel-terrain`).

`appendCommonTrailerBindings` / `appendDepthBinding` now take a `DepthAccess` argument. Image-pass SRBs bind the real depth texture, buffer-pass SRBs get the dummy so binding 12 stays populated for a shader that includes `depth.glsl` regardless. This matches how the packs are written: `buffer.frag` only writes `oDepth`, and `effect.frag` is what calls `readDepth()`.

## Testing

- Full build clean, 300/300 ctest pass.
- The context menu, the scroll hold on Layouts, and the shader-page hold were verified interactively by @fuddlesworth on a real session.
- The depth-binding fix needs a real GPU pass and could not be exercised headlessly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)