### PR TITLE
fix(tile-engine): keep per-algorithm tuning across settings-driven switches

### DIFF
--- a/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
+++ b/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
@@ -1444,6 +1444,14 @@ private:
     QSet<QString> m_autotileScreens;
     QString m_algorithmId;
     bool m_algorithmEverSet = false; ///< True after first successful setAlgorithm() call
+    /// True only while refreshConfigFromSettings() drives setAlgorithm(). In
+    /// that window savedAlgorithmSettings was just reloaded from disk, so the
+    /// outgoing algorithm's freshly-loaded slot is authoritative and must NOT
+    /// be re-stamped from the engine's live scalars — the global SYNC_FIELDs
+    /// earlier in the refresh already overwrote those scalars, and stamping
+    /// them back destroyed per-algorithm values the settings app had just
+    /// saved (discussion #853).
+    bool m_refreshingFromSettings = false;
     QString m_activeScreen; // Last-focused screen (updated by onWindowFocused)
 
     // Per-screen tiling states + the windowId→owning-key reverse map. States are

--- a/libs/phosphor-tile-engine/src/autotileengine/algorithm_state.cpp
+++ b/libs/phosphor-tile-engine/src/autotileengine/algorithm_state.cpp
@@ -103,7 +103,15 @@ void AutotileEngine::setAlgorithm(const QString& algorithmId)
     // Save current algorithm's ratio + master count before switching.
     // Only save after the first setAlgorithm() call has completed, to avoid
     // persisting uninitialised struct defaults from the constructor.
-    if (m_algorithmEverSet && oldAlgo) {
+    //
+    // Skipped on the settings-refresh path: there the saved map was just
+    // reloaded from disk and the live scalars have already been overwritten by
+    // the refresh's global SYNC_FIELDs, so this stamp would replace the
+    // freshly-saved slot with global-default values (discussion #853). The
+    // cost is bounded: live shortcut tunings not yet written back are dropped
+    // for the outgoing algorithm on a settings-driven switch, in favour of the
+    // values the user explicitly saved.
+    if (m_algorithmEverSet && oldAlgo && !m_refreshingFromSettings) {
         auto& entry = m_config->savedAlgorithmSettings[m_algorithmId];
         entry.splitRatio = m_config->splitRatio;
         entry.masterCount = m_config->masterCount;

--- a/libs/phosphor-tile-engine/src/autotileengine/config.cpp
+++ b/libs/phosphor-tile-engine/src/autotileengine/config.cpp
@@ -272,7 +272,16 @@ void AutotileEngine::refreshConfigFromSettings()
 #undef SYNC_FIELD
 
     const QString oldAlgorithmId = m_algorithmId;
+    // Flag the switch as settings-driven for the duration of the call:
+    // savedAlgorithmSettings was reloaded from disk just above, so the outgoing
+    // algorithm's slot in it is newer than the engine's live scalars (which the
+    // SYNC_FIELDs above have already pulled down to the global keys). Without
+    // the flag, setAlgorithm() stamped those clobbered scalars over the fresh
+    // slot and writeBackTuning() persisted the corruption — the "max windows
+    // reverts to its default" data loss of discussion #853.
+    m_refreshingFromSettings = true;
     setAlgorithm(s->defaultAutotileAlgorithm());
+    m_refreshingFromSettings = false;
     if (m_algorithmId != oldAlgorithmId) {
         configChanged = true;
     }

--- a/tests/unit/autotile/engine/test_engine_settings.cpp
+++ b/tests/unit/autotile/engine/test_engine_settings.cpp
@@ -11,6 +11,7 @@
 #include "helpers/AutotileTestHelpers.h"
 #include <PhosphorTileEngine/AutotileConfig.h>
 #include <PhosphorTiles/AlgorithmRegistry.h>
+#include <PhosphorTiles/AutotileConstants.h>
 #include <PhosphorTiles/TilingAlgorithm.h>
 #include <PhosphorTiles/TilingState.h>
 #include "core/types/constants.h"
@@ -194,6 +195,66 @@ private Q_SLOTS:
         // default, so grid's own default is authoritative.
         engine.refreshConfigFromSettings();
         QCOMPARE(engine.config()->maxWindows, gridAlgo->defaultMaxWindows());
+    }
+
+    // Discussion #853: a settings-driven refresh that ALSO switches the ambient
+    // algorithm must not stamp the outgoing algorithm's slot from the engine's
+    // live scalars. The saved map was just reloaded from disk inside the same
+    // refresh, so the outgoing slot in it is the value the user explicitly
+    // saved (settings app: slider → per-algorithm slot → Save → reload); the
+    // live scalars are stale — and, once the write-back guard has lapsed,
+    // already clobbered by the global SYNC_FIELDs. The stamp turned "set
+    // three-column max windows to 7, then switch algorithms" into a silent
+    // revert to 5 (its default), after which persistablePerAlgoSettings pruned
+    // the slot entirely.
+    void testRefresh_settingsDrivenSwitch_preservesOutgoingSlot()
+    {
+        Settings settings;
+        AutotileEngine engine(nullptr, nullptr, nullptr, PlasmaZones::TestHelpers::testRegistry());
+        engine.setEngineSettings(&settings);
+
+        auto* threeCol = m_scriptSetup.registry()->algorithm(QLatin1String("three-column"));
+        QVERIFY(threeCol);
+        const int customMaxWindows = threeCol->defaultMaxWindows() + 2;
+
+        // Land on three-column as the ambient algorithm.
+        settings.setDefaultAutotileAlgorithm(QLatin1String("three-column"));
+        engine.setAlgorithm(QLatin1String("three-column"));
+
+        // The settings app writes the user's customization: a per-algorithm
+        // slot only, never the global key (TilingAlgorithmController).
+        QVariantMap slot;
+        slot[PhosphorTiles::AutotileJsonKeys::MaxWindows] = customMaxWindows;
+        slot[PhosphorTiles::AutotileJsonKeys::SplitRatio] = 0.6;
+        slot[PhosphorTiles::AutotileJsonKeys::MasterCount] = 1;
+        QVariantMap perAlgo;
+        perAlgo[QStringLiteral("three-column")] = slot;
+        settings.setAutotilePerAlgorithmSettings(perAlgo);
+
+        // Let the switch's write-back guard lapse so the refresh below runs the
+        // global SYNC_FIELDs — the worst-case variant, where the live scalars
+        // hold the global default rather than merely stale values.
+        QTest::qWait(600);
+
+        // The settings app also switched the default algorithm before Save; the
+        // daemon reload delivers both changes in one refresh.
+        settings.setDefaultAutotileAlgorithm(QLatin1String("master-stack"));
+        engine.refreshConfigFromSettings();
+        QCOMPARE(engine.algorithm(), QStringLiteral("master-stack"));
+
+        // The freshly-saved slot survives the switch, both in the live config
+        // and in what writeBackTuning() persisted back to settings.
+        const auto savedIt = engine.config()->savedAlgorithmSettings.constFind(QStringLiteral("three-column"));
+        QVERIFY2(savedIt != engine.config()->savedAlgorithmSettings.constEnd(),
+                 "three-column slot was pruned by the settings-driven switch");
+        QCOMPARE(savedIt->maxWindows, customMaxWindows);
+        const QVariantMap persisted =
+            settings.autotilePerAlgorithmSettings().value(QStringLiteral("three-column")).toMap();
+        QCOMPARE(persisted.value(PhosphorTiles::AutotileJsonKeys::MaxWindows).toInt(), customMaxWindows);
+
+        // Switching back restores the customization.
+        engine.setAlgorithm(QLatin1String("three-column"));
+        QCOMPARE(engine.config()->maxWindows, customMaxWindows);
     }
 
     // ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
Fixes the "reverts to default" half of discussion #853: editing a tiling style's Max windows (or ratio) in Settings and then switching styles silently reverted the edit.

**Root cause.** `AutotileEngine::refreshConfigFromSettings()` syncs the global scalars into the live config before `setAlgorithm()` runs. When one daemon reload delivered both a per-algorithm map update and an ambient algorithm switch, `setAlgorithm()`'s outgoing-slot stamp wrote those clobbered scalars over the slot the settings app had just saved. `writeBackTuning()` then persisted the corruption, and `persistablePerAlgoSettings` pruned the slot entirely once it matched the algorithm's defaults, so the user's customization vanished from config.json. The reporter's attached config showed exactly this state (per-algorithm `maxWindows: 7`, everything else back at 5).

**Fix.** A scoped `m_refreshingFromSettings` flag suppresses the outgoing-slot stamp on the settings-refresh path only. There the just-reloaded disk map is authoritative for the outgoing algorithm; the engine's live scalars are stale by construction. Direct `setAlgorithm()` calls (D-Bus, scripts, layout applies) keep the stamp, so live shortcut tunings still persist across ordinary switches.

## Testing
- New regression test `testRefresh_settingsDrivenSwitch_preservesOutgoingSlot` reproduces the reporter's sequence (customize active algorithm's slot, let the write-back guard lapse, switch algorithms via settings, refresh) and asserts the slot survives in both the live config and the persisted map, and restores on switch-back.
- Mutation-verified: removing the guard makes the new test fail; restoring it passes.
- Full ctest: 314/314 in both the unity and no-unity trees.

The crash half of #853 remains open pending a backtrace from the reporter (no settings-app trace in the support report). Investigated and ruled out: re-entrant D-Bus signal dispatch during `QDBus::Block` calls (disproven with an empirical probe on Qt 6.11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)