### PR TITLE
feat(settings): set-a-pack selector for animation shaders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - **Animation shader pickers now describe the shader you picked**: choosing a shader for an animation event shows the pack's description, and the description and parameters fold into a collapsible section that opens with a click, the same way decoration packs behave ([#834](https://github.com/fuddlesworth/PlasmaZones/pull/834)).
-- **Picking an animation shader works like picking a decoration pack**: the pack you chose now gets its own named row, with a remove button and its description and parameters behind the same collapsible chevron a decoration surface uses. The picker moved below that row as a "Set shader pack" action, so choosing a pack replaces what is there and choosing None clears it. A pack that is no longer installed now reads as missing in the row rather than showing its internal id, on the decoration pages as well ([#839](https://github.com/fuddlesworth/PlasmaZones/pull/839)).
+- **Picking an animation shader works like picking a decoration pack**: the pack you chose now gets its own named row, with a remove button and its description and parameters behind the same collapsible chevron a decoration surface uses. The picker moved below that row as a "Set shader pack" action, so choosing a pack replaces what is there and choosing None clears it. A pack that is no longer installed now reads as missing instead of showing its internal id. The decoration pages read the same way ([#839](https://github.com/fuddlesworth/PlasmaZones/pull/839)).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - **Animation shader pickers now describe the shader you picked**: choosing a shader for an animation event shows the pack's description, and the description and parameters fold into a collapsible section that opens with a click, the same way decoration packs behave ([#834](https://github.com/fuddlesworth/PlasmaZones/pull/834)).
+- **Picking an animation shader works like picking a decoration pack**: the pack you chose now gets its own named row, with a remove button and its description and parameters behind the same collapsible chevron a decoration surface uses. The picker moved below that row as a "Set shader pack" action, so choosing a pack replaces what is there and choosing None clears it ([#839](https://github.com/fuddlesworth/PlasmaZones/pull/839)).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - **Animation shader pickers now describe the shader you picked**: choosing a shader for an animation event shows the pack's description, and the description and parameters fold into a collapsible section that opens with a click, the same way decoration packs behave ([#834](https://github.com/fuddlesworth/PlasmaZones/pull/834)).
-- **Picking an animation shader works like picking a decoration pack**: the pack you chose now gets its own named row, with a remove button and its description and parameters behind the same collapsible chevron a decoration surface uses. The picker moved below that row as a "Set shader pack" action, so choosing a pack replaces what is there and choosing None clears it ([#839](https://github.com/fuddlesworth/PlasmaZones/pull/839)).
+- **Picking an animation shader works like picking a decoration pack**: the pack you chose now gets its own named row, with a remove button and its description and parameters behind the same collapsible chevron a decoration surface uses. The picker moved below that row as a "Set shader pack" action, so choosing a pack replaces what is there and choosing None clears it. A pack that is no longer installed now reads as missing in the row rather than showing its internal id, on the decoration pages as well ([#839](https://github.com/fuddlesworth/PlasmaZones/pull/839)).
 
 ### Fixed
 

--- a/src/settings/qml/pages/animations/AnimationProfileEditor.qml
+++ b/src/settings/qml/pages/animations/AnimationProfileEditor.qml
@@ -650,6 +650,13 @@ ColumnLayout {
     // single shader, so picking REPLACES the row above (and None clears
     // it) rather than appending, and the button carries the current
     // selection instead of a permanent placeholder.
+    //
+    // The button deliberately carries NO `enabled` gate where the decoration
+    // add row disables itself on an empty candidate list. That row is a pure
+    // append action, so an empty list leaves it nothing to do, while this
+    // picker's None entry stays meaningful with an empty catalog: it is how a
+    // user blocks a shader inherited from an ancestor path. Gating it on
+    // `availableShaders` would take away the only picker route to that.
     SettingsRow {
         id: setShaderRow
 

--- a/src/settings/qml/pages/animations/AnimationProfileEditor.qml
+++ b/src/settings/qml/pages/animations/AnimationProfileEditor.qml
@@ -125,20 +125,32 @@ ColumnLayout {
     /// with neither text nor params, keeps the row-click inert and
     /// the chevron hidden.
     readonly property bool shaderSectionExpandable: shaderEffectId.length > 0 && (shaderDescription.length > 0 || shaderParamSchema.length > 0)
-    /// Description of the currently-picked shader, resolved from the
-    /// consumer-fed picker model. Empty when nothing is picked or the
-    /// pack ships no description.
-    readonly property string shaderDescription: {
+    /// Registry entry for the currently-picked shader, resolved from the
+    /// consumer-fed picker model. Null when nothing is picked or the id
+    /// has no match (a pack uninstalled while its override survives).
+    /// Hoisted so the name and description legs share one scan.
+    readonly property var shaderEffect: {
         if (shaderEffectId.length === 0)
-            return "";
+            return null;
 
         for (var i = 0; i < availableShaders.length; ++i) {
             var e = availableShaders[i];
             if (e && e.id === shaderEffectId)
-                return typeof e.description === "string" ? e.description : "";
+                return e;
         }
-        return "";
+        return null;
     }
+    /// Display name of the currently-picked shader, falling back to the
+    /// raw id so a pack that is no longer installed still names itself.
+    readonly property string shaderName: {
+        if (shaderEffectId.length === 0)
+            return "";
+
+        return (shaderEffect && shaderEffect.name) ? shaderEffect.name : shaderEffectId;
+    }
+    /// Description of the currently-picked shader. Empty when nothing is
+    /// picked or the pack ships no description.
+    readonly property string shaderDescription: (shaderEffect && typeof shaderEffect.description === "string") ? shaderEffect.description : ""
     /// Wire-format curve string the rule / profile schema expects.
     readonly property string curveString: {
         if (timingMode === CurvePresets.timingModeSpring)
@@ -424,23 +436,37 @@ ColumnLayout {
         visible: root.shaderLegSupported && root.showTimingSection
     }
 
-    // Shader header row — the same collapsed-row model as the decoration
-    // chain packs (ExpandableRowDelegate + ExpandChevron): whole-row click
-    // toggles, the chevron signals state, and the collapsed header shows a
-    // one-line elided description teaser while the expansion body carries
-    // the full text + parameter editor. Hand-rolled from the same pattern
-    // rather than reusing ExpandableRowDelegate, because that shell
-    // lazy-loads its body and the parameter editor must stay statically
-    // instantiated — the `lockedShaderParams` alias above targets its id.
+    // Empty state, mirroring the decoration chain editor's: an unset
+    // shader says so in place of the row, and points at the setter below.
+    Label {
+        Layout.fillWidth: true
+        Layout.leftMargin: Kirigami.Units.largeSpacing
+        Layout.rightMargin: Kirigami.Units.largeSpacing
+        visible: root.shaderLegSupported && root.shaderEffectId.length === 0
+        text: i18n("No shader pack. Set one below.")
+        wrapMode: Text.WordWrap
+        opacity: 0.7
+    }
+
+    // Selected-shader row — the same collapsed-row model as a decoration
+    // chain pack (ExpandableRowDelegate + ExpandChevron): the row names the
+    // PACK, whole-row click toggles, the chevron signals state, and the
+    // collapsed header shows a one-line elided description teaser while the
+    // expansion body carries the full text + parameter editor. Hand-rolled
+    // from the same pattern rather than reusing ExpandableRowDelegate,
+    // because that shell lazy-loads its body and the parameter editor must
+    // stay statically instantiated — the `lockedShaderParams` alias above
+    // targets its id. Unlike the decoration chain this slot holds at most
+    // one pack, so the picker lives in its own setter row below.
     ItemDelegate {
-        visible: root.shaderLegSupported
+        visible: root.shaderLegSupported && root.shaderEffectId.length > 0
         Layout.fillWidth: true
         hoverEnabled: true
         // Match the largeSpacing inset the SettingsRows in this editor
-        // self-apply, so the header text and picker line up with them.
+        // self-apply, so the row's text lines up with them.
         leftPadding: Kirigami.Units.largeSpacing
         rightPadding: Kirigami.Units.largeSpacing
-        Accessible.name: i18n("Shader effect")
+        Accessible.name: root.shaderName
         onClicked: {
             if (root.shaderSectionExpandable)
                 root.shaderSectionExpanded = !root.shaderSectionExpanded;
@@ -451,19 +477,12 @@ ColumnLayout {
 
             ColumnLayout {
                 Layout.fillWidth: true
-                spacing: Math.round(Kirigami.Units.smallSpacing / 2)
+                spacing: 0
 
                 Label {
                     Layout.fillWidth: true
-                    text: i18n("Shader effect")
-                    elide: Text.ElideRight
-                }
-
-                Label {
-                    Layout.fillWidth: true
-                    text: i18n("Apply a shader transition to this event")
-                    font: Kirigami.Theme.smallFont
-                    color: Kirigami.Theme.disabledTextColor
+                    text: root.shaderName
+                    font.bold: true
                     elide: Text.ElideRight
                 }
 
@@ -480,25 +499,16 @@ ColumnLayout {
                 }
             }
 
-            PZCommon.CategoryMenuButton {
-                id: shaderPicker
-
-                Layout.preferredWidth: Kirigami.Units.gridUnit * 16
-                Layout.alignment: Qt.AlignVCenter
-                // Bound straight to the consumer's property. The consumer owns the
-                // registry-tick dependency and re-assigns this on every bump, so an
-                // extra tick read here would only double the invalidation.
-                items: root.availableShaders
-                currentId: root.shaderEffectId
-                noneId: ""
-                includeNoneEntry: true
-                placeholderText: i18nc("@action:button", "Select shader…")
-                onSelected: function (id) {
-                    var sid = id || "";
-                    root.shaderEffectActivated(sid);
-                    // Picking a shader reveals its description + parameters
-                    // right away; clearing to None collapses the section.
-                    root.shaderSectionExpanded = sid.length > 0;
+            // Clearing the slot, in the same position a decoration pack row
+            // carries its remove button. Routes through the same activation
+            // signal the picker's None entry uses.
+            ToolButton {
+                icon.name: "edit-delete-remove"
+                display: ToolButton.IconOnly
+                Accessible.name: i18n("Remove %1", root.shaderName)
+                onClicked: {
+                    root.shaderEffectActivated("");
+                    root.shaderSectionExpanded = false;
                 }
             }
 
@@ -606,6 +616,58 @@ ColumnLayout {
                     root.shaderParams = defaults;
                     root.resetRequested(defaults);
                 }
+            }
+        }
+    }
+
+    // Divider between the selected shader and the setter row, so the
+    // picker reads as a separate affordance rather than running into the
+    // row it replaces (the same break the decoration chain draws above
+    // its add row).
+    SettingsSeparator {
+        Layout.topMargin: Kirigami.Units.smallSpacing
+        visible: root.shaderLegSupported && root.shaderEffectId.length > 0
+    }
+
+    // ── Setter row ──────────────────────────────────────────────────
+    // Compact right-aligned picker in a labelled SettingsRow, matching the
+    // decoration chain's add row. The difference is the slot: this holds a
+    // single shader, so picking REPLACES the row above (and None clears
+    // it) rather than appending, and the button carries the current
+    // selection instead of a permanent placeholder.
+    SettingsRow {
+        id: setShaderRow
+
+        visible: root.shaderLegSupported
+        title: i18n("Set shader pack")
+        // Two states, the way the decoration add row's caption tracks what
+        // the picker can currently do: an empty slot invites a pack, a
+        // filled one says the pick replaces what is already there.
+        description: root.shaderEffectId.length > 0 ? i18n("Swap this event's pack for another, or clear it") : i18n("Apply a shader pack to this event")
+
+        PZCommon.CategoryMenuButton {
+            // SettingsRow lays its default children out in a plain Row
+            // positioner, so Layout.* attached properties are inert here —
+            // size explicitly or the button sits at implicit width. Clamped
+            // to the same 45% of the row that SettingsRow caps its control
+            // slot at, measured against the INNER layout (inset by
+            // largeSpacing per side) so it cannot overhang the margin.
+            width: Math.min(Kirigami.Units.gridUnit * 16, Math.max(0, (setShaderRow.width - Kirigami.Units.largeSpacing * 2) * 0.45))
+            // Bound straight to the consumer's property. The consumer owns the
+            // registry-tick dependency and re-assigns this on every bump, so an
+            // extra tick read here would only double the invalidation.
+            items: root.availableShaders
+            currentId: root.shaderEffectId
+            noneId: ""
+            includeNoneEntry: true
+            placeholderText: i18nc("@action:button", "Select a pack…")
+            Accessible.description: i18n("Set the shader pack this event uses")
+            onSelected: function (id) {
+                var sid = id || "";
+                root.shaderEffectActivated(sid);
+                // Picking a shader reveals its description + parameters
+                // right away; clearing to None collapses the section.
+                root.shaderSectionExpanded = sid.length > 0;
             }
         }
     }

--- a/src/settings/qml/pages/animations/AnimationProfileEditor.qml
+++ b/src/settings/qml/pages/animations/AnimationProfileEditor.qml
@@ -159,6 +159,12 @@ ColumnLayout {
     /// Description of the currently-picked shader. Empty when nothing is
     /// picked or the pack ships no description.
     readonly property string shaderDescription: (_shaderEffect && typeof _shaderEffect.description === "string") ? _shaderEffect.description : ""
+    /// Whether the picker has anything to offer. False while the shader
+    /// registry is still loading (or absent), which is a state the empty
+    /// slot and the setter caption BOTH have to agree about: telling the
+    /// user to set a pack below while the picker holds only "None" is an
+    /// instruction they cannot follow.
+    readonly property bool _anyPackAvailable: availableShaders && availableShaders.length > 0
     /// Wire-format curve string the rule / profile schema expects.
     readonly property string curveString: {
         if (timingMode === CurvePresets.timingModeSpring)
@@ -451,7 +457,8 @@ ColumnLayout {
         Layout.leftMargin: Kirigami.Units.largeSpacing
         Layout.rightMargin: Kirigami.Units.largeSpacing
         visible: root.shaderLegSupported && root.shaderEffectId.length === 0
-        text: i18n("No shader pack. Set one below.")
+        // Points at the setter only when the setter can actually serve.
+        text: root._anyPackAvailable ? i18n("No shader pack. Set one below.") : i18n("No shader pack.")
         wrapMode: Text.WordWrap
         opacity: 0.7
     }
@@ -657,7 +664,7 @@ ColumnLayout {
             if (root.shaderEffectId.length > 0)
                 return i18n("Swap this event's pack for another, or clear it");
 
-            if (!root.availableShaders || root.availableShaders.length === 0)
+            if (!root._anyPackAvailable)
                 return i18n("No shader packs are available for this event");
 
             return i18n("Apply a shader pack to this event");

--- a/src/settings/qml/pages/animations/AnimationProfileEditor.qml
+++ b/src/settings/qml/pages/animations/AnimationProfileEditor.qml
@@ -129,7 +129,7 @@ ColumnLayout {
     /// consumer-fed picker model. Null when nothing is picked or the id
     /// has no match (a pack uninstalled while its override survives).
     /// Hoisted so the name and description legs share one scan.
-    readonly property var shaderEffect: {
+    readonly property var _shaderEffect: {
         if (shaderEffectId.length === 0)
             return null;
 
@@ -140,17 +140,25 @@ ColumnLayout {
         }
         return null;
     }
-    /// Display name of the currently-picked shader, falling back to the
-    /// raw id so a pack that is no longer installed still names itself.
+    /// Display name of the currently-picked shader. An id with no entry in
+    /// the picker model (a pack uninstalled while its override survives, or
+    /// one an ancestor set that this event's path filter excludes) renders
+    /// with the SAME "(missing: …)" wording CategoryMenuButton uses for the
+    /// same state — the picker sits directly below this row, so a bare id
+    /// here would read like a real pack name beside the picker's "(missing:
+    /// …)" for the very same shader.
     readonly property string shaderName: {
         if (shaderEffectId.length === 0)
             return "";
 
-        return (shaderEffect && shaderEffect.name) ? shaderEffect.name : shaderEffectId;
+        if (_shaderEffect && _shaderEffect.name)
+            return _shaderEffect.name;
+
+        return i18nc("@info item missing", "(missing: %1)", shaderEffectId);
     }
     /// Description of the currently-picked shader. Empty when nothing is
     /// picked or the pack ships no description.
-    readonly property string shaderDescription: (shaderEffect && typeof shaderEffect.description === "string") ? shaderEffect.description : ""
+    readonly property string shaderDescription: (_shaderEffect && typeof _shaderEffect.description === "string") ? _shaderEffect.description : ""
     /// Wire-format curve string the rule / profile schema expects.
     readonly property string curveString: {
         if (timingMode === CurvePresets.timingModeSpring)
@@ -640,10 +648,20 @@ ColumnLayout {
 
         visible: root.shaderLegSupported
         title: i18n("Set shader pack")
-        // Two states, the way the decoration add row's caption tracks what
-        // the picker can currently do: an empty slot invites a pack, a
-        // filled one says the pick replaces what is already there.
-        description: root.shaderEffectId.length > 0 ? i18n("Swap this event's pack for another, or clear it") : i18n("Apply a shader pack to this event")
+        // The caption tracks what the picker can currently do, the way the
+        // decoration add row's does: a filled slot says the pick replaces
+        // what is already there, an empty one invites a pack, and an empty
+        // registry says so instead of promising an action with nothing to
+        // offer.
+        description: {
+            if (root.shaderEffectId.length > 0)
+                return i18n("Swap this event's pack for another, or clear it");
+
+            if (!root.availableShaders || root.availableShaders.length === 0)
+                return i18n("No shader packs are available for this event");
+
+            return i18n("Apply a shader pack to this event");
+        }
 
         PZCommon.CategoryMenuButton {
             // SettingsRow lays its default children out in a plain Row

--- a/src/settings/qml/pages/tiling/ChainEditor.qml
+++ b/src/settings/qml/pages/tiling/ChainEditor.qml
@@ -83,9 +83,16 @@ ColumnLayout {
         return null;
     }
 
+    // A chained pack id with no entry in `availableShaders` (uninstalled out
+    // from under the chain) renders with the SAME "(missing: …)" wording
+    // CategoryMenuButton uses for an unmatched currentId, so the row does not
+    // pass a bare machine id off as a pack name.
     function _displayName(packId) {
         var e = root._effectFor(packId);
-        return (e && e.name) ? e.name : packId;
+        if (e && e.name)
+            return e.name;
+
+        return i18nc("@info item missing", "(missing: %1)", packId);
     }
 
     // Packs not already in the chain, for the Add combo's model.
@@ -299,7 +306,7 @@ ColumnLayout {
 
     // ── Add row ──────────────────────────────────────────────────────────
     // Compact right-aligned pack picker in a labelled SettingsRow, matching the
-    // animation "Set shader" selector (PZCommon.CategoryMenuButton) rather
+    // animation "Set shader pack" selector (PZCommon.CategoryMenuButton) rather
     // than a full-width dropdown bar. It is an ACTION, not a persistent
     // selection: selecting a pack appends it to the chain, so currentId stays
     // empty and the button always shows its placeholder.

--- a/src/settings/qml/pages/tiling/ChainEditor.qml
+++ b/src/settings/qml/pages/tiling/ChainEditor.qml
@@ -138,8 +138,17 @@ ColumnLayout {
     Label {
         Layout.fillWidth: true
         visible: !root.chain || root.chain.length === 0
-        // Points at the add row only when the add row can actually serve.
-        text: !root.showAddRow ? i18n("No decoration packs. Matched windows render undecorated.") : (root._anyPackAvailable ? i18n("No decoration packs. Add one below.") : i18n("No decoration packs."))
+        // Points at the add row only when the add row is there AND can
+        // actually serve.
+        text: {
+            if (!root.showAddRow)
+                return i18n("No decoration packs. Matched windows render undecorated.");
+
+            if (!root._anyPackAvailable)
+                return i18n("No decoration packs.");
+
+            return i18n("No decoration packs. Add one below.");
+        }
         wrapMode: Text.WordWrap
         opacity: 0.7
     }

--- a/src/settings/qml/pages/tiling/ChainEditor.qml
+++ b/src/settings/qml/pages/tiling/ChainEditor.qml
@@ -61,6 +61,13 @@ ColumnLayout {
     // every host refresh and churn its currentValues rebind (same hoist as
     // ActionRow's _emptyShaderParams).
     readonly property var _emptyParams: ({})
+    // Whether the catalog has anything to offer. False while the shader
+    // registry is still loading (or absent), which the empty-state hint and
+    // the add row's caption BOTH have to agree about: an empty chain with an
+    // empty catalog is "nothing is installed", NOT "everything is already in
+    // the chain", and telling the user to add one below is an instruction
+    // they cannot follow.
+    readonly property bool _anyPackAvailable: availableShaders && availableShaders.length > 0
 
     signal chainChangeRequested(var newChain)
     signal paramChangeRequested(string packId, string paramId, var value)
@@ -131,7 +138,8 @@ ColumnLayout {
     Label {
         Layout.fillWidth: true
         visible: !root.chain || root.chain.length === 0
-        text: root.showAddRow ? i18n("No decoration packs. Add one below.") : i18n("No decoration packs. Matched windows render undecorated.")
+        // Points at the add row only when the add row can actually serve.
+        text: !root.showAddRow ? i18n("No decoration packs. Matched windows render undecorated.") : (root._anyPackAvailable ? i18n("No decoration packs. Add one below.") : i18n("No decoration packs."))
         wrapMode: Text.WordWrap
         opacity: 0.7
     }
@@ -320,7 +328,18 @@ ColumnLayout {
         // Referenced by explicit id, not `parent`, because SettingsRow may
         // reparent the button into its own content layout.
         readonly property var _addable: root._addableEffects()
-        description: _addable.length > 0 ? i18n("Stack another pack onto this surface's chain") : i18n("All installed packs are already in the chain")
+        // "All installed packs are already in the chain" is only true when
+        // packs ARE installed. With an empty catalog the exhausted-list
+        // wording is a false claim, so the two cases are told apart.
+        description: {
+            if (addPackRow._addable.length > 0)
+                return i18n("Stack another pack onto this surface's chain");
+
+            if (!root._anyPackAvailable)
+                return i18n("No decoration packs are installed");
+
+            return i18n("All installed packs are already in the chain");
+        }
 
         PZCommon.CategoryMenuButton {
             // SettingsRow lays its default children out in a plain Row

--- a/src/settings/qml/pages/tiling/ChainEditor.qml
+++ b/src/settings/qml/pages/tiling/ChainEditor.qml
@@ -299,7 +299,7 @@ ColumnLayout {
 
     // ── Add row ──────────────────────────────────────────────────────────
     // Compact right-aligned pack picker in a labelled SettingsRow, matching the
-    // animation "Shader effect" selector (PZCommon.CategoryMenuButton) rather
+    // animation "Set shader" selector (PZCommon.CategoryMenuButton) rather
     // than a full-width dropdown bar. It is an ACTION, not a persistent
     // selection: selecting a pack appends it to the chain, so currentId stays
     // empty and the button always shows its placeholder.


### PR DESCRIPTION
## Summary

Brings the animation shader selector to the same shape as a decoration surface's pack list, for a single-pack slot.

Before, the animation shader section was one static row titled "Shader effect" with the picker inline in its header, so the selected pack's name only ever appeared inside the combo. Decoration reads the other way round: a row per pack (named, with its own description and parameters), and the picker below as a separate affordance.

After, top to bottom in `AnimationProfileEditor.qml`:

- **Empty state** — "No shader pack. Set one below.", mirroring the chain editor's "No decoration packs. Add one below."
- **Selected-pack row** — bold pack name, one-line elided description teaser while collapsed, remove button, chevron. Whole-row click expands, same accordion motion as a decoration pack row. Only exists when a pack is set.
- **Expansion body** — unchanged: full wrapped description + `ShaderParamsEditor`.
- **Separator + "Set shader pack" row** — `SettingsRow` holding the `CategoryMenuButton`, with the same 45%-of-row width clamp the decoration add row uses. Picking replaces the row above, None clears it.

Wording follows the decoration add row and the repo's existing "shader pack" terminology (the drop-zone, install toasts, and decoration browser all use it). The subtext is two-state like decoration's, but keyed on what the picker will do rather than on availability: an empty slot invites a pack, a filled one says the pick replaces what's there.

Two implementation notes:

- The picker keeps `currentId: root.shaderEffectId`. Decoration's add row is a pure action with an empty `currentId` because it appends; this one is a set, so the button carries the current selection and None reads as the live state.
- The remove button routes through the same `shaderEffectActivated("")` the None entry emits, so there is one write path and no new backend state. `shaderEffect` is hoisted so the name and description legs share one scan of the registry model, and `shaderName` falls back to the raw id, so a pack uninstalled out from under a surviving override still names itself in the row instead of rendering blank.

Also corrects a now-stale cross-reference comment in `ChainEditor.qml` that named the old "Shader effect" selector.

Follow-on to #834, which gave the section its description and collapsible parameters.

## Test plan

- `cmake --build build --parallel` clean.
- `ctest` 314/314 passed (`test_surface_decoration_orientation` skipped, as it is by default without the GPU opt-in).
- No behavioural change to the shader profile tree: every mutation path is the pre-existing `shaderEffectActivated` / `shaderParamWriteRequested` signal pair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)