### PR TITLE
fix: make per-algorithm Max Windows writes land and apply on mixed-algorithm screens

### DIFF
--- a/libs/phosphor-engine/include/PhosphorEngine/IPlacementEngine.h
+++ b/libs/phosphor-engine/include/PhosphorEngine/IPlacementEngine.h
@@ -595,6 +595,17 @@ public:
     {
         return -1;
     }
+    /// The user's saved per-algorithm max-windows tuning for @p algorithmId,
+    /// or std::nullopt when the engine keeps no such slot. Engines with
+    /// per-algorithm tuning (AutotileEngine) override this; the daemon's
+    /// per-screen MaxWindows injection consults it so a screen pinned to a
+    /// non-global algorithm gets the user's saved cap, not the algorithm's
+    /// built-in default.
+    virtual std::optional<int> savedMaxWindowsForAlgorithm(const QString& algorithmId) const
+    {
+        Q_UNUSED(algorithmId)
+        return std::nullopt;
+    }
 
     // ═══════════════════════════════════════════════════════════════════════════
     // OPTIONAL: Retile / refresh (override if engine supports on-demand retile)

--- a/libs/phosphor-engine/include/PhosphorEngine/IPlacementEngine.h
+++ b/libs/phosphor-engine/include/PhosphorEngine/IPlacementEngine.h
@@ -597,10 +597,11 @@ public:
     }
     /// The user's saved per-algorithm max-windows tuning for @p algorithmId,
     /// or std::nullopt when the engine keeps no such slot. Engines with
-    /// per-algorithm tuning (AutotileEngine) override this; the daemon's
-    /// per-screen MaxWindows injection consults it so a screen pinned to a
-    /// non-global algorithm gets the user's saved cap, not the algorithm's
-    /// built-in default.
+    /// per-algorithm tuning (AutotileEngine) override this; both mixed-
+    /// algorithm cap paths consult it — the daemon's per-screen MaxWindows
+    /// injection and PerScreenConfigResolver::effectiveMaxWindows step 3 —
+    /// so a screen pinned to a non-global algorithm gets the user's saved
+    /// cap, not the algorithm's built-in default.
     virtual std::optional<int> savedMaxWindowsForAlgorithm(const QString& algorithmId) const
     {
         Q_UNUSED(algorithmId)

--- a/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
+++ b/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
@@ -551,6 +551,17 @@ public:
     PhosphorTiles::AutotileInsertPosition effectiveInsertPosition(const QString& screenId) const;
     qreal effectiveSplitRatioStep(const QString& screenId) const override;
     int runtimeMaxWindows() const override;
+    /**
+     * @brief The user's saved per-algorithm max-windows tuning, if any
+     *
+     * Consulted by the mixed-algorithm cap paths (PerScreenConfigResolver
+     * step 3 and the daemon's per-screen MaxWindows injection): when a
+     * screen's assigned algorithm differs from the engine's global one, the
+     * saved slot is the user's explicit tuning for that algorithm and must
+     * win over the algorithm's built-in default. std::nullopt when the
+     * algorithm has no saved slot.
+     */
+    std::optional<int> savedMaxWindowsForAlgorithm(const QString& algorithmId) const override;
     QString effectiveAlgorithmId(const QString& screenId) const;
     PhosphorTiles::TilingAlgorithm* effectiveAlgorithm(const QString& screenId) const;
 

--- a/libs/phosphor-tile-engine/src/PerScreenConfigResolver.cpp
+++ b/libs/phosphor-tile-engine/src/PerScreenConfigResolver.cpp
@@ -591,6 +591,16 @@ int PerScreenConfigResolver::effectiveMaxWindows(const QString& screenId) const
     //    explicitly customized global maxWindows away from the global algo's default.
     const QString screenAlgo = effectiveAlgorithmId(screenId);
     if (screenAlgo != m_engine->m_algorithmId) {
+        // The user's saved per-algorithm tuning is the most specific answer for
+        // a screen pinned to its own algorithm — more specific than either the
+        // global maxWindows (which belongs to the global algorithm) or the
+        // screen algorithm's built-in default. Without this, a screen whose
+        // layout algorithm differed from the global one was silently capped at
+        // the built-in default no matter what the user saved for it.
+        if (const auto saved = m_engine->savedMaxWindowsForAlgorithm(screenAlgo)) {
+            return qBound(PhosphorTiles::AutotileDefaults::MinMaxWindows, *saved,
+                          PhosphorTiles::AutotileDefaults::MaxMaxWindows);
+        }
         // Registry guarded locally (AutotileEngine's ctor asserts nothing). With
         // no registry both lookups yield null, so this falls to the warning below
         // and returns the global maxWindows — the same outcome as an unknown id.

--- a/libs/phosphor-tile-engine/src/autotileengine/config.cpp
+++ b/libs/phosphor-tile-engine/src/autotileengine/config.cpp
@@ -431,6 +431,15 @@ int AutotileEngine::runtimeMaxWindows() const
     return m_config->maxWindows;
 }
 
+std::optional<int> AutotileEngine::savedMaxWindowsForAlgorithm(const QString& algorithmId) const
+{
+    const auto it = m_config->savedAlgorithmSettings.constFind(algorithmId);
+    if (it == m_config->savedAlgorithmSettings.constEnd()) {
+        return std::nullopt;
+    }
+    return it->maxWindows;
+}
+
 QString AutotileEngine::effectiveAlgorithmId(const QString& screenId) const
 {
     return m_configResolver->effectiveAlgorithmId(screenId);

--- a/src/daemon/daemon/autotile.cpp
+++ b/src/daemon/daemon/autotile.cpp
@@ -200,9 +200,17 @@ void Daemon::updateAutotileScreens()
                 // — those land in `overrides` directly and are untouched here.
                 const QString globalAlgo = m_autotileEngine->algorithmId();
                 if (screenAlgo != globalAlgo && !overrides.contains(PerScreenKeys::MaxWindows) && !contextUnlimited) {
-                    auto* screenAlgoPtr = m_algorithmRegistry->algorithm(screenAlgo);
-                    auto* globalAlgoPtr = m_algorithmRegistry->algorithm(globalAlgo);
-                    if (screenAlgoPtr) {
+                    // The user's saved per-algorithm tuning is more specific
+                    // than either the global maxWindows or the screen
+                    // algorithm's built-in default — mirror effectiveMaxWindows
+                    // step 3, which consults the saved slot first. Without
+                    // this, the injected built-in default sat at step 1 of
+                    // effectiveMaxWindows and pinned the cap over the user's
+                    // saved value for the screen's algorithm.
+                    if (const auto saved = m_autotileEngine->savedMaxWindowsForAlgorithm(screenAlgo)) {
+                        overrides[PerScreenKeys::MaxWindows] = *saved;
+                    } else if (auto* screenAlgoPtr = m_algorithmRegistry->algorithm(screenAlgo)) {
+                        auto* globalAlgoPtr = m_algorithmRegistry->algorithm(globalAlgo);
                         if (!globalAlgoPtr) {
                             qCDebug(lcDaemon) << "updateAutotileScreens: global algorithm" << globalAlgo
                                               << "not found - injecting per-screen default MaxWindows";

--- a/src/daemon/daemon/autotile.cpp
+++ b/src/daemon/daemon/autotile.cpp
@@ -172,10 +172,11 @@ void Daemon::updateAutotileScreens()
 
                 // When the per-screen algorithm differs from the engine's
                 // current global algorithm and there's no explicit MaxWindows
-                // override, inject the per-screen algorithm's default — but
-                // only if the global maxWindows is still at the global
-                // algorithm's default.  If the user customized maxWindows,
-                // respect their choice.
+                // override, inject that algorithm's cap: the user's saved
+                // per-algorithm slot when one exists, else the algorithm's own
+                // default — the default only if the global maxWindows is still
+                // at the global algorithm's default (a customized global is
+                // respected).
                 //
                 // Use the engine's runtime algorithm (m_autotileEngine->algorithm())
                 // instead of m_settings->defaultAutotileAlgorithm(). During layout cycling,
@@ -186,9 +187,10 @@ void Daemon::updateAutotileScreens()
                 //
                 // Note: in applyEntry(), this runs BEFORE setAlgorithm() updates
                 // the global ID, so globalAlgo is the OLD algorithm. This is safe:
-                // effectiveMaxWindows() has identical fallback logic (step 2) that
-                // dynamically derives the correct MaxWindows at retile time even
-                // without a per-screen override. The override here is an optimization.
+                // effectiveMaxWindows() has identical fallback logic (its step 3
+                // mirrors this cascade) that dynamically derives the correct
+                // MaxWindows at retile time even without a per-screen override.
+                // The override here is an optimization.
                 //
                 // Skip the injection entirely when the context is Unlimited: the
                 // injected finite default would sit at effectiveMaxWindows step 1,

--- a/src/settings/pages/tilingalgorithmcontroller.cpp
+++ b/src/settings/pages/tilingalgorithmcontroller.cpp
@@ -254,10 +254,21 @@ void TilingAlgorithmController::setCustomParam(const QString& algorithmId, const
 
     customParams[paramName] = coerced;
     algoEntry[PhosphorTiles::AutotileJsonKeys::CustomParams] = customParams;
-    // Persist only the key the user actually set. A missing splitRatio /
-    // masterCount is defaulted by perAlgoFromVariantMap on read, so injecting
-    // them here would just bake a redundant (and potentially-stale) per-algorithm
-    // override into the entry for a value the user never touched.
+    // Materialize the untouched numeric fields with the ALGORITHM'S own
+    // defaults, same as writeAlgorithmField: the Settings sanitize pass
+    // refills missing fields with the GENERIC schema defaults, so a thin
+    // {customParams} slot for an algorithm whose own defaults differ would
+    // read back with the wrong values (grid's max windows 9 would come back
+    // as the generic 5, silently re-capping the algorithm the moment any
+    // custom param is touched).
+    constexpr std::array numericFields{PhosphorTiles::AutotileJsonKeys::SplitRatio,
+                                       PhosphorTiles::AutotileJsonKeys::MasterCount,
+                                       PhosphorTiles::AutotileJsonKeys::MaxWindows};
+    for (const QLatin1String field : numericFields) {
+        if (!algoEntry.contains(field)) {
+            algoEntry[field] = algorithmFieldDefault(algorithmId, field);
+        }
+    }
 
     perAlgo[algorithmId] = algoEntry;
     m_settings->setAutotilePerAlgorithmSettings(perAlgo);

--- a/src/settings/pages/tilingalgorithmcontroller.cpp
+++ b/src/settings/pages/tilingalgorithmcontroller.cpp
@@ -14,6 +14,7 @@
 #include <QLatin1String>
 #include <QLoggingCategory>
 #include <algorithm>
+#include <array>
 #include <cmath> // std::isfinite — guards the NaN/inf clamp in setCustomParam
 
 namespace PlasmaZones {
@@ -312,27 +313,33 @@ QVariantMap TilingAlgorithmController::algorithmSettingsFor(const QString& algor
     return result;
 }
 
+QVariant TilingAlgorithmController::algorithmFieldDefault(const QString& algorithmId, QLatin1String key) const
+{
+    // Mirror the default derivation in algorithmSettingsFor() exactly (clamped
+    // algorithm defaults, DefaultMasterCount for master count) so "at default"
+    // here means the same value the page would show when no slot exists.
+    PhosphorTiles::TilingAlgorithm* algo = m_registry->algorithm(algorithmId);
+    if (key == PhosphorTiles::AutotileJsonKeys::MaxWindows) {
+        return algo ? std::clamp(algo->defaultMaxWindows(), ConfigDefaults::autotileMaxWindowsMin(),
+                                 ConfigDefaults::autotileMaxWindowsMax())
+                    : PhosphorTiles::AutotileDefaults::DefaultMaxWindows;
+    }
+    if (key == PhosphorTiles::AutotileJsonKeys::MasterCount) {
+        return PhosphorTiles::AutotileDefaults::DefaultMasterCount;
+    }
+    return algo ? std::clamp(algo->defaultSplitRatio(), ConfigDefaults::autotileSplitRatioMin(),
+                             ConfigDefaults::autotileSplitRatioMax())
+                : PhosphorTiles::AutotileDefaults::DefaultSplitRatio;
+}
+
 bool TilingAlgorithmController::fieldMatchesAlgorithmDefault(const QString& algorithmId, QLatin1String key,
                                                              const QVariant& value) const
 {
-    // Mirror the default derivation in algorithmSettingsFor() exactly (clamped
-    // algorithm defaults, DefaultMasterCount for master count) so "reset to
-    // default" here means the same value the page would show when no slot exists.
-    PhosphorTiles::TilingAlgorithm* algo = m_registry->algorithm(algorithmId);
-    if (key == PhosphorTiles::AutotileJsonKeys::MaxWindows) {
-        const int def = algo ? std::clamp(algo->defaultMaxWindows(), ConfigDefaults::autotileMaxWindowsMin(),
-                                          ConfigDefaults::autotileMaxWindowsMax())
-                             : PhosphorTiles::AutotileDefaults::DefaultMaxWindows;
-        return value.toInt() == def;
-    }
-    if (key == PhosphorTiles::AutotileJsonKeys::MasterCount) {
-        return value.toInt() == PhosphorTiles::AutotileDefaults::DefaultMasterCount;
-    }
     if (key == PhosphorTiles::AutotileJsonKeys::SplitRatio) {
-        const qreal def = algo ? std::clamp(algo->defaultSplitRatio(), ConfigDefaults::autotileSplitRatioMin(),
-                                            ConfigDefaults::autotileSplitRatioMax())
-                               : PhosphorTiles::AutotileDefaults::DefaultSplitRatio;
-        return qFuzzyCompare(1.0 + value.toDouble(), 1.0 + def);
+        return qFuzzyCompare(1.0 + value.toDouble(), 1.0 + algorithmFieldDefault(algorithmId, key).toDouble());
+    }
+    if (key == PhosphorTiles::AutotileJsonKeys::MaxWindows || key == PhosphorTiles::AutotileJsonKeys::MasterCount) {
+        return value.toInt() == algorithmFieldDefault(algorithmId, key).toInt();
     }
     return false;
 }
@@ -343,27 +350,41 @@ bool TilingAlgorithmController::writeAlgorithmField(const QString& algorithmId, 
     if (algorithmId.isEmpty())
         return false;
     QVariantMap perAlgo = m_settings->autotilePerAlgorithmSettings();
+    const bool hadSlot = perAlgo.contains(algorithmId);
     QVariantMap entry = perAlgo.value(algorithmId).toMap();
 
-    if (fieldMatchesAlgorithmDefault(algorithmId, key, value)) {
-        // Setting a field back to the algorithm's own default is not a
-        // customization: persisting it would leave a slot the profile diff
-        // reports as a change the user never made. Drop the field instead, and
-        // prune the whole entry when nothing customized (including customParams)
-        // remains. A field that was never stored means there is nothing to undo.
-        if (!entry.contains(key))
-            return false;
-        entry.remove(key);
-    } else {
-        if (entry.contains(key) && entry.value(key) == value)
-            return false;
-        entry[key] = value;
+    if (entry.contains(key) && entry.value(key) == value)
+        return false;
+
+    // Persistence cannot represent a thin slot: the sanitize pass in
+    // Settings::setAutotilePerAlgorithmSettings() materializes every missing
+    // numeric field with the GENERIC schema defaults, so a dropped field read
+    // back as the wrong value for any algorithm whose own default differs
+    // (centered-master's max windows 7 came back as 5, collapsing the write
+    // into a silent no-op that never reached the daemon). Store fully
+    // materialized slots instead, filling untouched fields with the
+    // algorithm's own defaults, and express "no customization" as whole-slot
+    // absence — the one state the sanitizer preserves, and the one every
+    // reader (engine restore, refresh fallback, this page) already resolves
+    // to the algorithm's own defaults.
+    entry[key] = value;
+    constexpr std::array fields{PhosphorTiles::AutotileJsonKeys::SplitRatio,
+                                PhosphorTiles::AutotileJsonKeys::MasterCount,
+                                PhosphorTiles::AutotileJsonKeys::MaxWindows};
+    bool allDefault = entry.value(PhosphorTiles::AutotileJsonKeys::CustomParams).toMap().isEmpty();
+    for (const QLatin1String field : fields) {
+        if (!entry.contains(field))
+            entry[field] = algorithmFieldDefault(algorithmId, field);
+        allDefault = allDefault && fieldMatchesAlgorithmDefault(algorithmId, field, entry.value(field));
     }
 
-    if (entry.isEmpty())
+    if (allDefault) {
+        if (!hadSlot)
+            return false; // a slot that would only echo the defaults is never authored
         perAlgo.remove(algorithmId);
-    else
+    } else {
         perAlgo[algorithmId] = entry;
+    }
     m_settings->setAutotilePerAlgorithmSettings(perAlgo);
     return true;
 }

--- a/src/settings/pages/tilingalgorithmcontroller.h
+++ b/src/settings/pages/tilingalgorithmcontroller.h
@@ -109,15 +109,21 @@ Q_SIGNALS:
 
 private:
     QVariantMap savedCustomParams(const QString& algorithmId) const;
-    /// True when @p value equals the algorithm's own default for @p key
-    /// (split ratio / master count / max windows), using the same clamped
-    /// defaults algorithmSettingsFor() seeds. Unknown keys are never defaults.
+    /// The algorithm's own default for @p key (split ratio / master count /
+    /// max windows), clamped exactly as algorithmSettingsFor() seeds it.
+    QVariant algorithmFieldDefault(const QString& algorithmId, QLatin1String key) const;
+    /// True when @p value equals algorithmFieldDefault() for @p key.
+    /// Unknown keys are never defaults.
     bool fieldMatchesAlgorithmDefault(const QString& algorithmId, QLatin1String key, const QVariant& value) const;
     /// Read-modify-write a single key in the per-algorithm settings entry,
-    /// preserving the other keys (incl. customParams). Writing a value equal to
-    /// the algorithm's default instead drops the key (and prunes the entry when
-    /// nothing customized remains) so a default never persists as a spurious
-    /// profile-diff row. Returns false (no-op) when nothing changed on disk.
+    /// preserving the other keys (incl. customParams). Always stores a fully
+    /// materialized slot (untouched fields filled with the algorithm's own
+    /// defaults) because the Settings sanitize pass refills missing fields
+    /// with the generic schema defaults, which are wrong for algorithms whose
+    /// own defaults differ. A slot whose every field matches the algorithm's
+    /// defaults (and has no customParams) is pruned instead, so an
+    /// uncustomized algorithm never surfaces as a spurious profile-diff row.
+    /// Returns false (no-op) when nothing changed on disk.
     bool writeAlgorithmField(const QString& algorithmId, QLatin1String key, const QVariant& value);
 
     ISettings* m_settings = nullptr;

--- a/tests/unit/autotile/engine/test_per_screen_config.cpp
+++ b/tests/unit/autotile/engine/test_per_screen_config.cpp
@@ -102,6 +102,44 @@ private Q_SLOTS:
         QCOMPARE(effective, engine.config()->maxWindows);
     }
 
+    // Regression (BullHorn report, July 2026): a saved per-algorithm slot is
+    // the user's explicit tuning for the screen's algorithm and must beat the
+    // screen algorithm's built-in default when the screen is pinned to a
+    // different algorithm than the global one. Before the fix this path only
+    // ever returned the built-in default, so a screen running a layout-picked
+    // algorithm ignored the user's saved max-windows entirely.
+    void testPerScreen_effectiveMaxWindows_savedSlotBeatsScreenAlgoDefault()
+    {
+        AutotileEngine engine(nullptr, nullptr, nullptr, PlasmaZones::TestHelpers::testRegistry());
+        const QString screen = QStringLiteral("HDMI-1");
+        engine.setAutotileScreens({screen});
+
+        engine.setAlgorithm(QLatin1String("master-stack"));
+
+        QVariantMap overrides;
+        overrides[QStringLiteral("Algorithm")] = QLatin1String("bsp");
+        engine.applyPerScreenConfig(screen, overrides);
+
+        auto* bspAlgo = m_scriptSetup.registry()->algorithm(QLatin1String("bsp"));
+        auto* msAlgo = m_scriptSetup.registry()->algorithm(QLatin1String("master-stack"));
+        QVERIFY(bspAlgo);
+        QVERIFY(msAlgo);
+
+        const int saved = bspAlgo->defaultMaxWindows() + 3;
+        AlgorithmSettings slot;
+        slot.maxWindows = saved;
+        engine.config()->savedAlgorithmSettings.insert(QStringLiteral("bsp"), slot);
+
+        // Global at the global algo's default: the slot, not bsp's built-in
+        // default, must win.
+        engine.config()->maxWindows = msAlgo->defaultMaxWindows();
+        QCOMPARE(engine.effectiveMaxWindows(screen), saved);
+
+        // The slot is more specific than a user-customized global too.
+        engine.config()->maxWindows = msAlgo->defaultMaxWindows() + 2;
+        QCOMPARE(engine.effectiveMaxWindows(screen), saved);
+    }
+
     // ─────────────────────────────────────────────────────────────────────
     // Unlimited overflow mode returns the named sentinel so std::min clamps
     // become idempotent and onWindowAdded's gate is wide open. The constant

--- a/tests/unit/settings/pages/test_tiling_algorithm_controller.cpp
+++ b/tests/unit/settings/pages/test_tiling_algorithm_controller.cpp
@@ -6,11 +6,19 @@
  * @brief Tests for TilingAlgorithmController's per-algorithm persistence.
  *
  * The tiling page writes per-algorithm split ratio / master count / max windows
- * into the PerAlgorithmSettings config map. A slot that merely echoes the
- * algorithm's own default carries no user intent, so persisting it would surface
- * as a spurious "you changed this" row in the config profile diff. These tests pin
- * that writing a field equal to the algorithm's default does NOT create (or leaves
- * pruned) a slot, while a genuine customization on another field survives.
+ * into the PerAlgorithmSettings config map. Two invariants are pinned here:
+ *
+ * 1. A slot whose every field echoes the algorithm's own defaults carries no
+ *    user intent and is never authored (and is pruned when a reset makes it
+ *    so) — persisting it would surface as a spurious "you changed this" row
+ *    in the config profile diff.
+ * 2. A slot that IS authored is fully materialized with the algorithm's own
+ *    defaults for the untouched fields. The Settings sanitize pass refills
+ *    missing fields with the GENERIC schema defaults, which are wrong for any
+ *    algorithm whose own defaults differ (grid's max windows is 9, the
+ *    generic default 5). Thin slots therefore cannot round-trip: the
+ *    BullHorn report (July 2026) hit exactly that as a silent no-op when
+ *    setting centered-master's max windows to its own default of 7.
  */
 
 #include <QTest>
@@ -81,8 +89,10 @@ private Q_SLOTS:
                  "resetting the sole customized field to default did not prune the slot");
     }
 
-    // Resetting one field to default must drop only that field, preserving an
-    // unrelated customization in the same slot.
+    // Resetting one field to default must keep the slot alive for the
+    // remaining customization, with the reset field stored explicitly at the
+    // algorithm's default — a dropped field would be refilled with the
+    // GENERIC default by the Settings sanitize pass and read back wrong.
     void resetOneField_keepsOtherCustomization()
     {
         StubSettings settings;
@@ -103,9 +113,65 @@ private Q_SLOTS:
         controller.setAlgorithmMaxWindows(QStringLiteral("grid"), mwDefault);
         QVERIFY2(settings.autotilePerAlgorithmSettings().contains(QStringLiteral("grid")),
                  "slot with a remaining customization was pruned");
-        QVERIFY2(!gridEntry(settings).contains(PhosphorTiles::AutotileJsonKeys::MaxWindows),
-                 "reset max-windows field was not dropped");
+        QCOMPARE(gridEntry(settings).value(PhosphorTiles::AutotileJsonKeys::MaxWindows).toInt(), mwDefault);
         QCOMPARE(gridEntry(settings).value(PhosphorTiles::AutotileJsonKeys::SplitRatio).toDouble(), srCustom);
+    }
+
+    // An authored slot must be fully materialized with the ALGORITHM'S own
+    // defaults for the untouched fields. The Settings sanitize pass
+    // (perAlgoFromVariantMap) fills missing fields with the generic schema
+    // defaults, so a thin {splitRatio} slot for grid would read back with
+    // maxWindows 5 instead of grid's own 9 and silently re-cap the algorithm.
+    void customizeOneField_materializesAlgorithmDefaults()
+    {
+        StubSettings settings;
+        TilingAlgorithmController controller(settings, *m_scriptSetup.registry());
+
+        auto* grid = m_scriptSetup.registry()->algorithm(QStringLiteral("grid"));
+        QVERIFY(grid);
+        QVERIFY(grid->defaultMaxWindows() != PhosphorTiles::AutotileDefaults::DefaultMaxWindows);
+
+        controller.setAlgorithmSplitRatio(QStringLiteral("grid"), 0.7);
+
+        const QVariantMap entry = gridEntry(settings);
+        QVERIFY2(entry.contains(PhosphorTiles::AutotileJsonKeys::MaxWindows),
+                 "authored slot left max windows thin — the sanitizer would refill it with the generic default");
+        QCOMPARE(entry.value(PhosphorTiles::AutotileJsonKeys::MaxWindows).toInt(), grid->defaultMaxWindows());
+        QVERIFY(entry.contains(PhosphorTiles::AutotileJsonKeys::MasterCount));
+        QCOMPARE(entry.value(PhosphorTiles::AutotileJsonKeys::MasterCount).toInt(),
+                 PhosphorTiles::AutotileDefaults::DefaultMasterCount);
+    }
+
+    // Regression for the BullHorn report: a stale sanitizer-shaped slot pins
+    // the generic max windows (5), and the user sets the value back to the
+    // algorithm's own default. Under the old delete-the-field contract this
+    // collapsed into a silent no-op (field removed, sanitizer refilled it
+    // with 5, equality bail) and the daemon kept evicting at 5. The write
+    // must land: with every field back at the algorithm's defaults the slot
+    // is pruned, and every reader derives the algorithm's own default (9).
+    void defaultValueWrite_replacesStaleGenericSlot()
+    {
+        StubSettings settings;
+        TilingAlgorithmController controller(settings, *m_scriptSetup.registry());
+
+        auto* grid = m_scriptSetup.registry()->algorithm(QStringLiteral("grid"));
+        QVERIFY(grid);
+        QVERIFY(grid->defaultMaxWindows() != PhosphorTiles::AutotileDefaults::DefaultMaxWindows);
+
+        // Sanitizer-shaped stale slot: generic defaults materialized into every field.
+        QVariantMap staleEntry;
+        staleEntry[PhosphorTiles::AutotileJsonKeys::SplitRatio] = grid->defaultSplitRatio();
+        staleEntry[PhosphorTiles::AutotileJsonKeys::MasterCount] = PhosphorTiles::AutotileDefaults::DefaultMasterCount;
+        staleEntry[PhosphorTiles::AutotileJsonKeys::MaxWindows] = PhosphorTiles::AutotileDefaults::DefaultMaxWindows;
+        QVariantMap perAlgo;
+        perAlgo[QStringLiteral("grid")] = staleEntry;
+        settings.setAutotilePerAlgorithmSettings(perAlgo);
+
+        controller.setAlgorithmMaxWindows(QStringLiteral("grid"), grid->defaultMaxWindows());
+
+        QVERIFY2(!settings.autotilePerAlgorithmSettings().contains(QStringLiteral("grid")),
+                 "stale generic-default slot survived a write of the algorithm's own default — "
+                 "the wrong cap would keep pinning the algorithm");
     }
 };
 

--- a/tests/unit/settings/pages/test_tiling_algorithm_controller.cpp
+++ b/tests/unit/settings/pages/test_tiling_algorithm_controller.cpp
@@ -142,6 +142,39 @@ private Q_SLOTS:
                  PhosphorTiles::AutotileDefaults::DefaultMasterCount);
     }
 
+    // setCustomParam is the other slot author and must uphold the same
+    // materialization contract: a custom-param write on an algorithm with no
+    // prior slot must not leave the numeric fields thin, or the sanitizer
+    // refills the max windows with the generic 5 and silently re-caps the
+    // algorithm the moment any custom param is touched. Cluster declares
+    // custom params AND a non-generic defaultMaxWindows (8), which is the
+    // combination that exposed the bug.
+    void setCustomParam_materializesAlgorithmDefaults()
+    {
+        StubSettings settings;
+        TilingAlgorithmController controller(settings, *m_scriptSetup.registry());
+
+        auto* cluster = m_scriptSetup.registry()->algorithm(QStringLiteral("cluster"));
+        QVERIFY(cluster);
+        QVERIFY(cluster->supportsCustomParams());
+        QVERIFY(cluster->defaultMaxWindows() != PhosphorTiles::AutotileDefaults::DefaultMaxWindows);
+
+        const QVariantList defs = cluster->customParamDefList();
+        QVERIFY(!defs.isEmpty());
+        const QVariantMap def = defs.first().toMap();
+        const QString paramName = def.value(QStringLiteral("name")).toString();
+        QVERIFY(!paramName.isEmpty());
+
+        controller.setCustomParam(QStringLiteral("cluster"), paramName, def.value(QStringLiteral("defaultValue")));
+
+        const QVariantMap entry = settings.autotilePerAlgorithmSettings().value(QStringLiteral("cluster")).toMap();
+        QVERIFY2(entry.contains(PhosphorTiles::AutotileJsonKeys::MaxWindows),
+                 "custom-param write left max windows thin — the sanitizer would refill it with the generic default");
+        QCOMPARE(entry.value(PhosphorTiles::AutotileJsonKeys::MaxWindows).toInt(), cluster->defaultMaxWindows());
+        QVERIFY(entry.contains(PhosphorTiles::AutotileJsonKeys::SplitRatio));
+        QVERIFY(entry.contains(PhosphorTiles::AutotileJsonKeys::MasterCount));
+    }
+
     // Regression for the BullHorn report: a stale sanitizer-shaped slot pins
     // the generic max windows (5), and the user sets the value back to the
     // algorithm's own default. Under the old delete-the-field contract this


### PR DESCRIPTION
## Summary

Fixes the tiling half of BullHorn's Discord report (Centered Master, Max Windows slider 5 → 7 shows 7 zones in Overview but the daemon keeps evicting at 5, and only a switch-away-and-back workaround applied it). Two independent bugs:

**1. Silent no-op in the settings write path (`fix(settings)` commit).** Centered Master's own `defaultMaxWindows` is 7. `writeAlgorithmField` treated a value matching the algorithm's own default as "not a customization" and deleted the field, but the sanitize pass in `Settings::setAutotilePerAlgorithmSettings` refills missing fields with the GENERIC schema defaults (max windows 5). The refilled candidate compared equal to the stale on-disk slot, so the setter bailed: nothing written, no signal, daemon never notified, UI showing 7 from page-local state only. This made each algorithm's own default unwritable whenever it differs from 5 (grid 9, cluster 8, centered-master 7, tatami/paper/theater 6, most stack algorithms 4), and it also meant customizing one field silently pinned the others to the generic defaults. The controller now always stores fully materialized slots using the algorithm's own clamped defaults, and expresses "no customization" as whole-slot absence, the one state the sanitizer preserves and every reader already resolves to the algorithm's defaults.

**2. Saved tuning ignored on mixed-algorithm screens (`fix(tile-engine)` commit).** Picking a tiling layout in Overview pins the screen's algorithm without rewriting the settings default algorithm, so screen algo != engine global algo is the normal steady state. In that state both cap paths (`effectiveMaxWindows` step 3 and the daemon's per-screen MaxWindows injection) fell back to the algorithm's built-in default and never consulted `savedAlgorithmSettings`. Added `IPlacementEngine::savedMaxWindowsForAlgorithm` (nullopt default; AutotileEngine returns the saved slot) and consult it first in both paths. The Unlimited-overflow gate is unchanged.

The stale 5 in the slot was originally planted by the #853 clobber (fixed separately in #854); this PR makes the write land and the value apply even in the mixed-algorithm state.

## Tests

- `test_tiling_algorithm_controller`: contract updated (reset field stays materialized at the algorithm default) plus two regressions: authored slots materialize the ALGORITHM's defaults, and the exact BullHorn scenario (stale sanitizer-shaped slot + write of the algorithm's own default) must change disk state.
- `test_per_screen_config`: new `savedSlotBeatsScreenAlgoDefault` regression covering resolver step 3.
- Full suite: 315/315 passing in the unity tree; no-unity tree builds clean.

Not in scope (from the same report): the settings-app crash (still needs a coredump from the reporter; best candidate is the Overview page's blocking D-Bus calls during async incubation) and the editor "Edit"-on-autotile affordance (preview mode is by design; the menu item deserves a relabel, which is a wording decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)