### PR TITLE
fix(daemon): stop purging user shortcut customisations on service restart

### DIFF
--- a/src/daemon/controllers/shortcutmanager.cpp
+++ b/src/daemon/controllers/shortcutmanager.cpp
@@ -684,6 +684,17 @@ bool ShortcutManager::updateShortcuts()
 void ShortcutManager::setBackendForTesting(std::unique_ptr<PhosphorShortcuts::IBackend> backend)
 {
     Q_ASSERT_X(m_entries.isEmpty(), "setBackendForTesting", "inject before registerShortcuts()");
+    if (!m_entries.isEmpty()) {
+        // Release-build pair for the assert. Resetting the registry while
+        // m_entries stays populated would break the "entries non-empty
+        // implies registry present" invariant updateShortcuts() relies on —
+        // the next settings save would deref a null m_registry in
+        // rebindAll(). Release the live registration first so the invariant
+        // survives the misuse.
+        qCWarning(lcShortcuts) << "setBackendForTesting() called after registerShortcuts() — releasing the live "
+                                  "registration before installing the injected backend";
+        unregisterShortcuts();
+    }
     m_registry.reset();
     m_backend = std::move(backend);
 }

--- a/src/daemon/controllers/shortcutmanager.cpp
+++ b/src/daemon/controllers/shortcutmanager.cpp
@@ -681,6 +681,13 @@ bool ShortcutManager::updateShortcuts()
     return true;
 }
 
+void ShortcutManager::setBackendForTesting(std::unique_ptr<PhosphorShortcuts::IBackend> backend)
+{
+    Q_ASSERT_X(m_entries.isEmpty(), "setBackendForTesting", "inject before registerShortcuts()");
+    m_registry.reset();
+    m_backend = std::move(backend);
+}
+
 void ShortcutManager::unregisterShortcuts()
 {
     m_registrationInProgress = false;
@@ -692,11 +699,16 @@ void ShortcutManager::unregisterShortcuts()
     // teardown; replaying them on the next registerShortcuts() would
     // re-bind a stale grab.
     m_pendingAdhocOps.clear();
-    if (m_registry) {
-        for (const auto& e : std::as_const(m_entries)) {
-            m_registry->unbind(e.id);
-        }
-    }
+    // Deliberately NO Registry::unbind() sweep over m_entries: unbind routes
+    // to IBackend::unregisterShortcut, and on KGlobalAccel that purges the
+    // id's persistent kglobalshortcutsrc record — the store where the user's
+    // System Settings customisations live. This runs on the daemon stop()
+    // path (SIGTERM included), so the sweep deleted every customised binding
+    // on each service restart (discussion #851). Destroying the backend below
+    // releases the grabs without touching persistent records: KGlobalAccel
+    // drops its in-memory action table when the QActions die and the backend
+    // destructor purges only transient ids, while PortalBackend releases
+    // everything by closing the session.
     m_entries.clear();
 
     // Tear down the backend so any Portal session is closed and grabs are

--- a/src/daemon/controllers/shortcutmanager.h
+++ b/src/daemon/controllers/shortcutmanager.h
@@ -108,6 +108,15 @@ public:
     static QVector<QVariantMap> compressCheatsheetFamilies(QVector<QVariantMap> rows,
                                                            const QVector<CheatsheetFamily>& families);
 
+    /**
+     * Test-only backend injection. Must be called before registerShortcuts()
+     * (which otherwise creates the real platform backend lazily). Lets tests
+     * observe the exact IBackend calls the manager makes — in particular that
+     * unregisterShortcuts() never purges persistent bindings via
+     * IBackend::unregisterShortcut (discussion #851).
+     */
+    void setBackendForTesting(std::unique_ptr<PhosphorShortcuts::IBackend> backend);
+
 Q_SIGNALS:
     /**
      * The cheatsheet catalog's contents changed: a sequence was rebound

--- a/src/daemon/controllers/shortcutmanager.h
+++ b/src/daemon/controllers/shortcutmanager.h
@@ -110,8 +110,10 @@ public:
 
     /**
      * Test-only backend injection. Must be called before registerShortcuts()
-     * (which otherwise creates the real platform backend lazily). Lets tests
-     * observe the exact IBackend calls the manager makes — in particular that
+     * (which otherwise creates the real platform backend lazily); a call
+     * arriving after registration asserts in debug builds and releases the
+     * live registration first in release builds. Lets tests observe the
+     * exact IBackend calls the manager makes — in particular that
      * unregisterShortcuts() never purges persistent bindings via
      * IBackend::unregisterShortcut (discussion #851).
      */

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -474,6 +474,18 @@ target_link_libraries(test_cheatsheet_compression
     PRIVATE Qt6::Test Qt6::Core Qt6::Gui plasmazones_core PhosphorShortcuts::PhosphorShortcuts)
 add_test(NAME test_cheatsheet_compression COMMAND test_cheatsheet_compression)
 
+# Shortcut teardown contract (discussion #851): unregisterShortcuts() must not
+# purge persistent bindings from the backend. Same daemon-source compilation
+# as test_cheatsheet_compression, plus a backend injected via
+# setBackendForTesting to observe the IBackend calls.
+add_executable(test_shortcutmanager_teardown
+    daemon/test_shortcutmanager_teardown.cpp
+    ${CMAKE_SOURCE_DIR}/src/daemon/controllers/shortcutmanager.cpp
+)
+target_link_libraries(test_shortcutmanager_teardown
+    PRIVATE Qt6::Test Qt6::Core Qt6::Gui plasmazones_core PhosphorShortcuts::PhosphorShortcuts)
+add_test(NAME test_shortcutmanager_teardown COMMAND test_shortcutmanager_teardown)
+
 # ═══════════════════════════════════════════════════════════════════════════════
 # core/ - Layout Tests (core, zones)
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/tests/unit/daemon/test_shortcutmanager_teardown.cpp
+++ b/tests/unit/daemon/test_shortcutmanager_teardown.cpp
@@ -1,0 +1,132 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Pins the teardown contract of ShortcutManager::unregisterShortcuts()
+// (discussion #851): releasing the registration on the daemon stop() path
+// must NOT call IBackend::unregisterShortcut for the persistent catalog
+// entries. On KGlobalAccel that call purges the id's on-disk
+// kglobalshortcutsrc record — the store holding the user's System Settings
+// customisations — so a sweep there wiped every customised binding on each
+// service restart. Teardown releases grabs by destroying the backend, whose
+// destructor preserves persistent records.
+//
+// The explicit adhoc release path is the intended purge and must keep
+// purging; the second case pins that the fix did not overreach.
+
+#include "daemon/controllers/shortcutmanager.h"
+
+#include "config/settings.h"
+#include "helpers/IsolatedConfigGuard.h"
+
+#include <PhosphorShortcuts/IBackend.h>
+
+#include <QKeySequence>
+#include <QStringList>
+#include <QTest>
+
+#include <memory>
+
+using PlasmaZones::Settings;
+using PlasmaZones::ShortcutManager;
+using PlasmaZones::TestHelpers::IsolatedConfigGuard;
+
+namespace {
+
+// Records calls into test-owned lists (passed by pointer) so the record
+// survives the backend's destruction — unregisterShortcuts() destroys the
+// injected backend as part of teardown.
+class RecordingBackend : public PhosphorShortcuts::IBackend
+{
+    Q_OBJECT
+public:
+    RecordingBackend(QStringList* registers, QStringList* unregisters)
+        : m_registers(registers)
+        , m_unregisters(unregisters)
+    {
+    }
+
+    void registerShortcut(const QString& id, const QKeySequence& /*defaultSeq*/, const QKeySequence& /*currentSeq*/,
+                          const QString& /*description*/, bool /*persistent*/) override
+    {
+        m_registers->append(id);
+    }
+
+    void updateShortcut(const QString& /*id*/, const QKeySequence& /*defaultSeq*/,
+                        const QKeySequence& /*newTrigger*/) override
+    {
+    }
+
+    void unregisterShortcut(const QString& id) override
+    {
+        m_unregisters->append(id);
+    }
+
+    void flush() override
+    {
+        Q_EMIT ready();
+    }
+
+private:
+    QStringList* m_registers;
+    QStringList* m_unregisters;
+};
+
+} // namespace
+
+class TestShortcutManagerTeardown : public QObject
+{
+    Q_OBJECT
+
+private:
+    std::unique_ptr<IsolatedConfigGuard> m_configGuard;
+
+private Q_SLOTS:
+    void init()
+    {
+        m_configGuard = std::make_unique<IsolatedConfigGuard>();
+    }
+
+    void cleanup()
+    {
+        m_configGuard.reset();
+    }
+
+    void teardownDoesNotPurgePersistentBindings()
+    {
+        Settings settings;
+        ShortcutManager manager(&settings);
+        QStringList registers;
+        QStringList unregisters;
+        manager.setBackendForTesting(std::make_unique<RecordingBackend>(&registers, &unregisters));
+
+        manager.registerShortcuts();
+        QVERIFY2(!registers.isEmpty(), "expected the catalog to reach the backend on registerShortcuts()");
+
+        manager.unregisterShortcuts();
+        QVERIFY2(unregisters.isEmpty(),
+                 qPrintable(QStringLiteral("teardown purged %1 persistent binding(s) from the backend, e.g. \"%2\" — "
+                                           "on KGlobalAccel this deletes the user's customised shortcut")
+                                .arg(unregisters.size())
+                                .arg(unregisters.value(0))));
+    }
+
+    void explicitAdhocReleaseStillPurges()
+    {
+        Settings settings;
+        ShortcutManager manager(&settings);
+        QStringList registers;
+        QStringList unregisters;
+        manager.setBackendForTesting(std::make_unique<RecordingBackend>(&registers, &unregisters));
+        manager.registerShortcuts();
+
+        const QString id = QStringLiteral("pz.test.adhoc.escape");
+        manager.registerAdhocShortcut(id, QKeySequence(QStringLiteral("Escape")), QStringLiteral("Test grab"), [] { });
+        QVERIFY(registers.contains(id));
+
+        manager.unregisterAdhocShortcut(id);
+        QCOMPARE(unregisters, QStringList{id});
+    }
+};
+
+QTEST_MAIN(TestShortcutManagerTeardown)
+#include "test_shortcutmanager_teardown.moc"


### PR DESCRIPTION
Fixes #851 (discussion): custom shortcuts set in System Settings (for example Meta+Alt+Arrows on the Move Window quad) were deleted every time plasmazones.service restarted, starting with 3.3.0.

## Root cause

`Daemon::stop()` runs on every SIGTERM. The 3.3.0 restart-hygiene audit fix made it release the shortcut registration with a `Registry::unbind()` sweep over the whole catalog. `unbind()` routes to `IBackend::unregisterShortcut`, which on KGlobalAccel calls `removeAllShortcuts` and deletes the id's persistent `kglobalshortcutsrc` record. That record is where System Settings customisations live, so every service shutdown wiped them and the next start re-registered the compiled defaults from config.json. Customisations made in the PlasmaZones settings app were unaffected because they live in config.json and are re-applied at registration.

The sweep was never needed to release the grabs: `unregisterShortcuts()` destroys the registry and backend immediately afterwards, and the backend teardown already implements the correct persistence split. KGlobalAccel drops its in-memory action table with the QActions and its destructor purges only transient ids, while PortalBackend releases everything by closing the session.

## Fix

- Drop the unbind sweep from `ShortcutManager::unregisterShortcuts()` and let the backend teardown do the release.
- The explicit adhoc release path (transient grabs like the drag-cancel Escape) still purges, as intended.

## Tests

- New `test_shortcutmanager_teardown` pins the contract from both sides through a `setBackendForTesting()` injection seam: teardown must not emit `unregisterShortcut` for the persistent catalog, and the explicit adhoc release must keep purging.
- Mutation-verified: reinstating the old sweep makes the new test fail.
- Full suite: 315/315 passing (one GPU-gated test skipped by design).

Users already bitten will need to re-add their custom keys once; after this fix, restarts preserve them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)