### PR TITLE
fix(settings): card grid gaps and unreadable thumbnails at large sizes

### DIFF
--- a/src/settings/qml/LayoutGridDelegate.qml
+++ b/src/settings/qml/LayoutGridDelegate.qml
@@ -197,13 +197,14 @@ Item {
                 LayoutThumbnail {
                     id: layoutThumbnail
 
-                    // Safe scale calculation - fit thumbnail within parent bounds
-                    readonly property real safeImplicitWidth: Math.max(1, implicitWidth)
-                    readonly property real safeImplicitHeight: Math.max(1, implicitHeight)
-                    readonly property real safeParentWidth: Math.max(1, parent.width)
-                    readonly property real safeParentHeight: Math.max(1, parent.height)
-
                     anchors.centerIn: parent
+                    // Fit-size the preview box to the available card area
+                    // instead of scale-transforming the whole thumbnail down:
+                    // a scale transform shrinks the name/badge text with the
+                    // zone graphic, making it unreadable in small cards. Fit
+                    // mode resizes only the geometry; text stays natural size.
+                    fitWidth: Math.max(1, parent.width)
+                    fitHeight: Math.max(1, parent.height)
                     layout: root.modelData
                     isSelected: root.isSelected
                     isHovered: root.isHovered
@@ -214,8 +215,6 @@ Item {
                     fontItalic: root.appSettings ? root.appSettings.labelFontItalic : false
                     fontUnderline: root.appSettings ? root.appSettings.labelFontUnderline : false
                     fontStrikeout: root.appSettings ? root.appSettings.labelFontStrikeout : false
-                    transformOrigin: Item.Center
-                    scale: Math.min(1, safeParentWidth / safeImplicitWidth, safeParentHeight / safeImplicitHeight)
 
                     // Hover the preview to read the layout/algorithm description.
                     // Scoped to the thumbnail graphic (not the whole card) so it

--- a/src/settings/qml/LayoutThumbnail.qml
+++ b/src/settings/qml/LayoutThumbnail.qml
@@ -71,10 +71,24 @@ Item {
             return refAR > 0 ? refAR : fallbackAspectRatio;
         }
     }
+    // Opt-in fit sizing: when both are set (> 0) the preview box derives its
+    // height from the given bounds instead of the fixed default, so the zone
+    // graphic resizes with the host card while the label/badge text keeps its
+    // natural pixel size. Hosts that previously shrank the whole thumbnail
+    // with a scale transform (which also shrank the text into illegibility)
+    // should use this instead.
+    property real fitWidth: 0
+    property real fitHeight: 0
+    readonly property bool _fitMode: fitWidth > 0 && fitHeight > 0
+    // The tallest preview that fits both bounds once the side padding and
+    // vertical chrome are reserved. The width-derived bound divides by the
+    // aspect ratio; the min/max width clamp below can only make the box
+    // narrower than this budget, never wider, so the fit stays conservative.
+    readonly property real _fitBaseHeight: Math.max(Kirigami.Units.gridUnit * 3, Math.min(fitHeight - _verticalChrome, (fitWidth - _sidePadding * 2) / Math.max(0.1, layoutAspectRatio)))
     // Preview-box sizing. Height is the fixed side for every class, so a
     // portrait ratio (< 1) simply yields a narrower width, which the
     // min/max clamp below keeps usable.
-    property real baseHeight: Kirigami.Units.gridUnit * 9
+    property real baseHeight: _fitMode ? _fitBaseHeight : Kirigami.Units.gridUnit * 9
     readonly property real calculatedWidth: baseHeight * layoutAspectRatio
     property real minThumbnailWidth: Kirigami.Units.gridUnit * 5 // Narrower min for portrait
     property real maxThumbnailWidth: Kirigami.Units.gridUnit * 26 // Wider max for super-ultrawide

--- a/src/settings/qml/LayoutThumbnail.qml
+++ b/src/settings/qml/LayoutThumbnail.qml
@@ -84,7 +84,11 @@ Item {
     // vertical chrome are reserved. The width-derived bound divides by the
     // aspect ratio; the min/max width clamp below can only make the box
     // narrower than this budget, never wider, so the fit stays conservative.
-    readonly property real _fitBaseHeight: Math.max(Kirigami.Units.gridUnit * 3, Math.min(fitHeight - _verticalChrome, (fitWidth - _sidePadding * 2) / Math.max(0.1, layoutAspectRatio)))
+    // The lower bound only guards against degenerate (zero/negative) budgets
+    // during layout; it must stay below every realistic budget or the box
+    // overflows the very bounds it is meant to fit (a gridUnit*3 floor already
+    // exceeds the 32:9 width budget at minimum card width).
+    readonly property real _fitBaseHeight: Math.max(Kirigami.Units.gridUnit, Math.min(fitHeight - _verticalChrome, (fitWidth - _sidePadding * 2) / Math.max(0.1, layoutAspectRatio)))
     // Preview-box sizing. Height is the fixed side for every class, so a
     // portrait ratio (< 1) simply yields a narrower width, which the
     // min/max clamp below keeps usable.

--- a/src/settings/qml/LayoutsPage.qml
+++ b/src/settings/qml/LayoutsPage.qml
@@ -31,6 +31,10 @@ SettingsFlickable {
     // explicitly to LayoutGridDelegate (whose own `settingsController` property
     // would otherwise shadow the context name inside the delegate's bindings).
     readonly property var controllerBridge: settingsController
+    // Minimum card size. The grid fits as many columns as minCardWidth allows
+    // and stretches the cards to fill the row; each card's height then scales
+    // with its stretched width at the cardHeight:minCardWidth ratio, so these
+    // two set the minimum size AND the fixed aspect of every card.
     readonly property real cardHeight: Kirigami.Units.gridUnit * 12
     readonly property real minCardWidth: Kirigami.Units.gridUnit * 14
     // View mode: 0 = Snapping Layouts, 1 = Auto Tile Algorithms

--- a/src/settings/qml/LayoutsPage.qml
+++ b/src/settings/qml/LayoutsPage.qml
@@ -444,8 +444,12 @@ SettingsFlickable {
                         // Responsive columns: fit as many cards as the minimum
                         // card width allows, then stretch each to fill the row
                         // evenly so there's no dead gap on the right edge.
+                        // The width must be floored: a fractional card width
+                        // accumulates float error in Flow's x positions, and a
+                        // sub-pixel overshoot wraps the last card of every row,
+                        // leaving a full empty slot on the right.
                         readonly property int _columns: Math.max(1, Math.floor((width + spacing) / (root.minCardWidth + spacing)))
-                        readonly property real _cardWidth: (width - spacing * (_columns - 1)) / _columns
+                        readonly property real _cardWidth: Math.floor((width - spacing * (_columns - 1)) / _columns)
 
                         Repeater {
                             model: groupCard.modelData.items
@@ -454,7 +458,12 @@ SettingsFlickable {
                                 appSettings: root.settingsBridge
                                 settingsController: root.controllerBridge
                                 cellWidth: cardFlow._cardWidth
-                                cellHeight: root.cardHeight
+                                // Height tracks the stretched width so cards keep
+                                // the same proportions at every window size and
+                                // the fit-sized preview grows with them, instead
+                                // of a fixed height capping the preview no matter
+                                // how wide the card gets.
+                                cellHeight: cardFlow._cardWidth * (root.cardHeight / root.minCardWidth)
                                 viewMode: root.viewMode
                                 isSelected: String(modelData.id) === root.selectedLayoutId
                                 // When LayoutsPage is hosted outside Main.qml

--- a/src/settings/qml/ShaderBrowserPage.qml
+++ b/src/settings/qml/ShaderBrowserPage.qml
@@ -620,9 +620,13 @@ SettingsFlickable {
                         // Responsive columns: fit as many cards as the minimum
                         // card width allows, then stretch each card to fill the
                         // row evenly so there's no dead gap on the right edge.
+                        // The width must be floored: a fractional card width
+                        // accumulates float error in Flow's x positions, and a
+                        // sub-pixel overshoot wraps the last card of every row,
+                        // leaving a full empty slot on the right.
                         readonly property real _minCardWidth: Kirigami.Units.gridUnit * 13
                         readonly property int _columns: Math.max(1, Math.floor((width + spacing) / (_minCardWidth + spacing)))
-                        readonly property real _cardWidth: (width - spacing * (_columns - 1)) / _columns
+                        readonly property real _cardWidth: Math.floor((width - spacing * (_columns - 1)) / _columns)
 
                         Repeater {
                             model: modelData.items

--- a/src/settings/qml/ShaderBrowserPage.qml
+++ b/src/settings/qml/ShaderBrowserPage.qml
@@ -601,8 +601,8 @@ SettingsFlickable {
                     spacing: Kirigami.Units.smallSpacing
 
                     // Cards in a Flow wrap to the next row when out of
-                    // horizontal space — 3-4 cards per row at typical
-                    // settings-window widths. The inner delegate declares its
+                    // horizontal space — as many per row as the minimum card
+                    // width below allows. The inner delegate declares its
                     // own `required property var modelData` so the section
                     // delegate's identically-named `modelData` doesn't shadow
                     // the Repeater's auto-injection.


### PR DESCRIPTION
## Summary
- Floor the stretched card width in the Layouts and shader browser grids. The fractional width accumulated float error in `Flow`'s x positions, so the last card of every row overshot by a sub-pixel and wrapped, leaving a full empty card slot on the right edge at wide window sizes.
- Replace the layout thumbnail's scale-to-fit transform with fit sizing. The transform shrank the name/badge text together with the zone graphic, making it unreadable in small cards. `LayoutThumbnail` now takes opt-in `fitWidth`/`fitHeight` bounds and derives the preview-box height from them, so the zone graphic resizes geometrically while the label, badges, and zone numbers keep their natural font sizes. Other `LayoutThumbnail` consumers (`NewLayoutDialog`, `MonitorStatePage`, `NewAlgorithmDialog`) don't set the new properties and are unchanged.
- Make the layout card cell height track the stretched card width so cards keep the same proportions at every window size and the preview grows with the card instead of being capped by a fixed height.

## Testing
- Full build succeeds
- 300/300 ctest pass (the one skip is the opt-in GPU test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)