### PR TITLE
fix(tiling): preserve placement across minimize mode switches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Minimized windows stay out of tiling across a mode switch**: switching a screen between snapping and tiling no longer counts minimized windows in the tiled layout or moves them, and unminimizing restores each window to the place it had before it was minimized, on either engine and across restarts ([#859](https://github.com/fuddlesworth/PlasmaZones/pull/859)).
 - **The support report script no longer needs Perl's JSON::PP module**: some distros package Perl core modules separately, so `plasmazones-report` failed with a module error and wrongly reported that the daemon was not running. The script now does all of its text processing with python3 ([#861](https://github.com/fuddlesworth/PlasmaZones/pull/861)).
 
 ## [3.3.1] - 2026-07-27
@@ -1765,6 +1766,7 @@ Initial packaged release. Wayland-only (X11 support removed). Requires KDE Plasm
 - Session restoration and rotation after login ([#66])
 - Window tracking: snap/restore behavior, zone clearing, startup timing, rotation zone ID matching, floating window exclusion ([#67])
 
+[Unreleased]: https://github.com/fuddlesworth/PlasmaZones/compare/v3.3.1...HEAD
 [3.3.1]: https://github.com/fuddlesworth/PlasmaZones/compare/v3.3.0...v3.3.1
 [3.3.0]: https://github.com/fuddlesworth/PlasmaZones/compare/v3.2.7...v3.3.0
 [3.2.7]: https://github.com/fuddlesworth/PlasmaZones/compare/v3.2.6...v3.2.7

--- a/dbus/org.plasmazones.WindowTracking.xml
+++ b/dbus/org.plasmazones.WindowTracking.xml
@@ -148,7 +148,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
             </arg>
         </method>
         <method name="getFloatingWindows">
-            <annotation name="org.gtk.GDBus.DocString" value="Return all window IDs that are floating."/>
+            <annotation name="org.gtk.GDBus.DocString" value="Return the window IDs that are floating, excluding suspension (minimize-as-float) entries: a minimized window's float is daemon-side occupancy bookkeeping, and the effect's own minimize-float claim paths own it. Consumers re-seeding float state from this list therefore never adopt a suspension float."/>
             <arg name="windowIds" type="as" direction="out">
                 <annotation name="org.gtk.GDBus.DocString" value="Floating window IDs."/>
             </arg>
@@ -384,7 +384,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
                 <annotation name="org.gtk.GDBus.DocString" value="PhosphorProtocol::WindowType underlying value; out-of-range values are clamped to Unknown."/>
             </arg>
             <arg name="extended" type="a{sv}" direction="in">
-                <annotation name="org.gtk.GDBus.DocString" value="Extended window-property snapshot (state flags, geometry, accessory flags, captionNormal, multi-desktop span list) keyed by PhosphorProtocol::Service::WindowMetadataKey. A key is present only when the value is known, so absent keys leave the derived window-rule field disengaged. Lets the daemon's Float/RestorePosition resolvers match the same KWin-property fields the effect path resolves live."/>
+                <annotation name="org.gtk.GDBus.DocString" value="Extended window-property snapshot (state flags, geometry, accessory flags, captionNormal, multi-desktop span list) keyed by PhosphorProtocol::Service::WindowMetadataKey. A key is present only when the value is known, so absent keys leave the derived window-rule field disengaged. Caption-only refresh protocol: an EMPTY map, or a map whose sole key is CaptionNormal, carries the daemon's existing extended snapshot forward (updating only the caption when supplied) rather than clearing it — a sender meaning 'nothing is known' must not use those shapes. Lets the daemon's Float/RestorePosition resolvers match the same KWin-property fields the effect path resolves live."/>
             </arg>
         </method>
         <method name="windowClosed">

--- a/kwin-effect/autotilehandler/autotilehandler.cpp
+++ b/kwin-effect/autotilehandler/autotilehandler.cpp
@@ -373,6 +373,14 @@ void AutotileHandler::handleWindowOutputChanged(KWin::EffectWindow* w)
     const QString windowId = m_effect->getWindowId(w);
     const QString newScreenId = m_effect->getWindowScreenId(w);
 
+    // Consume the one-shot cross-mode marker HERE, at the top, into a local:
+    // every branch below used to be responsible for erasing it and three
+    // early-return paths (untracked-guard miss, same-screen, neither-screen-
+    // autotile) leaked it — a stale marker then swallowed the NEXT genuine
+    // cross-monitor move by taking the bookkeeping-only path. Destination
+    // matching stays each consumer's job.
+    const QString expectedScreen = m_expectedOutputMove.take(windowId);
+
     if (!m_notifiedWindows.contains(windowId)) {
         // Window not tracked — but if it moved TO an autotile screen, add it
         if (m_autotileScreens.contains(newScreenId) && m_effect->shouldHandleWindow(w) && !w->isMinimized()
@@ -386,7 +394,12 @@ void AutotileHandler::handleWindowOutputChanged(KWin::EffectWindow* w)
             // notifyWindowAdded below establishes the effect-side tracking the daemon
             // does not touch, and is a no-op daemon-side (insertWindow rejects an
             // already-tracked window).
-            const bool expectedMove = m_expectedOutputMove.remove(windowId) > 0;
+            // Destination match, mirroring the tracked branch: a stale marker
+            // armed for a DIFFERENT screen means a later genuine move
+            // superseded it, and treating that move as expected would flip
+            // knownFreeFloating and silently drop a fresh window's geometry
+            // capture.
+            const bool expectedMove = !expectedScreen.isEmpty() && expectedScreen == newScreenId;
             notifyWindowAdded(w, /*knownFreeFloating=*/!expectedMove);
             m_effect->updateAllDecorations();
         }
@@ -422,21 +435,17 @@ void AutotileHandler::handleWindowOutputChanged(KWin::EffectWindow* w)
     // and move the decoration claim, then stop. Consume the marker one-shot; honour
     // it only when the destination matches (a mismatch means a later genuine move
     // superseded it → fall through to the normal transfer).
-    if (const auto expIt = m_expectedOutputMove.constFind(windowId); expIt != m_expectedOutputMove.constEnd()) {
-        const QString expectedScreen = expIt.value();
-        m_expectedOutputMove.erase(expIt);
-        if (expectedScreen == newScreenId) {
-            if (newIsAutotile) {
-                m_notifiedWindowScreens[windowId] = newScreenId;
-            } else {
-                // Cross-MODE move: window left autotile for a SNAP screen. Drop
-                // effect-side autotile tracking (daemon already relinquished via
-                // handoffRelease) — else it lingers phantom.
-                cleanupAutotileTracking(windowId, oldScreenId);
-            }
-            m_effect->updateAllDecorations();
-            return;
+    if (!expectedScreen.isEmpty() && expectedScreen == newScreenId) {
+        if (newIsAutotile) {
+            m_notifiedWindowScreens[windowId] = newScreenId;
+        } else {
+            // Cross-MODE move: window left autotile for a SNAP screen. Drop
+            // effect-side autotile tracking (daemon already relinquished via
+            // handoffRelease) — else it lingers phantom.
+            cleanupAutotileTracking(windowId, oldScreenId);
         }
+        m_effect->updateAllDecorations();
+        return;
     }
 
     qCInfo(lcEffect) << "Window moved between monitors:" << windowId << oldScreenId << "->" << newScreenId;
@@ -641,6 +650,13 @@ void AutotileHandler::cleanupAutotileTracking(const QString& windowId, const QSt
     AutotileStateHelpers::cleanupClosedWindowState(windowId, m_border, windowState);
     m_untiledMinimizeFloats.remove(windowId);
     m_unfloatInFlight.remove(windowId);
+    // Retry budget and route/provenance markers die with the tracking: a
+    // reused windowId must not inherit an exhausted budget, and every direct
+    // caller of this cleanup (not just onWindowClosed) must drop the
+    // spawn-provenance entries or they leak past cross-mode moves.
+    m_unfloatRetryAttempts.remove(windowId);
+    m_pendingFreshWindows.remove(windowId);
+    m_deferredWindowRoutes.remove(windowId);
     cancelPendingMinimizeFloat(windowId);
     cancelPendingUnminimizeUnfloat(windowId);
     // KWin-specific cleanup. NOTE: m_savedPreAutotileForDesktopMove is NOT cleared
@@ -723,7 +739,7 @@ QSet<QString> AutotileHandler::completeDeferredWindowRoutes()
                 m_effect->endRestoreSuppression(window);
                 continue;
             }
-            if (it->canSnapRestore) {
+            if (it->canSnapRestore && m_effect->snapHandler()) {
                 QPointer<KWin::EffectWindow> safeWindow = window;
                 m_effect->snapHandler()->callResolveWindowRestore(
                     window,
@@ -751,7 +767,7 @@ QSet<QString> AutotileHandler::completeDeferredWindowRoutes()
 
         m_pendingFreshWindows.remove(it.key());
         m_pendingFreshWindows.remove(windowId);
-        if (it->canSnapRestore && !window->isMinimized()) {
+        if (it->canSnapRestore && !window->isMinimized() && m_effect->snapHandler()) {
             m_effect->snapHandler()->callResolveWindowRestore(window);
         } else {
             m_effect->endRestoreSuppression(window);
@@ -887,6 +903,12 @@ void AutotileHandler::onDaemonReady()
     m_unfloatInFlight.clear();
     m_unfloatRetryAttempts.clear();
     m_untiledMinimizeFloats.clear();
+    // Routes deferred against the dead daemon session and their provenance
+    // markers must not survive into the new one: a stale m_pendingFreshWindows
+    // entry silently upgrades a later re-add to knownFreeFloating=true, which
+    // is the free-geometry overwrite this contract exists to prevent.
+    m_pendingFreshWindows.clear();
+    m_deferredWindowRoutes.clear();
     for (auto connIt = m_pendingCrossScreenRestore.begin(); connIt != m_pendingCrossScreenRestore.end(); ++connIt) {
         QObject::disconnect(connIt.value());
     }

--- a/kwin-effect/autotilehandler/autotilehandler.cpp
+++ b/kwin-effect/autotilehandler/autotilehandler.cpp
@@ -5,6 +5,7 @@
 #include "plasmazoneseffect/plasmazoneseffect.h"
 #include "compositor/windowanimator.h"
 #include "handlers/navigationhandler.h"
+#include "handlers/snaphandler.h"
 
 #include <PhosphorProtocol/ServiceConstants.h>
 #include <PhosphorProtocol/ClientHelpers.h>
@@ -187,7 +188,11 @@ bool AutotileHandler::notifyWindowAdded(KWin::EffectWindow* w, bool knownFreeFlo
 
     const QString windowId = m_effect->getWindowId(w);
 
-    if (!isEligibleForAutotileNotify(w)) {
+    bool minimizedOnly = false;
+    if (!isEligibleForAutotileNotify(w, &minimizedOnly)) {
+        if (knownFreeFloating && minimizedOnly && m_initialScreenQueryPending) {
+            m_pendingFreshWindows.insert(windowId);
+        }
         return false;
     }
 
@@ -306,7 +311,8 @@ void AutotileHandler::notifyWindowsAddedBatch(const QList<KWin::EffectWindow*>& 
 
         // Existing windows use the guarded path. A window first observed while
         // the initial screen query was pending retains explicit spawn provenance.
-        const bool knownFreeFloating = m_pendingFreshWindows.remove(windowId);
+        const bool knownFreeFloating = m_pendingFreshWindows.remove(windowId)
+            || (enteringAutotile && !AutotileStateHelpers::isTiledWindow(m_border, windowId));
         saveAndRecordPreAutotileGeometry(windowId, screenId, w, w->frameGeometry(), knownFreeFloating);
 
         const QSize minSize = declaredMinSize(w);
@@ -375,8 +381,8 @@ void AutotileHandler::handleWindowOutputChanged(KWin::EffectWindow* w)
             // notifyWindowAdded below establishes the effect-side tracking the daemon
             // does not touch, and is a no-op daemon-side (insertWindow rejects an
             // already-tracked window).
-            m_expectedOutputMove.remove(windowId);
-            notifyWindowAdded(w, /*knownFreeFloating=*/false);
+            const bool expectedMove = m_expectedOutputMove.remove(windowId) > 0;
+            notifyWindowAdded(w, /*knownFreeFloating=*/!expectedMove);
             m_effect->updateAllDecorations();
         }
         return;
@@ -624,6 +630,7 @@ void AutotileHandler::cleanupAutotileTracking(const QString& windowId, const QSt
 void AutotileHandler::onWindowClosed(const QString& windowId, const QString& screenId)
 {
     m_pendingFreshWindows.remove(windowId);
+    m_deferredWindowRoutes.remove(windowId);
     cleanupAutotileTracking(windowId, screenId);
 
     // Notify autotile daemon
@@ -633,6 +640,81 @@ void AutotileHandler::onWindowClosed(const QString& windowId, const QString& scr
                                                        QStringLiteral("windowClosed"));
         qCDebug(lcEffect) << "Notified autotile: windowClosed" << windowId << "on screen" << screenId;
     }
+}
+
+void AutotileHandler::deferWindowRouting(KWin::EffectWindow* window, bool canSnapRestore)
+{
+    if (!window || window->isDeleted()) {
+        return;
+    }
+    const QString windowId = m_effect->getWindowId(window);
+    m_pendingFreshWindows.insert(windowId);
+    m_deferredWindowRoutes.insert(windowId, DeferredWindowRoute{QPointer<KWin::EffectWindow>(window), canSnapRestore});
+}
+
+QSet<QString> AutotileHandler::completeDeferredWindowRoutes()
+{
+    const auto routes = m_deferredWindowRoutes;
+    m_deferredWindowRoutes.clear();
+    QSet<QString> routedWindowIds;
+    routedWindowIds.reserve(routes.size());
+    for (auto it = routes.constBegin(); it != routes.constEnd(); ++it) {
+        routedWindowIds.insert(it.key());
+        KWin::EffectWindow* window = it->window.data();
+        if (!window || window->isDeleted()) {
+            m_pendingFreshWindows.remove(it.key());
+            continue;
+        }
+        const QString windowId = m_effect->getWindowId(window);
+        routedWindowIds.insert(windowId);
+        const QString screenId = m_effect->getWindowScreenId(window);
+        if (m_autotileScreens.contains(screenId)) {
+            if (window->isMinimized()) {
+                continue;
+            }
+            if (it->canSnapRestore) {
+                QPointer<KWin::EffectWindow> safeWindow = window;
+                m_effect->snapHandler()->callResolveWindowRestore(
+                    window,
+                    [this, safeWindow, windowId]() {
+                        if (!safeWindow || safeWindow->isDeleted()) {
+                            return;
+                        }
+                        if (!m_autotileScreens.contains(m_effect->getWindowScreenId(safeWindow.data()))) {
+                            m_pendingFreshWindows.remove(windowId);
+                            m_effect->endRestoreSuppression(safeWindow.data());
+                            return;
+                        }
+                        if (!notifyWindowAdded(safeWindow.data(), /*knownFreeFloating=*/true)
+                            && !m_notifiedWindows.contains(windowId)) {
+                            m_effect->endRestoreSuppression(safeWindow.data());
+                        }
+                    },
+                    /*releaseSuppressionOnMiss=*/false);
+            } else if (!notifyWindowAdded(window, /*knownFreeFloating=*/true)
+                       && !m_notifiedWindows.contains(windowId)) {
+                m_effect->endRestoreSuppression(window);
+            }
+            continue;
+        }
+
+        m_pendingFreshWindows.remove(it.key());
+        m_pendingFreshWindows.remove(windowId);
+        if (it->canSnapRestore && !window->isMinimized()) {
+            m_effect->snapHandler()->callResolveWindowRestore(window);
+        } else {
+            m_effect->endRestoreSuppression(window);
+        }
+    }
+
+    const auto pendingIds = m_pendingFreshWindows.values();
+    for (const QString& windowId : pendingIds) {
+        KWin::EffectWindow* window = m_effect->findWindowById(windowId);
+        if (!window || window->isDeleted() || !m_autotileScreens.contains(m_effect->getWindowScreenId(window))) {
+            m_pendingFreshWindows.remove(windowId);
+        }
+    }
+    return routedWindowIds;
 }
 
 void AutotileHandler::handleDragToFloat(KWin::EffectWindow* w, const QString& windowId, bool immediate)
@@ -748,6 +830,7 @@ void AutotileHandler::onDaemonReady()
     clearAllPendingMinimizeFloats();
     m_minimizeFloatedWindows.clear();
     m_unfloatInFlight.clear();
+    m_unfloatRetryAttempts.clear();
     m_untiledMinimizeFloats.clear();
     for (auto connIt = m_pendingCrossScreenRestore.begin(); connIt != m_pendingCrossScreenRestore.end(); ++connIt) {
         QObject::disconnect(connIt.value());

--- a/kwin-effect/autotilehandler/autotilehandler.cpp
+++ b/kwin-effect/autotilehandler/autotilehandler.cpp
@@ -203,13 +203,13 @@ bool AutotileHandler::notifyWindowAdded(KWin::EffectWindow* w, bool knownFreeFlo
     if (m_notifiedWindows.contains(windowId)) {
         return false;
     }
-    m_notifiedWindows.insert(windowId);
 
     QString screenId = m_effect->getWindowScreenId(w);
-    m_notifiedWindowScreens[windowId] = screenId;
 
     // Only notify autotile daemon for windows on autotile screens
     if (m_autotileScreens.contains(screenId)) {
+        m_notifiedWindows.insert(windowId);
+        m_notifiedWindowScreens[windowId] = screenId;
         // Save pre-autotile geometry BEFORE the daemon tiles the window.
         // Without this, a window launched directly into autotile has no saved
         // geometry — floating it would leave it at its tiled position instead
@@ -260,7 +260,8 @@ bool AutotileHandler::notifyWindowAdded(KWin::EffectWindow* w, bool knownFreeFlo
 }
 
 void AutotileHandler::notifyWindowsAddedBatch(const QList<KWin::EffectWindow*>& windows,
-                                              const QSet<QString>& screenFilter, bool resetNotified)
+                                              const QSet<QString>& screenFilter, bool resetNotified,
+                                              bool enteringAutotile)
 {
     // Collect eligible windows using the same filtering as notifyWindowAdded,
     // then send one batch D-Bus call instead of per-window round-trips.
@@ -295,7 +296,7 @@ void AutotileHandler::notifyWindowsAddedBatch(const QList<KWin::EffectWindow*>& 
         bool minimizedOnly = false;
         if (!isEligibleForAutotileNotify(w, &minimizedOnly)) {
             if (minimizedOnly && !suppressed) {
-                claimAlreadyMinimizedAsFloated(w, windowId, screenFilter);
+                claimAlreadyMinimizedAsFloated(w, windowId, screenFilter, enteringAutotile);
             }
             continue;
         }
@@ -313,19 +314,13 @@ void AutotileHandler::notifyWindowsAddedBatch(const QList<KWin::EffectWindow*>& 
         m_notifiedWindows.insert(windowId);
         m_notifiedWindowScreens[windowId] = screenId;
 
-        // knownFreeFloating only for windows we do NOT track as tiled. The
-        // batch is also the RE-announce path (daemon restart, toggle-on,
-        // screen-add) where a window's current frame is its tiled zone rect —
-        // border tracking survives daemon restarts, so isTiledWindow is
-        // authoritative here. Passing true for a tiled window would push
-        // storePreTileGeometry with overwrite=true and destroy the daemon's
-        // persisted free geometry (a snap→autotile window has no local
-        // bucket entry, so the exact-match early-return cannot save it).
-        // Genuinely fresh windows (not yet tiled) keep the spawn-geometry
-        // overwrite semantics — see notifyWindowAdded() for that rationale.
-        const bool freshFrame = !AutotileStateHelpers::isTiledWindow(m_border, windowId);
+        // A batch only contains already-existing windows (mode entry, screen
+        // change, or daemon re-announcement), never the genuine spawn path.
+        // Its current frame may therefore belong to snap or autotile even when
+        // local border tracking was cleared on daemon loss. Always run the
+        // floating/ownership guards and never overwrite durable free geometry.
         saveAndRecordPreAutotileGeometry(windowId, screenId, w, w->frameGeometry(),
-                                         /*knownFreeFloating=*/freshFrame);
+                                         /*knownFreeFloating=*/false);
 
         const QSize minSize = declaredMinSize(w);
 
@@ -820,7 +815,7 @@ void AutotileHandler::onDaemonReady()
 }
 
 // handleAutotileFloatToggle removed: float toggle is now daemon-local via
-// WindowTrackingAdaptor::toggleWindowFloat (which emits applyGeometryRequested).
+// SnapAdaptor::toggleFloatForWindow (which emits applyGeometryRequested).
 
 // connectSignals() / loadSettings() live in autotilehandler/wiring.cpp.
 

--- a/kwin-effect/autotilehandler/autotilehandler.cpp
+++ b/kwin-effect/autotilehandler/autotilehandler.cpp
@@ -295,6 +295,9 @@ void AutotileHandler::notifyWindowsAddedBatch(const QList<KWin::EffectWindow*>& 
         // already-notified bail and silently never announces it.
         if (resetNotified) {
             m_notifiedWindows.remove(windowId);
+            // Its screen record travels with it — leaving it behind orphans a
+            // stale screen association the next notify would read.
+            m_notifiedWindowScreens.remove(windowId);
         }
 
         bool minimizedOnly = false;

--- a/kwin-effect/autotilehandler/autotilehandler.cpp
+++ b/kwin-effect/autotilehandler/autotilehandler.cpp
@@ -222,9 +222,10 @@ bool AutotileHandler::notifyWindowAdded(KWin::EffectWindow* w, bool knownFreeFlo
         // geometry — floating it would leave it at its tiled position instead
         // of restoring to its original free-floating size.
         //
-        // knownFreeFloating defaults true for the genuine window-opened path
-        // (the frame is KWin's spawn geometry — the authoritative pre-autotile
-        // position — and the FloatingCache is not yet populated, so the
+        // knownFreeFloating is passed EXPLICITLY by every caller (no default
+        // argument): the genuine window-opened path passes true (the frame is
+        // KWin's spawn geometry — the authoritative pre-autotile position —
+        // and the FloatingCache is not yet populated, so the
         // isWindowFloating() guard would otherwise drop the one-shot save).
         // RE-ADD callers pass false so the floating guard runs and rejects a
         // tiled zone rect instead of persisting it as free geometry.

--- a/kwin-effect/autotilehandler/autotilehandler.cpp
+++ b/kwin-effect/autotilehandler/autotilehandler.cpp
@@ -180,21 +180,12 @@ void AutotileHandler::handleCursorMoved(const QPointF& pos, const QString& scree
 
 bool AutotileHandler::notifyWindowAdded(KWin::EffectWindow* w, bool knownFreeFloating)
 {
-    // Deleted windows bail before getWindowId (cache-pollution hazard);
-    // every other rejection comes after the pending-close consume below.
+    // Deleted windows bail before getWindowId (cache-pollution hazard).
     if (!w || w->isDeleted()) {
         return false;
     }
 
     const QString windowId = m_effect->getWindowId(w);
-
-    // Window was already closed before we could notify open — skip (D-Bus
-    // ordering race). Consumed BEFORE the eligibility check so an entry
-    // whose racing add arrives ineligible doesn't strand in the set until
-    // the next daemon restart.
-    if (m_pendingCloses.remove(windowId)) {
-        return false;
-    }
 
     if (!isEligibleForAutotileNotify(w)) {
         return false;
@@ -204,10 +195,16 @@ bool AutotileHandler::notifyWindowAdded(KWin::EffectWindow* w, bool knownFreeFlo
         return false;
     }
 
-    QString screenId = m_effect->getWindowScreenId(w);
+    const QString screenId = m_effect->getWindowScreenId(w);
+    if (knownFreeFloating && m_initialScreenQueryPending && !m_autotileScreens.contains(screenId)) {
+        // Retain spawn provenance until the initial screen query reveals
+        // whether this window belongs in its follow-up batch.
+        m_pendingFreshWindows.insert(windowId);
+    }
 
     // Only notify autotile daemon for windows on autotile screens
     if (m_autotileScreens.contains(screenId)) {
+        knownFreeFloating = knownFreeFloating || m_pendingFreshWindows.remove(windowId);
         m_notifiedWindows.insert(windowId);
         m_notifiedWindowScreens[windowId] = screenId;
         // Save pre-autotile geometry BEFORE the daemon tiles the window.
@@ -269,16 +266,12 @@ void AutotileHandler::notifyWindowsAddedBatch(const QList<KWin::EffectWindow*>& 
     QStringList batchWindowIds; // for error rollback
 
     for (KWin::EffectWindow* w : windows) {
-        // Deleted windows bail before any id/screen lookup (cache-pollution
-        // hazard); the pending-close consume runs BEFORE the eligibility
-        // check — same ordering rationale as notifyWindowAdded.
+        // Deleted windows bail before any id/screen lookup (cache-pollution hazard).
         if (!w || w->isDeleted()) {
             continue;
         }
 
         const QString windowId = m_effect->getWindowId(w);
-        const bool suppressed = m_pendingCloses.remove(windowId);
-
         const QString screenId = m_effect->getWindowScreenId(w);
         if (!screenFilter.isEmpty() && !screenFilter.contains(screenId)) {
             continue;
@@ -295,12 +288,9 @@ void AutotileHandler::notifyWindowsAddedBatch(const QList<KWin::EffectWindow*>& 
 
         bool minimizedOnly = false;
         if (!isEligibleForAutotileNotify(w, &minimizedOnly)) {
-            if (minimizedOnly && !suppressed) {
+            if (minimizedOnly) {
                 claimAlreadyMinimizedAsFloated(w, windowId, screenFilter, enteringAutotile);
             }
-            continue;
-        }
-        if (suppressed) {
             continue;
         }
 
@@ -314,13 +304,10 @@ void AutotileHandler::notifyWindowsAddedBatch(const QList<KWin::EffectWindow*>& 
         m_notifiedWindows.insert(windowId);
         m_notifiedWindowScreens[windowId] = screenId;
 
-        // A batch only contains already-existing windows (mode entry, screen
-        // change, or daemon re-announcement), never the genuine spawn path.
-        // Its current frame may therefore belong to snap or autotile even when
-        // local border tracking was cleared on daemon loss. Always run the
-        // floating/ownership guards and never overwrite durable free geometry.
-        saveAndRecordPreAutotileGeometry(windowId, screenId, w, w->frameGeometry(),
-                                         /*knownFreeFloating=*/false);
+        // Existing windows use the guarded path. A window first observed while
+        // the initial screen query was pending retains explicit spawn provenance.
+        const bool knownFreeFloating = m_pendingFreshWindows.remove(windowId);
+        saveAndRecordPreAutotileGeometry(windowId, screenId, w, w->frameGeometry(), knownFreeFloating);
 
         const QSize minSize = declaredMinSize(w);
 
@@ -389,7 +376,7 @@ void AutotileHandler::handleWindowOutputChanged(KWin::EffectWindow* w)
             // does not touch, and is a no-op daemon-side (insertWindow rejects an
             // already-tracked window).
             m_expectedOutputMove.remove(windowId);
-            notifyWindowAdded(w);
+            notifyWindowAdded(w, /*knownFreeFloating=*/false);
             m_effect->updateAllDecorations();
         }
         return;
@@ -614,6 +601,7 @@ void AutotileHandler::cleanupAutotileTracking(const QString& windowId, const QSt
         m_centeredWaylandZones, m_monocleMaximizedWindows, m_preAutotileGeometries};
     AutotileStateHelpers::cleanupClosedWindowState(windowId, m_border, windowState);
     m_untiledMinimizeFloats.remove(windowId);
+    m_unfloatInFlight.remove(windowId);
     cancelPendingMinimizeFloat(windowId);
     cancelPendingUnminimizeUnfloat(windowId);
     // KWin-specific cleanup. NOTE: m_savedPreAutotileForDesktopMove is NOT cleared
@@ -633,18 +621,9 @@ void AutotileHandler::cleanupAutotileTracking(const QString& windowId, const QSt
     }
 }
 
-void AutotileHandler::onWindowClosed(const QString& windowId, const QString& screenId, bool windowDestroyed)
+void AutotileHandler::onWindowClosed(const QString& windowId, const QString& screenId)
 {
-    // If we haven't notified the daemon about this window yet, record the
-    // close so we can suppress the open if it arrives late (D-Bus ordering
-    // race). Genuine destruction only: a LIVE window routed through here
-    // (transfer / desktop move / drag-bypass) that is untracked because it
-    // was eligibility-filtered would otherwise have its NEXT genuine add
-    // silently swallowed when it later becomes eligible.
-    if (windowDestroyed && !m_notifiedWindows.contains(windowId) && m_autotileScreens.contains(screenId)) {
-        m_pendingCloses.insert(windowId);
-    }
-
+    m_pendingFreshWindows.remove(windowId);
     cleanupAutotileTracking(windowId, screenId);
 
     // Notify autotile daemon
@@ -733,12 +712,12 @@ void AutotileHandler::onDaemonReady()
     // strictly sound — a signal lost pre-AddMatch implies the Get (served
     // after the change) already returns the new set.
     connectSignals();
+    m_initialScreenQueryPending = false;
     loadSettings();
     m_notifiedWindows.clear();
     m_notifiedWindowScreens.clear();
     m_savedNotifiedForDesktopReturn.clear();
     m_savedPreAutotileForDesktopMove.clear();
-    m_pendingCloses.clear();
     // Centering state is per-retile transient: the restarted daemon has no
     // memory of the zones these entries point at, and a stale
     // m_centeredWaylandZones entry that happens to equal the first
@@ -765,9 +744,10 @@ void AutotileHandler::onDaemonReady()
     // cross-screen size-restore connections are likewise per-session.
     // clearAllPendingMinimizeFloats() also cancels the pending deferred
     // unminimize→unfloat timers; an escapee's timeout would bail anyway when
-    // m_minimizeFloatedWindows.remove() misses after the clear below.
+    // ownership lookup misses after the clear below.
     clearAllPendingMinimizeFloats();
     m_minimizeFloatedWindows.clear();
+    m_unfloatInFlight.clear();
     m_untiledMinimizeFloats.clear();
     for (auto connIt = m_pendingCrossScreenRestore.begin(); connIt != m_pendingCrossScreenRestore.end(); ++connIt) {
         QObject::disconnect(connIt.value());

--- a/kwin-effect/autotilehandler/autotilehandler.cpp
+++ b/kwin-effect/autotilehandler/autotilehandler.cpp
@@ -278,24 +278,35 @@ void AutotileHandler::notifyWindowsAddedBatch(const QList<KWin::EffectWindow*>& 
         const QString windowId = m_effect->getWindowId(w);
         const bool suppressed = m_pendingCloses.remove(windowId);
 
-        if (!isEligibleForAutotileNotify(w)) {
+        const QString screenId = m_effect->getWindowScreenId(w);
+        if (!screenFilter.isEmpty() && !screenFilter.contains(screenId)) {
+            continue;
+        }
+
+        // Reset BEFORE the eligibility check: a window that is currently
+        // ineligible (minimized, fullscreen) must still shed its stale
+        // m_notifiedWindows entry on a re-announce cycle, or its later
+        // notifyWindowAdded (unminimize, exit-fullscreen) hits the
+        // already-notified bail and silently never announces it.
+        if (resetNotified) {
+            m_notifiedWindows.remove(windowId);
+        }
+
+        bool minimizedOnly = false;
+        if (!isEligibleForAutotileNotify(w, &minimizedOnly)) {
+            if (minimizedOnly && !suppressed) {
+                claimAlreadyMinimizedAsFloated(w, windowId, screenFilter);
+            }
             continue;
         }
         if (suppressed) {
             continue;
         }
 
-        const QString screenId = m_effect->getWindowScreenId(w);
-        if (!screenFilter.isEmpty() && !screenFilter.contains(screenId)) {
-            continue;
-        }
         if (!m_autotileScreens.contains(screenId)) {
             continue;
         }
 
-        if (resetNotified) {
-            m_notifiedWindows.remove(windowId);
-        }
         if (m_notifiedWindows.contains(windowId)) {
             continue;
         }
@@ -607,6 +618,7 @@ void AutotileHandler::cleanupAutotileTracking(const QString& windowId, const QSt
         m_notifiedWindows,      m_notifiedWindowScreens,   m_minimizeFloatedWindows, m_autotileTargetZones,
         m_centeredWaylandZones, m_monocleMaximizedWindows, m_preAutotileGeometries};
     AutotileStateHelpers::cleanupClosedWindowState(windowId, m_border, windowState);
+    m_untiledMinimizeFloats.remove(windowId);
     cancelPendingMinimizeFloat(windowId);
     cancelPendingUnminimizeUnfloat(windowId);
     // KWin-specific cleanup. NOTE: m_savedPreAutotileForDesktopMove is NOT cleared
@@ -761,6 +773,7 @@ void AutotileHandler::onDaemonReady()
     // m_minimizeFloatedWindows.remove() misses after the clear below.
     clearAllPendingMinimizeFloats();
     m_minimizeFloatedWindows.clear();
+    m_untiledMinimizeFloats.clear();
     for (auto connIt = m_pendingCrossScreenRestore.begin(); connIt != m_pendingCrossScreenRestore.end(); ++connIt) {
         QObject::disconnect(connIt.value());
     }

--- a/kwin-effect/autotilehandler/autotilehandler.cpp
+++ b/kwin-effect/autotilehandler/autotilehandler.cpp
@@ -752,7 +752,9 @@ QSet<QString> AutotileHandler::completeDeferredWindowRoutes()
                 // stalls its eventual restore for the 250 ms deadline), and
                 // drop the spawn-provenance marker so a later re-add cannot
                 // inherit knownFreeFloating=true from a stale entry.
-                claimAlreadyMinimizedAsFloated(window, windowId, m_autotileScreens, /*enteringAutotile=*/true);
+                // Empty filter: passing m_autotileScreens duplicated the
+                // claim's own internal autotile-screen gate verbatim.
+                claimAlreadyMinimizedAsFloated(window, windowId, {}, /*enteringAutotile=*/true);
                 m_pendingFreshWindows.remove(windowId);
                 m_effect->endRestoreSuppression(window);
                 continue;
@@ -886,7 +888,8 @@ void AutotileHandler::onDaemonReady()
     // strictly sound — a signal lost pre-AddMatch implies the Get (served
     // after the change) already returns the new set.
     connectSignals();
-    m_initialScreenQueryPending = false;
+    // No m_initialScreenQueryPending write here: loadSettings() below arms it
+    // for its query and the reply clears it — a false store first was dead.
     loadSettings();
     m_notifiedWindows.clear();
     m_notifiedWindowScreens.clear();

--- a/kwin-effect/autotilehandler/autotilehandler.cpp
+++ b/kwin-effect/autotilehandler/autotilehandler.cpp
@@ -451,8 +451,36 @@ void AutotileHandler::handleWindowOutputChanged(KWin::EffectWindow* w)
     // The predicate mirrors the re-add condition below.
     const bool willReAdd = newIsAutotile && !w->isMinimized() && w->isOnCurrentDesktop() && w->isOnCurrentActivity();
 
+    // Minimize-float ownership must SURVIVE the transfer: onWindowClosed's
+    // cleanup wipes it wholesale, the window is alive and still floated
+    // daemon-side, and willReAdd is false for a minimized window — without
+    // re-establishing the claim (or handing it to the snap handler for a
+    // snap destination) nobody ever unfloats the window and it stays
+    // floating until the next mode toggle. Reachable in bulk on monitor
+    // hotplug and VS reconfigure.
+    const bool ownedMinimizeFloat = m_minimizeFloatedWindows.contains(windowId);
+    const bool wasUntiledMinimizeFloat = m_untiledMinimizeFloats.contains(windowId);
+
     // Remove from old screen's autotile state
     onWindowClosed(windowId, oldScreenId);
+
+    if (ownedMinimizeFloat && w->isMinimized()) {
+        if (newIsAutotile) {
+            m_minimizeFloatedWindows.insert(windowId);
+            if (wasUntiledMinimizeFloat) {
+                m_untiledMinimizeFloats.insert(windowId);
+            }
+            qCInfo(lcEffect) << "Autotile: minimize-float ownership carried across screens:" << windowId << "->"
+                             << newScreenId;
+        } else if (SnapHandler* snap = m_effect->snapHandler()) {
+            // Snap destination: hand the record over so the unminimize edge
+            // on that screen finds an owner (mirrors the deferred-commit
+            // transfer in the unfloat grace path).
+            snap->adoptMinimizeFloated(windowId);
+            qCInfo(lcEffect) << "Autotile: minimize-float ownership handed to snap on screen change:" << windowId
+                             << "->" << newScreenId;
+        }
+    }
 
     if (willReAdd) {
         // Re-add on new autotile screen, carrying over pre-autotile geometry.

--- a/kwin-effect/autotilehandler/autotilehandler.cpp
+++ b/kwin-effect/autotilehandler/autotilehandler.cpp
@@ -723,7 +723,21 @@ QSet<QString> AutotileHandler::completeDeferredWindowRoutes()
         if (windowId != it.key()) {
             m_pendingFreshWindows.remove(it.key());
         }
-        const QString screenId = m_effect->getWindowScreenId(window);
+        // The defer-time first-frame suppression was armed with the standard
+        // deadline, but the screen query this dispatch waited on can outlast
+        // it — re-arm (deadline only, no-op for unsuppressed windows) so the
+        // window doesn't return to compositing at its centred spawn placement
+        // between deadline expiry and the reposition below.
+        m_effect->refreshRestoreSuppressionDeadline(window);
+        // Consume (and maybe apply) the instant snap-restore cache entry,
+        // exactly as the non-deferred open path does — a deferred window must
+        // not leave its entry alive for a later same-app sibling to claim.
+        // A teleport can move the window to another screen; re-resolve after.
+        QString screenId = m_effect->getWindowScreenId(window);
+        if (it->canSnapRestore && !window->isMinimized()
+            && m_effect->tryInstantSnapRestore(window, windowId, /*canSnapRestore=*/true)) {
+            screenId = m_effect->getWindowScreenId(window);
+        }
         if (m_autotileScreens.contains(screenId)) {
             if (window->isMinimized()) {
                 // A window that minimized while the screen query was pending
@@ -743,7 +757,7 @@ QSet<QString> AutotileHandler::completeDeferredWindowRoutes()
                 QPointer<KWin::EffectWindow> safeWindow = window;
                 m_effect->snapHandler()->callResolveWindowRestore(
                     window,
-                    [this, safeWindow, windowId]() {
+                    [this, safeWindow, windowId](bool snapApplied) {
                         if (!safeWindow || safeWindow->isDeleted()) {
                             return;
                         }
@@ -752,7 +766,10 @@ QSet<QString> AutotileHandler::completeDeferredWindowRoutes()
                             m_effect->endRestoreSuppression(safeWindow.data());
                             return;
                         }
-                        if (!notifyWindowAdded(safeWindow.data(), /*knownFreeFloating=*/true)
+                        // knownFreeFloating only when the restore did NOT
+                        // apply — a zone-placed window's live frame is the
+                        // zone rect, not a genuine free frame.
+                        if (!notifyWindowAdded(safeWindow.data(), /*knownFreeFloating=*/!snapApplied)
                             && !m_notifiedWindows.contains(windowId)) {
                             m_effect->endRestoreSuppression(safeWindow.data());
                         }

--- a/kwin-effect/autotilehandler/autotilehandler.cpp
+++ b/kwin-effect/autotilehandler/autotilehandler.cpp
@@ -471,8 +471,16 @@ void AutotileHandler::handleWindowOutputChanged(KWin::EffectWindow* w)
     // snap destination) nobody ever unfloats the window and it stays
     // floating until the next mode toggle. Reachable in bulk on monitor
     // hotplug and VS reconfigure.
-    const bool ownedMinimizeFloat = m_minimizeFloatedWindows.contains(windowId);
+    // isMinimizeFloated covers the in-flight unfloat interval too — a window
+    // crossing screens mid-unfloat is still owned, and letting the cleanup
+    // below drop it without re-establishing the claim strands it floating.
+    const bool ownedMinimizeFloat = isMinimizeFloated(windowId);
     const bool wasUntiledMinimizeFloat = m_untiledMinimizeFloats.contains(windowId);
+    // Snapshot the retry budget too: cleanupAutotileTracking erases it, and
+    // the header documents that the budget must survive the ownership hop
+    // (a persistently-refused unfloat must not reset to a fresh budget on
+    // every cross-screen bounce).
+    const int savedUnfloatBudget = unfloatRetryBudgetUsed(windowId);
 
     // Remove from old screen's autotile state
     onWindowClosed(windowId, oldScreenId);
@@ -483,13 +491,20 @@ void AutotileHandler::handleWindowOutputChanged(KWin::EffectWindow* w)
             if (wasUntiledMinimizeFloat) {
                 m_untiledMinimizeFloats.insert(windowId);
             }
+            seedUnfloatRetryBudget(windowId, savedUnfloatBudget);
             qCInfo(lcEffect) << "Autotile: minimize-float ownership carried across screens:" << windowId << "->"
                              << newScreenId;
         } else if (SnapHandler* snap = m_effect->snapHandler()) {
             // Snap destination: hand the record over so the unminimize edge
             // on that screen finds an owner (mirrors the deferred-commit
-            // transfer in the unfloat grace path).
+            // transfer in the unfloat grace path). The untiled marker is
+            // deliberately NOT carried: snap has no untiled fast path, so an
+            // adopted window whose rect belongs to the prior mode takes
+            // snap's normal deferred grace and may visibly hop once at the
+            // unminimize — accepted over teaching snap a second commit path
+            // for this rare cross-screen-while-minimized case.
             snap->adoptMinimizeFloated(windowId);
+            snap->seedUnfloatRetryBudget(windowId, savedUnfloatBudget);
             qCInfo(lcEffect) << "Autotile: minimize-float ownership handed to snap on screen change:" << windowId
                              << "->" << newScreenId;
         }

--- a/kwin-effect/autotilehandler/autotilehandler.cpp
+++ b/kwin-effect/autotilehandler/autotilehandler.cpp
@@ -209,7 +209,12 @@ bool AutotileHandler::notifyWindowAdded(KWin::EffectWindow* w, bool knownFreeFlo
 
     // Only notify autotile daemon for windows on autotile screens
     if (m_autotileScreens.contains(screenId)) {
-        knownFreeFloating = knownFreeFloating || m_pendingFreshWindows.remove(windowId);
+        // Consume the spawn-provenance marker UNCONDITIONALLY — a short-circuit
+        // (|| with remove second) would leave the entry behind whenever the
+        // caller already passed true, and a later RE-ADD that deliberately
+        // passes false would then flip to true off the stale entry.
+        const bool wasFresh = m_pendingFreshWindows.remove(windowId) > 0;
+        knownFreeFloating = knownFreeFloating || wasFresh;
         m_notifiedWindows.insert(windowId);
         m_notifiedWindowScreens[windowId] = screenId;
         // Save pre-autotile geometry BEFORE the daemon tiles the window.
@@ -667,9 +672,27 @@ QSet<QString> AutotileHandler::completeDeferredWindowRoutes()
         }
         const QString windowId = m_effect->getWindowId(window);
         routedWindowIds.insert(windowId);
+        // The pending-fresh entry was keyed by the id at defer time; if the
+        // live id diverged, the old key would leak forever (the tail prune
+        // below only drops dead/off-screen windows, and this window is
+        // neither).
+        if (windowId != it.key()) {
+            m_pendingFreshWindows.remove(it.key());
+        }
         const QString screenId = m_effect->getWindowScreenId(window);
         if (m_autotileScreens.contains(screenId)) {
             if (window->isMinimized()) {
+                // A window that minimized while the screen query was pending
+                // is excluded from the follow-up batch (it is in
+                // routedWindowIds), so nothing else will claim it — claim it
+                // here, release the first-frame suppression (a minimized
+                // window paints nothing, and leaving the suppression armed
+                // stalls its eventual restore for the 250 ms deadline), and
+                // drop the spawn-provenance marker so a later re-add cannot
+                // inherit knownFreeFloating=true from a stale entry.
+                claimAlreadyMinimizedAsFloated(window, windowId, m_autotileScreens, /*enteringAutotile=*/true);
+                m_pendingFreshWindows.remove(windowId);
+                m_effect->endRestoreSuppression(window);
                 continue;
             }
             if (it->canSnapRestore) {
@@ -709,7 +732,11 @@ QSet<QString> AutotileHandler::completeDeferredWindowRoutes()
 
     const auto pendingIds = m_pendingFreshWindows.values();
     for (const QString& windowId : pendingIds) {
-        KWin::EffectWindow* window = m_effect->findWindowById(windowId);
+        // EXACT resolve: the entry is keyed to a specific instance's id, so a
+        // fuzzy hit on a same-app sibling must not keep a dead entry alive —
+        // a retained stale entry later flips knownFreeFloating to true and
+        // poisons the free-geometry capture.
+        KWin::EffectWindow* window = m_effect->findWindowByIdExact(windowId);
         if (!window || window->isDeleted() || !m_autotileScreens.contains(m_effect->getWindowScreenId(window))) {
             m_pendingFreshWindows.remove(windowId);
         }

--- a/kwin-effect/autotilehandler/autotilehandler.h
+++ b/kwin-effect/autotilehandler/autotilehandler.h
@@ -118,6 +118,13 @@ public:
         return m_unfloatInFlight.remove(windowId) > 0 || owned;
     }
 
+    /// Whether this handler currently owns @p windowId's minimize-float
+    /// marker (mirrors SnapHandler::isMinimizeFloated).
+    bool isMinimizeFloated(const QString& windowId) const
+    {
+        return m_minimizeFloatedWindows.contains(windowId);
+    }
+
     /// Take ownership of a minimize-float relinquished by the snap handler
     /// (cross-mode countermand / hand-off on a screen autotile now owns).
     /// @p untiled marks the window's rect as belonging to the prior mode so

--- a/kwin-effect/autotilehandler/autotilehandler.h
+++ b/kwin-effect/autotilehandler/autotilehandler.h
@@ -113,12 +113,17 @@ public:
     {
         cancelPendingUnminimizeUnfloat(windowId);
         m_untiledMinimizeFloats.remove(windowId);
+        m_unfloatRetryAttempts.remove(windowId);
         const bool owned = m_minimizeFloatedWindows.remove(windowId);
         return m_unfloatInFlight.remove(windowId) > 0 || owned;
     }
     bool hasPendingUnminimizeUnfloat(const QString& windowId) const
     {
         return m_pendingUnminimizeUnfloat.contains(windowId);
+    }
+    bool hasUnfloatInFlight(const QString& windowId) const
+    {
+        return m_unfloatInFlight.contains(windowId);
     }
     /// Drop a destroyed window's desktop-move geometry stash. Separate from
     /// onWindowClosed because the desktop-MOVE path calls onWindowClosed
@@ -128,6 +133,11 @@ public:
     {
         m_savedPreAutotileForDesktopMove.remove(windowId);
     }
+    bool isScreenQueryPending() const
+    {
+        return m_initialScreenQueryPending;
+    }
+    void deferWindowRouting(KWin::EffectWindow* window, bool canSnapRestore);
     void onDaemonReady();
 
     /**
@@ -333,6 +343,8 @@ private:
     /// Returns whether the daemon request may be dispatched.
     bool beginUnminimizeUnfloat(const QString& windowId);
     void dispatchUnminimizeUnfloat(const QString& windowId, const QString& screenId);
+    void scheduleUnminimizeUnfloatRetry(const QString& windowId);
+    QSet<QString> completeDeferredWindowRoutes();
 
     /**
      * @brief Save the pre-autotile free-float geometry for @p windowId.
@@ -414,6 +426,12 @@ private:
     quint64 m_screenQueryGeneration = 0;
     bool m_initialScreenQueryPending = false;
     QSet<QString> m_pendingFreshWindows;
+    struct DeferredWindowRoute
+    {
+        QPointer<KWin::EffectWindow> window;
+        bool canSnapRestore = false;
+    };
+    QHash<QString, DeferredWindowRoute> m_deferredWindowRoutes;
     /// Pre-autotile frame geometry, keyed [screenId][windowId].
     ///
     /// Ownership: this is a local cache. The daemon's unified
@@ -459,6 +477,7 @@ private:
     /// A re-minimize countermand moves the window back to the active set.
     QHash<QString, quint64> m_unfloatInFlight;
     quint64 m_unfloatRequestGeneration = 0;
+    QHash<QString, int> m_unfloatRetryAttempts;
     /// Subset of m_minimizeFloatedWindows claimed at batch-announce time
     /// (already minimized when the screen entered autotile). These windows
     /// still carry geometry from the prior mode, so their unminimize commits

--- a/kwin-effect/autotilehandler/autotilehandler.h
+++ b/kwin-effect/autotilehandler/autotilehandler.h
@@ -342,7 +342,11 @@ private:
     /// Move active minimize ownership into the asynchronous unfloat interval.
     /// Returns whether the daemon request may be dispatched.
     bool beginUnminimizeUnfloat(const QString& windowId);
-    void dispatchUnminimizeUnfloat(const QString& windowId, const QString& screenId);
+    /// Returns whether the daemon unfloat was actually dispatched. False
+    /// (window not ours, or daemon unregistered) means the daemon still
+    /// considers the window floating — callers must not announce it as
+    /// tileable via notifyWindowAdded on that branch.
+    bool dispatchUnminimizeUnfloat(const QString& windowId, const QString& screenId);
     void scheduleUnminimizeUnfloatRetry(const QString& windowId);
     QSet<QString> completeDeferredWindowRoutes();
 

--- a/kwin-effect/autotilehandler/autotilehandler.h
+++ b/kwin-effect/autotilehandler/autotilehandler.h
@@ -289,6 +289,14 @@ public Q_SLOTS:
 
     // Window state change handlers (connected per-window in setupWindowConnections)
     void slotWindowMinimizedChanged(KWin::EffectWindow* w);
+    /// Cross-mode transfer entry point over slotWindowMinimizedChanged.
+    /// Returns false when the ENTRY GATES would refuse the window
+    /// (unhandleable / not on an autotile screen) WITHOUT forwarding the
+    /// edge; true after forwarding. SnapHandler's became-autotile hand-offs
+    /// must use this instead of the raw slot: a silently refused transfer
+    /// left ownership with the sender while the edge was already spent, so
+    /// the suspension stranded until the next minimize cycle.
+    bool offerMinimizeEdge(KWin::EffectWindow* w);
     void slotWindowMaximizedStateChanged(KWin::EffectWindow* w, bool horizontal, bool vertical);
     void slotWindowFullScreenChanged(KWin::EffectWindow* w);
     void slotWindowFrameGeometryChanged(KWin::EffectWindow* w, const QRectF& oldGeometry);

--- a/kwin-effect/autotilehandler/autotilehandler.h
+++ b/kwin-effect/autotilehandler/autotilehandler.h
@@ -96,6 +96,11 @@ public:
                                  bool resetNotified = false, bool enteringAutotile = false);
 
     /// Remove a window from this handler's autotile tracking and notify the daemon.
+    /// INTENT NOTE: an earlier m_pendingCloses guard (deduping a close racing
+    /// its own re-announce) was deliberately deleted — window ids are
+    /// uuid-based, so a closed id can never be re-announced, and the
+    /// regression the guard defended against is unreachable. Do not
+    /// reintroduce it as "missing hardening".
     void onWindowClosed(const QString& windowId, const QString& screenId);
     /// Tear down all effect-side autotile tracking for @p windowId (shared +
     /// KWin-specific state, incl. the pending cross-screen-restore connection)

--- a/kwin-effect/autotilehandler/autotilehandler.h
+++ b/kwin-effect/autotilehandler/autotilehandler.h
@@ -117,6 +117,34 @@ public:
         const bool owned = m_minimizeFloatedWindows.remove(windowId);
         return m_unfloatInFlight.remove(windowId) > 0 || owned;
     }
+
+    /// Take ownership of a minimize-float relinquished by the snap handler
+    /// (cross-mode countermand / hand-off on a screen autotile now owns).
+    /// @p untiled marks the window's rect as belonging to the prior mode so
+    /// its unminimize commits immediately instead of through the animation
+    /// grace.
+    void adoptMinimizeFloated(const QString& windowId, bool untiled)
+    {
+        m_minimizeFloatedWindows.insert(windowId);
+        if (untiled) {
+            m_untiledMinimizeFloats.insert(windowId);
+        }
+    }
+
+    /// Retry-budget hand-off for cross-mode adoptions: the budget is a
+    /// per-WINDOW cap on daemon unfloat attempts, and it must survive the
+    /// ownership hop or a persistently-refused unfloat ping-ponging between
+    /// handlers resets to a fresh budget on every bounce.
+    int unfloatRetryBudgetUsed(const QString& windowId) const
+    {
+        return m_unfloatRetryAttempts.value(windowId);
+    }
+    void seedUnfloatRetryBudget(const QString& windowId, int attemptsUsed)
+    {
+        if (attemptsUsed > m_unfloatRetryAttempts.value(windowId)) {
+            m_unfloatRetryAttempts.insert(windowId, attemptsUsed);
+        }
+    }
     bool hasPendingUnminimizeUnfloat(const QString& windowId) const
     {
         return m_pendingUnminimizeUnfloat.contains(windowId);

--- a/kwin-effect/autotilehandler/autotilehandler.h
+++ b/kwin-effect/autotilehandler/autotilehandler.h
@@ -88,9 +88,12 @@ public:
      * @param screenFilter If non-empty, only process windows on these screens
      * @param resetNotified If true, remove windowId from m_notifiedWindows before processing
      *        (for re-announce on daemon restart / screen change)
+     * @param enteringAutotile True when the screen has just changed from snap
+     *        mode. Already-minimized windows then need an immediate first
+     *        autotile placement when they become visible.
      */
     void notifyWindowsAddedBatch(const QList<KWin::EffectWindow*>& windows, const QSet<QString>& screenFilter = {},
-                                 bool resetNotified = false);
+                                 bool resetNotified = false, bool enteringAutotile = false);
 
     /**
      * @brief Remove a window from this handler's autotile tracking.
@@ -262,8 +265,8 @@ private:
      *
      * Updates the float cache, clears tiled tracking, removes the border
      * overlay, and unmaximizes monocle (title-bar restores flow through the
-     * rule path). Used by both slotWindowFloatingChanged (per-window D-Bus
-     * signal path) and slotWindowsTileRequested (batch float path).
+     * rule path). Used by the per-window D-Bus signal, batch float, and
+     * drag-to-float paths.
      */
     void applyFloatCleanup(const QString& windowId);
 
@@ -286,20 +289,19 @@ private:
      * @brief Claim a window that was already minimized at batch-announce time
      *        as minimize-floated.
      *
-     * A window minimized BEFORE its screen entered autotile never gets a
-     * minimizedChanged edge, so the runtime minimize→float path cannot float
-     * it — while the daemon's mode-transition seed (saved order / zone order)
-     * has no live minimize knowledge and would tile it. Marking it
-     * minimize-floated here keeps the invariant "minimized ⇒ not counted in
-     * the tiling geometry" and routes its later unminimize through the
-     * existing deferred unfloat → notifyWindowAdded commit, which tiles it.
+     * A window minimized BEFORE a batch announcement never gets a
+     * minimizedChanged edge for that transition. Marking it minimize-floated
+     * keeps it out of the live tiling geometry until its later unminimize.
+     * Mode-entry batches commit that first placement immediately, while daemon
+     * re-announcements retain the normal animation grace for windows already
+     * parked at an autotile rect.
      *
      * Skips windows the daemon already tracks as floating (a user float or
      * another mode's minimize-float record) — mirroring the runtime minimize
      * path, we never claim ownership of a float we did not create.
      */
     void claimAlreadyMinimizedAsFloated(KWin::EffectWindow* w, const QString& windowId,
-                                        const QSet<QString>& screenFilter);
+                                        const QSet<QString>& screenFilter, bool enteringAutotile);
 
     /**
      * @brief Cancel a pending debounced minimize→float commit.
@@ -412,9 +414,9 @@ private:
     quint64 m_screensSignalGeneration = 0;
     /// Pre-autotile frame geometry, keyed [screenId][windowId].
     ///
-    /// Ownership: this is a local cache. The daemon's
-    /// `WindowTrackingService::m_preTileGeometries` is the authoritative
-    /// store and survives daemon restart. The effect populates this map on
+    /// Ownership: this is a local cache. The daemon's unified
+    /// `WindowPlacementStore` record is authoritative and survives daemon
+    /// restart. The effect populates this map on
     /// the first autotile transition for a window so it can restore the
     /// frame instantly when the window leaves autotile mode (untile, mode
     /// switch, screen change) without waiting on a D-Bus round-trip.

--- a/kwin-effect/autotilehandler/autotilehandler.h
+++ b/kwin-effect/autotilehandler/autotilehandler.h
@@ -110,7 +110,8 @@ public:
     void cleanupAutotileTracking(const QString& windowId, const QString& screenId);
     /// Drop @p windowId from the minimize-float set and cancel EITHER
     /// deferred edge — the minimize debounce and the unminimize commit —
-    /// mirroring SnapHandler::removeMinimizeFloated exactly. Returns true if
+    /// mirroring SnapHandler::removeMinimizeFloated, plus the untiled-marker
+    /// drop (snap has no untiled-marker counterpart). Returns true if
     /// the window was tracked. Callers: close cleanup, the effect's
     /// authoritative visible unfloat (slotWindowFloatingChanged, including
     /// its dual-hold repair), and the cross-mode adoption hops (snap's
@@ -126,10 +127,14 @@ public:
     }
 
     /// Whether this handler currently owns @p windowId's minimize-float
-    /// marker (mirrors SnapHandler::isMinimizeFloated).
+    /// marker (mirrors SnapHandler::isMinimizeFloated). Includes the
+    /// in-flight unfloat interval: dispatchUnminimizeUnfloat moves the id
+    /// from the marker set into m_unfloatInFlight, and during that window
+    /// the handler still owns the float — the dual-hold repair and the
+    /// capture guards must not treat it as unowned.
     bool isMinimizeFloated(const QString& windowId) const
     {
-        return m_minimizeFloatedWindows.contains(windowId);
+        return m_minimizeFloatedWindows.contains(windowId) || m_unfloatInFlight.contains(windowId);
     }
 
     /// Take ownership of a minimize-float relinquished by the snap handler

--- a/kwin-effect/autotilehandler/autotilehandler.h
+++ b/kwin-effect/autotilehandler/autotilehandler.h
@@ -119,6 +119,7 @@ public:
     bool removeMinimizeFloated(const QString& windowId)
     {
         cancelPendingUnminimizeUnfloat(windowId);
+        m_untiledMinimizeFloats.remove(windowId);
         return m_minimizeFloatedWindows.remove(windowId);
     }
     /// Drop a destroyed window's desktop-move geometry stash. Separate from
@@ -272,9 +273,33 @@ private:
      * Shared predicate used by both notifyWindowAdded and notifyWindowsAddedBatch
      * to keep filtering logic in sync.
      *
+     * @param rejectedOnlyBecauseMinimized When non-null, set to true if the
+     *        window passed every other gate and was rejected solely for being
+     *        minimized — the batch announce uses this to claim the window as
+     *        minimize-floated instead of silently dropping it (a daemon-side
+     *        mode-transition seed would otherwise tile it).
      * @return true if the window should be notified to the autotile daemon
      */
-    bool isEligibleForAutotileNotify(KWin::EffectWindow* w) const;
+    bool isEligibleForAutotileNotify(KWin::EffectWindow* w, bool* rejectedOnlyBecauseMinimized = nullptr) const;
+
+    /**
+     * @brief Claim a window that was already minimized at batch-announce time
+     *        as minimize-floated.
+     *
+     * A window minimized BEFORE its screen entered autotile never gets a
+     * minimizedChanged edge, so the runtime minimize→float path cannot float
+     * it — while the daemon's mode-transition seed (saved order / zone order)
+     * has no live minimize knowledge and would tile it. Marking it
+     * minimize-floated here keeps the invariant "minimized ⇒ not counted in
+     * the tiling geometry" and routes its later unminimize through the
+     * existing deferred unfloat → notifyWindowAdded commit, which tiles it.
+     *
+     * Skips windows the daemon already tracks as floating (a user float or
+     * another mode's minimize-float record) — mirroring the runtime minimize
+     * path, we never claim ownership of a float we did not create.
+     */
+    void claimAlreadyMinimizedAsFloated(KWin::EffectWindow* w, const QString& windowId,
+                                        const QSet<QString>& screenFilter);
 
     /**
      * @brief Cancel a pending debounced minimize→float commit.
@@ -426,6 +451,14 @@ private:
     QHash<QString, QMetaObject::Connection>
         m_pendingCrossScreenRestore; ///< windowId → deferred size-restore connection
     QSet<QString> m_minimizeFloatedWindows;
+    /// Subset of m_minimizeFloatedWindows claimed at batch-announce time
+    /// (already minimized when the screen entered autotile). These windows
+    /// sit at their free-floating rect, NOT a tile rect, so their unminimize
+    /// commits the unfloat immediately instead of through the deferred
+    /// animation grace — the grace is invisible only for a window parked at
+    /// its tile; for these it parks the window at the free rect for the
+    /// whole animation and then visibly hops it into the tile.
+    QSet<QString> m_untiledMinimizeFloats;
     // NOTE: title-bar (borderless) state is owned by the effect's
     // DecorationManager; this handler only tracks tiled membership for
     // border RENDERING via m_border.tiledWindowsByScreen.

--- a/kwin-effect/autotilehandler/autotilehandler.h
+++ b/kwin-effect/autotilehandler/autotilehandler.h
@@ -75,7 +75,7 @@ public:
     /// a tiled zone rect, so the floating guard MUST run and reject it,
     /// otherwise the tiled rect would be persisted as the window's
     /// free-floating geometry and clobber the daemon's real float-back.
-    bool notifyWindowAdded(KWin::EffectWindow* w, bool knownFreeFloating = true);
+    bool notifyWindowAdded(KWin::EffectWindow* w, bool knownFreeFloating);
 
     /**
      * @brief Batch-notify windows added to autotile screens
@@ -95,18 +95,8 @@ public:
     void notifyWindowsAddedBatch(const QList<KWin::EffectWindow*>& windows, const QSet<QString>& screenFilter = {},
                                  bool resetNotified = false, bool enteringAutotile = false);
 
-    /**
-     * @brief Remove a window from this handler's autotile tracking.
-     *
-     * @param windowDestroyed True ONLY from the genuine window-destruction
-     *        path (slotWindowClosed). The other callers (cross-screen
-     *        transfer, desktop move, drag-bypass) pass a LIVE window: for
-     *        those, recording an m_pendingCloses suppression entry would
-     *        poison the window's next notifyWindowAdded — the entry exists
-     *        solely to absorb the D-Bus ordering race where a real close
-     *        overtakes an in-flight windowOpened.
-     */
-    void onWindowClosed(const QString& windowId, const QString& screenId, bool windowDestroyed = false);
+    /// Remove a window from this handler's autotile tracking and notify the daemon.
+    void onWindowClosed(const QString& windowId, const QString& screenId);
     /// Tear down all effect-side autotile tracking for @p windowId (shared +
     /// KWin-specific state, incl. the pending cross-screen-restore connection)
     /// WITHOUT notifying the daemon. Shared by onWindowClosed (which adds the
@@ -123,7 +113,12 @@ public:
     {
         cancelPendingUnminimizeUnfloat(windowId);
         m_untiledMinimizeFloats.remove(windowId);
-        return m_minimizeFloatedWindows.remove(windowId);
+        const bool owned = m_minimizeFloatedWindows.remove(windowId);
+        return m_unfloatInFlight.remove(windowId) > 0 || owned;
+    }
+    bool hasPendingUnminimizeUnfloat(const QString& windowId) const
+    {
+        return m_pendingUnminimizeUnfloat.contains(windowId);
     }
     /// Drop a destroyed window's desktop-move geometry stash. Separate from
     /// onWindowClosed because the desktop-MOVE path calls onWindowClosed
@@ -334,6 +329,11 @@ private:
      */
     void clearAllPendingMinimizeFloats();
 
+    /// Move active minimize ownership into the asynchronous unfloat interval.
+    /// Returns whether the daemon request may be dispatched.
+    bool beginUnminimizeUnfloat(const QString& windowId);
+    void dispatchUnminimizeUnfloat(const QString& windowId, const QString& screenId);
+
     /**
      * @brief Save the pre-autotile free-float geometry for @p windowId.
      *
@@ -349,10 +349,9 @@ private:
      * @param w The window, used to read its maximize/fullscreen restore rect.
      * @param knownFreeFloating Bypass the isWindowFloating guard when the
      *        caller knows the frame is authoritatively a free-float rect.
-     *        Use true from the window-added paths (notifyWindowAdded and
-     *        notifyWindowsAddedBatch) — fresh windows are NOT tracked in
-     *        the FloatingCache yet, so isWindowFloating() returns false
-     *        and would incorrectly reject the one-shot initial capture.
+     *        Use true only for a genuine window-open event. Fresh windows are
+     *        not tracked in the FloatingCache yet, so isWindowFloating()
+     *        returns false and would incorrectly reject the initial capture.
      */
     void saveAndRecordPreAutotileGeometry(const QString& windowId, const QString& screenId, KWin::EffectWindow* w,
                                           const QRectF& frameIn, bool knownFreeFloating = false);
@@ -412,6 +411,9 @@ private:
     /// set AND ran the full per-screen transition handling the raw reply
     /// assignment lacks.
     quint64 m_screensSignalGeneration = 0;
+    quint64 m_screenQueryGeneration = 0;
+    bool m_initialScreenQueryPending = false;
+    QSet<QString> m_pendingFreshWindows;
     /// Pre-autotile frame geometry, keyed [screenId][windowId].
     ///
     /// Ownership: this is a local cache. The daemon's unified
@@ -448,18 +450,19 @@ private:
     /// source screen's coordinate space and would land off-target on a
     /// different monitor).
     QHash<QString, QPair<QString, QRectF>> m_savedPreAutotileForDesktopMove;
-    QSet<QString> m_pendingCloses;
     bool m_inOutputChanged = false; ///< re-entrancy guard for handleWindowOutputChanged
     QHash<QString, QMetaObject::Connection>
         m_pendingCrossScreenRestore; ///< windowId → deferred size-restore connection
     QSet<QString> m_minimizeFloatedWindows;
+    /// Ownership after an unfloat dispatch and before its authoritative echo.
+    /// The generation rejects completions from a countermanded older request.
+    /// A re-minimize countermand moves the window back to the active set.
+    QHash<QString, quint64> m_unfloatInFlight;
+    quint64 m_unfloatRequestGeneration = 0;
     /// Subset of m_minimizeFloatedWindows claimed at batch-announce time
     /// (already minimized when the screen entered autotile). These windows
-    /// sit at their free-floating rect, NOT a tile rect, so their unminimize
-    /// commits the unfloat immediately instead of through the deferred
-    /// animation grace — the grace is invisible only for a window parked at
-    /// its tile; for these it parks the window at the free rect for the
-    /// whole animation and then visibly hops it into the tile.
+    /// still carry geometry from the prior mode, so their unminimize commits
+    /// immediately instead of through the deferred animation grace.
     QSet<QString> m_untiledMinimizeFloats;
     // NOTE: title-bar (borderless) state is owned by the effect's
     // DecorationManager; this handler only tracks tiled membership for

--- a/kwin-effect/autotilehandler/autotilehandler.h
+++ b/kwin-effect/autotilehandler/autotilehandler.h
@@ -103,14 +103,16 @@ public:
     /// daemon windowClosed call) and the cross-mode-move marker path (where the
     /// daemon already relinquished the window via handoffRelease).
     void cleanupAutotileTracking(const QString& windowId, const QString& screenId);
-    /// Drop @p windowId from the minimize-float set and cancel any deferred
-    /// unminimize→unfloat commit (mirrors SnapHandler::removeMinimizeFloated).
-    /// Returns true if the window was tracked. Called from the effect's
-    /// windowFloatingChanged handler: an authoritative external unfloat moots
-    /// the deferred commit — the daemon already unfloated the window, so a
-    /// later commit would re-send a redundant unfloat.
+    /// Drop @p windowId from the minimize-float set and cancel EITHER
+    /// deferred edge — the minimize debounce and the unminimize commit —
+    /// mirroring SnapHandler::removeMinimizeFloated exactly. Returns true if
+    /// the window was tracked. Callers: close cleanup, the effect's
+    /// authoritative visible unfloat (slotWindowFloatingChanged, including
+    /// its dual-hold repair), and the cross-mode adoption hops (snap's
+    /// adoption paths and countermand hand-offs).
     bool removeMinimizeFloated(const QString& windowId)
     {
+        cancelPendingMinimizeFloat(windowId);
         cancelPendingUnminimizeUnfloat(windowId);
         m_untiledMinimizeFloats.remove(windowId);
         m_unfloatRetryAttempts.remove(windowId);
@@ -355,9 +357,10 @@ private:
      * @brief Cancel a pending debounced minimize→float commit.
      *
      * No-op if no timer is pending for the window. Called from the
-     * unminimize path (to coalesce spurious cycles) and from onWindowClosed
-     * (so pending timers never fire against destroyed windows); bulk
-     * teardown goes through the helper's cancelAll in
+     * unminimize path (to coalesce spurious cycles), from
+     * removeMinimizeFloated, and from cleanupAutotileTracking's per-window
+     * teardown (so pending timers never fire against destroyed windows);
+     * bulk teardown goes through the helper's cancelAll in
      * clearAllPendingMinimizeFloats instead.
      */
     void cancelPendingMinimizeFloat(const QString& windowId);

--- a/kwin-effect/autotilehandler/autotilehandler.h
+++ b/kwin-effect/autotilehandler/autotilehandler.h
@@ -222,10 +222,6 @@ public:
 
     // Screen accessors (for gating drag/snap/overlay behavior per-screen)
     bool isAutotileScreen(const QString& screenId) const;
-    const QSet<QString>& autotileScreens() const
-    {
-        return m_autotileScreens;
-    }
 
     /// Check if a window is tracked by the autotile handler (in m_notifiedWindows).
     bool isTrackedWindow(const QString& windowId) const

--- a/kwin-effect/autotilehandler/signals.cpp
+++ b/kwin-effect/autotilehandler/signals.cpp
@@ -232,7 +232,13 @@ void AutotileHandler::slotScreensChanged(const QStringList& screenIds, bool isDe
                 // stacking order — getWindowScreenId/getWindowId on them
                 // would re-pollute the scrubbed id caches.
                 if (w && !w->isDeleted() && removed.contains(m_effect->getWindowScreenId(w))) {
-                    if (!w->isOnCurrentDesktop()) {
+                    // Activity axis too: an ACTIVITY switch arrives here with
+                    // isDesktopSwitch=true as well (the engine ORs both into
+                    // the switch flag), and a window of the left activity is
+                    // still on the current desktop — it must be demoted the
+                    // same way, or pass 2 un-tiles it below (#808, activity
+                    // variant).
+                    if (!w->isOnCurrentDesktop() || !w->isOnCurrentActivity()) {
                         const QString wid = m_effect->getWindowId(w);
                         if (m_notifiedWindows.remove(wid)) {
                             m_notifiedWindowScreens.remove(wid);
@@ -255,7 +261,10 @@ void AutotileHandler::slotScreensChanged(const QStringList& screenIds, bool isDe
             for (KWin::EffectWindow* w : windows) {
                 // isDeleted: a window mid-close must not be churned through
                 // the per-window restore steps (same cache hygiene as pass 1).
-                if (!w || w->isDeleted() || !w->isOnCurrentDesktop()) {
+                // Activity term matches pass 1: a left-activity window is
+                // still tiled in that activity's live session and must not be
+                // restored/teleported here.
+                if (!w || w->isDeleted() || !w->isOnCurrentDesktop() || !w->isOnCurrentActivity()) {
                     continue;
                 }
                 const QString screenId = m_effect->getWindowScreenId(w);
@@ -271,7 +280,11 @@ void AutotileHandler::slotScreensChanged(const QStringList& screenIds, bool isDe
                 // that session. The only sanctioned restore for these windows
                 // is the genuine-toggle path below (full disable arrives with
                 // isDesktopSwitch=false and an empty set).
-                if (w->isOnAllDesktops() || w->desktops().size() > 1) {
+                // Activities carry the same hazard: empty activities() means
+                // all-activities, and a multi-activity window may be tiled in
+                // another activity's live session.
+                if (w->isOnAllDesktops() || w->desktops().size() > 1 || w->activities().isEmpty()
+                    || w->activities().size() > 1) {
                     continue;
                 }
                 const QString windowId = m_effect->getWindowId(w);
@@ -376,11 +389,12 @@ void AutotileHandler::slotScreensChanged(const QStringList& screenIds, bool isDe
             QSet<QString> windowsOnRemovedScreens;
             for (KWin::EffectWindow* w : windows) {
                 if (w && removed.contains(m_effect->getWindowScreenId(w))) {
-                    // Only restore borders for windows on the CURRENT desktop.
-                    // Windows on other desktops may still be autotiled and must keep
-                    // their borderless state — restoring them here would leak title bars
-                    // into other desktops' autotile sessions.
-                    if (!w->isOnCurrentDesktop()) {
+                    // Only restore borders for windows on the CURRENT desktop
+                    // AND activity. Windows in other contexts may still be
+                    // autotiled and must keep their borderless state —
+                    // restoring them here would leak title bars into those
+                    // contexts' autotile sessions.
+                    if (!w->isOnCurrentDesktop() || !w->isOnCurrentActivity()) {
                         continue;
                     }
                     // Skip sticky (all-desktops) and multi-desktop windows when
@@ -415,8 +429,8 @@ void AutotileHandler::slotScreensChanged(const QStringList& screenIds, bool isDe
             for (const QString& screenId : removed) {
                 QStringList autotileOrder;
                 for (KWin::EffectWindow* w : windows) {
-                    if (w && m_effect->shouldHandleWindow(w) && w->isOnCurrentDesktop()
-                        && m_effect->getWindowScreenId(w) == screenId) {
+                    if (w && !w->isDeleted() && m_effect->shouldHandleWindow(w) && w->isOnCurrentDesktop()
+                        && w->isOnCurrentActivity() && m_effect->getWindowScreenId(w) == screenId) {
                         autotileOrder.append(m_effect->getWindowId(w));
                     }
                 }
@@ -428,7 +442,8 @@ void AutotileHandler::slotScreensChanged(const QStringList& screenIds, bool isDe
             // Unmaximize monocle windows on removed screens so they return to
             // normal geometry when resnapped or restored.
             for (KWin::EffectWindow* w : windows) {
-                if (!w || !m_effect->shouldHandleWindow(w) || !w->isOnCurrentDesktop()) {
+                if (!w || w->isDeleted() || !m_effect->shouldHandleWindow(w) || !w->isOnCurrentDesktop()
+                    || !w->isOnCurrentActivity()) {
                     continue;
                 }
                 const QString screenId = m_effect->getWindowScreenId(w);

--- a/kwin-effect/autotilehandler/signals.cpp
+++ b/kwin-effect/autotilehandler/signals.cpp
@@ -88,6 +88,43 @@ void AutotileHandler::clearAllPendingMinimizeFloats()
     m_pendingUnminimizeUnfloat.cancelAll();
 }
 
+bool AutotileHandler::beginUnminimizeUnfloat(const QString& windowId)
+{
+    if (!m_minimizeFloatedWindows.contains(windowId) || !m_effect->m_daemonGate.serviceRegistered) {
+        return false;
+    }
+    m_minimizeFloatedWindows.remove(windowId);
+    m_unfloatInFlight.insert(windowId, ++m_unfloatRequestGeneration);
+    return true;
+}
+
+void AutotileHandler::dispatchUnminimizeUnfloat(const QString& windowId, const QString& screenId)
+{
+    if (!beginUnminimizeUnfloat(windowId)) {
+        return;
+    }
+    const quint64 requestGeneration = m_unfloatInFlight.value(windowId);
+    auto* watcher =
+        new QDBusPendingCallWatcher(PhosphorProtocol::ClientHelpers::asyncCall(
+                                        PhosphorProtocol::Service::Interface::WindowTracking,
+                                        QStringLiteral("setWindowFloatingForScreen"), {windowId, screenId, false}),
+                                    this);
+    connect(watcher, &QDBusPendingCallWatcher::finished, this,
+            [this, windowId, requestGeneration](QDBusPendingCallWatcher* w) {
+                w->deleteLater();
+                const auto inFlight = m_unfloatInFlight.constFind(windowId);
+                if (inFlight == m_unfloatInFlight.constEnd() || inFlight.value() != requestGeneration) {
+                    return;
+                }
+                if (w->isError()) {
+                    m_unfloatInFlight.remove(windowId);
+                    m_minimizeFloatedWindows.insert(windowId);
+                    qCWarning(lcEffect) << "Autotile: unfloat request failed for" << windowId << ':'
+                                        << w->error().message();
+                }
+            });
+}
+
 void AutotileHandler::slotScreensChanged(const QStringList& screenIds, bool isDesktopSwitch)
 {
     // Invalidate in-flight stagger timers from prior autotile operations.
@@ -397,7 +434,7 @@ void AutotileHandler::slotScreensChanged(const QStringList& screenIds, bool isDe
                         } else {
                             // Genuinely new window opened while this desktop was
                             // not active — notify daemon so it's added to PhosphorTiles::TilingState
-                            notifyWindowAdded(w);
+                            notifyWindowAdded(w, /*knownFreeFloating=*/true);
                         }
                     }
                 }
@@ -707,6 +744,17 @@ void AutotileHandler::slotWindowMinimizedChanged(KWin::EffectWindow* w)
         // commit: the window never unfloated, so it is still minimize-floated
         // and the isWindowFloating skip below covers the rest.
         cancelPendingUnminimizeUnfloat(windowId);
+        if (m_unfloatInFlight.remove(windowId)) {
+            m_minimizeFloatedWindows.insert(windowId);
+            qCInfo(lcEffect) << "Autotile: re-minimize countermanding in-flight unfloat:" << windowId;
+            if (m_effect->m_daemonGate.serviceRegistered) {
+                PhosphorProtocol::ClientHelpers::fireAndForget(
+                    m_effect, PhosphorProtocol::Service::Interface::WindowTracking,
+                    QStringLiteral("setWindowFloatingForScreen"), {windowId, screenId, true},
+                    QStringLiteral("setWindowFloatingForScreen"));
+            }
+            return;
+        }
         if (m_effect->isWindowFloating(windowId)) {
             qCDebug(lcEffect) << "Autotile: minimized already-floating window, skipping floatWindow:" << windowId;
             return;
@@ -779,7 +827,7 @@ void AutotileHandler::slotWindowMinimizedChanged(KWin::EffectWindow* w)
     if (m_pendingMinimizeFloat.contains(windowId)) {
         cancelPendingMinimizeFloat(windowId);
         qCDebug(lcEffect) << "Autotile: coalesced spurious minimize/unminimize cycle for" << windowId;
-        notifyWindowAdded(w);
+        notifyWindowAdded(w, /*knownFreeFloating=*/false);
         return;
     }
 
@@ -804,20 +852,17 @@ void AutotileHandler::slotWindowMinimizedChanged(KWin::EffectWindow* w)
         // (trading a cancelled restore animation for the correct position).
         SnapHandler* snap = m_effect->snapHandler();
         if (snap && snap->removeMinimizeFloated(windowId)) {
+            m_minimizeFloatedWindows.insert(windowId);
+            m_untiledMinimizeFloats.insert(windowId);
             qCInfo(lcEffect) << "Autotile: adopted snap-mode minimize-float, unfloating immediately:" << windowId
                              << "on" << screenId;
-            if (m_effect->m_daemonGate.serviceRegistered) {
-                PhosphorProtocol::ClientHelpers::fireAndForget(
-                    m_effect, PhosphorProtocol::Service::Interface::WindowTracking,
-                    QStringLiteral("setWindowFloatingForScreen"), {windowId, screenId, false},
-                    QStringLiteral("setWindowFloatingForScreen"));
-            }
+            dispatchUnminimizeUnfloat(windowId, screenId);
             notifyWindowAdded(w, /*knownFreeFloating=*/false);
             return;
         }
         qCDebug(lcEffect) << "Autotile: unminimized window was not minimize-floated, skipping unfloatWindow:"
                           << windowId;
-        notifyWindowAdded(w);
+        notifyWindowAdded(w, /*knownFreeFloating=*/false);
         return;
     }
     // A window claimed at batch-announce time was never tiled by us — it
@@ -826,16 +871,11 @@ void AutotileHandler::slotWindowMinimizedChanged(KWin::EffectWindow* w)
     // its tile. Commit the unfloat immediately instead, same rationale as
     // the snap-mode adoption above: the tile decision lands while the
     // restore is still starting and the window goes straight to its tile.
-    if (m_untiledMinimizeFloats.remove(windowId)) {
+    if (m_untiledMinimizeFloats.contains(windowId)) {
         qCInfo(lcEffect) << "Autotile: window unminimized (claimed at announce), unfloating immediately:" << windowId
                          << "on" << screenId;
-        if (m_effect->m_daemonGate.serviceRegistered) {
-            PhosphorProtocol::ClientHelpers::fireAndForget(
-                m_effect, PhosphorProtocol::Service::Interface::WindowTracking,
-                QStringLiteral("setWindowFloatingForScreen"), {windowId, screenId, false},
-                QStringLiteral("setWindowFloatingForScreen"));
-        }
-        notifyWindowAdded(w);
+        dispatchUnminimizeUnfloat(windowId, screenId);
+        notifyWindowAdded(w, /*knownFreeFloating=*/false);
         return;
     }
     // A commit is already scheduled for this window — nothing new to do.
@@ -859,10 +899,8 @@ void AutotileHandler::slotWindowMinimizedChanged(KWin::EffectWindow* w)
     // that same factor, so the deferral tracks the user's actual animation
     // length with margin. The window sits at its tiled rect meanwhile (it
     // could not move while minimized), so the deferral only shifts the
-    // retile timing. All state mutation (m_minimizeFloatedWindows removal,
-    // D-Bus, notifyWindowAdded) happens at COMMIT, mirroring the minimize
-    // debounce, so a cancelled commit leaves the window minimize-floated
-    // exactly as it was.
+    // retile timing. Ownership moves to m_unfloatInFlight at COMMIT, so a
+    // re-minimize can countermand the asynchronous unfloat before its echo.
     const int graceMs = int(KWin::Effect::animationTime(std::chrono::milliseconds(400)).count());
     QPointer<KWin::EffectWindow> wPtr(w);
     m_pendingUnminimizeUnfloat.schedule(windowId, graceMs, [this, windowId, wPtr]() {
@@ -903,14 +941,9 @@ void AutotileHandler::slotWindowMinimizedChanged(KWin::EffectWindow* w)
         qCInfo(lcEffect) << "Autotile: window unminimized, unfloating (after animation grace):" << windowId << "on"
                          << currentScreenId;
 
-        if (m_effect->m_daemonGate.serviceRegistered) {
-            PhosphorProtocol::ClientHelpers::fireAndForget(
-                m_effect, PhosphorProtocol::Service::Interface::WindowTracking,
-                QStringLiteral("setWindowFloatingForScreen"), {windowId, currentScreenId, false},
-                QStringLiteral("setWindowFloatingForScreen"));
-        }
+        dispatchUnminimizeUnfloat(windowId, currentScreenId);
 
-        notifyWindowAdded(fw);
+        notifyWindowAdded(fw, /*knownFreeFloating=*/false);
     });
 }
 
@@ -961,7 +994,7 @@ void AutotileHandler::slotWindowFullScreenChanged(KWin::EffectWindow* w)
             // including the current desktop/activity).
             const QString currentScreen = m_effect->getWindowScreenId(w);
             if (m_autotileScreens.contains(currentScreen)) {
-                notifyWindowAdded(w);
+                notifyWindowAdded(w, /*knownFreeFloating=*/true);
             }
             return;
         }

--- a/kwin-effect/autotilehandler/signals.cpp
+++ b/kwin-effect/autotilehandler/signals.cpp
@@ -101,10 +101,19 @@ bool AutotileHandler::beginUnminimizeUnfloat(const QString& windowId)
     return true;
 }
 
-void AutotileHandler::dispatchUnminimizeUnfloat(const QString& windowId, const QString& screenId)
+bool AutotileHandler::dispatchUnminimizeUnfloat(const QString& windowId, const QString& screenId)
 {
     if (!beginUnminimizeUnfloat(windowId)) {
-        return;
+        // Either the window is no longer ours (benign — a concurrent path
+        // consumed it) or the daemon is not registered. In the latter case
+        // the window STAYS minimize-floated with the unminimize edge spent;
+        // onDaemonReady's re-sync is the recovery path, but the strand must
+        // be diagnosable rather than silent, and callers must not announce a
+        // window the daemon still considers floating.
+        qCWarning(lcEffect) << "Autotile: unfloat dispatch declined for" << windowId
+                            << "(owned:" << m_minimizeFloatedWindows.contains(windowId)
+                            << "daemon:" << m_effect->m_daemonGate.serviceRegistered << ")";
+        return false;
     }
     const quint64 requestGeneration = m_unfloatInFlight.value(windowId);
     auto* watcher =
@@ -159,6 +168,7 @@ void AutotileHandler::dispatchUnminimizeUnfloat(const QString& windowId, const Q
                             m_effect->slotWindowFloatingChanged(windowId, false, QString());
                         });
             });
+    return true;
 }
 
 void AutotileHandler::scheduleUnminimizeUnfloatRetry(const QString& windowId)
@@ -187,8 +197,9 @@ void AutotileHandler::scheduleUnminimizeUnfloatRetry(const QString& windowId)
             }
             return;
         }
-        dispatchUnminimizeUnfloat(windowId, screenId);
-        notifyWindowAdded(safeWindow.data(), /*knownFreeFloating=*/false);
+        if (dispatchUnminimizeUnfloat(windowId, screenId)) {
+            notifyWindowAdded(safeWindow.data(), /*knownFreeFloating=*/false);
+        }
     });
 }
 
@@ -807,6 +818,33 @@ void AutotileHandler::claimAlreadyMinimizedAsFloated(KWin::EffectWindow* w, cons
         }
         return;
     }
+    // A snap-owned MINIMIZE-float is adoptable, not foreign: on a mode swap
+    // the float's owner must follow the screen's current mode, and the snap
+    // handler's own unminimize path bails on autotile screens — without the
+    // adoption nobody claims the window, the daemon keeps (or re-seeds) a
+    // tiling slot for it, and the effect never corrects it (the empty-
+    // tile-spot defect). The re-asserted per-screen float below tells the
+    // daemon's freshly seeded state this window floats in THIS mode too.
+    if (enteringAutotile) {
+        if (SnapHandler* snap = m_effect->snapHandler(); snap && snap->isMinimizeFloated(windowId)) {
+            snap->removeMinimizeFloated(windowId);
+            qCInfo(lcEffect) << "Autotile: adopting snap-mode minimize-float at announce:" << windowId << "on"
+                             << screenId;
+            m_minimizeFloatedWindows.insert(windowId);
+            m_untiledMinimizeFloats.insert(windowId);
+            applyFloatCleanup(windowId);
+            if (m_effect->m_daemonGate.serviceRegistered) {
+                PhosphorProtocol::ClientHelpers::fireAndForget(
+                    m_effect, PhosphorProtocol::Service::Interface::WindowTracking,
+                    QStringLiteral("setWindowFloatingForScreen"), {windowId, screenId, true},
+                    QStringLiteral("setWindowFloatingForScreen"));
+            }
+            return;
+        }
+    }
+    // Genuine foreign float (user float, or another mode's float we must not
+    // own): keep the float and its owner — claiming it would make our
+    // unminimize path force-tile a window whose float we did not create.
     if (m_effect->isWindowFloating(windowId)) {
         return;
     }
@@ -818,6 +856,12 @@ void AutotileHandler::claimAlreadyMinimizedAsFloated(KWin::EffectWindow* w, cons
     }
     qCInfo(lcEffect) << "Autotile: window already minimized at announce, claiming as minimize-floated:" << windowId
                      << "on" << screenId;
+    // Full float reconcile, not just the D-Bus call: the claim must clear
+    // stale tiled-membership, centering targets, and the decoration claim the
+    // same way every runtime float path does, or the next frameGeometryChanged
+    // on unminimize can consume a stale centering entry and snap the window
+    // into an old zone rect.
+    applyFloatCleanup(windowId);
     if (m_effect->m_daemonGate.serviceRegistered) {
         PhosphorProtocol::ClientHelpers::fireAndForget(m_effect, PhosphorProtocol::Service::Interface::WindowTracking,
                                                        QStringLiteral("setWindowFloatingForScreen"),
@@ -958,8 +1002,13 @@ void AutotileHandler::slotWindowMinimizedChanged(KWin::EffectWindow* w)
             m_untiledMinimizeFloats.insert(windowId);
             qCInfo(lcEffect) << "Autotile: adopted snap-mode minimize-float, unfloating immediately:" << windowId
                              << "on" << screenId;
-            dispatchUnminimizeUnfloat(windowId, screenId);
-            notifyWindowAdded(w, /*knownFreeFloating=*/false);
+            if (dispatchUnminimizeUnfloat(windowId, screenId)) {
+                // The frame still belongs to the prior mode; withhold paints
+                // until the tile geometry lands (or the suppression's own
+                // deadline) so the restore appears once, in its tile.
+                m_effect->beginRestoreSuppression(w);
+                notifyWindowAdded(w, /*knownFreeFloating=*/false);
+            }
             return;
         }
         qCDebug(lcEffect) << "Autotile: unminimized window was not minimize-floated, skipping unfloatWindow:"
@@ -976,8 +1025,13 @@ void AutotileHandler::slotWindowMinimizedChanged(KWin::EffectWindow* w)
     if (m_untiledMinimizeFloats.contains(windowId)) {
         qCInfo(lcEffect) << "Autotile: window unminimized (claimed at announce), unfloating immediately:" << windowId
                          << "on" << screenId;
-        dispatchUnminimizeUnfloat(windowId, screenId);
-        notifyWindowAdded(w, /*knownFreeFloating=*/false);
+        if (dispatchUnminimizeUnfloat(windowId, screenId)) {
+            // Same stale-frame rationale as the adoption branch above: the
+            // rect belongs to the prior mode, so withhold paints until the
+            // tile geometry lands.
+            m_effect->beginRestoreSuppression(w);
+            notifyWindowAdded(w, /*knownFreeFloating=*/false);
+        }
         return;
     }
     // A commit is already scheduled for this window — nothing new to do.
@@ -1043,9 +1097,9 @@ void AutotileHandler::slotWindowMinimizedChanged(KWin::EffectWindow* w)
         qCInfo(lcEffect) << "Autotile: window unminimized, unfloating (after animation grace):" << windowId << "on"
                          << currentScreenId;
 
-        dispatchUnminimizeUnfloat(windowId, currentScreenId);
-
-        notifyWindowAdded(fw, /*knownFreeFloating=*/false);
+        if (dispatchUnminimizeUnfloat(windowId, currentScreenId)) {
+            notifyWindowAdded(fw, /*knownFreeFloating=*/false);
+        }
     });
 }
 

--- a/kwin-effect/autotilehandler/signals.cpp
+++ b/kwin-effect/autotilehandler/signals.cpp
@@ -34,6 +34,9 @@ namespace PlasmaZones {
 
 Q_DECLARE_LOGGING_CATEGORY(lcEffect)
 
+static constexpr int kAutotileUnfloatRetryDelayMs = 250;
+static constexpr int kAutotileMaxUnfloatRetries = 3;
+
 // Debounce window for minimize→float commits. KWin can transiently flip a
 // tiled window's isMinimized() state to true and back within a few
 // milliseconds when a plasmashell notification popup rearranges stacking.
@@ -121,8 +124,72 @@ void AutotileHandler::dispatchUnminimizeUnfloat(const QString& windowId, const Q
                     m_minimizeFloatedWindows.insert(windowId);
                     qCWarning(lcEffect) << "Autotile: unfloat request failed for" << windowId << ':'
                                         << w->error().message();
+                    scheduleUnminimizeUnfloatRetry(windowId);
+                    return;
                 }
+
+                auto* stateWatcher = new QDBusPendingCallWatcher(
+                    PhosphorProtocol::ClientHelpers::asyncCall(PhosphorProtocol::Service::Interface::WindowTracking,
+                                                               QStringLiteral("queryWindowFloating"), {windowId}),
+                    this);
+                connect(stateWatcher, &QDBusPendingCallWatcher::finished, this,
+                        [this, windowId, requestGeneration](QDBusPendingCallWatcher* stateCall) {
+                            stateCall->deleteLater();
+                            const auto current = m_unfloatInFlight.constFind(windowId);
+                            if (current == m_unfloatInFlight.constEnd() || current.value() != requestGeneration) {
+                                return;
+                            }
+                            QDBusPendingReply<bool> reply = *stateCall;
+                            if (!reply.isValid()) {
+                                m_unfloatInFlight.remove(windowId);
+                                m_minimizeFloatedWindows.insert(windowId);
+                                scheduleUnminimizeUnfloatRetry(windowId);
+                                return;
+                            }
+                            if (reply.value()) {
+                                m_unfloatInFlight.remove(windowId);
+                                m_minimizeFloatedWindows.insert(windowId);
+                                scheduleUnminimizeUnfloatRetry(windowId);
+                                return;
+                            }
+                            m_unfloatInFlight.remove(windowId);
+                            m_minimizeFloatedWindows.remove(windowId);
+                            m_untiledMinimizeFloats.remove(windowId);
+                            m_unfloatRetryAttempts.remove(windowId);
+                            m_effect->slotWindowFloatingChanged(windowId, false, QString());
+                        });
             });
+}
+
+void AutotileHandler::scheduleUnminimizeUnfloatRetry(const QString& windowId)
+{
+    if (!m_effect->m_daemonGate.serviceRegistered || m_pendingUnminimizeUnfloat.contains(windowId)
+        || m_unfloatRetryAttempts.value(windowId) >= kAutotileMaxUnfloatRetries) {
+        return;
+    }
+    KWin::EffectWindow* window = m_effect->findWindowById(windowId);
+    if (!window || window->isDeleted() || window->isMinimized()) {
+        return;
+    }
+    QPointer<KWin::EffectWindow> safeWindow = window;
+    ++m_unfloatRetryAttempts[windowId];
+    m_pendingUnminimizeUnfloat.schedule(windowId, kAutotileUnfloatRetryDelayMs, [this, windowId, safeWindow]() {
+        if (!safeWindow || safeWindow->isDeleted() || safeWindow->isMinimized()) {
+            return;
+        }
+        const QString screenId = m_effect->getWindowScreenId(safeWindow.data());
+        if (!m_minimizeFloatedWindows.contains(windowId)) {
+            return;
+        }
+        if (!m_autotileScreens.contains(screenId)) {
+            if (SnapHandler* snap = m_effect->snapHandler()) {
+                snap->handleMinimizeChanged(safeWindow.data(), windowId, screenId, false);
+            }
+            return;
+        }
+        dispatchUnminimizeUnfloat(windowId, screenId);
+        notifyWindowAdded(safeWindow.data(), /*knownFreeFloating=*/false);
+    });
 }
 
 void AutotileHandler::slotScreensChanged(const QStringList& screenIds, bool isDesktopSwitch)
@@ -402,6 +469,13 @@ void AutotileHandler::slotScreensChanged(const QStringList& screenIds, bool isDe
     }
 
     m_autotileScreens = newScreens;
+    QSet<QString> completedDeferredRoutes;
+    bool completedInitialQuery = false;
+    if (m_initialScreenQueryPending) {
+        m_initialScreenQueryPending = false;
+        completedDeferredRoutes = completeDeferredWindowRoutes();
+        completedInitialQuery = true;
+    }
 
     // A desktop switch enters even with empty `added`: when both desktops'
     // autotile sets are IDENTICAL the engine re-emits the unchanged set with
@@ -556,7 +630,14 @@ void AutotileHandler::slotScreensChanged(const QStringList& screenIds, bool isDe
             // Batch-notify all windows on newly-added autotile screens in one D-Bus
             // call (windowsOpenedBatch) instead of per-window windowOpened round-trips.
             // saveAndRecordPreAutotileGeometry is called inside notifyWindowsAddedBatch.
-            notifyWindowsAddedBatch(windows, added, /*resetNotified=*/true,
+            QList<KWin::EffectWindow*> batchWindows;
+            batchWindows.reserve(windows.size());
+            for (KWin::EffectWindow* window : windows) {
+                if (window && !completedDeferredRoutes.contains(m_effect->getWindowId(window))) {
+                    batchWindows.append(window);
+                }
+            }
+            notifyWindowsAddedBatch(batchWindows, added, /*resetNotified=*/true,
                                     /*enteringAutotile=*/true);
             qCInfo(lcEffect) << "Saved pre-autotile geometries for screens:" << added;
 
@@ -586,12 +667,20 @@ void AutotileHandler::slotScreensChanged(const QStringList& screenIds, bool isDe
                             return;
                         }
                         const PhosphorProtocol::PreTileGeometryList entries = reply.value();
+                        QHash<QString, QHash<QString, int>> entryCounts;
+                        for (const auto& entry : entries) {
+                            if (added.contains(entry.screenId) && entry.width > 0 && entry.height > 0) {
+                                ++entryCounts[entry.appId][entry.screenId];
+                            }
+                        }
                         const auto allWindows = KWin::effects->stackingOrder();
                         for (const auto& entry : entries) {
                             const QString stableId = entry.appId;
                             QRectF geom = QRectF(entry.toRect());
-                            if (geom.width() <= 0 || geom.height() <= 0)
+                            if (geom.width() <= 0 || geom.height() <= 0 || !added.contains(entry.screenId)
+                                || entryCounts.value(stableId).value(entry.screenId) != 1) {
                                 continue;
+                            }
                             // Find all windows on added screens matching this stableId.
                             // If multiple windows share the same stableId (e.g., 3 Dolphin instances),
                             // the daemon's single geometry is ambiguous — skip the override entirely.
@@ -605,7 +694,7 @@ void AutotileHandler::slotScreensChanged(const QStringList& screenIds, bool isDe
                                     continue;
                                 if (::PhosphorIdentity::WindowId::extractAppId(m_effect->getWindowId(ew)) != stableId)
                                     continue;
-                                if (!added.contains(m_effect->getWindowScreenId(ew)))
+                                if (m_effect->getWindowScreenId(ew) != entry.screenId)
                                     continue;
                                 if (matchedWindow) {
                                     ambiguous = true;
@@ -647,6 +736,9 @@ void AutotileHandler::slotScreensChanged(const QStringList& screenIds, bool isDe
         } // else (genuine user toggle)
     }
 
+    if (completedInitialQuery) {
+        m_effect->snapHandler()->retryVisibleMinimizeFloats();
+    }
     qCInfo(lcEffect) << "Autotile screens changed:" << m_autotileScreens;
 }
 
@@ -703,10 +795,19 @@ void AutotileHandler::claimAlreadyMinimizedAsFloated(KWin::EffectWindow* w, cons
     // (user float, or another mode's minimize-float record) keeps its float
     // and its owner — claiming it would make our unminimize path force-tile
     // a window whose float we did not create.
-    if (m_effect->isWindowFloating(windowId)) {
+    if (m_minimizeFloatedWindows.contains(windowId)) {
+        if (enteringAutotile) {
+            m_untiledMinimizeFloats.insert(windowId);
+            if (m_effect->m_daemonGate.serviceRegistered) {
+                PhosphorProtocol::ClientHelpers::fireAndForget(
+                    m_effect, PhosphorProtocol::Service::Interface::WindowTracking,
+                    QStringLiteral("setWindowFloatingForScreen"), {windowId, screenId, true},
+                    QStringLiteral("setWindowFloatingForScreen"));
+            }
+        }
         return;
     }
-    if (m_minimizeFloatedWindows.contains(windowId)) {
+    if (m_effect->isWindowFloating(windowId)) {
         return;
     }
     m_minimizeFloatedWindows.insert(windowId);
@@ -744,6 +845,7 @@ void AutotileHandler::slotWindowMinimizedChanged(KWin::EffectWindow* w)
         // commit: the window never unfloated, so it is still minimize-floated
         // and the isWindowFloating skip below covers the rest.
         cancelPendingUnminimizeUnfloat(windowId);
+        m_unfloatRetryAttempts.remove(windowId);
         if (m_unfloatInFlight.remove(windowId)) {
             m_minimizeFloatedWindows.insert(windowId);
             qCInfo(lcEffect) << "Autotile: re-minimize countermanding in-flight unfloat:" << windowId;

--- a/kwin-effect/autotilehandler/signals.cpp
+++ b/kwin-effect/autotilehandler/signals.cpp
@@ -365,9 +365,11 @@ void AutotileHandler::slotScreensChanged(const QStringList& screenIds, bool isDe
                     // same-screen restore is not mistaken for a virtual-
                     // screen crossing — the genuine retile path guards the
                     // same way (tiling.cpp).
+                    // Save/restore, not set/clear (nesting-safe).
+                    const bool prevInApply = m_effect->m_daemonGate.inGeometryApply;
                     m_effect->m_daemonGate.inGeometryApply = true;
-                    const auto geomGuard = qScopeGuard([this] {
-                        m_effect->m_daemonGate.inGeometryApply = false;
+                    const auto geomGuard = qScopeGuard([this, prevInApply] {
+                        m_effect->m_daemonGate.inGeometryApply = prevInApply;
                     });
                     // Clear any lingering KWin maximize flag before restoring
                     // the pre-autotile geometry: a still-maximized window

--- a/kwin-effect/autotilehandler/signals.cpp
+++ b/kwin-effect/autotilehandler/signals.cpp
@@ -192,8 +192,11 @@ void AutotileHandler::scheduleUnminimizeUnfloatRetry(const QString& windowId)
             return;
         }
         if (!m_autotileScreens.contains(screenId)) {
-            if (SnapHandler* snap = m_effect->snapHandler()) {
-                snap->handleMinimizeChanged(safeWindow.data(), windowId, screenId, false);
+            SnapHandler* snap = m_effect->snapHandler();
+            if (!snap || !snap->offerMinimizeEdge(safeWindow.data(), windowId, screenId)) {
+                // Refused (screen flipped again mid-transfer) — ownership
+                // stayed here, so re-arm rather than spending the edge.
+                scheduleUnminimizeUnfloatRetry(windowId);
             }
             return;
         }
@@ -891,6 +894,19 @@ void AutotileHandler::claimAlreadyMinimizedAsFloated(KWin::EffectWindow* w, cons
     }
 }
 
+bool AutotileHandler::offerMinimizeEdge(KWin::EffectWindow* w)
+{
+    // Mirror of slotWindowMinimizedChanged's entry gates. See the header doc:
+    // a transfer the gates would refuse must be reported to the sender, not
+    // silently dropped.
+    if (!w || !m_effect->shouldHandleWindow(w) || !m_effect->isTileableWindow(w)
+        || !m_autotileScreens.contains(m_effect->getWindowScreenId(w))) {
+        return false;
+    }
+    slotWindowMinimizedChanged(w);
+    return true;
+}
+
 void AutotileHandler::slotWindowMinimizedChanged(KWin::EffectWindow* w)
 {
     if (!w || !m_effect->shouldHandleWindow(w) || !m_effect->isTileableWindow(w)) {
@@ -1058,10 +1074,12 @@ void AutotileHandler::slotWindowMinimizedChanged(KWin::EffectWindow* w)
         }
         return;
     }
-    // A commit is already scheduled for this window — nothing new to do.
-    if (m_pendingUnminimizeUnfloat.contains(windowId)) {
-        return;
-    }
+    // Supersede any surviving pending entry rather than skipping the edge:
+    // the shared queue also carries RETRY timers (the twin of snap's
+    // scheduleUnminimizeUnfloatRetry), and a genuine unminimize must never be
+    // swallowed by whichever stale timer slipped through — the fresh edge is
+    // the authoritative signal, so the grace re-arms from it.
+    cancelPendingUnminimizeUnfloat(windowId);
     // No pre-autotile geometry capture here: a minimize-floated window cannot
     // move while minimized, so its frame is always the tiled rect — recording
     // it would poison the local float-back cache for windows with no prior
@@ -1108,9 +1126,12 @@ void AutotileHandler::slotWindowMinimizedChanged(KWin::EffectWindow* w)
             // snap now instead of retaining ownership for an edge that will
             // never be emitted again.
             SnapHandler* snap = m_effect->snapHandler();
-            if (snap) {
-                qCInfo(lcEffect) << "Autotile: deferred unfloat screen became snap, transferring:" << windowId;
-                snap->handleMinimizeChanged(fw, windowId, currentScreenId, false);
+            qCInfo(lcEffect) << "Autotile: deferred unfloat screen became snap, transferring:" << windowId;
+            if (!snap || !snap->offerMinimizeEdge(fw, windowId, currentScreenId)) {
+                // Refused (screen flipped again mid-transfer) — ownership
+                // stayed here, so re-arm rather than spending the edge.
+                qCInfo(lcEffect) << "Autotile: snap refused transferred edge, re-arming retry:" << windowId;
+                scheduleUnminimizeUnfloatRetry(windowId);
             }
             return;
         }

--- a/kwin-effect/autotilehandler/signals.cpp
+++ b/kwin-effect/autotilehandler/signals.cpp
@@ -7,6 +7,7 @@
 #include "autotilehandler.h"
 #include "plasmazoneseffect/plasmazoneseffect.h"
 #include "handlers/navigationhandler.h"
+#include "handlers/snaphandler.h" // cross-mode minimize-float adoption
 #include <PhosphorProtocol/ServiceConstants.h>
 #include <PhosphorProtocol/ClientHelpers.h>
 #include <PhosphorIdentity/WindowId.h>
@@ -650,6 +651,40 @@ void AutotileHandler::slotWindowFloatingChanged(const QString& windowId, bool is
     }
 }
 
+void AutotileHandler::claimAlreadyMinimizedAsFloated(KWin::EffectWindow* w, const QString& windowId,
+                                                     const QSet<QString>& screenFilter)
+{
+    const QString screenId = m_effect->getWindowScreenId(w);
+    if (!screenFilter.isEmpty() && !screenFilter.contains(screenId)) {
+        return;
+    }
+    if (!m_autotileScreens.contains(screenId)) {
+        return;
+    }
+    // Same skip as the runtime minimize path: an already-floating window
+    // (user float, or another mode's minimize-float record) keeps its float
+    // and its owner — claiming it would make our unminimize path force-tile
+    // a window whose float we did not create.
+    if (m_effect->isWindowFloating(windowId)) {
+        return;
+    }
+    if (m_minimizeFloatedWindows.contains(windowId)) {
+        return;
+    }
+    m_minimizeFloatedWindows.insert(windowId);
+    // The window was never tiled by us — it sits at its free-floating rect,
+    // so its unminimize must commit immediately (see m_untiledMinimizeFloats).
+    m_untiledMinimizeFloats.insert(windowId);
+    qCInfo(lcEffect) << "Autotile: window already minimized at announce, claiming as minimize-floated:" << windowId
+                     << "on" << screenId;
+    if (m_effect->m_daemonGate.serviceRegistered) {
+        PhosphorProtocol::ClientHelpers::fireAndForget(m_effect, PhosphorProtocol::Service::Interface::WindowTracking,
+                                                       QStringLiteral("setWindowFloatingForScreen"),
+                                                       {windowId, screenId, true},
+                                                       QStringLiteral("setWindowFloatingForScreen"));
+    }
+}
+
 void AutotileHandler::slotWindowMinimizedChanged(KWin::EffectWindow* w)
 {
     if (!w || !m_effect->shouldHandleWindow(w) || !m_effect->isTileableWindow(w)) {
@@ -746,8 +781,58 @@ void AutotileHandler::slotWindowMinimizedChanged(KWin::EffectWindow* w)
     }
 
     if (!m_minimizeFloatedWindows.contains(windowId)) {
+        // Adopt a minimize-float created by the SNAP handler before this
+        // screen swapped to autotile. Ownership must follow the screen's
+        // current mode: the snap handler's own unminimize path bails on
+        // autotile screens (and its deferred commit bails when the screen
+        // flipped mid-grace), so without the adoption NOBODY unfloats the
+        // window — it unminimizes into a permanent floating limbo until the
+        // next mode toggle.
+        //
+        // Committed IMMEDIATELY, not through the deferred grace below. The
+        // grace exists so the retile's moveResize doesn't cancel the stock
+        // unminimize animation, and it is invisible in the normal cycle only
+        // because a window we minimize-floated ourselves still sits at its
+        // tiled rect — the deferral merely shifts retile timing. An adopted
+        // window sits at its snap-mode free-float rect: deferring parks it
+        // there for the whole animation and then visibly hops it into the
+        // tile. Unfloating at the edge lets the tile decision land while the
+        // restore is still starting, so the window goes straight to its tile
+        // (trading a cancelled restore animation for the correct position).
+        SnapHandler* snap = m_effect->snapHandler();
+        if (snap && snap->removeMinimizeFloated(windowId)) {
+            qCInfo(lcEffect) << "Autotile: adopted snap-mode minimize-float, unfloating immediately:" << windowId
+                             << "on" << screenId;
+            if (m_effect->m_daemonGate.serviceRegistered) {
+                PhosphorProtocol::ClientHelpers::fireAndForget(
+                    m_effect, PhosphorProtocol::Service::Interface::WindowTracking,
+                    QStringLiteral("setWindowFloatingForScreen"), {windowId, screenId, false},
+                    QStringLiteral("setWindowFloatingForScreen"));
+            }
+            notifyWindowAdded(w);
+            return;
+        }
         qCDebug(lcEffect) << "Autotile: unminimized window was not minimize-floated, skipping unfloatWindow:"
                           << windowId;
+        notifyWindowAdded(w);
+        return;
+    }
+    // A window claimed at batch-announce time was never tiled by us — it
+    // sits at its free-floating rect, so the deferred grace below would park
+    // it there for the whole restore animation and then visibly hop it into
+    // its tile. Commit the unfloat immediately instead, same rationale as
+    // the snap-mode adoption above: the tile decision lands while the
+    // restore is still starting and the window goes straight to its tile.
+    if (m_untiledMinimizeFloats.remove(windowId)) {
+        m_minimizeFloatedWindows.remove(windowId);
+        qCInfo(lcEffect) << "Autotile: window unminimized (claimed at announce), unfloating immediately:" << windowId
+                         << "on" << screenId;
+        if (m_effect->m_daemonGate.serviceRegistered) {
+            PhosphorProtocol::ClientHelpers::fireAndForget(
+                m_effect, PhosphorProtocol::Service::Interface::WindowTracking,
+                QStringLiteral("setWindowFloatingForScreen"), {windowId, screenId, false},
+                QStringLiteral("setWindowFloatingForScreen"));
+        }
         notifyWindowAdded(w);
         return;
     }
@@ -799,7 +884,14 @@ void AutotileHandler::slotWindowMinimizedChanged(KWin::EffectWindow* w)
         }
         const QString currentScreenId = m_effect->getWindowScreenId(fw);
         if (!m_autotileScreens.contains(currentScreenId)) {
-            qCDebug(lcEffect) << "Autotile: deferred unfloat screen no longer autotiled, skipping:" << windowId;
+            // The unminimize edge already happened. Hand the pending commit to
+            // snap now instead of retaining ownership for an edge that will
+            // never be emitted again.
+            SnapHandler* snap = m_effect->snapHandler();
+            if (snap) {
+                qCInfo(lcEffect) << "Autotile: deferred unfloat screen became snap, transferring:" << windowId;
+                snap->handleMinimizeChanged(fw, windowId, currentScreenId, false);
+            }
             return;
         }
         if (!m_minimizeFloatedWindows.remove(windowId)) {

--- a/kwin-effect/autotilehandler/signals.cpp
+++ b/kwin-effect/autotilehandler/signals.cpp
@@ -399,7 +399,11 @@ void AutotileHandler::slotScreensChanged(const QStringList& screenIds, bool isDe
         } else {
             QSet<QString> windowsOnRemovedScreens;
             for (KWin::EffectWindow* w : windows) {
-                if (w && removed.contains(m_effect->getWindowScreenId(w))) {
+                // isDeleted: close-grabbed dying windows linger in the
+                // stacking order — getWindowId on them would re-pollute the
+                // scrubbed id caches (same hazard as the batch loop in
+                // wiring.cpp).
+                if (w && !w->isDeleted() && removed.contains(m_effect->getWindowScreenId(w))) {
                     // Only restore borders for windows on the CURRENT desktop
                     // AND activity. Windows in other contexts may still be
                     // autotiled and must keep their borderless state —
@@ -534,8 +538,8 @@ void AutotileHandler::slotScreensChanged(const QStringList& screenIds, bool isDe
                              << "autotile screens:" << m_autotileScreens;
             for (const QString& screenId : added) {
                 for (KWin::EffectWindow* w : windows) {
-                    if (w && m_effect->shouldHandleWindow(w) && w->isOnCurrentDesktop() && w->isOnCurrentActivity()
-                        && m_effect->getWindowScreenId(w) == screenId) {
+                    if (w && !w->isDeleted() && m_effect->shouldHandleWindow(w) && w->isOnCurrentDesktop()
+                        && w->isOnCurrentActivity() && m_effect->getWindowScreenId(w) == screenId) {
                         const QString windowId = m_effect->getWindowId(w);
                         if (m_savedNotifiedForDesktopReturn.contains(windowId)
                             || m_notifiedWindows.contains(windowId)) {
@@ -560,8 +564,8 @@ void AutotileHandler::slotScreensChanged(const QStringList& screenIds, bool isDe
             // must remain in the set for when their screen returns.
             for (const QString& screenId : added) {
                 for (KWin::EffectWindow* w : windows) {
-                    if (w && m_effect->shouldHandleWindow(w) && w->isOnCurrentDesktop() && w->isOnCurrentActivity()
-                        && m_effect->getWindowScreenId(w) == screenId) {
+                    if (w && !w->isDeleted() && m_effect->shouldHandleWindow(w) && w->isOnCurrentDesktop()
+                        && w->isOnCurrentActivity() && m_effect->getWindowScreenId(w) == screenId) {
                         m_savedNotifiedForDesktopReturn.remove(m_effect->getWindowId(w));
                     }
                 }
@@ -578,8 +582,8 @@ void AutotileHandler::slotScreensChanged(const QStringList& screenIds, bool isDe
             // notifyWindowAdded is idempotent (checks m_notifiedWindows).
             for (const QString& screenId : m_autotileScreens) {
                 for (KWin::EffectWindow* w : windows) {
-                    if (!w || !m_effect->shouldHandleWindow(w) || !w->isOnCurrentDesktop() || !w->isOnCurrentActivity()
-                        || w->isMinimized()) {
+                    if (!w || w->isDeleted() || !m_effect->shouldHandleWindow(w) || !w->isOnCurrentDesktop()
+                        || !w->isOnCurrentActivity() || w->isMinimized()) {
                         continue;
                     }
                     if (m_effect->getWindowScreenId(w) != screenId) {
@@ -636,7 +640,7 @@ void AutotileHandler::slotScreensChanged(const QStringList& screenIds, bool isDe
             // explains why an overflow float must not clobber a correct
             // existing entry).
             for (KWin::EffectWindow* w : windows) {
-                if (!w || !m_effect->shouldHandleWindow(w)) {
+                if (!w || w->isDeleted() || !m_effect->shouldHandleWindow(w)) {
                     continue;
                 }
                 if (!w->isOnCurrentDesktop() || !w->isOnCurrentActivity()) {
@@ -675,7 +679,10 @@ void AutotileHandler::slotScreensChanged(const QStringList& screenIds, bool isDe
             QList<KWin::EffectWindow*> batchWindows;
             batchWindows.reserve(windows.size());
             for (KWin::EffectWindow* window : windows) {
-                if (window && !completedDeferredRoutes.contains(m_effect->getWindowId(window))) {
+                // isDeleted mirrors the batch loop in wiring.cpp — a dying
+                // window's getWindowId would re-pollute the scrubbed caches.
+                if (window && !window->isDeleted()
+                    && !completedDeferredRoutes.contains(m_effect->getWindowId(window))) {
                     batchWindows.append(window);
                 }
             }

--- a/kwin-effect/autotilehandler/signals.cpp
+++ b/kwin-effect/autotilehandler/signals.cpp
@@ -763,7 +763,10 @@ void AutotileHandler::slotScreensChanged(const QStringList& screenIds, bool isDe
     }
 
     if (completedInitialQuery) {
-        m_effect->snapHandler()->retryVisibleMinimizeFloats();
+        // Guarded: snap handler dies before this one during effect teardown.
+        if (SnapHandler* snap = m_effect->snapHandler()) {
+            snap->retryVisibleMinimizeFloats();
+        }
     }
     qCInfo(lcEffect) << "Autotile screens changed:" << m_autotileScreens;
 }
@@ -842,7 +845,10 @@ void AutotileHandler::claimAlreadyMinimizedAsFloated(KWin::EffectWindow* w, cons
     // daemon's freshly seeded state this window floats in THIS mode too.
     if (enteringAutotile) {
         if (SnapHandler* snap = m_effect->snapHandler(); snap && snap->isMinimizeFloated(windowId)) {
+            // Budget survives the hop (see seedUnfloatRetryBudget).
+            const int usedBudget = snap->unfloatRetryBudgetUsed(windowId);
             snap->removeMinimizeFloated(windowId);
+            seedUnfloatRetryBudget(windowId, usedBudget);
             qCInfo(lcEffect) << "Autotile: adopting snap-mode minimize-float at announce:" << windowId << "on"
                              << screenId;
             m_minimizeFloatedWindows.insert(windowId);
@@ -1012,9 +1018,12 @@ void AutotileHandler::slotWindowMinimizedChanged(KWin::EffectWindow* w)
         // restore is still starting, so the window goes straight to its tile
         // (trading a cancelled restore animation for the correct position).
         SnapHandler* snap = m_effect->snapHandler();
+        const int snapBudgetUsed = snap ? snap->unfloatRetryBudgetUsed(windowId) : 0;
         if (snap && snap->removeMinimizeFloated(windowId)) {
             m_minimizeFloatedWindows.insert(windowId);
             m_untiledMinimizeFloats.insert(windowId);
+            // Budget survives the hop (see seedUnfloatRetryBudget).
+            seedUnfloatRetryBudget(windowId, snapBudgetUsed);
             qCInfo(lcEffect) << "Autotile: adopted snap-mode minimize-float, unfloating immediately:" << windowId
                              << "on" << screenId;
             if (dispatchUnminimizeUnfloat(windowId, screenId)) {

--- a/kwin-effect/autotilehandler/signals.cpp
+++ b/kwin-effect/autotilehandler/signals.cpp
@@ -519,7 +519,8 @@ void AutotileHandler::slotScreensChanged(const QStringList& screenIds, bool isDe
             // Batch-notify all windows on newly-added autotile screens in one D-Bus
             // call (windowsOpenedBatch) instead of per-window windowOpened round-trips.
             // saveAndRecordPreAutotileGeometry is called inside notifyWindowsAddedBatch.
-            notifyWindowsAddedBatch(windows, added, /*resetNotified=*/true);
+            notifyWindowsAddedBatch(windows, added, /*resetNotified=*/true,
+                                    /*enteringAutotile=*/true);
             qCInfo(lcEffect) << "Saved pre-autotile geometries for screens:" << added;
 
             // Async fetch of daemon's persisted pre-autotile geometries from previous session.
@@ -652,7 +653,7 @@ void AutotileHandler::slotWindowFloatingChanged(const QString& windowId, bool is
 }
 
 void AutotileHandler::claimAlreadyMinimizedAsFloated(KWin::EffectWindow* w, const QString& windowId,
-                                                     const QSet<QString>& screenFilter)
+                                                     const QSet<QString>& screenFilter, bool enteringAutotile)
 {
     const QString screenId = m_effect->getWindowScreenId(w);
     if (!screenFilter.isEmpty() && !screenFilter.contains(screenId)) {
@@ -672,9 +673,11 @@ void AutotileHandler::claimAlreadyMinimizedAsFloated(KWin::EffectWindow* w, cons
         return;
     }
     m_minimizeFloatedWindows.insert(windowId);
-    // The window was never tiled by us — it sits at its free-floating rect,
-    // so its unminimize must commit immediately (see m_untiledMinimizeFloats).
-    m_untiledMinimizeFloats.insert(windowId);
+    if (enteringAutotile) {
+        // The current rect belongs to the prior mode. Place it in autotile at
+        // the visibility edge instead of after the animation grace.
+        m_untiledMinimizeFloats.insert(windowId);
+    }
     qCInfo(lcEffect) << "Autotile: window already minimized at announce, claiming as minimize-floated:" << windowId
                      << "on" << screenId;
     if (m_effect->m_daemonGate.serviceRegistered) {
@@ -809,7 +812,7 @@ void AutotileHandler::slotWindowMinimizedChanged(KWin::EffectWindow* w)
                     QStringLiteral("setWindowFloatingForScreen"), {windowId, screenId, false},
                     QStringLiteral("setWindowFloatingForScreen"));
             }
-            notifyWindowAdded(w);
+            notifyWindowAdded(w, /*knownFreeFloating=*/false);
             return;
         }
         qCDebug(lcEffect) << "Autotile: unminimized window was not minimize-floated, skipping unfloatWindow:"
@@ -824,7 +827,6 @@ void AutotileHandler::slotWindowMinimizedChanged(KWin::EffectWindow* w)
     // the snap-mode adoption above: the tile decision lands while the
     // restore is still starting and the window goes straight to its tile.
     if (m_untiledMinimizeFloats.remove(windowId)) {
-        m_minimizeFloatedWindows.remove(windowId);
         qCInfo(lcEffect) << "Autotile: window unminimized (claimed at announce), unfloating immediately:" << windowId
                          << "on" << screenId;
         if (m_effect->m_daemonGate.serviceRegistered) {
@@ -894,7 +896,7 @@ void AutotileHandler::slotWindowMinimizedChanged(KWin::EffectWindow* w)
             }
             return;
         }
-        if (!m_minimizeFloatedWindows.remove(windowId)) {
+        if (!m_minimizeFloatedWindows.contains(windowId)) {
             return; // State moved under us (e.g. bulk cleanup); nothing to commit.
         }
 

--- a/kwin-effect/autotilehandler/signals.cpp
+++ b/kwin-effect/autotilehandler/signals.cpp
@@ -69,6 +69,14 @@ void AutotileHandler::slotEnabledChanged(bool enabled)
         // Drop any in-flight debounced minimize→float commits — they must not
         // fire against a disabled engine.
         clearAllPendingMinimizeFloats();
+        // Cancel the ASYNC unfloat continuations too: clearing the in-flight
+        // map makes their generation checks miss, so a D-Bus reply landing
+        // after the disable cannot mutate ownership state against a torn-down
+        // engine. The minimize-float MARKERS deliberately survive — the snap
+        // handler adopts them when the screen's new mode fields the
+        // unminimize.
+        m_unfloatInFlight.clear();
+        m_unfloatRetryAttempts.clear();
         m_effect->updateAllDecorations();
     }
 }
@@ -470,7 +478,12 @@ void AutotileHandler::slotScreensChanged(const QStringList& screenIds, bool isDe
             // function entry; no stagger can have been scheduled since.)
             const auto pruneRemovedScreenEntries = [this, &removed](QHash<QString, QRect>& map) {
                 for (auto it = map.begin(); it != map.end();) {
-                    KWin::EffectWindow* mw = m_effect->findWindowById(it.key());
+                    // EXACT resolve: the entry is keyed to a specific
+                    // instance's id, and a fuzzy same-app hit would keep a
+                    // dead-keyed entry alive forever (its key never matches a
+                    // live window again, so the not-found prune is its only
+                    // exit).
+                    KWin::EffectWindow* mw = m_effect->findWindowByIdExact(it.key());
                     if (!mw) {
                         it = map.erase(it);
                         continue;
@@ -899,7 +912,7 @@ bool AutotileHandler::offerMinimizeEdge(KWin::EffectWindow* w)
     // Mirror of slotWindowMinimizedChanged's entry gates. See the header doc:
     // a transfer the gates would refuse must be reported to the sender, not
     // silently dropped.
-    if (!w || !m_effect->shouldHandleWindow(w) || !m_effect->isTileableWindow(w)
+    if (!w || w->isDeleted() || !m_effect->shouldHandleWindow(w) || !m_effect->isTileableWindow(w)
         || !m_autotileScreens.contains(m_effect->getWindowScreenId(w))) {
         return false;
     }
@@ -909,7 +922,10 @@ bool AutotileHandler::offerMinimizeEdge(KWin::EffectWindow* w)
 
 void AutotileHandler::slotWindowMinimizedChanged(KWin::EffectWindow* w)
 {
-    if (!w || !m_effect->shouldHandleWindow(w) || !m_effect->isTileableWindow(w)) {
+    // isDeleted: the edge can race close teardown (Deleted shell), and
+    // proceeding would repollute the scrubbed id caches and arm a debounce
+    // for a corpse.
+    if (!w || w->isDeleted() || !m_effect->shouldHandleWindow(w) || !m_effect->isTileableWindow(w)) {
         return;
     }
     const QString windowId = m_effect->getWindowId(w);

--- a/kwin-effect/autotilehandler/state.cpp
+++ b/kwin-effect/autotilehandler/state.cpp
@@ -92,6 +92,12 @@ void AutotileHandler::clearTiledTracking()
     // DecorationManager's job — teardown callers pair this with
     // DecorationManager::restoreAll().
     m_border.tiledWindowsByScreen.clear();
+    // The screen set belongs to the daemon session that published it. Both
+    // callers (daemon loss, effect teardown) mean that session is gone —
+    // keeping the set let stale membership answer isAutotileScreen until the
+    // next bringup reply, and left the bringup's fresh-set replacement with
+    // no removed-screen delta to act on.
+    m_autotileScreens.clear();
 }
 
 void AutotileHandler::setFocusFollowsMouse(bool enabled)

--- a/kwin-effect/autotilehandler/state.cpp
+++ b/kwin-effect/autotilehandler/state.cpp
@@ -239,9 +239,12 @@ void AutotileHandler::requestDaemonPreTileRestore(KWin::EffectWindow* w, const Q
         // Suppress the VS-crossing detectors across the synchronous
         // frameGeometryChanged this apply emits — same rationale as the
         // local-bucket restore path in slotScreensChanged.
+        // Save/restore, not set/clear: a clearing guard nested inside an outer
+        // apply would hand the outer scope back an un-flagged window.
+        const bool prevInApply = m_effect->m_daemonGate.inGeometryApply;
         m_effect->m_daemonGate.inGeometryApply = true;
-        const auto geomGuard = qScopeGuard([this] {
-            m_effect->m_daemonGate.inGeometryApply = false;
+        const auto geomGuard = qScopeGuard([this, prevInApply] {
+            m_effect->m_daemonGate.inGeometryApply = prevInApply;
         });
         // Clear any lingering KWin maximize flag first or KWin re-asserts
         // the maximize-area rect and defeats the restore (discussion #461).

--- a/kwin-effect/autotilehandler/state.cpp
+++ b/kwin-effect/autotilehandler/state.cpp
@@ -253,8 +253,11 @@ void AutotileHandler::savePreAutotileForDesktopMove(const QString& windowId)
     }
 }
 
-bool AutotileHandler::isEligibleForAutotileNotify(KWin::EffectWindow* w) const
+bool AutotileHandler::isEligibleForAutotileNotify(KWin::EffectWindow* w, bool* rejectedOnlyBecauseMinimized) const
 {
+    if (rejectedOnlyBecauseMinimized) {
+        *rejectedOnlyBecauseMinimized = false;
+    }
     // Close-grabbed dying windows survive in the stacking order for the
     // close-animation duration; announcing one as opened would insert an
     // orphan into the tiling tree (shrinking live tiles) until a later
@@ -276,10 +279,6 @@ bool AutotileHandler::isEligibleForAutotileNotify(KWin::EffectWindow* w) const
     }
     if (!m_effect->isTileableWindow(w)) {
         qCDebug(lcEffect) << "isEligibleForAutotileNotify: rejected (not tileable)" << m_effect->getWindowId(w);
-        return false;
-    }
-    if (w->isMinimized()) {
-        qCDebug(lcEffect) << "isEligibleForAutotileNotify: rejected (minimized)" << m_effect->getWindowId(w);
         return false;
     }
     // A window that is fullscreen at first contact (opened fullscreen, or
@@ -307,6 +306,19 @@ bool AutotileHandler::isEligibleForAutotileNotify(KWin::EffectWindow* w) const
         qCDebug(lcEffect) << "isEligibleForAutotileNotify: rejected (too small)" << m_effect->getWindowId(w)
                           << "size=" << frame.size() << "threshold=" << m_effect->m_cachedMinWindowWidth << "x"
                           << m_effect->m_cachedMinWindowHeight;
+        return false;
+    }
+    // Checked LAST so the out-flag means "every other gate passed": the batch
+    // announce claims such a window as minimize-floated (minimizedChanged
+    // never fires for a window that was already minimized when its screen
+    // entered autotile, so the runtime minimize→float path cannot cover it).
+    // frameGeometry stays at the pre-minimize frame while minimized, so the
+    // min-size gate above evaluates real dimensions for this ordering.
+    if (w->isMinimized()) {
+        qCDebug(lcEffect) << "isEligibleForAutotileNotify: rejected (minimized)" << m_effect->getWindowId(w);
+        if (rejectedOnlyBecauseMinimized) {
+            *rejectedOnlyBecauseMinimized = true;
+        }
         return false;
     }
     qCDebug(lcEffect) << "isEligibleForAutotileNotify: accepted" << m_effect->getWindowId(w) << "size=" << frame.size()

--- a/kwin-effect/autotilehandler/state.cpp
+++ b/kwin-effect/autotilehandler/state.cpp
@@ -32,7 +32,10 @@ void AutotileHandler::unmaximizeMonocleWindow(const QString& windowId)
     if (!m_monocleMaximizedWindows.remove(windowId)) {
         return;
     }
-    KWin::EffectWindow* w = m_effect->findWindowById(windowId);
+    // EXACT resolve: a stale monocle entry whose window is gone must restore
+    // nothing — the fuzzy appId fallback would un-maximize an unrelated
+    // same-app sibling under suppression, invisibly.
+    KWin::EffectWindow* w = m_effect->findWindowByIdExact(windowId);
     if (!w) {
         return;
     }
@@ -40,9 +43,19 @@ void AutotileHandler::unmaximizeMonocleWindow(const QString& windowId)
     if (!kw) {
         return;
     }
+    // maximize() emits windowFrameGeometryChanged SYNCHRONOUSLY, and the
+    // restore rect can sit in a different virtual-screen region of the same
+    // monitor. Without the geometry-apply gate that edge takes the
+    // VS-crossing path (handleWindowOutputChanged -> windowClosed +
+    // notifyWindowAdded) and tears down whatever float/tile transition the
+    // caller is mid-way through. Save/restore rather than set/clear so the
+    // guard nests inside already-guarded callers.
+    const bool prevInApply = m_effect->m_daemonGate.inGeometryApply;
+    m_effect->m_daemonGate.inGeometryApply = true;
     ++m_suppressMaximizeChanged;
     kw->maximize(KWin::MaximizeRestore);
     --m_suppressMaximizeChanged;
+    m_effect->m_daemonGate.inGeometryApply = prevInApply;
 }
 
 void AutotileHandler::restoreAllMonocleMaximized()
@@ -50,9 +63,18 @@ void AutotileHandler::restoreAllMonocleMaximized()
     if (m_monocleMaximizedWindows.isEmpty()) {
         return;
     }
+    // Snapshot and clear FIRST: maximize() can synchronously re-enter
+    // cleanupClosedWindowState (via the VS-crossing / output-changed path),
+    // which mutates m_monocleMaximizedWindows — iterating the live set here
+    // is iterator invalidation in a compositor loop.
+    const QStringList ids = m_monocleMaximizedWindows.values();
+    m_monocleMaximizedWindows.clear();
+    const bool prevInApply = m_effect->m_daemonGate.inGeometryApply;
+    m_effect->m_daemonGate.inGeometryApply = true;
     ++m_suppressMaximizeChanged;
-    for (const QString& wid : std::as_const(m_monocleMaximizedWindows)) {
-        KWin::EffectWindow* w = m_effect->findWindowById(wid);
+    for (const QString& wid : ids) {
+        // EXACT resolve — same sibling hazard as unmaximizeMonocleWindow.
+        KWin::EffectWindow* w = m_effect->findWindowByIdExact(wid);
         if (w) {
             KWin::Window* kw = w->window();
             if (kw) {
@@ -61,7 +83,7 @@ void AutotileHandler::restoreAllMonocleMaximized()
         }
     }
     --m_suppressMaximizeChanged;
-    m_monocleMaximizedWindows.clear();
+    m_effect->m_daemonGate.inGeometryApply = prevInApply;
 }
 
 void AutotileHandler::clearTiledTracking()

--- a/kwin-effect/autotilehandler/state.cpp
+++ b/kwin-effect/autotilehandler/state.cpp
@@ -168,8 +168,11 @@ void AutotileHandler::saveAndRecordPreAutotileGeometry(const QString& windowId, 
     // is the TILE rect. The UNTILED subset is carved out — those windows'
     // rects belong to the PRIOR mode, and the snap-owned guard above already
     // rejects zone rects, so a surviving untiled rect is a genuine free
-    // position worth capturing.
-    if (m_minimizeFloatedWindows.contains(windowId) && !m_untiledMinimizeFloats.contains(windowId)) {
+    // position worth capturing. isMinimizeFloated (not the raw marker set):
+    // a window mid-unfloat sits in m_unfloatInFlight instead, and its frame
+    // is still the tile rect until the restore lands — capturing during that
+    // interval is the same poison.
+    if (isMinimizeFloated(windowId) && !m_untiledMinimizeFloats.contains(windowId)) {
         qCDebug(lcEffect) << "Skipped pre-autotile geometry for own minimize-float (frame is tile rect)" << windowId
                           << "on" << screenId;
         return;

--- a/kwin-effect/autotilehandler/state.cpp
+++ b/kwin-effect/autotilehandler/state.cpp
@@ -209,7 +209,7 @@ void AutotileHandler::requestDaemonPreTileRestore(KWin::EffectWindow* w, const Q
         // switch, a re-tile (re-notified), the screen re-entering
         // autotile, a snap commit, a float toggle, or the user actively
         // moving/resizing it.
-        if (!safeW->isOnCurrentDesktop() || m_notifiedWindows.contains(windowId)
+        if (!safeW->isOnCurrentDesktop() || !safeW->isOnCurrentActivity() || m_notifiedWindows.contains(windowId)
             || m_autotileScreens.contains(m_effect->getWindowScreenId(safeW))
             || m_effect->isWindowMarkedSnapped(windowId) || m_effect->isWindowFloating(windowId) || safeW->isUserMove()
             || safeW->isUserResize()) {

--- a/kwin-effect/autotilehandler/state.cpp
+++ b/kwin-effect/autotilehandler/state.cpp
@@ -3,6 +3,7 @@
 
 #include "autotilehandler.h"
 #include "handlers/navigationhandler.h"
+#include "handlers/snaphandler.h"
 #include "plasmazoneseffect/plasmazoneseffect.h"
 
 #include <PhosphorProtocol/ClientHelpers.h>
@@ -127,8 +128,9 @@ void AutotileHandler::saveAndRecordPreAutotileGeometry(const QString& windowId, 
     // genuine pre-snap free position. isWindowFloating() below misses this because
     // knownFreeFloating bypasses it, so check the snap-managed state explicitly and
     // unconditionally.
-    if (m_effect->isWindowMarkedSnapped(windowId)) {
-        qCDebug(lcEffect) << "Skipped pre-autotile geometry for snap-managed window (frame is zone rect)" << windowId
+    const SnapHandler* snap = m_effect->snapHandler();
+    if (m_effect->isWindowMarkedSnapped(windowId) || (snap && snap->isMinimizeFloated(windowId))) {
+        qCDebug(lcEffect) << "Skipped pre-autotile geometry for snap-owned window (frame is zone rect)" << windowId
                           << "on" << screenId;
         return;
     }

--- a/kwin-effect/autotilehandler/state.cpp
+++ b/kwin-effect/autotilehandler/state.cpp
@@ -156,6 +156,18 @@ void AutotileHandler::saveAndRecordPreAutotileGeometry(const QString& windowId, 
                           << "on" << screenId;
         return;
     }
+    // Own-side twin of the guard above: a window THIS handler holds as a
+    // minimize-float was tiled when it minimized (the daemon-restart re-claim
+    // path re-adds such windows with knownFreeFloating routing), so its frame
+    // is the TILE rect. The UNTILED subset is carved out — those windows'
+    // rects belong to the PRIOR mode, and the snap-owned guard above already
+    // rejects zone rects, so a surviving untiled rect is a genuine free
+    // position worth capturing.
+    if (m_minimizeFloatedWindows.contains(windowId) && !m_untiledMinimizeFloats.contains(windowId)) {
+        qCDebug(lcEffect) << "Skipped pre-autotile geometry for own minimize-float (frame is tile rect)" << windowId
+                          << "on" << screenId;
+        return;
+    }
     if (!knownFreeFloating && !m_effect->isWindowFloating(windowId)) {
         qCDebug(lcEffect) << "Skipped pre-autotile geometry for snapped window" << windowId << "on" << screenId;
         return;

--- a/kwin-effect/autotilehandler/tiling.cpp
+++ b/kwin-effect/autotilehandler/tiling.cpp
@@ -266,6 +266,14 @@ void AutotileHandler::slotWindowsTileRequested(const PhosphorProtocol::TileReque
         if (!e.window) {
             continue;
         }
+        // Re-key to the RESOLVED window's live id. The disambiguation above
+        // can match a candidate whose uuid differs from the daemon-supplied
+        // entry id (stale across a KWin restart), and every write this batch
+        // performs — tiled tracking, the Wayland centering cache, the
+        // pre-autotile capture — must key on the live id the readers use, or
+        // the tiling goes untracked and the stale-keyed entries are never
+        // reclaimed.
+        e.windowId = m_effect->getWindowId(e.window);
         // Key on the daemon's TARGET screen (from the tile request), NOT the
         // window's current physical screen. On a cross-output move the moved
         // window has not physically relocated when this batch is built, so
@@ -499,6 +507,13 @@ void AutotileHandler::slotWindowsTileRequested(const PhosphorProtocol::TileReque
             // mode toggles.
             for (auto it = newTiledByScreen.constBegin(); it != newTiledByScreen.constEnd(); ++it) {
                 const QString& screenId = it.key();
+                // Per-screen supersession guard, same as the raise loops
+                // above: a stale batch must neither replay a z-order over the
+                // newer batch's result nor CONSUME the saved order the newer
+                // batch's own restore still needs.
+                if (m_autotileStaggerGenByScreen.value(screenId) != genByScreen.value(screenId)) {
+                    continue;
+                }
                 const QStringList savedOrder = m_savedAutotileStackingOrder.value(screenId);
                 if (savedOrder.isEmpty()) {
                     continue;

--- a/kwin-effect/autotilehandler/tiling.cpp
+++ b/kwin-effect/autotilehandler/tiling.cpp
@@ -165,9 +165,11 @@ void AutotileHandler::slotWindowsTileRequested(const PhosphorProtocol::TileReque
                     // frameGeometryChanged would resolve the new position
                     // against stale m_virtualScreenDefs and spuriously
                     // re-announce the just-floated window.
+                    // Save/restore, not set/clear (nesting-safe).
+                    const bool prevInApply = m_effect->m_daemonGate.inGeometryApply;
                     m_effect->m_daemonGate.inGeometryApply = true;
-                    const auto floatGuard = qScopeGuard([this] {
-                        m_effect->m_daemonGate.inGeometryApply = false;
+                    const auto floatGuard = qScopeGuard([this, prevInApply] {
+                        m_effect->m_daemonGate.inGeometryApply = prevInApply;
                     });
                     // Snap-out: leaving tile-managed sizing.
                     m_effect->applyWindowGeometry(floatWin, savedGeo.toRect(), /*allowDuringDrag=*/false,
@@ -639,9 +641,11 @@ void AutotileHandler::slotWindowsTileRequested(const PhosphorProtocol::TileReque
             // m_virtualScreenDefs may still hold pre-rotation regions — without this
             // guard the slot would resolve the new position against stale boundaries
             // and falsely conclude the window crossed VSes, then unsnap it.
+            // Save/restore, not set/clear (nesting-safe).
+            const bool prevInApply = m_effect->m_daemonGate.inGeometryApply;
             m_effect->m_daemonGate.inGeometryApply = true;
-            const auto guard = qScopeGuard([this] {
-                m_effect->m_daemonGate.inGeometryApply = false;
+            const auto guard = qScopeGuard([this, prevInApply] {
+                m_effect->m_daemonGate.inGeometryApply = prevInApply;
             });
             saveAndRecordPreAutotileGeometry(snap.windowId, snap.screenId, snap.window, snap.window->frameGeometry());
             KWin::Window* kwForLog = snap.window->window();

--- a/kwin-effect/autotilehandler/tiling.cpp
+++ b/kwin-effect/autotilehandler/tiling.cpp
@@ -474,7 +474,10 @@ void AutotileHandler::slotWindowsTileRequested(const PhosphorProtocol::TileReque
                     if (groupRaised.contains(wPtr.data())) {
                         continue;
                     }
-                    const auto& group = overlapStackByScreen[memberIt.value()];
+                    // constFind, not operator[]: on a const QHash the
+                    // subscript returns BY VALUE, deep-copying the group per
+                    // member visit (O(members²) across the loop).
+                    const auto& group = *overlapStackByScreen.constFind(memberIt.value());
                     for (const auto& gPtr : group) {
                         if (gPtr && !gPtr->isDeleted()) {
                             if (KWin::Window* gkw = gPtr->window()) {

--- a/kwin-effect/autotilehandler/tiling.cpp
+++ b/kwin-effect/autotilehandler/tiling.cpp
@@ -151,8 +151,10 @@ void AutotileHandler::slotWindowsTileRequested(const PhosphorProtocol::TileReque
             // Restore pre-autotile geometry from the effect's local cache.
             // Scan all screen buckets (all-bucket reader policy — a VS
             // config change can re-key the window's screen without moving
-            // its geometry bucket).
-            KWin::EffectWindow* floatWin = m_effect->findWindowById(windowId);
+            // its geometry bucket). Exact resolve, matching the tile lambda's
+            // deliberate policy: a fuzzy hit would teleport a same-app
+            // SIBLING onto this window's restored rect.
+            KWin::EffectWindow* floatWin = m_effect->findWindowByIdExact(windowId);
             if (floatWin) {
                 if (const QRectF savedGeo = findPreAutotileGeometry(windowId); savedGeo.isValid()) {
                     // Daemon-driven apply: the restored rect may lie in a
@@ -351,7 +353,8 @@ void AutotileHandler::slotWindowsTileRequested(const PhosphorProtocol::TileReque
         genByScreen.insert(it.key(), ++m_autotileStaggerGenByScreen[it.key()]);
     }
 
-    auto onComplete = [this, newTiledByScreen, savedGlobalStack, overlapStackByScreen, gen, genByScreen]() {
+    const bool hasApplies = !toApply.isEmpty();
+    auto onComplete = [this, newTiledByScreen, savedGlobalStack, overlapStackByScreen, gen, genByScreen, hasApplies]() {
         if (m_autotileStaggerGeneration != gen) {
             return;
         }
@@ -418,8 +421,13 @@ void AutotileHandler::slotWindowsTileRequested(const PhosphorProtocol::TileReque
                 }
             }
         }
+        // A batch with NO tile applies (every request resolved away or the
+        // batch was floats-only) still owes the untile cleanup above, but
+        // must not churn the whole stacking order or spend the one-shot
+        // saved-order/pending-focus state — nothing moved, so there is no
+        // z-order to repair.
         auto* ws = KWin::Workspace::self();
-        if (ws) {
+        if (ws && hasApplies) {
             // Membership index for the overlap restack: window -> the screen
             // whose ordered group it belongs to. Resolved at completion time
             // because QPointers may have gone null since the batch was built.
@@ -519,7 +527,9 @@ void AutotileHandler::slotWindowsTileRequested(const PhosphorProtocol::TileReque
                     continue;
                 }
                 for (const QString& windowId : savedOrder) {
-                    KWin::EffectWindow* w = m_effect->findWindowById(windowId);
+                    // Exact: a fuzzy same-app hit would raise a SIBLING into
+                    // this window's saved z-position.
+                    KWin::EffectWindow* w = m_effect->findWindowByIdExact(windowId);
                     if (w && !w->isDeleted()) {
                         KWin::Window* kw = w->window();
                         if (kw) {
@@ -531,7 +541,9 @@ void AutotileHandler::slotWindowsTileRequested(const PhosphorProtocol::TileReque
             }
 
             if (!m_pendingAutotileFocusWindowId.isEmpty()) {
-                KWin::EffectWindow* focusWin = m_effect->findWindowById(m_pendingAutotileFocusWindowId);
+                // Exact for the same sibling-raise reason as the saved-order
+                // loop above.
+                KWin::EffectWindow* focusWin = m_effect->findWindowByIdExact(m_pendingAutotileFocusWindowId);
                 m_pendingAutotileFocusWindowId.clear();
                 if (focusWin) {
                     KWin::Window* kw = focusWin->window();

--- a/kwin-effect/autotilehandler/wiring.cpp
+++ b/kwin-effect/autotilehandler/wiring.cpp
@@ -109,6 +109,12 @@ void AutotileHandler::loadSettings()
                 if (reply.isValid()) {
                     QStringList screens = reply.value().variant().toStringList();
                     const QSet<QString> added(screens.begin(), screens.end());
+                    // Wholesale replacement is safe HERE because the previous
+                    // session's set was cleared at daemon loss
+                    // (clearTiledTracking) — there is no live removed-screen
+                    // delta to tear down at bringup; runtime screen-set
+                    // changes go through slotScreensChanged, which handles
+                    // removals.
                     m_autotileScreens = added;
                     qCInfo(lcEffect) << "Loaded autotile screens:" << m_autotileScreens;
                     const QSet<QString> completedDeferredRoutes = completeDeferredWindowRoutes();

--- a/kwin-effect/autotilehandler/wiring.cpp
+++ b/kwin-effect/autotilehandler/wiring.cpp
@@ -131,7 +131,11 @@ void AutotileHandler::loadSettings()
                     qCDebug(lcEffect) << "Autotile screens: query failed, daemon may not be running";
                     completeDeferredWindowRoutes();
                 }
-                m_effect->snapHandler()->retryVisibleMinimizeFloats();
+                // Guarded: m_snapHandler is declared after m_autotileHandler
+                // and destroyed first during effect teardown.
+                if (SnapHandler* snap = m_effect->snapHandler()) {
+                    snap->retryVisibleMinimizeFloats();
+                }
             });
 }
 

--- a/kwin-effect/autotilehandler/wiring.cpp
+++ b/kwin-effect/autotilehandler/wiring.cpp
@@ -108,7 +108,8 @@ void AutotileHandler::loadSettings()
                         const auto windows = KWin::effects->stackingOrder();
                         // Batch-notify all windows on autotile screens in one D-Bus call
                         // instead of per-window windowOpened round-trips.
-                        notifyWindowsAddedBatch(windows, added, /*resetNotified=*/true);
+                        notifyWindowsAddedBatch(windows, added, /*resetNotified=*/true,
+                                                /*enteringAutotile=*/false);
                     }
                 } else {
                     qCDebug(lcEffect) << "Autotile screens: query failed, daemon may not be running";

--- a/kwin-effect/autotilehandler/wiring.cpp
+++ b/kwin-effect/autotilehandler/wiring.cpp
@@ -8,6 +8,7 @@
 
 #include "autotilehandler.h"
 #include "plasmazoneseffect/plasmazoneseffect.h"
+#include "handlers/snaphandler.h"
 
 #include <PhosphorProtocol/ServiceConstants.h>
 
@@ -101,7 +102,7 @@ void AutotileHandler::loadSettings()
                 // with the older snapshot.
                 if (m_screensSignalGeneration != generationAtDispatch) {
                     qCDebug(lcEffect) << "Autotile screens: property reply superseded by a live signal, discarding";
-                    m_pendingFreshWindows.clear();
+                    completeDeferredWindowRoutes();
                     return;
                 }
                 QDBusPendingReply<QDBusVariant> reply = *w;
@@ -110,19 +111,27 @@ void AutotileHandler::loadSettings()
                     const QSet<QString> added(screens.begin(), screens.end());
                     m_autotileScreens = added;
                     qCInfo(lcEffect) << "Loaded autotile screens:" << m_autotileScreens;
+                    const QSet<QString> completedDeferredRoutes = completeDeferredWindowRoutes();
 
                     if (!added.isEmpty()) {
                         const auto windows = KWin::effects->stackingOrder();
+                        QList<KWin::EffectWindow*> batchWindows;
+                        batchWindows.reserve(windows.size());
+                        for (KWin::EffectWindow* window : windows) {
+                            if (window && !completedDeferredRoutes.contains(m_effect->getWindowId(window))) {
+                                batchWindows.append(window);
+                            }
+                        }
                         // Batch-notify all windows on autotile screens in one D-Bus call
                         // instead of per-window windowOpened round-trips.
-                        notifyWindowsAddedBatch(windows, added, /*resetNotified=*/true,
+                        notifyWindowsAddedBatch(batchWindows, added, /*resetNotified=*/true,
                                                 /*enteringAutotile=*/false);
                     }
                 } else {
                     qCDebug(lcEffect) << "Autotile screens: query failed, daemon may not be running";
-                    return;
+                    completeDeferredWindowRoutes();
                 }
-                m_pendingFreshWindows.clear();
+                m_effect->snapHandler()->retryVisibleMinimizeFloats();
             });
 }
 

--- a/kwin-effect/autotilehandler/wiring.cpp
+++ b/kwin-effect/autotilehandler/wiring.cpp
@@ -118,7 +118,12 @@ void AutotileHandler::loadSettings()
                         QList<KWin::EffectWindow*> batchWindows;
                         batchWindows.reserve(windows.size());
                         for (KWin::EffectWindow* window : windows) {
-                            if (window && !completedDeferredRoutes.contains(m_effect->getWindowId(window))) {
+                            // isDeleted: close-grabbed dying windows linger in
+                            // the stacking order — getWindowId on them would
+                            // re-pollute the scrubbed id caches before the
+                            // batch's own guards run.
+                            if (window && !window->isDeleted()
+                                && !completedDeferredRoutes.contains(m_effect->getWindowId(window))) {
                                 batchWindows.append(window);
                             }
                         }

--- a/kwin-effect/autotilehandler/wiring.cpp
+++ b/kwin-effect/autotilehandler/wiring.cpp
@@ -83,18 +83,25 @@ void AutotileHandler::loadSettings()
                                        QStringLiteral("org.freedesktop.DBus.Properties"), QStringLiteral("Get"));
     msg << PhosphorProtocol::Service::Interface::Autotile << QStringLiteral("autotileScreens");
 
+    m_initialScreenQueryPending = true;
+    const quint64 queryGeneration = ++m_screenQueryGeneration;
     QDBusPendingCall call = QDBusConnection::sessionBus().asyncCall(msg, PhosphorProtocol::Service::SyncCallTimeoutMs);
     auto* watcher = new QDBusPendingCallWatcher(call, this);
     const quint64 generationAtDispatch = m_screensSignalGeneration;
     connect(watcher, &QDBusPendingCallWatcher::finished, this,
-            [this, generationAtDispatch](QDBusPendingCallWatcher* w) {
+            [this, generationAtDispatch, queryGeneration](QDBusPendingCallWatcher* w) {
                 w->deleteLater();
+                if (queryGeneration != m_screenQueryGeneration) {
+                    return;
+                }
+                m_initialScreenQueryPending = false;
                 // An autotileScreensChanged signal that landed while this query was
                 // in flight carried a NEWER set and already ran the full per-screen
                 // transition handling — the raw assignment below would clobber it
                 // with the older snapshot.
                 if (m_screensSignalGeneration != generationAtDispatch) {
                     qCDebug(lcEffect) << "Autotile screens: property reply superseded by a live signal, discarding";
+                    m_pendingFreshWindows.clear();
                     return;
                 }
                 QDBusPendingReply<QDBusVariant> reply = *w;
@@ -113,7 +120,9 @@ void AutotileHandler::loadSettings()
                     }
                 } else {
                     qCDebug(lcEffect) << "Autotile screens: query failed, daemon may not be running";
+                    return;
                 }
+                m_pendingFreshWindows.clear();
             });
 }
 

--- a/kwin-effect/compositor/deferredwindowcommits.h
+++ b/kwin-effect/compositor/deferredwindowcommits.h
@@ -50,11 +50,12 @@ public:
         return m_pending.contains(windowId);
     }
 
-    /// Schedule @p fire to run after @p intervalMs, replacing nothing —
-    /// callers gate on contains() when an existing pending commit should
-    /// win. The pending entry is consumed (erased, timer released) before
-    /// @p fire runs, so every early-return inside the callback leaves no
-    /// bookkeeping behind.
+    /// Schedule @p fire to run after @p intervalMs, superseding any pending
+    /// commit for the same @p windowId (cancelled structurally at the top of
+    /// the body — callers that want an existing commit to win must gate on
+    /// contains() BEFORE calling). The pending entry is consumed (erased,
+    /// timer released) before @p fire runs, so every early-return inside the
+    /// callback leaves no bookkeeping behind.
     void schedule(const QString& windowId, int intervalMs, std::function<void()> fire)
     {
         // Supersede any pending entry FIRST: a bare insert would orphan the

--- a/kwin-effect/compositor/deferredwindowcommits.h
+++ b/kwin-effect/compositor/deferredwindowcommits.h
@@ -57,6 +57,12 @@ public:
     /// bookkeeping behind.
     void schedule(const QString& windowId, int intervalMs, std::function<void()> fire)
     {
+        // Supersede any pending entry FIRST: a bare insert would orphan the
+        // old entry's still-running timer, whose firing lambda would then
+        // consume (and delete) the NEW entry and run the stale callback in
+        // its place. Callers currently gate with contains()/cancel at every
+        // site; this makes the contract structural instead of by convention.
+        cancel(windowId);
         auto* timer = new QTimer(m_owner);
         timer->setSingleShot(true);
         timer->setInterval(intervalMs);

--- a/kwin-effect/handlers/snaphandler.cpp
+++ b/kwin-effect/handlers/snaphandler.cpp
@@ -35,6 +35,8 @@ namespace PlasmaZones {
 
 Q_DECLARE_LOGGING_CATEGORY(lcEffect)
 
+static constexpr int kSnapMinimizeFloatDebounceMs = kSpuriousMinimizePairMs;
+
 SnapHandler::SnapHandler(PlasmaZonesEffect* effect, QObject* parent)
     : QObject(parent)
     , m_effect(effect)
@@ -339,8 +341,48 @@ void SnapHandler::handleMinimizeChanged(KWin::EffectWindow* window, const QStrin
             qCDebug(lcEffect) << "Snap: minimized already-floating window, skipping float:" << windowId;
             return;
         }
-        m_minimizeFloatedWindows.insert(windowId);
+        // Only a snap-managed window owns a zone that minimizing should free.
+        // A free window can reach this path with a cold floating cache after
+        // daemon/effect bring-up and must remain unmanaged.
+        if (!isTiledWindow(windowId)) {
+            qCDebug(lcEffect) << "Snap: minimized unmanaged window, skipping float:" << windowId;
+            return;
+        }
+        if (m_pendingMinimizeFloat.contains(windowId)) {
+            return;
+        }
+
+        QPointer<KWin::EffectWindow> wPtr(window);
+        m_pendingMinimizeFloat.schedule(windowId, kSnapMinimizeFloatDebounceMs, [this, windowId, screenId, wPtr]() {
+            if (!wPtr || wPtr->isDeleted()) {
+                return;
+            }
+            KWin::EffectWindow* live = wPtr.data();
+            if (!live->isMinimized() || !m_effect->shouldHandleWindow(live) || !m_effect->isTileableWindow(live)) {
+                return;
+            }
+            const QString currentScreenId = m_effect->getWindowScreenId(live);
+            if (currentScreenId != screenId || m_effect->autotileHandler()->isAutotileScreen(currentScreenId)
+                || m_effect->isWindowFloating(windowId)) {
+                return;
+            }
+
+            m_minimizeFloatedWindows.insert(windowId);
+            qCInfo(lcEffect) << "Snap: window minimized (after debounce), floating:" << windowId << "on" << screenId;
+            if (m_effect->isDaemonReady("snap minimize float")) {
+                PhosphorProtocol::ClientHelpers::fireAndForget(
+                    m_effect, PhosphorProtocol::Service::Interface::WindowTracking,
+                    QStringLiteral("setWindowFloatingForScreen"), {windowId, screenId, true},
+                    QStringLiteral("setWindowFloatingForScreen"));
+            }
+        });
+        return;
     } else {
+        if (m_pendingMinimizeFloat.contains(windowId)) {
+            cancelPendingMinimizeFloat(windowId);
+            qCDebug(lcEffect) << "Snap: coalesced spurious minimize/unminimize cycle for" << windowId;
+            return;
+        }
         if (!m_minimizeFloatedWindows.contains(windowId)) {
             // Adopt a minimize-float created by the AUTOTILE handler before
             // this screen swapped away from autotile — the mirror of the
@@ -411,21 +453,12 @@ void SnapHandler::handleMinimizeChanged(KWin::EffectWindow* window, const QStrin
                 m_effect->autotileHandler()->slotWindowMinimizedChanged(fw);
                 return;
             }
-            if (!m_minimizeFloatedWindows.remove(windowId)) {
+            if (!m_minimizeFloatedWindows.contains(windowId)) {
                 return; // State moved under us (e.g. bulk cleanup); nothing to commit.
             }
             commitUnminimizeUnfloat(fw, windowId, currentScreenId);
         });
         return;
-    }
-
-    qCInfo(lcEffect) << "Snap: window minimized, floating:" << windowId << "on" << screenId;
-
-    if (m_effect->isDaemonReady("snap minimize float")) {
-        PhosphorProtocol::ClientHelpers::fireAndForget(m_effect, PhosphorProtocol::Service::Interface::WindowTracking,
-                                                       QStringLiteral("setWindowFloatingForScreen"),
-                                                       {windowId, screenId, true},
-                                                       QStringLiteral("setWindowFloatingForScreen"));
     }
 }
 
@@ -448,9 +481,8 @@ void SnapHandler::commitUnminimizeUnfloat(KWin::EffectWindow* window, const QStr
     // before the unfloat fireAndForget below enters the same D-Bus send
     // queue, so the daemon answers them against the pre-unfloat state.
     //
-    // The restore-on-orphan is deliberately scoped to windows this effect
-    // session minimize-floated (the caller removed the entry from
-    // m_minimizeFloatedWindows just before committing): an
+    // The restore-on-orphan is deliberately scoped to an owned or adopted
+    // minimize transition: an
     // unconditional net would fire resolveWindowRestore on every
     // unminimize of any never-tracked window, re-running its open-time
     // placement routing (RouteToDesktop) and churning the placement

--- a/kwin-effect/handlers/snaphandler.cpp
+++ b/kwin-effect/handlers/snaphandler.cpp
@@ -129,6 +129,15 @@ void SnapHandler::clearSnapTracking()
         m_restartSnapCandidates.unite(it.value());
     }
     m_pendingUnminimizeUnfloat.cancelAll();
+    // BOTH deferred queues, matching AutotileHandler's clearAllPendingMinimizeFloats:
+    // this also runs on daemon LOSS (not just teardown), and a minimize→float
+    // debounce armed just before the loss would otherwise still fire — its
+    // isDaemonReady gate suppresses the D-Bus call but the callback would
+    // fabricate m_minimizeFloatedWindows ownership of a float that was never
+    // issued and destroy the restart-candidate provenance the reconnect path
+    // depends on. The retry budget is per-session too.
+    m_pendingMinimizeFloat.cancelAll();
+    m_unfloatRetryAttempts.clear();
     for (auto it = m_unfloatInFlight.cbegin(); it != m_unfloatInFlight.cend(); ++it) {
         m_minimizeFloatedWindows.insert(it.key());
     }
@@ -356,9 +365,7 @@ void SnapHandler::handleMinimizeChanged(KWin::EffectWindow* window, const QStrin
         // commit: the window never unfloated, so it is still minimize-floated
         // and the isWindowFloating skip below covers the rest.
         cancelPendingUnminimizeUnfloat(windowId);
-        m_unfloatRetryAttempts.remove(windowId);
         if (m_unfloatInFlight.remove(windowId)) {
-            m_minimizeFloatedWindows.insert(windowId);
             qCInfo(lcEffect) << "Snap: re-minimize countermanding in-flight unfloat:" << windowId;
             if (m_effect->isDaemonReady("snap re-minimize countermand")) {
                 PhosphorProtocol::ClientHelpers::fireAndForget(
@@ -366,11 +373,26 @@ void SnapHandler::handleMinimizeChanged(KWin::EffectWindow* window, const QStrin
                     QStringLiteral("setWindowFloatingForScreen"), {windowId, screenId, true},
                     QStringLiteral("setWindowFloatingForScreen"));
             }
+            if (autotileScreen) {
+                // The screen's mode owns the window now: hand the countermanded
+                // float to autotile (single owner) instead of re-claiming a
+                // record snap has no release path for on this screen. The
+                // untiled marker routes the eventual unminimize through the
+                // immediate-commit path — the rect belongs to the other mode.
+                if (AutotileHandler* autotile = m_effect->autotileHandler()) {
+                    autotile->adoptMinimizeFloated(windowId, /*untiled=*/true);
+                }
+            } else {
+                m_minimizeFloatedWindows.insert(windowId);
+            }
             return;
         }
         if (autotileScreen) {
             return;
         }
+        // Refund below the autotile bail: a minimize on a screen snap refuses
+        // to handle must not reset snap's retry budget for that window.
+        m_unfloatRetryAttempts.remove(windowId);
         if (m_effect->isWindowFloating(windowId)) {
             qCDebug(lcEffect) << "Snap: minimized already-floating window, skipping float:" << windowId;
             return;
@@ -427,8 +449,11 @@ void SnapHandler::handleMinimizeChanged(KWin::EffectWindow* window, const QStrin
             // until the next mode toggle. removeMinimizeFloated also cancels
             // that handler's pending deferred commit for the window.
             AutotileHandler* autotile = m_effect->autotileHandler();
+            const int autotileBudgetUsed = autotile ? autotile->unfloatRetryBudgetUsed(windowId) : 0;
             if (autotile && autotile->removeMinimizeFloated(windowId)) {
                 m_minimizeFloatedWindows.insert(windowId);
+                // Budget survives the hop (see seedUnfloatRetryBudget).
+                seedUnfloatRetryBudget(windowId, autotileBudgetUsed);
                 // The window still carries its autotile rect, not its snap-zone
                 // rect. Committing at the edge dispatches the unfloat
                 // immediately, but the daemon's resnap geometry only lands
@@ -682,14 +707,24 @@ void SnapHandler::retryVisibleMinimizeFloats()
 {
     const auto windowIds = m_minimizeFloatedWindows.values();
     for (const QString& windowId : windowIds) {
-        m_unfloatRetryAttempts.remove(windowId);
-        KWin::EffectWindow* window = m_effect->findWindowById(windowId);
-        if (!window || window->isDeleted() || window->isMinimized()) {
+        // A window mid-grace keeps its scheduled commit: firing here too
+        // would land the moveResize mid-animation — the exact stutter the
+        // #816 grace exists to prevent — and leave the armed timer to fire
+        // against a consumed entry.
+        if (m_pendingUnminimizeUnfloat.contains(windowId)) {
             continue;
         }
+        KWin::EffectWindow* window = m_effect->findWindowById(windowId);
+        if (!window || window->isDeleted() || window->isMinimized()) {
+            // Budget stays: a still-minimized window's exhausted retries must
+            // not be silently refunded by an unrelated screen-set change.
+            continue;
+        }
+        m_unfloatRetryAttempts.remove(windowId);
         const QString screenId = m_effect->getWindowScreenId(window);
-        if (m_effect->autotileHandler()->isAutotileScreen(screenId)) {
-            m_effect->autotileHandler()->slotWindowMinimizedChanged(window);
+        AutotileHandler* autotile = m_effect->autotileHandler();
+        if (autotile && autotile->isAutotileScreen(screenId)) {
+            autotile->slotWindowMinimizedChanged(window);
             continue;
         }
         commitUnminimizeUnfloat(window, windowId, screenId);

--- a/kwin-effect/handlers/snaphandler.cpp
+++ b/kwin-effect/handlers/snaphandler.cpp
@@ -364,6 +364,18 @@ void SnapHandler::callCancelSnap()
                                                 QStringLiteral("cancelSnap"));
 }
 
+bool SnapHandler::offerMinimizeEdge(KWin::EffectWindow* window, const QString& windowId, const QString& screenId)
+{
+    // Mirror of handleMinimizeChanged's unminimize entry gate. See the
+    // header doc: a transfer the gate would refuse must be reported to the
+    // sender, not silently dropped.
+    if (m_effect->autotileHandler()->isAutotileScreen(screenId)) {
+        return false;
+    }
+    handleMinimizeChanged(window, windowId, screenId, /*minimized=*/false);
+    return true;
+}
+
 void SnapHandler::handleMinimizeChanged(KWin::EffectWindow* window, const QString& windowId, const QString& screenId,
                                         bool minimized)
 {
@@ -486,10 +498,13 @@ void SnapHandler::handleMinimizeChanged(KWin::EffectWindow* window, const QStrin
                 return;
             }
         }
-        // A commit is already scheduled for this window — nothing new to do.
-        if (m_pendingUnminimizeUnfloat.contains(windowId)) {
-            return;
-        }
+        // Supersede any surviving pending entry rather than skipping the
+        // edge: the shared queue also carries RETRY timers
+        // (scheduleUnminimizeUnfloatRetry), and while the minimize edge
+        // cancels entries on its own path, a genuine unminimize must never be
+        // swallowed by whichever stale timer slipped through — the fresh edge
+        // is the authoritative signal, so the grace re-arms from it.
+        cancelPendingUnminimizeUnfloat(windowId);
         // Defer the whole unfloat commit (restore-net queries included) past
         // KWin's unminimize animation, mirroring AutotileHandler's deferred
         // unfloat and for the same reason: the unfloat re-snaps the window,
@@ -529,7 +544,14 @@ void SnapHandler::handleMinimizeChanged(KWin::EffectWindow* window, const QStrin
                 // commit to the handler that owns the screen now; its adoption
                 // path removes our marker and tiles immediately.
                 qCInfo(lcEffect) << "Snap: deferred unfloat screen became autotile, transferring:" << windowId;
-                m_effect->autotileHandler()->slotWindowMinimizedChanged(fw);
+                if (!m_effect->autotileHandler()->offerMinimizeEdge(fw)) {
+                    // Receiver's entry gates refused (window became
+                    // unhandleable or the screen set moved again). The edge
+                    // is spent, so re-arm from our side — ownership stayed
+                    // here.
+                    qCInfo(lcEffect) << "Snap: autotile refused transferred edge, re-arming retry:" << windowId;
+                    scheduleUnminimizeUnfloatRetry(windowId);
+                }
                 return;
             }
             if (!m_minimizeFloatedWindows.contains(windowId)) {
@@ -710,7 +732,11 @@ void SnapHandler::scheduleUnminimizeUnfloatRetry(const QString& windowId)
             return;
         }
         if (m_effect->autotileHandler()->isAutotileScreen(screenId)) {
-            m_effect->autotileHandler()->slotWindowMinimizedChanged(safeWindow.data());
+            if (!m_effect->autotileHandler()->offerMinimizeEdge(safeWindow.data())) {
+                // Same re-arm contract as the deferred-commit transfer above.
+                qCInfo(lcEffect) << "Snap: autotile refused retry transfer, re-arming:" << windowId;
+                scheduleUnminimizeUnfloatRetry(windowId);
+            }
             return;
         }
         commitUnminimizeUnfloat(safeWindow.data(), windowId, screenId);

--- a/kwin-effect/handlers/snaphandler.cpp
+++ b/kwin-effect/handlers/snaphandler.cpp
@@ -70,6 +70,7 @@ void SnapHandler::markWindowSnapped(const QString& windowId, const QString& scre
     // (mirrors the autotile cross-screen-transfer cleanup in tiling.cpp).
     AutotileStateHelpers::removeFromOtherScreens(m_border, windowId, screenId);
     AutotileStateHelpers::addTiledOnScreen(m_border, screenId, windowId);
+    m_restartSnapCandidates.remove(windowId);
 
     // Title-bar (borderless) state is driven entirely by rules through
     // the effect's reconcileRuleHiddenTitleBar → DecorationManager path; this
@@ -90,6 +91,7 @@ void SnapHandler::clearWindowSnapped(const QString& windowId)
         return;
     }
     AutotileStateHelpers::removeFromAllScreens(m_border, windowId);
+    m_restartSnapCandidates.remove(windowId);
     // A window that is no longer snap-managed occupies no zone. The zone cache
     // is the source of the IsSnapped / Zone rule-match fields, and several
     // unsnap paths (drag-out unsnap in particular) get their answer in the
@@ -119,6 +121,16 @@ void SnapHandler::clearSnapTracking()
     // DecorationManager's job — teardown callers pair this with
     // DecorationManager::restoreAll(). Callers also pair it with
     // clearAllDecorations() to release the per-window border shader redirect.
+    // Preserve unresolved candidates from an earlier daemon cycle. They are
+    // retired only by an authoritative snap, float, close, or restore miss.
+    for (auto it = m_border.tiledWindowsByScreen.cbegin(); it != m_border.tiledWindowsByScreen.cend(); ++it) {
+        m_restartSnapCandidates.unite(it.value());
+    }
+    m_pendingUnminimizeUnfloat.cancelAll();
+    for (auto it = m_unfloatInFlight.cbegin(); it != m_unfloatInFlight.cend(); ++it) {
+        m_minimizeFloatedWindows.insert(it.key());
+    }
+    m_unfloatInFlight.clear();
     m_border.tiledWindowsByScreen.clear();
 }
 
@@ -128,6 +140,7 @@ void SnapHandler::onWindowClosed(const QString& windowId)
     // removeWindowDecoration is needed (the effect's close path drops the border
     // entry / shader redirect and the title bar dies with the window).
     AutotileStateHelpers::removeFromAllScreens(m_border, windowId);
+    m_restartSnapCandidates.remove(windowId);
 }
 
 void SnapHandler::setFocusFollowsMouse(bool enabled)
@@ -166,14 +179,17 @@ void SnapHandler::callResolveWindowRestore(KWin::EffectWindow* window, std::func
     // suppression — unless the caller says another path will still
     // reposition the window (autotile-screen path), in which case the
     // suppression must hold until that reposition's geometry settles.
-    std::function<void()> onMiss;
-    if (releaseSuppressionOnMiss) {
-        onMiss = [this, safeWindow]() {
+    const auto releaseSuppression = [this, safeWindow, releaseSuppressionOnMiss]() {
+        if (releaseSuppressionOnMiss) {
             if (safeWindow) {
                 m_effect->endRestoreSuppression(safeWindow);
             }
-        };
-    }
+        }
+    };
+    const auto onMiss = [this, windowId, releaseSuppression]() {
+        m_restartSnapCandidates.remove(windowId);
+        releaseSuppression();
+    };
 
     // Single D-Bus call — daemon runs the full appRule → persisted → emptyZone → lastZone chain.
     //
@@ -192,7 +208,7 @@ void SnapHandler::callResolveWindowRestore(KWin::EffectWindow* window, std::func
     const int kindInt = static_cast<int>(m_effect->classifyWindowKind(window));
     m_effect->tryAsyncSnapCall(PhosphorProtocol::Service::Interface::Snap, QStringLiteral("resolveWindowRestore"),
                                {windowId, screenId, sticky, kindInt}, safeWindow, windowId, false, onMiss, nullptr,
-                               /*skipAnimation=*/true, onComplete);
+                               /*skipAnimation=*/true, onComplete, releaseSuppression);
 }
 
 void SnapHandler::ensurePreSnapGeometryStored(KWin::EffectWindow* w, const QString& windowId,
@@ -337,6 +353,17 @@ void SnapHandler::handleMinimizeChanged(KWin::EffectWindow* window, const QStrin
         // commit: the window never unfloated, so it is still minimize-floated
         // and the isWindowFloating skip below covers the rest.
         cancelPendingUnminimizeUnfloat(windowId);
+        if (m_unfloatInFlight.remove(windowId)) {
+            m_minimizeFloatedWindows.insert(windowId);
+            qCInfo(lcEffect) << "Snap: re-minimize countermanding in-flight unfloat:" << windowId;
+            if (m_effect->isDaemonReady("snap re-minimize countermand")) {
+                PhosphorProtocol::ClientHelpers::fireAndForget(
+                    m_effect, PhosphorProtocol::Service::Interface::WindowTracking,
+                    QStringLiteral("setWindowFloatingForScreen"), {windowId, screenId, true},
+                    QStringLiteral("setWindowFloatingForScreen"));
+            }
+            return;
+        }
         if (m_effect->isWindowFloating(windowId)) {
             qCDebug(lcEffect) << "Snap: minimized already-floating window, skipping float:" << windowId;
             return;
@@ -344,7 +371,7 @@ void SnapHandler::handleMinimizeChanged(KWin::EffectWindow* window, const QStrin
         // Only a snap-managed window owns a zone that minimizing should free.
         // A free window can reach this path with a cold floating cache after
         // daemon/effect bring-up and must remain unmanaged.
-        if (!isTiledWindow(windowId)) {
+        if (!isTiledWindow(windowId) && !m_restartSnapCandidates.contains(windowId)) {
             qCDebug(lcEffect) << "Snap: minimized unmanaged window, skipping float:" << windowId;
             return;
         }
@@ -368,6 +395,7 @@ void SnapHandler::handleMinimizeChanged(KWin::EffectWindow* window, const QStrin
             }
 
             m_minimizeFloatedWindows.insert(windowId);
+            m_restartSnapCandidates.remove(windowId);
             qCInfo(lcEffect) << "Snap: window minimized (after debounce), floating:" << windowId << "on" << screenId;
             if (m_effect->isDaemonReady("snap minimize float")) {
                 PhosphorProtocol::ClientHelpers::fireAndForget(
@@ -393,6 +421,7 @@ void SnapHandler::handleMinimizeChanged(KWin::EffectWindow* window, const QStrin
             // that handler's pending deferred commit for the window.
             AutotileHandler* autotile = m_effect->autotileHandler();
             if (autotile && autotile->removeMinimizeFloated(windowId)) {
+                m_minimizeFloatedWindows.insert(windowId);
                 // The window still carries its autotile rect, not its snap-zone
                 // rect. Do not leave that wrong frame visible for the normal
                 // animation grace: commit at the unminimize edge so KWin starts
@@ -417,10 +446,8 @@ void SnapHandler::handleMinimizeChanged(KWin::EffectWindow* window, const QStrin
         // no cross-effect API to observe the animation, so the grace is
         // animationTime(400ms) — stock minimize animations are 250ms base
         // scaled by the user's global animation-speed factor, which
-        // animationTime applies too. All state mutation
-        // (m_minimizeFloatedWindows removal, queries, D-Bus) happens at
-        // COMMIT, so a cancelled commit (re-minimize, close) leaves the
-        // window minimize-floated exactly as it was.
+        // animationTime applies too. Ownership moves to the in-flight set at
+        // commit so a re-minimize can countermand the asynchronous unfloat.
         const int graceMs = int(KWin::Effect::animationTime(std::chrono::milliseconds(400)).count());
         QPointer<KWin::EffectWindow> wPtr(window);
         m_pendingUnminimizeUnfloat.schedule(windowId, graceMs, [this, windowId, wPtr]() {
@@ -464,6 +491,13 @@ void SnapHandler::handleMinimizeChanged(KWin::EffectWindow* window, const QStrin
 
 void SnapHandler::commitUnminimizeUnfloat(KWin::EffectWindow* window, const QString& windowId, const QString& screenId)
 {
+    const bool daemonReady = m_effect->isDaemonReady("snap unminimize");
+    if (!daemonReady || !m_minimizeFloatedWindows.contains(windowId)) {
+        return;
+    }
+    m_minimizeFloatedWindows.remove(windowId);
+    const quint64 requestGeneration = ++m_unfloatRequestGeneration;
+    m_unfloatInFlight.insert(windowId, requestGeneration);
     // Restore net for a snap-tracked window minimized across a daemon
     // restart: every restore pass (slotDaemonReady's untracked sweep,
     // slotPendingRestoresAvailable) deliberately skips minimized windows,
@@ -493,7 +527,7 @@ void SnapHandler::commitUnminimizeUnfloat(KWin::EffectWindow* window, const QStr
     // entry for the window's appId, and burning it on a window the daemon
     // still owns robs a sibling window's restore. A failed query counts
     // as tracked for the same reason.
-    if (window && m_effect->isDaemonReady("unminimize restore check")) {
+    if (window) {
         struct QueryJoin
         {
             int pending = 2;
@@ -547,12 +581,25 @@ void SnapHandler::commitUnminimizeUnfloat(KWin::EffectWindow* window, const QStr
 
     qCInfo(lcEffect) << "Snap: window unminimized, unfloating:" << windowId << "on" << screenId;
 
-    if (m_effect->isDaemonReady("snap minimize float")) {
-        PhosphorProtocol::ClientHelpers::fireAndForget(m_effect, PhosphorProtocol::Service::Interface::WindowTracking,
-                                                       QStringLiteral("setWindowFloatingForScreen"),
-                                                       {windowId, screenId, false},
-                                                       QStringLiteral("setWindowFloatingForScreen"));
-    }
+    auto* watcher =
+        new QDBusPendingCallWatcher(PhosphorProtocol::ClientHelpers::asyncCall(
+                                        PhosphorProtocol::Service::Interface::WindowTracking,
+                                        QStringLiteral("setWindowFloatingForScreen"), {windowId, screenId, false}),
+                                    this);
+    connect(watcher, &QDBusPendingCallWatcher::finished, this,
+            [this, windowId, requestGeneration](QDBusPendingCallWatcher* w) {
+                w->deleteLater();
+                const auto inFlight = m_unfloatInFlight.constFind(windowId);
+                if (inFlight == m_unfloatInFlight.constEnd() || inFlight.value() != requestGeneration) {
+                    return;
+                }
+                if (w->isError()) {
+                    m_unfloatInFlight.remove(windowId);
+                    m_minimizeFloatedWindows.insert(windowId);
+                    qCWarning(lcEffect) << "Snap: unfloat request failed for" << windowId << ':'
+                                        << w->error().message();
+                }
+            });
 }
 
 void SnapHandler::slotSnapAssistReady(const QString& windowId, const QString& releaseScreenId,

--- a/kwin-effect/handlers/snaphandler.cpp
+++ b/kwin-effect/handlers/snaphandler.cpp
@@ -159,12 +159,12 @@ void SnapHandler::setFocusFollowsMouse(bool enabled)
     m_focusFollowsMouse = enabled;
 }
 
-void SnapHandler::callResolveWindowRestore(KWin::EffectWindow* window, std::function<void()> onComplete,
+void SnapHandler::callResolveWindowRestore(KWin::EffectWindow* window, std::function<void(bool)> onComplete,
                                            bool releaseSuppressionOnMiss)
 {
     if (!window) {
         if (onComplete) {
-            onComplete();
+            onComplete(false);
         }
         return;
     }
@@ -176,7 +176,7 @@ void SnapHandler::callResolveWindowRestore(KWin::EffectWindow* window, std::func
         // never come.
         m_effect->endRestoreSuppression(window);
         if (onComplete) {
-            onComplete();
+            onComplete(false);
         }
         return;
     }
@@ -217,9 +217,23 @@ void SnapHandler::callResolveWindowRestore(KWin::EffectWindow* window, std::func
     // zone geometry — NOT the free-floating geometry. Storing it as pre-tile would cause
     // float toggle to restore to the zone geometry instead of the original free-floating position.
     const int kindInt = static_cast<int>(m_effect->classifyWindowKind(window));
+    // Thread the applied outcome to onComplete: onSnapSuccess fires only on
+    // the zone-applied branch of tryAsyncSnapCall, and every branch calls
+    // onComplete afterwards, so the flag is always settled when it runs.
+    auto snapApplied = std::make_shared<bool>(false);
+    std::function<void(const QString&, const QString&)> markApplied;
+    std::function<void()> completeWithOutcome;
+    if (onComplete) {
+        markApplied = [snapApplied](const QString&, const QString&) {
+            *snapApplied = true;
+        };
+        completeWithOutcome = [onComplete, snapApplied]() {
+            onComplete(*snapApplied);
+        };
+    }
     m_effect->tryAsyncSnapCall(PhosphorProtocol::Service::Interface::Snap, QStringLiteral("resolveWindowRestore"),
-                               {windowId, screenId, sticky, kindInt}, safeWindow, windowId, false, onMiss, nullptr,
-                               /*skipAnimation=*/true, onComplete, releaseSuppression);
+                               {windowId, screenId, sticky, kindInt}, safeWindow, windowId, false, onMiss, markApplied,
+                               /*skipAnimation=*/true, completeWithOutcome, releaseSuppression);
 }
 
 void SnapHandler::ensurePreSnapGeometryStored(KWin::EffectWindow* w, const QString& windowId,

--- a/kwin-effect/handlers/snaphandler.cpp
+++ b/kwin-effect/handlers/snaphandler.cpp
@@ -342,8 +342,26 @@ void SnapHandler::handleMinimizeChanged(KWin::EffectWindow* window, const QStrin
         m_minimizeFloatedWindows.insert(windowId);
     } else {
         if (!m_minimizeFloatedWindows.contains(windowId)) {
-            qCDebug(lcEffect) << "Snap: unminimized window was not minimize-floated, skipping unfloat:" << windowId;
-            return;
+            // Adopt a minimize-float created by the AUTOTILE handler before
+            // this screen swapped away from autotile — the mirror of the
+            // adoption in AutotileHandler::slotWindowMinimizedChanged, and
+            // for the same reason: ownership must follow the screen's
+            // current mode or the unminimize leaves the window floating
+            // until the next mode toggle. removeMinimizeFloated also cancels
+            // that handler's pending deferred commit for the window.
+            AutotileHandler* autotile = m_effect->autotileHandler();
+            if (autotile && autotile->removeMinimizeFloated(windowId)) {
+                // The window still carries its autotile rect, not its snap-zone
+                // rect. Do not leave that wrong frame visible for the normal
+                // animation grace: commit at the unminimize edge so KWin starts
+                // the restore against the saved snap placement.
+                qCInfo(lcEffect) << "Snap: adopted autotile-mode minimize-float, unfloating immediately:" << windowId;
+                commitUnminimizeUnfloat(window, windowId, screenId);
+                return;
+            } else {
+                qCDebug(lcEffect) << "Snap: unminimized window was not minimize-floated, skipping unfloat:" << windowId;
+                return;
+            }
         }
         // A commit is already scheduled for this window — nothing new to do.
         if (m_pendingUnminimizeUnfloat.contains(windowId)) {
@@ -385,13 +403,12 @@ void SnapHandler::handleMinimizeChanged(KWin::EffectWindow* window, const QStrin
             }
             const QString currentScreenId = m_effect->getWindowScreenId(fw);
             if (m_effect->autotileHandler()->isAutotileScreen(currentScreenId)) {
-                // The screen flipped to autotile during the grace; that
-                // engine's own minimize-float machine owns the window now.
-                // The m_minimizeFloatedWindows entry is deliberately LEFT in
-                // place (mirroring the autotile twin's symmetric bail): the
-                // window is still floating daemon-side, and the entry drains
-                // on close via removeMinimizeFloated.
-                qCDebug(lcEffect) << "Snap: deferred unfloat screen became autotile, skipping:" << windowId;
+                // The unminimize edge already happened, so waiting for another
+                // edge would strand the suspension permanently. Transfer the
+                // commit to the handler that owns the screen now; its adoption
+                // path removes our marker and tiles immediately.
+                qCInfo(lcEffect) << "Snap: deferred unfloat screen became autotile, transferring:" << windowId;
+                m_effect->autotileHandler()->slotWindowMinimizedChanged(fw);
                 return;
             }
             if (!m_minimizeFloatedWindows.remove(windowId)) {
@@ -496,7 +513,7 @@ void SnapHandler::commitUnminimizeUnfloat(KWin::EffectWindow* window, const QStr
                 });
     }
 
-    qCInfo(lcEffect) << "Snap: window unminimized, unfloating (after animation grace):" << windowId << "on" << screenId;
+    qCInfo(lcEffect) << "Snap: window unminimized, unfloating:" << windowId << "on" << screenId;
 
     if (m_effect->isDaemonReady("snap minimize float")) {
         PhosphorProtocol::ClientHelpers::fireAndForget(m_effect, PhosphorProtocol::Service::Interface::WindowTracking,

--- a/kwin-effect/handlers/snaphandler.cpp
+++ b/kwin-effect/handlers/snaphandler.cpp
@@ -36,6 +36,8 @@ namespace PlasmaZones {
 Q_DECLARE_LOGGING_CATEGORY(lcEffect)
 
 static constexpr int kSnapMinimizeFloatDebounceMs = kSpuriousMinimizePairMs;
+static constexpr int kSnapUnfloatRetryDelayMs = 250;
+static constexpr int kSnapMaxUnfloatRetries = 3;
 
 SnapHandler::SnapHandler(PlasmaZonesEffect* effect, QObject* parent)
     : QObject(parent)
@@ -344,7 +346,8 @@ void SnapHandler::handleMinimizeChanged(KWin::EffectWindow* window, const QStrin
 {
     // Snap-mode-only: the autotile handler runs its own snap-state / float-state
     // machine for autotile screens.
-    if (m_effect->autotileHandler()->isAutotileScreen(screenId)) {
+    const bool autotileScreen = m_effect->autotileHandler()->isAutotileScreen(screenId);
+    if (!minimized && autotileScreen) {
         return;
     }
 
@@ -353,6 +356,7 @@ void SnapHandler::handleMinimizeChanged(KWin::EffectWindow* window, const QStrin
         // commit: the window never unfloated, so it is still minimize-floated
         // and the isWindowFloating skip below covers the rest.
         cancelPendingUnminimizeUnfloat(windowId);
+        m_unfloatRetryAttempts.remove(windowId);
         if (m_unfloatInFlight.remove(windowId)) {
             m_minimizeFloatedWindows.insert(windowId);
             qCInfo(lcEffect) << "Snap: re-minimize countermanding in-flight unfloat:" << windowId;
@@ -362,6 +366,9 @@ void SnapHandler::handleMinimizeChanged(KWin::EffectWindow* window, const QStrin
                     QStringLiteral("setWindowFloatingForScreen"), {windowId, screenId, true},
                     QStringLiteral("setWindowFloatingForScreen"));
             }
+            return;
+        }
+        if (autotileScreen) {
             return;
         }
         if (m_effect->isWindowFloating(windowId)) {
@@ -535,8 +542,11 @@ void SnapHandler::commitUnminimizeUnfloat(KWin::EffectWindow* window, const QStr
         };
         auto join = std::make_shared<QueryJoin>();
         QPointer<KWin::EffectWindow> safeWindow = window;
-        const auto onReplyDone = [this, join, safeWindow, windowId]() {
+        const auto onReplyDone = [this, join, safeWindow, windowId, requestGeneration]() {
             if (--join->pending > 0 || join->trackedOrFailed) {
+                return;
+            }
+            if (m_unfloatInFlight.value(windowId) != requestGeneration) {
                 return;
             }
             // Same eligibility guards as slotPendingRestoresAvailable's
@@ -598,8 +608,86 @@ void SnapHandler::commitUnminimizeUnfloat(KWin::EffectWindow* window, const QStr
                     m_minimizeFloatedWindows.insert(windowId);
                     qCWarning(lcEffect) << "Snap: unfloat request failed for" << windowId << ':'
                                         << w->error().message();
+                    scheduleUnminimizeUnfloatRetry(windowId);
+                    return;
                 }
+
+                auto* stateWatcher = new QDBusPendingCallWatcher(
+                    PhosphorProtocol::ClientHelpers::asyncCall(PhosphorProtocol::Service::Interface::WindowTracking,
+                                                               QStringLiteral("queryWindowFloating"), {windowId}),
+                    this);
+                connect(stateWatcher, &QDBusPendingCallWatcher::finished, this,
+                        [this, windowId, requestGeneration](QDBusPendingCallWatcher* stateCall) {
+                            stateCall->deleteLater();
+                            const auto current = m_unfloatInFlight.constFind(windowId);
+                            if (current == m_unfloatInFlight.constEnd() || current.value() != requestGeneration) {
+                                return;
+                            }
+                            QDBusPendingReply<bool> reply = *stateCall;
+                            if (!reply.isValid()) {
+                                m_unfloatInFlight.remove(windowId);
+                                m_minimizeFloatedWindows.insert(windowId);
+                                scheduleUnminimizeUnfloatRetry(windowId);
+                                return;
+                            }
+                            if (reply.value()) {
+                                m_unfloatInFlight.remove(windowId);
+                                m_minimizeFloatedWindows.insert(windowId);
+                                scheduleUnminimizeUnfloatRetry(windowId);
+                                return;
+                            }
+                            m_unfloatInFlight.remove(windowId);
+                            m_minimizeFloatedWindows.remove(windowId);
+                            m_unfloatRetryAttempts.remove(windowId);
+                            m_effect->slotWindowFloatingChanged(windowId, false, QString());
+                        });
             });
+}
+
+void SnapHandler::scheduleUnminimizeUnfloatRetry(const QString& windowId)
+{
+    if (!m_effect->m_daemonGate.serviceRegistered || m_pendingUnminimizeUnfloat.contains(windowId)
+        || m_unfloatRetryAttempts.value(windowId) >= kSnapMaxUnfloatRetries) {
+        return;
+    }
+    KWin::EffectWindow* window = m_effect->findWindowById(windowId);
+    if (!window || window->isDeleted() || window->isMinimized()) {
+        return;
+    }
+    QPointer<KWin::EffectWindow> safeWindow = window;
+    ++m_unfloatRetryAttempts[windowId];
+    m_pendingUnminimizeUnfloat.schedule(windowId, kSnapUnfloatRetryDelayMs, [this, windowId, safeWindow]() {
+        if (!safeWindow || safeWindow->isDeleted() || safeWindow->isMinimized()) {
+            return;
+        }
+        const QString screenId = m_effect->getWindowScreenId(safeWindow.data());
+        if (!m_minimizeFloatedWindows.contains(windowId)) {
+            return;
+        }
+        if (m_effect->autotileHandler()->isAutotileScreen(screenId)) {
+            m_effect->autotileHandler()->slotWindowMinimizedChanged(safeWindow.data());
+            return;
+        }
+        commitUnminimizeUnfloat(safeWindow.data(), windowId, screenId);
+    });
+}
+
+void SnapHandler::retryVisibleMinimizeFloats()
+{
+    const auto windowIds = m_minimizeFloatedWindows.values();
+    for (const QString& windowId : windowIds) {
+        m_unfloatRetryAttempts.remove(windowId);
+        KWin::EffectWindow* window = m_effect->findWindowById(windowId);
+        if (!window || window->isDeleted() || window->isMinimized()) {
+            continue;
+        }
+        const QString screenId = m_effect->getWindowScreenId(window);
+        if (m_effect->autotileHandler()->isAutotileScreen(screenId)) {
+            m_effect->autotileHandler()->slotWindowMinimizedChanged(window);
+            continue;
+        }
+        commitUnminimizeUnfloat(window, windowId, screenId);
+    }
 }
 
 void SnapHandler::slotSnapAssistReady(const QString& windowId, const QString& releaseScreenId,

--- a/kwin-effect/handlers/snaphandler.cpp
+++ b/kwin-effect/handlers/snaphandler.cpp
@@ -430,10 +430,16 @@ void SnapHandler::handleMinimizeChanged(KWin::EffectWindow* window, const QStrin
             if (autotile && autotile->removeMinimizeFloated(windowId)) {
                 m_minimizeFloatedWindows.insert(windowId);
                 // The window still carries its autotile rect, not its snap-zone
-                // rect. Do not leave that wrong frame visible for the normal
-                // animation grace: commit at the unminimize edge so KWin starts
-                // the restore against the saved snap placement.
+                // rect. Committing at the edge dispatches the unfloat
+                // immediately, but the daemon's resnap geometry only lands
+                // after a D-Bus round trip — KWin would play the whole
+                // restore against the stale autotile frame and then hop.
+                // Withhold the first frames instead: the suppression releases
+                // the moment the resnap moves the frame, or at its own 250 ms
+                // deadline if no reposition arrives, so the window appears
+                // once, at its snap placement.
                 qCInfo(lcEffect) << "Snap: adopted autotile-mode minimize-float, unfloating immediately:" << windowId;
+                m_effect->beginRestoreSuppression(window);
                 commitUnminimizeUnfloat(window, windowId, screenId);
                 return;
             } else {

--- a/kwin-effect/handlers/snaphandler.cpp
+++ b/kwin-effect/handlers/snaphandler.cpp
@@ -423,9 +423,10 @@ void SnapHandler::handleMinimizeChanged(KWin::EffectWindow* window, const QStrin
                 // record snap has no release path for on this screen. The
                 // untiled marker routes the eventual unminimize through the
                 // immediate-commit path — the rect belongs to the other mode.
-                if (AutotileHandler* autotile = m_effect->autotileHandler()) {
-                    autotile->adoptMinimizeFloated(windowId, /*untiled=*/true);
-                }
+                // Unguarded like this function's other autotileHandler()
+                // derefs: m_autotileHandler is declared before m_snapHandler
+                // on the effect, so it outlives every SnapHandler call.
+                m_effect->autotileHandler()->adoptMinimizeFloated(windowId, /*untiled=*/true);
             } else {
                 m_minimizeFloatedWindows.insert(windowId);
             }
@@ -604,7 +605,7 @@ void SnapHandler::commitUnminimizeUnfloat(KWin::EffectWindow* window, const QStr
     // cycle it is absent from getSnappedWindows too — but it IS in the
     // daemon's floating set, and the unfloat below re-snaps it. Only a
     // window in NEITHER set is orphaned. Both queries are dispatched HERE,
-    // before the unfloat fireAndForget below enters the same D-Bus send
+    // before the unfloat call (asyncCall + watcher) below enters the same D-Bus send
     // queue, so the daemon answers them against the pre-unfloat state.
     //
     // The restore-on-orphan is deliberately scoped to an owned or adopted

--- a/kwin-effect/handlers/snaphandler.cpp
+++ b/kwin-effect/handlers/snaphandler.cpp
@@ -258,6 +258,18 @@ void SnapHandler::ensurePreSnapGeometryStored(KWin::EffectWindow* w, const QStri
         return;
     }
 
+    // Mirror of the autotile capture's snap-owned guard
+    // (saveAndRecordPreAutotileGeometry): a window the AUTOTILE side owns —
+    // actively tiled, or held as an autotile minimize-float — is sitting on
+    // its TILE rect, never a free-floating position. Capturing it here would
+    // poison the shared float-back with the tile rect (the reverse of the
+    // per-mode leak that guard closes).
+    if (AutotileHandler* autotile = m_effect->autotileHandler();
+        autotile && (autotile->isTiledWindow(windowId) || autotile->isMinimizeFloated(windowId))) {
+        qCDebug(lcEffect) << "Skipped pre-snap geometry for autotile-owned window (frame is tile rect)" << windowId;
+        return;
+    }
+
     // Use virtual-screen-aware ID — getWindowScreenId() falls back to the physical
     // ID when virtual screen defs haven't loaded yet, so it is safe to call
     // unconditionally. Using it here ensures the stored screen ID always matches

--- a/kwin-effect/handlers/snaphandler.cpp
+++ b/kwin-effect/handlers/snaphandler.cpp
@@ -125,6 +125,12 @@ void SnapHandler::clearSnapTracking()
     // clearAllDecorations() to release the per-window border shader redirect.
     // Preserve unresolved candidates from an earlier daemon cycle. They are
     // retired only by an authoritative snap, float, close, or restore miss.
+    // CONSCIOUS BREADTH: every window snap-tracked at teardown becomes a
+    // candidate, and one that never gets an authoritative answer stays a
+    // minimize-float candidate indefinitely. Accepted — the alternative
+    // (expiring candidates) re-strands the daemon-restart-while-minimized
+    // window this set exists for, and the cost of the breadth is only that a
+    // once-snapped window minimizing later is floated like a snapped one.
     for (auto it = m_border.tiledWindowsByScreen.cbegin(); it != m_border.tiledWindowsByScreen.cend(); ++it) {
         m_restartSnapCandidates.unite(it.value());
     }

--- a/kwin-effect/handlers/snaphandler.h
+++ b/kwin-effect/handlers/snaphandler.h
@@ -194,6 +194,18 @@ public:
         m_minimizeFloatedWindows.insert(windowId);
     }
 
+    /// Retry-budget hand-off — see AutotileHandler's twin for rationale.
+    int unfloatRetryBudgetUsed(const QString& windowId) const
+    {
+        return m_unfloatRetryAttempts.value(windowId);
+    }
+    void seedUnfloatRetryBudget(const QString& windowId, int attemptsUsed)
+    {
+        if (attemptsUsed > m_unfloatRetryAttempts.value(windowId)) {
+            m_unfloatRetryAttempts.insert(windowId, attemptsUsed);
+        }
+    }
+
     /// Drop @p windowId from the minimize-float set and cancel either deferred
     /// edge. Returns true if it was present. Used by close cleanup,
     /// authoritative visible unfloat, and cross-mode adoption.

--- a/kwin-effect/handlers/snaphandler.h
+++ b/kwin-effect/handlers/snaphandler.h
@@ -139,11 +139,17 @@ public:
     // ── Snap restore-on-open orchestration ──
     /// Ask the daemon whether @p window has a saved zone and apply it (async) —
     /// the async counterpart of the instant restore-cache teleport.
+    /// onComplete receives snapApplied: true when the daemon resolved a zone
+    /// and the geometry was applied. Callers that go on to notify autotile
+    /// must thread !snapApplied into knownFreeFloating — a zone-placed
+    /// window's live frame is the zone rect, and reporting it as a known free
+    /// frame persists the zone rect as the float-back geometry.
     /// releaseSuppressionOnMiss: when the daemon resolves no zone, release the
     /// window's first-frame suppression. Pass false when something else will
     /// still reposition it on a miss (the autotile-screen path tiles it via
     /// onComplete) — there the suppression must hold through that reposition.
-    void callResolveWindowRestore(KWin::EffectWindow* window, std::function<void()> onComplete = nullptr,
+    void callResolveWindowRestore(KWin::EffectWindow* window,
+                                  std::function<void(bool snapApplied)> onComplete = nullptr,
                                   bool releaseSuppressionOnMiss = true);
     /// Store a window's pre-snap (free-float) geometry with the daemon before a
     /// snap commit, so a later float toggle restores the original position.

--- a/kwin-effect/handlers/snaphandler.h
+++ b/kwin-effect/handlers/snaphandler.h
@@ -188,13 +188,13 @@ public:
     {
         cancelPendingMinimizeFloat(windowId);
         cancelPendingUnminimizeUnfloat(windowId);
-        return m_minimizeFloatedWindows.remove(windowId);
+        const bool owned = m_minimizeFloatedWindows.remove(windowId);
+        return m_unfloatInFlight.remove(windowId) > 0 || owned;
     }
 
-    /// Cancel a pending debounced minimize→float commit.
-    void cancelPendingMinimizeFloat(const QString& windowId)
+    bool hasPendingUnminimizeUnfloat(const QString& windowId) const
     {
-        m_pendingMinimizeFloat.cancel(windowId);
+        return m_pendingUnminimizeUnfloat.contains(windowId);
     }
 
     /// Cancel a pending deferred unminimize→unfloat commit. No-op if no timer
@@ -227,6 +227,11 @@ public Q_SLOTS:
                              const PhosphorProtocol::EmptyZoneList& emptyZones);
 
 private:
+    void cancelPendingMinimizeFloat(const QString& windowId)
+    {
+        m_pendingMinimizeFloat.cancel(windowId);
+    }
+
     /// Deferred-commit body of the unminimize→unfloat edge: the restore-net
     /// queries (dispatched before the unfloat enters the same D-Bus send
     /// queue, so the daemon answers against pre-unfloat state) plus the
@@ -266,6 +271,11 @@ private:
     // fires for windows still in this set — clearing on daemon-ready would
     // strand exactly the windows the net exists to recover.
     QSet<QString> m_minimizeFloatedWindows;
+    QHash<QString, quint64> m_unfloatInFlight;
+    quint64 m_unfloatRequestGeneration = 0;
+    // Snap membership retained only as minimize provenance while daemon-owned
+    // visual placement state is unavailable.
+    QSet<QString> m_restartSnapCandidates;
     // Pending debounced minimize→float commits. Shares the compositor's
     // spurious minimize-pair window with the shader and autotile paths.
     DeferredWindowCommits m_pendingMinimizeFloat{this};

--- a/kwin-effect/handlers/snaphandler.h
+++ b/kwin-effect/handlers/snaphandler.h
@@ -167,10 +167,11 @@ public:
     /// the net inert and the plain unfloat re-snaps as before. Called from
     /// PlasmaZonesEffect::slotWindowMinimizedChanged after the shared minimize
     /// shader event.
-    /// The unfloat side does NOT commit synchronously: it is deferred by an
-    /// Effect::animationTime-scaled grace so the re-snap's geometry apply
-    /// cannot land mid-flight and cancel KWin's own unminimize animation
-    /// (discussion #816); see m_pendingUnminimizeUnfloat.
+    /// The normal same-mode unfloat is deferred by an Effect::animationTime-
+    /// scaled grace so the re-snap's geometry apply cannot land mid-flight and
+    /// cancel KWin's own unminimize animation (discussion #816). A float adopted
+    /// across a mode boundary commits immediately because its current geometry
+    /// belongs to the other mode; see m_pendingUnminimizeUnfloat.
     void handleMinimizeChanged(KWin::EffectWindow* window, const QString& windowId, const QString& screenId,
                                bool minimized);
 
@@ -221,7 +222,8 @@ private:
     /// queue, so the daemon answers against pre-unfloat state) plus the
     /// unfloat itself. Called only from the grace timer in
     /// handleMinimizeChanged after revalidation; @p window is alive,
-    /// unminimized, handleable, and on a snap-mode screen.
+    /// unminimized, handleable, and on a snap-mode screen. Cross-mode adoption
+    /// also calls it immediately at the unminimize edge.
     void commitUnminimizeUnfloat(KWin::EffectWindow* window, const QString& windowId, const QString& screenId);
 
     PlasmaZonesEffect* m_effect;

--- a/kwin-effect/handlers/snaphandler.h
+++ b/kwin-effect/handlers/snaphandler.h
@@ -162,7 +162,12 @@ public:
     // ── Snap minimize-float (mirrors AutotileHandler's minimize→float machine) ──
     /// Drive the snap-mode minimize→float state machine: on a snapping-mode
     /// screen, float a window when it minimizes and unfloat it when it
-    /// unminimizes (autotile screens run AutotileHandler's own machine). When
+    /// unminimizes. The autotile-screen gate is DIRECTION-ASYMMETRIC by
+    /// design: a MINIMIZE on an autotile screen bails outright (that screen's
+    /// machine owns the float), but an UNMINIMIZE on an autotile screen is
+    /// NOT gated at entry — the adoption/transfer paths below must still run
+    /// for a float this handler owns from before the screen's mode flipped.
+    /// When
     /// unminimizing a window this session minimize-floated, it also retries
     /// snap restore if the daemon tracks the window as neither snapped nor
     /// floating — every restore pass (daemon-ready, pendingRestoresAvailable)

--- a/kwin-effect/handlers/snaphandler.h
+++ b/kwin-effect/handlers/snaphandler.h
@@ -169,9 +169,12 @@ public:
     /// shader event.
     /// The normal same-mode unfloat is deferred by an Effect::animationTime-
     /// scaled grace so the re-snap's geometry apply cannot land mid-flight and
-    /// cancel KWin's own unminimize animation (discussion #816). A float adopted
-    /// across a mode boundary commits immediately because its current geometry
-    /// belongs to the other mode; see m_pendingUnminimizeUnfloat.
+    /// cancel KWin's own unminimize animation (discussion #816). A float
+    /// adopted across a mode boundary dispatches immediately AND withholds the
+    /// first frames via restore suppression: its current geometry belongs to
+    /// the other mode, and the resnap that corrects it only lands after a
+    /// D-Bus round trip — without the suppression KWin would play the restore
+    /// against the stale frame and then hop. See m_pendingUnminimizeUnfloat.
     void handleMinimizeChanged(KWin::EffectWindow* window, const QString& windowId, const QString& screenId,
                                bool minimized);
     void retryVisibleMinimizeFloats();

--- a/kwin-effect/handlers/snaphandler.h
+++ b/kwin-effect/handlers/snaphandler.h
@@ -185,6 +185,15 @@ public:
         return m_minimizeFloatedWindows.contains(windowId) || m_unfloatInFlight.contains(windowId);
     }
 
+    /// Take ownership of a minimize-float relinquished by the autotile
+    /// handler (cross-screen move of a still-minimized window onto a
+    /// snap-mode screen): the unminimize edge on that screen must find an
+    /// owner or the window stays floating until the next mode toggle.
+    void adoptMinimizeFloated(const QString& windowId)
+    {
+        m_minimizeFloatedWindows.insert(windowId);
+    }
+
     /// Drop @p windowId from the minimize-float set and cancel either deferred
     /// edge. Returns true if it was present. Used by close cleanup,
     /// authoritative visible unfloat, and cross-mode adoption.

--- a/kwin-effect/handlers/snaphandler.h
+++ b/kwin-effect/handlers/snaphandler.h
@@ -175,16 +175,26 @@ public:
     void handleMinimizeChanged(KWin::EffectWindow* window, const QString& windowId, const QString& screenId,
                                bool minimized);
 
-    /// Drop @p windowId from the minimize-float set and cancel any deferred
-    /// unfloat commit. Returns true if it was present. Two callers, two
-    /// reasons (mirrors AutotileHandler::removeMinimizeFloated): the close
-    /// path (a grace timer must never fire against a destroyed window) and
-    /// the daemon's windowFloatingChanged(false) echo (an authoritative
-    /// external unfloat moots the deferred commit).
+    /// Whether snap owns a temporary minimize-float for @p windowId.
+    bool isMinimizeFloated(const QString& windowId) const
+    {
+        return m_minimizeFloatedWindows.contains(windowId);
+    }
+
+    /// Drop @p windowId from the minimize-float set and cancel either deferred
+    /// edge. Returns true if it was present. Used by close cleanup,
+    /// authoritative visible unfloat, and cross-mode adoption.
     bool removeMinimizeFloated(const QString& windowId)
     {
+        cancelPendingMinimizeFloat(windowId);
         cancelPendingUnminimizeUnfloat(windowId);
         return m_minimizeFloatedWindows.remove(windowId);
+    }
+
+    /// Cancel a pending debounced minimize→float commit.
+    void cancelPendingMinimizeFloat(const QString& windowId)
+    {
+        m_pendingMinimizeFloat.cancel(windowId);
     }
 
     /// Cancel a pending deferred unminimize→unfloat commit. No-op if no timer
@@ -220,10 +230,9 @@ private:
     /// Deferred-commit body of the unminimize→unfloat edge: the restore-net
     /// queries (dispatched before the unfloat enters the same D-Bus send
     /// queue, so the daemon answers against pre-unfloat state) plus the
-    /// unfloat itself. Called only from the grace timer in
-    /// handleMinimizeChanged after revalidation; @p window is alive,
-    /// unminimized, handleable, and on a snap-mode screen. Cross-mode adoption
-    /// also calls it immediately at the unminimize edge.
+    /// unfloat itself. Called from the grace timer after revalidation, or
+    /// immediately when cross-mode adoption must replace the other mode's
+    /// geometry at the unminimize edge.
     void commitUnminimizeUnfloat(KWin::EffectWindow* window, const QString& windowId, const QString& screenId);
 
     PlasmaZonesEffect* m_effect;
@@ -257,6 +266,9 @@ private:
     // fires for windows still in this set — clearing on daemon-ready would
     // strand exactly the windows the net exists to recover.
     QSet<QString> m_minimizeFloatedWindows;
+    // Pending debounced minimize→float commits. Shares the compositor's
+    // spurious minimize-pair window with the shader and autotile paths.
+    DeferredWindowCommits m_pendingMinimizeFloat{this};
     // Pending deferred unminimize→unfloat commits, keyed by windowId — the
     // snap-mode mirror of AutotileHandler::m_pendingUnminimizeUnfloat, for the
     // same reason: the unfloat re-snaps the window (the daemon applies its

--- a/kwin-effect/handlers/snaphandler.h
+++ b/kwin-effect/handlers/snaphandler.h
@@ -183,6 +183,13 @@ public:
     /// against the stale frame and then hop. See m_pendingUnminimizeUnfloat.
     void handleMinimizeChanged(KWin::EffectWindow* window, const QString& windowId, const QString& screenId,
                                bool minimized);
+    /// Cross-mode transfer entry point over handleMinimizeChanged's
+    /// unminimize path (mirror of AutotileHandler::offerMinimizeEdge).
+    /// Returns false when the entry gate would refuse the window (the screen
+    /// moved back under autotile) WITHOUT forwarding; true after forwarding.
+    /// AutotileHandler's became-snap hand-offs must use this so a refused
+    /// transfer re-arms on the sender instead of stranding the suspension.
+    bool offerMinimizeEdge(KWin::EffectWindow* window, const QString& windowId, const QString& screenId);
     void retryVisibleMinimizeFloats();
 
     /// Whether snap owns a temporary minimize-float for @p windowId.

--- a/kwin-effect/handlers/snaphandler.h
+++ b/kwin-effect/handlers/snaphandler.h
@@ -174,11 +174,12 @@ public:
     /// belongs to the other mode; see m_pendingUnminimizeUnfloat.
     void handleMinimizeChanged(KWin::EffectWindow* window, const QString& windowId, const QString& screenId,
                                bool minimized);
+    void retryVisibleMinimizeFloats();
 
     /// Whether snap owns a temporary minimize-float for @p windowId.
     bool isMinimizeFloated(const QString& windowId) const
     {
-        return m_minimizeFloatedWindows.contains(windowId);
+        return m_minimizeFloatedWindows.contains(windowId) || m_unfloatInFlight.contains(windowId);
     }
 
     /// Drop @p windowId from the minimize-float set and cancel either deferred
@@ -188,6 +189,7 @@ public:
     {
         cancelPendingMinimizeFloat(windowId);
         cancelPendingUnminimizeUnfloat(windowId);
+        m_unfloatRetryAttempts.remove(windowId);
         const bool owned = m_minimizeFloatedWindows.remove(windowId);
         return m_unfloatInFlight.remove(windowId) > 0 || owned;
     }
@@ -195,6 +197,11 @@ public:
     bool hasPendingUnminimizeUnfloat(const QString& windowId) const
     {
         return m_pendingUnminimizeUnfloat.contains(windowId);
+    }
+
+    bool hasUnfloatInFlight(const QString& windowId) const
+    {
+        return m_unfloatInFlight.contains(windowId);
     }
 
     /// Cancel a pending deferred unminimize→unfloat commit. No-op if no timer
@@ -239,6 +246,7 @@ private:
     /// immediately when cross-mode adoption must replace the other mode's
     /// geometry at the unminimize edge.
     void commitUnminimizeUnfloat(KWin::EffectWindow* window, const QString& windowId, const QString& screenId);
+    void scheduleUnminimizeUnfloatRetry(const QString& windowId);
 
     PlasmaZonesEffect* m_effect;
     // Snapping focus-follows-mouse (Snapping.Behavior.FocusFollowsMouse). When
@@ -273,6 +281,7 @@ private:
     QSet<QString> m_minimizeFloatedWindows;
     QHash<QString, quint64> m_unfloatInFlight;
     quint64 m_unfloatRequestGeneration = 0;
+    QHash<QString, int> m_unfloatRetryAttempts;
     // Snap membership retained only as minimize provenance while daemon-owned
     // visual placement state is unavailable.
     QSet<QString> m_restartSnapCandidates;

--- a/kwin-effect/plasmazoneseffect/daemon_apply.cpp
+++ b/kwin-effect/plasmazoneseffect/daemon_apply.cpp
@@ -390,9 +390,11 @@ void PlasmaZonesEffect::slotApplyGeometriesBatch(const PhosphorProtocol::WindowG
                 m_trackedScreenPerWindow[p.window] = p.screenId;
                 m_autotileHandler->updateNotifiedScreen(getWindowId(p.window), p.screenId);
             }
+            // Save/restore, not set/clear (nesting-safe).
+            const bool prevInApply = m_daemonGate.inGeometryApply;
             m_daemonGate.inGeometryApply = true;
-            const auto guard = qScopeGuard([this] {
-                m_daemonGate.inGeometryApply = false;
+            const auto guard = qScopeGuard([this, prevInApply] {
+                m_daemonGate.inGeometryApply = prevInApply;
             });
             // Minimized guard for float/restore entries (empty screenId), the
             // batch twin of slotApplyGeometryRequested's check: applying the

--- a/kwin-effect/plasmazoneseffect/daemon_apply.cpp
+++ b/kwin-effect/plasmazoneseffect/daemon_apply.cpp
@@ -377,8 +377,18 @@ void PlasmaZonesEffect::slotApplyGeometriesBatch(const PhosphorProtocol::WindowG
             const auto guard = qScopeGuard([this] {
                 m_daemonGate.inGeometryApply = false;
             });
-            applyWindowGeometry(p.window, p.geometry, /*allowDuringDrag=*/false,
-                                /*skipAnimation=*/false, batchProfilePath);
+            // Minimized guard for float/restore entries (empty screenId), the
+            // batch twin of slotApplyGeometryRequested's check: applying the
+            // pre-tile geometry while minimized would poison what KWin
+            // restores to on unminimize, causing a visible flash of the
+            // pre-snap geometry before the unfloat re-snaps to the zone. The
+            // snap-tracking bookkeeping below still runs — the entry
+            // genuinely un-snaps the window regardless of visibility.
+            const bool skipMinimizedRestore = p.screenId.isEmpty() && p.window->isMinimized();
+            if (!skipMinimizedRestore) {
+                applyWindowGeometry(p.window, p.geometry, /*allowDuringDrag=*/false,
+                                    /*skipAnimation=*/false, batchProfilePath);
+            }
             // Snapping owns its border set (mirrors autotile). The daemon
             // supplies a non-empty authoritative screenId only for real
             // placements; an EMPTY screenId marks a float/restore entry

--- a/kwin-effect/plasmazoneseffect/daemon_apply.cpp
+++ b/kwin-effect/plasmazoneseffect/daemon_apply.cpp
@@ -499,8 +499,25 @@ void PlasmaZonesEffect::slotWindowFloatingChanged(const QString& windowId, bool 
         // engines' own commits consume their pending entry and minimize-float
         // tracking BEFORE dispatching the unfloat, so this can never cancel
         // the commit whose echo delivered this signal.
-        m_autotileHandler->removeMinimizeFloated(windowId);
-        m_snapHandler->removeMinimizeFloated(windowId);
+        // Mode teardown and a hidden snap-zone commit can legitimately clear
+        // the daemon's live float while the window is still minimized. The
+        // float is only the daemon-side occupancy mechanism; the effect-side
+        // marker still owns the later unminimize transition. Dropping it here
+        // loses that edge and leaves KWin restoring whichever geometry was last
+        // applied by the old mode. Genuine visible unfloats still clear both
+        // handlers below.
+        bool stillMinimized = false;
+        if (KWin::EffectWindow* live = findWindowById(windowId)) {
+            stillMinimized = live->isMinimized()
+                && ::PhosphorIdentity::WindowId::extractInstanceId(getWindowId(live))
+                    == ::PhosphorIdentity::WindowId::extractInstanceId(windowId);
+        }
+        if (stillMinimized) {
+            qCDebug(lcEffect) << "Preserving minimize-float ownership across hidden unfloat:" << windowId;
+        } else {
+            m_autotileHandler->removeMinimizeFloated(windowId);
+            m_snapHandler->removeMinimizeFloated(windowId);
+        }
     } else {
         // Backstop: a window that becomes floating is no longer snap-managed.
         // Covers float paths that don't emit applyGeometryRequested with an

--- a/kwin-effect/plasmazoneseffect/daemon_apply.cpp
+++ b/kwin-effect/plasmazoneseffect/daemon_apply.cpp
@@ -528,39 +528,50 @@ void PlasmaZonesEffect::slotWindowFloatingChanged(const QString& windowId, bool 
         // loses that edge and leaves KWin restoring whichever geometry was last
         // applied by the old mode. Genuine visible unfloats still clear both
         // handlers below.
+        // Exact resolve, and hoist the LIVE id: the handler maps are keyed by
+        // the effect-side ids they claimed with, so after a uuid drift a
+        // daemon-id query would miss the live window's entries and the
+        // visible unfloat would never drop them.
         bool stillMinimized = false;
-        if (KWin::EffectWindow* live = findWindowById(windowId)) {
-            stillMinimized = live->isMinimized()
-                && ::PhosphorIdentity::WindowId::extractInstanceId(getWindowId(live))
-                    == ::PhosphorIdentity::WindowId::extractInstanceId(windowId);
+        QString liveWindowId = windowId;
+        KWin::EffectWindow* liveForOwner = nullptr;
+        if (KWin::EffectWindow* live = findWindowByIdExact(windowId)) {
+            stillMinimized = live->isMinimized();
+            liveWindowId = getWindowId(live);
+            liveForOwner = live;
+        } else if (findWindowById(windowId)) {
+            // A same-app window exists but the exact instance is not
+            // resolvable (drifted or ambiguous id). Default to PRESERVING
+            // ownership: wrongly dropping a still-minimized window's marker
+            // strands its unminimize, while wrongly keeping it is healed by
+            // the next authoritative edge.
+            stillMinimized = true;
         }
-        const bool recoveryPending = m_autotileHandler->hasPendingUnminimizeUnfloat(windowId)
-            || m_snapHandler->hasPendingUnminimizeUnfloat(windowId) || m_autotileHandler->hasUnfloatInFlight(windowId)
-            || m_snapHandler->hasUnfloatInFlight(windowId);
+        const bool recoveryPending = m_autotileHandler->hasPendingUnminimizeUnfloat(liveWindowId)
+            || m_snapHandler->hasPendingUnminimizeUnfloat(liveWindowId)
+            || m_autotileHandler->hasUnfloatInFlight(liveWindowId) || m_snapHandler->hasUnfloatInFlight(liveWindowId);
         if (stillMinimized || recoveryPending) {
-            qCDebug(lcEffect) << "Preserving minimize-float ownership across non-terminal unfloat:" << windowId;
+            qCDebug(lcEffect) << "Preserving minimize-float ownership across non-terminal unfloat:" << liveWindowId;
             // Single-owner repair: preservation must never leave the marker in
             // BOTH engines (a missed cross-mode adoption hop can). Resolve a
             // dual hold to the window's current screen mode — the same rule
             // every adoption site applies.
-            if (m_autotileHandler->isMinimizeFloated(windowId) && m_snapHandler->isMinimizeFloated(windowId)) {
+            if (m_autotileHandler->isMinimizeFloated(liveWindowId) && m_snapHandler->isMinimizeFloated(liveWindowId)) {
                 QString ownerScreen = screenId;
-                if (ownerScreen.isEmpty()) {
-                    if (KWin::EffectWindow* live = findWindowById(windowId)) {
-                        ownerScreen = getWindowScreenId(live);
-                    }
+                if (ownerScreen.isEmpty() && liveForOwner) {
+                    ownerScreen = getWindowScreenId(liveForOwner);
                 }
-                qCWarning(lcEffect) << "Minimize-float marker held by BOTH engines for" << windowId
+                qCWarning(lcEffect) << "Minimize-float marker held by BOTH engines for" << liveWindowId
                                     << "— resolving to owner of screen" << ownerScreen;
                 if (m_autotileHandler->isAutotileScreen(ownerScreen)) {
-                    m_snapHandler->removeMinimizeFloated(windowId);
+                    m_snapHandler->removeMinimizeFloated(liveWindowId);
                 } else {
-                    m_autotileHandler->removeMinimizeFloated(windowId);
+                    m_autotileHandler->removeMinimizeFloated(liveWindowId);
                 }
             }
         } else {
-            m_autotileHandler->removeMinimizeFloated(windowId);
-            m_snapHandler->removeMinimizeFloated(windowId);
+            m_autotileHandler->removeMinimizeFloated(liveWindowId);
+            m_snapHandler->removeMinimizeFloated(liveWindowId);
         }
     } else {
         // Backstop: a window that becomes floating is no longer snap-managed.
@@ -714,14 +725,17 @@ void PlasmaZonesEffect::slotWindowMinimizedChanged(KWin::EffectWindow* w)
         const qint64 nowMs = ShaderInternal::shaderClockNowMs();
         const MinimizeShaderStamp stamp = m_minimizeShaderStamp.take(w);
         const bool spuriousPair = stamp.timeMs > 0 && nowMs - stamp.timeMs < kSpuriousMinimizePairMs;
-        if (spuriousPair) {
-            // Only the exact leg we stamped is ours to drop — the
-            // generation check keeps a superseding leg (or anything else
-            // live on the window) on its own teardown.
-            if (const auto* st = m_shaderManager.findTransition(w);
-                st && st->reverse && st->generation == stamp.generation) {
-                endShaderTransition(w);
-            }
+        // Only the exact leg we stamped is ours to drop — the generation
+        // check keeps a superseding leg (or anything else live on the
+        // window) on its own teardown. Liveness is part of the SUPPRESSION
+        // decision, not just the teardown: when our stamped leg is no
+        // longer live, the earlier shape skipped BOTH the teardown and the
+        // forward leg, so a fast genuine minimize/unminimize cycle got no
+        // unminimize animation at all.
+        const auto* st = m_shaderManager.findTransition(w);
+        const bool stampedLegLive = st && st->reverse && st->generation == stamp.generation;
+        if (spuriousPair && stampedLegLive) {
+            endShaderTransition(w);
         } else {
             tryBeginShaderForEvent(w, PhosphorAnimation::ProfilePaths::WindowMinimize, animationDurationMs(),
                                    /*reverse=*/false);

--- a/kwin-effect/plasmazoneseffect/daemon_apply.cpp
+++ b/kwin-effect/plasmazoneseffect/daemon_apply.cpp
@@ -490,15 +490,11 @@ void PlasmaZonesEffect::slotWindowFloatingChanged(const QString& windowId, bool 
     // because m_dragActivation.floatedWindowIds still has the entry from the original drag.
     if (!isFloating) {
         m_dragActivation.floatedWindowIds.remove(windowId);
-        // An authoritative external unfloat moots any deferred
-        // unminimize→unfloat commit in either engine: the daemon has already
-        // unfloated (and re-snapped/retiled) the window — a user float toggle
-        // or rule action landing inside the animation grace — so the pending
-        // commit's unfloat would be redundant and snap's restore net would
-        // misread the post-unfloat daemon state as an orphaned window. Both
-        // Pending timers consume themselves before dispatch. Minimize-float
-        // ownership remains until this authoritative visible echo so a
-        // re-minimize racing the asynchronous write cannot lose its owner.
+        // A visible external unfloat normally moots any deferred recovery in
+        // either engine. The daemon signal has no request generation, though,
+        // so an older hidden-unfloat echo can arrive after the window becomes
+        // visible. Preserve ownership while a recovery timer or confirmation
+        // query is active; that query provides the terminal daemon state.
         // Mode teardown and a hidden snap-zone commit can legitimately clear
         // the daemon's live float while the window is still minimized. The
         // float is only the daemon-side occupancy mechanism; the effect-side
@@ -512,10 +508,11 @@ void PlasmaZonesEffect::slotWindowFloatingChanged(const QString& windowId, bool 
                 && ::PhosphorIdentity::WindowId::extractInstanceId(getWindowId(live))
                     == ::PhosphorIdentity::WindowId::extractInstanceId(windowId);
         }
-        const bool unminimizePending = m_autotileHandler->hasPendingUnminimizeUnfloat(windowId)
-            || m_snapHandler->hasPendingUnminimizeUnfloat(windowId);
-        if (stillMinimized || unminimizePending) {
-            qCDebug(lcEffect) << "Preserving minimize-float ownership across hidden unfloat:" << windowId;
+        const bool recoveryPending = m_autotileHandler->hasPendingUnminimizeUnfloat(windowId)
+            || m_snapHandler->hasPendingUnminimizeUnfloat(windowId) || m_autotileHandler->hasUnfloatInFlight(windowId)
+            || m_snapHandler->hasUnfloatInFlight(windowId);
+        if (stillMinimized || recoveryPending) {
+            qCDebug(lcEffect) << "Preserving minimize-float ownership across non-terminal unfloat:" << windowId;
         } else {
             m_autotileHandler->removeMinimizeFloated(windowId);
             m_snapHandler->removeMinimizeFloated(windowId);

--- a/kwin-effect/plasmazoneseffect/daemon_apply.cpp
+++ b/kwin-effect/plasmazoneseffect/daemon_apply.cpp
@@ -262,38 +262,55 @@ void PlasmaZonesEffect::slotApplyGeometriesBatch(const PhosphorProtocol::WindowG
     };
     QVector<PendingApply> pending;
 
-    for (const auto& entry : geometries) {
-        if (entry.windowId.isEmpty() || entry.width <= 0 || entry.height <= 0) {
-            continue;
-        }
-
-        // Exact match first, appId fallback for single-instance apps
-        KWin::EffectWindow* window = windowMap.value(entry.windowId);
-        if (!window) {
-            QString appId = ::PhosphorIdentity::WindowId::extractAppId(entry.windowId);
-            KWin::EffectWindow* candidate = nullptr;
-            int matchCount = 0;
-            for (auto it = windowMap.constBegin(); it != windowMap.constEnd(); ++it) {
-                if (::PhosphorIdentity::WindowId::extractAppId(it.key()) == appId) {
-                    candidate = it.value();
-                    if (++matchCount > 1)
-                        break;
-                }
-            }
-            if (matchCount == 1) {
-                window = candidate;
-            }
-        }
-
-        if (!window) {
-            continue;
-        }
-
+    // Two-pass resolution with a claim set. Exact uuid matches claim their
+    // window first; the appId fallback then resolves only entries whose
+    // window no exact entry claimed, and skips already-claimed windows.
+    // Without the claim set, a batch carrying BOTH a stale-uuid entry and
+    // the live-uuid entry for the same app resolved both onto the one live
+    // window — a double apply where the losing entry's (often empty)
+    // screenId then wiped the snap tracking the winner just marked.
+    QSet<KWin::EffectWindow*> claimedWindows;
+    QVector<const PhosphorProtocol::WindowGeometryEntry*> needFallback;
+    const auto appendPending = [&pending, &claimedWindows](const auto& entry, KWin::EffectWindow* window) {
+        claimedWindows.insert(window);
         PendingApply p;
         p.window = QPointer<KWin::EffectWindow>(window);
         p.geometry = entry.toRect();
         p.screenId = entry.screenId;
         pending.append(p);
+    };
+    for (const auto& entry : geometries) {
+        if (entry.windowId.isEmpty() || entry.width <= 0 || entry.height <= 0) {
+            continue;
+        }
+        if (KWin::EffectWindow* window = windowMap.value(entry.windowId)) {
+            appendPending(entry, window);
+        } else {
+            needFallback.append(&entry);
+        }
+    }
+    for (const auto* entryPtr : needFallback) {
+        const auto& entry = *entryPtr;
+        // appId fallback for single-instance apps (uuid drift across a KWin
+        // restart), counting only UNCLAIMED windows so a stale sibling entry
+        // can neither double-apply onto a claimed window nor trip the
+        // ambiguity bail against it.
+        const QString appId = ::PhosphorIdentity::WindowId::extractAppId(entry.windowId);
+        KWin::EffectWindow* candidate = nullptr;
+        int matchCount = 0;
+        for (auto it = windowMap.constBegin(); it != windowMap.constEnd(); ++it) {
+            if (claimedWindows.contains(it.value())) {
+                continue;
+            }
+            if (::PhosphorIdentity::WindowId::extractAppId(it.key()) == appId) {
+                candidate = it.value();
+                if (++matchCount > 1)
+                    break;
+            }
+        }
+        if (matchCount == 1) {
+            appendPending(entry, candidate);
+        }
     }
 
     if (pending.isEmpty()) {
@@ -488,7 +505,6 @@ void PlasmaZonesEffect::slotRaiseWindowsRequested(const QStringList& windowIds)
 
 void PlasmaZonesEffect::slotWindowFloatingChanged(const QString& windowId, bool isFloating, const QString& screenId)
 {
-    Q_UNUSED(screenId)
     // Update local floating cache when daemon notifies us of state changes
     // This keeps the effect's cache in sync with the daemon, preventing
     // inverted toggle behavior when a floating window is drag-snapped.
@@ -523,6 +539,25 @@ void PlasmaZonesEffect::slotWindowFloatingChanged(const QString& windowId, bool 
             || m_snapHandler->hasUnfloatInFlight(windowId);
         if (stillMinimized || recoveryPending) {
             qCDebug(lcEffect) << "Preserving minimize-float ownership across non-terminal unfloat:" << windowId;
+            // Single-owner repair: preservation must never leave the marker in
+            // BOTH engines (a missed cross-mode adoption hop can). Resolve a
+            // dual hold to the window's current screen mode — the same rule
+            // every adoption site applies.
+            if (m_autotileHandler->isMinimizeFloated(windowId) && m_snapHandler->isMinimizeFloated(windowId)) {
+                QString ownerScreen = screenId;
+                if (ownerScreen.isEmpty()) {
+                    if (KWin::EffectWindow* live = findWindowById(windowId)) {
+                        ownerScreen = getWindowScreenId(live);
+                    }
+                }
+                qCWarning(lcEffect) << "Minimize-float marker held by BOTH engines for" << windowId
+                                    << "— resolving to owner of screen" << ownerScreen;
+                if (m_autotileHandler->isAutotileScreen(ownerScreen)) {
+                    m_snapHandler->removeMinimizeFloated(windowId);
+                } else {
+                    m_autotileHandler->removeMinimizeFloated(windowId);
+                }
+            }
         } else {
             m_autotileHandler->removeMinimizeFloated(windowId);
             m_snapHandler->removeMinimizeFloated(windowId);

--- a/kwin-effect/plasmazoneseffect/daemon_apply.cpp
+++ b/kwin-effect/plasmazoneseffect/daemon_apply.cpp
@@ -496,9 +496,9 @@ void PlasmaZonesEffect::slotWindowFloatingChanged(const QString& windowId, bool 
         // or rule action landing inside the animation grace — so the pending
         // commit's unfloat would be redundant and snap's restore net would
         // misread the post-unfloat daemon state as an orphaned window. Both
-        // engines' own commits consume their pending entry and minimize-float
-        // tracking BEFORE dispatching the unfloat, so this can never cancel
-        // the commit whose echo delivered this signal.
+        // Pending timers consume themselves before dispatch. Minimize-float
+        // ownership remains until this authoritative visible echo so a
+        // re-minimize racing the asynchronous write cannot lose its owner.
         // Mode teardown and a hidden snap-zone commit can legitimately clear
         // the daemon's live float while the window is still minimized. The
         // float is only the daemon-side occupancy mechanism; the effect-side

--- a/kwin-effect/plasmazoneseffect/daemon_apply.cpp
+++ b/kwin-effect/plasmazoneseffect/daemon_apply.cpp
@@ -510,12 +510,35 @@ void PlasmaZonesEffect::slotWindowFloatingChanged(const QString& windowId, bool 
     // inverted toggle behavior when a floating window is drag-snapped.
     // Uses full windowId for per-instance tracking (appId fallback in isWindowFloating).
     qCInfo(lcEffect) << "Floating state changed for" << windowId << "- isFloating:" << isFloating;
-    m_navigationHandler->setWindowFloating(windowId, isFloating);
+    // Re-key to the window's LIVE id up front, mirroring slotWindowStateChanged
+    // and slotApplyGeometryRequested: every effect-side cache below
+    // (FloatingCache, drag-float skip set, snap tracking, rule-cache
+    // invalidation) is keyed by the id the effect claimed with, so after a
+    // cross-session uuid drift the daemon-supplied id would write entries the
+    // rule matcher never reads. Preserve the daemon id when the exact instance
+    // is unresolvable (ambiguous fuzzy hit) — same policy as the minimize
+    // handlers below.
+    bool stillMinimized = false;
+    QString liveWindowId = windowId;
+    KWin::EffectWindow* liveForOwner = nullptr;
+    if (KWin::EffectWindow* live = findWindowByIdExact(windowId)) {
+        stillMinimized = live->isMinimized();
+        liveWindowId = getWindowId(live);
+        liveForOwner = live;
+    } else if (findWindowById(windowId)) {
+        // A same-app window exists but the exact instance is not
+        // resolvable (drifted or ambiguous id). Default to PRESERVING
+        // ownership: wrongly dropping a still-minimized window's marker
+        // strands its unminimize, while wrongly keeping it is healed by
+        // the next authoritative edge.
+        stillMinimized = true;
+    }
+    m_navigationHandler->setWindowFloating(liveWindowId, isFloating);
     // When a window is unfloated (tiled/snapped), clear the drag-float skip flag.
     // Without this, a subsequent float toggle's geometry restore would be skipped
     // because m_dragActivation.floatedWindowIds still has the entry from the original drag.
     if (!isFloating) {
-        m_dragActivation.floatedWindowIds.remove(windowId);
+        m_dragActivation.floatedWindowIds.remove(liveWindowId);
         // A visible external unfloat normally moots any deferred recovery in
         // either engine. The daemon signal has no request generation, though,
         // so an older hidden-unfloat echo can arrive after the window becomes
@@ -528,25 +551,9 @@ void PlasmaZonesEffect::slotWindowFloatingChanged(const QString& windowId, bool 
         // loses that edge and leaves KWin restoring whichever geometry was last
         // applied by the old mode. Genuine visible unfloats still clear both
         // handlers below.
-        // Exact resolve, and hoist the LIVE id: the handler maps are keyed by
-        // the effect-side ids they claimed with, so after a uuid drift a
-        // daemon-id query would miss the live window's entries and the
-        // visible unfloat would never drop them.
-        bool stillMinimized = false;
-        QString liveWindowId = windowId;
-        KWin::EffectWindow* liveForOwner = nullptr;
-        if (KWin::EffectWindow* live = findWindowByIdExact(windowId)) {
-            stillMinimized = live->isMinimized();
-            liveWindowId = getWindowId(live);
-            liveForOwner = live;
-        } else if (findWindowById(windowId)) {
-            // A same-app window exists but the exact instance is not
-            // resolvable (drifted or ambiguous id). Default to PRESERVING
-            // ownership: wrongly dropping a still-minimized window's marker
-            // strands its unminimize, while wrongly keeping it is healed by
-            // the next authoritative edge.
-            stillMinimized = true;
-        }
+        // liveWindowId / stillMinimized were resolved at the top of the
+        // function (the handler maps are keyed by the effect-side ids they
+        // claimed with).
         const bool recoveryPending = m_autotileHandler->hasPendingUnminimizeUnfloat(liveWindowId)
             || m_snapHandler->hasPendingUnminimizeUnfloat(liveWindowId)
             || m_autotileHandler->hasUnfloatInFlight(liveWindowId) || m_snapHandler->hasUnfloatInFlight(liveWindowId);
@@ -582,7 +589,7 @@ void PlasmaZonesEffect::slotWindowFloatingChanged(const QString& windowId, bool 
         // clearWindowSnapped also drops the ZoneCache entry (the IsSnapped /
         // Zone rule-fact source), covering float paths that don't emit
         // windowStateChanged with an empty zone.
-        m_snapHandler->clearWindowSnapped(windowId);
+        m_snapHandler->clearWindowSnapped(liveWindowId);
 
         // Invalidate any stale instant-restore entry for this app. The snap
         // restore cache (SnapHandler) is a single-shot latency cache populated at
@@ -595,7 +602,7 @@ void PlasmaZonesEffect::slotWindowFloatingChanged(const QString& windowId, bool 
         // snapped but untracked. Dropping the entry makes the reopen take the
         // authoritative daemon path so the window stays floating. Keyed by
         // appId to survive the window's identity change across close/reopen.
-        m_snapHandler->invalidateRestore(::PhosphorIdentity::WindowId::extractAppId(windowId));
+        m_snapHandler->invalidateRestore(::PhosphorIdentity::WindowId::extractAppId(liveWindowId));
     }
     // The change-gated write above (setWindowFloating, plus the zone-cache
     // clear that now runs inside clearWindowSnapped on the floating branch)
@@ -610,7 +617,7 @@ void PlasmaZonesEffect::slotWindowFloatingChanged(const QString& windowId, bool 
     // unconditionally; invalidateRuleCacheForStateChange coalesces to a single flush
     // per event-loop turn, so the redundant call when a write did flip the cache is
     // cheap. Mirrors the drag-end paths, which invalidate directly and unconditionally.
-    invalidateRuleCacheForStateChange(windowId);
+    invalidateRuleCacheForStateChange(liveWindowId);
 }
 
 void PlasmaZonesEffect::slotWindowStateChanged(const QString& windowId, const PhosphorProtocol::WindowStateEntry& state)

--- a/kwin-effect/plasmazoneseffect/daemon_apply.cpp
+++ b/kwin-effect/plasmazoneseffect/daemon_apply.cpp
@@ -109,7 +109,7 @@ void PlasmaZonesEffect::slotWindowOutputMoveExpected(const QString& windowId, co
 
 // slotToggleWindowFloatRequested removed — the daemon now handles float-toggle
 // locally against its active-window + frame-geometry shadow and emits
-// applyGeometryRequested directly. See WindowTrackingAdaptor::toggleWindowFloat.
+// applyGeometryRequested directly. See SnapAdaptor::toggleFloatForWindow.
 
 void PlasmaZonesEffect::slotApplyGeometryRequested(const QString& windowId, int x, int y, int width, int height,
                                                    const QString& zoneId, const QString& screenId, bool sizeOnly)
@@ -512,7 +512,9 @@ void PlasmaZonesEffect::slotWindowFloatingChanged(const QString& windowId, bool 
                 && ::PhosphorIdentity::WindowId::extractInstanceId(getWindowId(live))
                     == ::PhosphorIdentity::WindowId::extractInstanceId(windowId);
         }
-        if (stillMinimized) {
+        const bool unminimizePending = m_autotileHandler->hasPendingUnminimizeUnfloat(windowId)
+            || m_snapHandler->hasPendingUnminimizeUnfloat(windowId);
+        if (stillMinimized || unminimizePending) {
             qCDebug(lcEffect) << "Preserving minimize-float ownership across hidden unfloat:" << windowId;
         } else {
             m_autotileHandler->removeMinimizeFloated(windowId);

--- a/kwin-effect/plasmazoneseffect/daemon_bringup.cpp
+++ b/kwin-effect/plasmazoneseffect/daemon_bringup.cpp
@@ -522,7 +522,7 @@ void PlasmaZonesEffect::processDaemonReadyWindowState()
                 QRectF geoBefore = safeWindow->frameGeometry();
 
                 m_snapHandler->callResolveWindowRestore(
-                    safeWindow.data(), [pending, movedCount, safeWindow, geoBefore, savedStackingOrder]() {
+                    safeWindow.data(), [pending, movedCount, safeWindow, geoBefore, savedStackingOrder](bool) {
                         // Detect whether moveResize actually fired by comparing geometry.
                         if (safeWindow && !safeWindow->isDeleted() && safeWindow->frameGeometry() != geoBefore) {
                             ++(*movedCount);

--- a/kwin-effect/plasmazoneseffect/drag_end.cpp
+++ b/kwin-effect/plasmazoneseffect/drag_end.cpp
@@ -292,8 +292,8 @@ void PlasmaZonesEffect::callEndDrag(KWin::EffectWindow* window, const QString& w
                         m_snapAssistHandler->showContinuationIfNeeded(snappedScreenId);
                     };
                     tryAsyncSnapCall(PhosphorProtocol::Service::Interface::Snap, QStringLiteral("snapToEmptyZone"),
-                                     {windowId, outcome.targetScreenId, sticky}, safeWindow, windowId, true, nullptr,
-                                     onSnapSuccess);
+                                     {windowId, outcome.targetScreenId, sticky}, safeWindow, windowId,
+                                     /*storePreSnap=*/true, /*fallback=*/nullptr, onSnapSuccess);
                 }
 
                 // Snap Assist: show the window picker if the daemon requested

--- a/kwin-effect/plasmazoneseffect/drag_end.cpp
+++ b/kwin-effect/plasmazoneseffect/drag_end.cpp
@@ -78,16 +78,21 @@ void PlasmaZonesEffect::callEndDrag(KWin::EffectWindow* window, const QString& w
     auto handled = std::make_shared<bool>(false);
     QTimer* timeoutTimer = new QTimer(this);
     timeoutTimer->setSingleShot(true);
-    connect(timeoutTimer, &QTimer::timeout, this, [windowId, handled, watcher, timeoutTimer]() {
-        if (*handled) {
-            return;
-        }
-        *handled = true;
-        qCWarning(lcEffect) << "endDrag timed out after" << EndDragTimeoutMs
-                            << "ms; daemon unresponsive. Leaving window" << windowId << "at release position.";
-        watcher->deleteLater();
-        timeoutTimer->deleteLater();
-    });
+    // QPointer: the `handled` handshake already prevents a double-delete, but
+    // a raw watcher capture would still dangle if that invariant ever slips.
+    connect(timeoutTimer, &QTimer::timeout, this,
+            [windowId, handled, watcherGuard = QPointer<QDBusPendingCallWatcher>(watcher), timeoutTimer]() {
+                if (*handled) {
+                    return;
+                }
+                *handled = true;
+                qCWarning(lcEffect) << "endDrag timed out after" << EndDragTimeoutMs
+                                    << "ms; daemon unresponsive. Leaving window" << windowId << "at release position.";
+                if (watcherGuard) {
+                    watcherGuard->deleteLater();
+                }
+                timeoutTimer->deleteLater();
+            });
     timeoutTimer->start(EndDragTimeoutMs);
 
     connect(watcher, &QDBusPendingCallWatcher::finished, this,

--- a/kwin-effect/plasmazoneseffect/drag_snap.cpp
+++ b/kwin-effect/plasmazoneseffect/drag_snap.cpp
@@ -670,8 +670,6 @@ void PlasmaZonesEffect::slotDragPolicyChanged(const QString& windowId, const Pho
 
     m_currentDragPolicy = newPolicy;
 
-    KWin::EffectWindow* dragW = m_dragTracker->draggedWindow();
-
     if (newReason == PhosphorProtocol::DragBypassReason::AutotileScreen) {
         // Snap → autotile (or context-disabled → autotile). Cancel any
         // active snap overlay, enter bypass mode. Mirrors the old
@@ -699,9 +697,10 @@ void PlasmaZonesEffect::slotDragPolicyChanged(const QString& windowId, const Pho
         // Do NOT call handleDragToFloat here: the mid-drag schedule would
         // race against the zone snap at drop, making the window jump after
         // the user lets go. onWindowClosed alone clears the tracking state.
-        // Guarded on the ID, not dragW: the call is id-keyed bookkeeping that
-        // never derefs the window, and a died-mid-drag pointer must not skip
-        // the tracking cleanup for a still-valid id.
+        // Guarded on the ID, not the dragged-window pointer: the call is
+        // id-keyed bookkeeping that never derefs the window, and a
+        // died-mid-drag pointer must not skip the tracking cleanup for a
+        // still-valid id.
         if (!windowId.isEmpty()) {
             m_autotileHandler->onWindowClosed(windowId, m_dragBypassScreenId);
         }

--- a/kwin-effect/plasmazoneseffect/drag_snap.cpp
+++ b/kwin-effect/plasmazoneseffect/drag_snap.cpp
@@ -434,9 +434,9 @@ void PlasmaZonesEffect::applyWindowGeometry(KWin::EffectWindow* window, const QR
             // uses `evaluator.resolveCached(windowId, query)`). When a rule
             // set is configured, the sister `resolveEventMotionProfile`
             // call above already warmed the per-window cache slot for this
-            // query, so this cached read is a hit. (With an empty rule set
-            // that resolver never touches the evaluator, but then there is
-            // no priority-order walk to pay for either.) The earlier shape
+            // query, so this cached read is a hit. (An empty rule set still
+            // goes through resolveCached, but its walk over zero rules is
+            // trivially cheap and the cache slot dedups it.) The earlier shape
             // called a standalone uncached shader-profile resolver here, which
             // paid an extra priority-order walk per snap on every
             // non-empty rule set — same regression the shim was

--- a/kwin-effect/plasmazoneseffect/drag_snap.cpp
+++ b/kwin-effect/plasmazoneseffect/drag_snap.cpp
@@ -71,6 +71,15 @@ void PlasmaZonesEffect::tryAsyncSnapCall(const QString& interface, const QString
                         onComplete();
                     return;
                 }
+                if (reply.argumentAt<4>() && (!window || window->isDeleted())) {
+                    // The daemon DID resolve/commit — the window just died in
+                    // flight. This is not a restore miss: onMiss/fallback
+                    // would drop restart-candidate state a same-app reopen
+                    // may still need. Nothing to apply; just complete.
+                    if (onComplete)
+                        onComplete();
+                    return;
+                }
                 if (reply.argumentAt<4>() && window && !window->isDeleted()) {
                     QRect geo(reply.argumentAt<0>(), reply.argumentAt<1>(), reply.argumentAt<2>(),
                               reply.argumentAt<3>());
@@ -299,8 +308,12 @@ void PlasmaZonesEffect::applyWindowGeometry(KWin::EffectWindow* window, const QR
     // normally.
     const ShaderTransition* const inFlight = m_shaderManager.findTransition(window);
     const bool openAnimationInFlight = inFlight && inFlight->addedGrabHeld;
+    // Caller-owned memoisation slot: when the gate builds the WindowQuery for
+    // its rule probes, the resolver pass below reuses it instead of walking
+    // the ~30 accessors a second time per animated apply.
+    std::optional<PhosphorRules::WindowQuery> sharedQuery;
     if (!skipAnimation && !allowDuringDrag && !openAnimationInFlight && m_windowAnimator->isEnabled()
-        && shouldAnimateWindow(window)) {
+        && shouldAnimateWindow(window, &sharedQuery)) {
         const QRectF targetFrame(geo);
 
         // Bail before any work when the in-flight animation already
@@ -331,11 +344,12 @@ void PlasmaZonesEffect::applyWindowGeometry(KWin::EffectWindow* window, const QR
         // not re-apply the cascade — once an animation is in flight, it
         // stays on the curve that started it for visual continuity.
         //
-        // Build the full per-window query once and reuse for the shader
-        // resolver call below — matches the shape `shouldAnimateWindow`
-        // uses for its rule-override gate, so a rule that gates the
-        // animation also resolves its curve / timing / shader slots.
-        const PhosphorRules::WindowQuery query = ruleQuery(window);
+        // Reuse the gate's query when it built one (rules present); build
+        // only when the gate's fast paths never needed it — matches the shape
+        // `shouldAnimateWindow` uses for its rule-override gate, so a rule
+        // that gates the animation also resolves its curve / timing / shader
+        // slots.
+        const PhosphorRules::WindowQuery query = sharedQuery ? *sharedQuery : ruleQuery(window);
         const QString windowId = getWindowId(window);
         const auto& baseProfile = m_windowAnimator->profile();
         // Resolve the fully-cascaded motion profile for this event (curve +
@@ -683,7 +697,10 @@ void PlasmaZonesEffect::slotDragPolicyChanged(const QString& windowId, const Pho
         // Do NOT call handleDragToFloat here: the mid-drag schedule would
         // race against the zone snap at drop, making the window jump after
         // the user lets go. onWindowClosed alone clears the tracking state.
-        if (dragW) {
+        // Guarded on the ID, not dragW: the call is id-keyed bookkeeping that
+        // never derefs the window, and a died-mid-drag pointer must not skip
+        // the tracking cleanup for a still-valid id.
+        if (!windowId.isEmpty()) {
             m_autotileHandler->onWindowClosed(windowId, m_dragBypassScreenId);
         }
         m_dragBypassedForAutotile = false;

--- a/kwin-effect/plasmazoneseffect/drag_snap.cpp
+++ b/kwin-effect/plasmazoneseffect/drag_snap.cpp
@@ -51,18 +51,21 @@ void PlasmaZonesEffect::tryAsyncSnapCall(const QString& interface, const QString
                                          QPointer<KWin::EffectWindow> window, const QString& windowId,
                                          bool storePreSnap, std::function<void()> fallback,
                                          std::function<void(const QString&, const QString&)> onSnapSuccess,
-                                         bool skipAnimation, std::function<void()> onComplete)
+                                         bool skipAnimation, std::function<void()> onComplete,
+                                         std::function<void()> onError)
 {
     QDBusPendingCall call = PhosphorProtocol::ClientHelpers::asyncCall(interface, method, args);
     auto* watcher = new QDBusPendingCallWatcher(call, this);
     connect(watcher, &QDBusPendingCallWatcher::finished, this,
-            [this, window, windowId, storePreSnap, method, fallback, onSnapSuccess, args, skipAnimation,
-             onComplete](QDBusPendingCallWatcher* w) {
+            [this, window, windowId, storePreSnap, method, fallback, onSnapSuccess, args, skipAnimation, onComplete,
+             onError](QDBusPendingCallWatcher* w) {
                 w->deleteLater();
                 QDBusPendingReply<int, int, int, int, bool> reply = *w;
                 if (reply.isError()) {
                     qCDebug(lcEffect) << method << "error:" << reply.error().message();
-                    if (fallback)
+                    if (onError)
+                        onError();
+                    else if (fallback)
                         fallback();
                     if (onComplete)
                         onComplete();

--- a/kwin-effect/plasmazoneseffect/drag_snap.cpp
+++ b/kwin-effect/plasmazoneseffect/drag_snap.cpp
@@ -274,9 +274,11 @@ void PlasmaZonesEffect::applyWindowGeometry(KWin::EffectWindow* window, const QR
                 // synchronous frame change from this moveResize
                 // reads as an external move and can report a
                 // phantom cross-VS unsnap.
+                // Save/restore, not set/clear (nesting-safe).
+                const bool prevInApply = m_daemonGate.inGeometryApply;
                 m_daemonGate.inGeometryApply = true;
-                const auto guard = qScopeGuard([this] {
-                    m_daemonGate.inGeometryApply = false;
+                const auto guard = qScopeGuard([this, prevInApply] {
+                    m_daemonGate.inGeometryApply = prevInApply;
                 });
                 applyWindowGeometry(safeWindow, geo, false, skipAnimation, profilePath);
             });

--- a/kwin-effect/plasmazoneseffect/drag_snap.cpp
+++ b/kwin-effect/plasmazoneseffect/drag_snap.cpp
@@ -239,14 +239,38 @@ void PlasmaZonesEffect::applyWindowGeometry(KWin::EffectWindow* window, const QR
     if (!allowDuringDrag && (window->isUserMove() || window->isUserResize())) {
         qCDebug(lcEffect) << "Window in user move/resize, deferring geometry via windowFinishUserMovedResized";
         QPointer<KWin::EffectWindow> safeWindow = window;
+        // Snapshot the batch-supersession context at defer time: the fire can
+        // land arbitrarily later (the user keeps dragging), and replaying the
+        // old rect after a NEWER per-screen batch repositioned things would
+        // clobber it — or, after the drag crossed screens, teleport the
+        // window back to the old screen's rect.
+        const QString deferScreen = getWindowScreenId(window);
+        const uint64_t deferGen = m_daemonGate.batchGenByScreen.value(deferScreen);
         auto conn = std::make_shared<QMetaObject::Connection>();
-        *conn = connect(window, &KWin::EffectWindow::windowFinishUserMovedResized, this,
-                        [this, safeWindow, geo, skipAnimation, profilePath, conn](KWin::EffectWindow*) {
-                            disconnect(*conn);
-                            if (safeWindow && !safeWindow->isDeleted() && !safeWindow->isFullScreen()) {
-                                applyWindowGeometry(safeWindow, geo, false, skipAnimation, profilePath);
-                            }
-                        });
+        *conn = connect(
+            window, &KWin::EffectWindow::windowFinishUserMovedResized, this,
+            [this, safeWindow, geo, skipAnimation, profilePath, conn, deferScreen, deferGen](KWin::EffectWindow*) {
+                disconnect(*conn);
+                if (!safeWindow || safeWindow->isDeleted() || safeWindow->isFullScreen()) {
+                    return;
+                }
+                const QString nowScreen = getWindowScreenId(safeWindow.data());
+                if (nowScreen != deferScreen || m_daemonGate.batchGenByScreen.value(deferScreen) != deferGen) {
+                    qCDebug(lcEffect) << "Deferred geometry superseded (screen or batch changed), dropping:"
+                                      << getWindowId(safeWindow.data());
+                    return;
+                }
+                // Re-assert the self-caused-frame-change guard the
+                // original (batch) apply held — without it the
+                // synchronous frame change from this moveResize
+                // reads as an external move and can report a
+                // phantom cross-VS unsnap.
+                m_daemonGate.inGeometryApply = true;
+                const auto guard = qScopeGuard([this] {
+                    m_daemonGate.inGeometryApply = false;
+                });
+                applyWindowGeometry(safeWindow, geo, false, skipAnimation, profilePath);
+            });
         return;
     }
 

--- a/kwin-effect/plasmazoneseffect/lifecycle_wiring.cpp
+++ b/kwin-effect/plasmazoneseffect/lifecycle_wiring.cpp
@@ -768,6 +768,7 @@ void PlasmaZonesEffect::connectWindowAndScreenSignals()
         // m_shaderManager.m_lastFullyMaximized is a raw-pointer-keyed QHash so we explicitly
         // erase here to keep it bounded across long sessions.
         m_shaderManager.m_lastFullyMaximized.remove(w);
+        m_lastPushedCaption.remove(w);
         // Sibling raw-pointer-keyed hashes — the maximize morph's departure
         // rect and the deferred-install entry. Same bounded-across-long-
         // sessions rationale as above, plus address-reuse safety for the

--- a/kwin-effect/plasmazoneseffect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect/plasmazoneseffect.h
@@ -946,6 +946,11 @@ private:
     // window dies before the flush; the flush skips those entries.
     // PendingFrameGeometry moved to effect_state.h.
     QHash<QString, PendingFrameGeometry> m_pendingFrameGeometry;
+    /// Last caption pushed via the caption-only metadata refresh, per window.
+    /// Skips content-identical pushes (spurious captionChanged emissions).
+    /// Raw-pointer-keyed; erased in the windowDeleted cleanup with its
+    /// siblings.
+    QHash<KWin::EffectWindow*, QString> m_lastPushedCaption;
     QTimer* m_frameGeometryFlushTimer = nullptr;
     void flushPendingFrameGeometry();
 

--- a/kwin-effect/plasmazoneseffect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect/plasmazoneseffect.h
@@ -378,6 +378,11 @@ private:
      *                     true return. @see shouldHandleWindow.
      */
     bool isStructurallyUnmanageableWindowType(KWin::EffectWindow* w, QString* rejectReason = nullptr) const;
+    // Cached user-Exclude-rule verdict shared by shouldHandleWindow and
+    // shouldAnimateWindow. Fast-paths on an empty exclusion slice; otherwise
+    // resolves through the exclusion evaluator's per-window cache (same
+    // freshness contract as the animation verdicts — see the implementation).
+    bool isExcludedBySnappingRule(KWin::EffectWindow* w) const;
 
     /// Classify a window's structural kind for the snap-restore consume gate.
     PhosphorEngine::WindowKind classifyWindowKind(KWin::EffectWindow* w) const;

--- a/kwin-effect/plasmazoneseffect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect/plasmazoneseffect.h
@@ -954,7 +954,7 @@ private:
     // resize) the per-tick gate was an uncached rule resolve plus a full
     // ruleQuery build, hundreds of times per second (discussion #816). The
     // decoration resync deliberately stays PER TICK in the stash lambda (see
-    // window_lifecycle.cpp): it is cheap, and deferring it let a re-decorated
+    // window_connections.cpp): it is cheap, and deferring it let a re-decorated
     // title bar flash for the throttle window. QPointer auto-nulls if the
     // window dies before the flush; the flush skips those entries.
     // PendingFrameGeometry moved to effect_state.h.
@@ -1840,7 +1840,7 @@ private:
     // either directly from the maximize state edge (geometry already landed)
     // or deferred to the size-delivering windowFrameGeometryChanged when the
     // state signal outran the client's commit. Implementation in
-    // window_lifecycle.cpp beside its two call sites.
+    // window_connections.cpp beside its two call sites.
     void beginMaximizeShaderMorph(KWin::EffectWindow* window, const QRectF& departureFrame);
     /// Evict least-recently-used cached textures back under the soft bound, never
     /// touching one a live transition still points at. @p pending is the transition

--- a/kwin-effect/plasmazoneseffect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect/plasmazoneseffect.h
@@ -1770,6 +1770,17 @@ private:
     // it opens; endRestoreSuppression releases it once it has settled into
     // its zone / tile (or on the hard deadline). See RestoreSuppression.
     void beginRestoreSuppression(KWin::EffectWindow* window);
+    /// Re-arm an already-suppressed window's deadline (no-op when the window
+    /// is not suppressed). Used when a routing decision is deferred past the
+    /// original deadline (screen-query wait) so the window does not flash at
+    /// its spawn placement mid-route.
+    void refreshRestoreSuppressionDeadline(KWin::EffectWindow* window);
+    /// Consume (single-shot) and, when valid for a snap-mode screen, apply the
+    /// instant snap-restore cache entry for this window's app. Returns true
+    /// when the window was teleported (caller should re-evaluate its screen).
+    /// Shared by slotWindowAdded and the deferred-routing dispatch so a
+    /// deferred window cannot leave a stale entry for a same-app sibling.
+    bool tryInstantSnapRestore(KWin::EffectWindow* w, const QString& windowId, bool canSnapRestore);
     void endRestoreSuppression(KWin::EffectWindow* window);
 
     void loadShaderProfileFromDbus();

--- a/kwin-effect/plasmazoneseffect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect/plasmazoneseffect.h
@@ -688,11 +688,13 @@ private:
     // Async D-Bus helper for 5-arg snap replies (x, y, w, h, shouldSnap).
     // Uses QDBusMessage::createMethodCall (no QDBusInterface) to avoid synchronous introspection.
     // onSnapSuccess: optional callback when snap is applied, receives (windowId, screenId)
+    // onError: optional transport-error callback; valid no-snap replies still use fallback.
     void tryAsyncSnapCall(const QString& interface, const QString& method, const QList<QVariant>& args,
                           QPointer<KWin::EffectWindow> window, const QString& windowId, bool storePreSnap,
                           std::function<void()> fallback,
                           std::function<void(const QString&, const QString&)> onSnapSuccess = nullptr,
-                          bool skipAnimation = false, std::function<void()> onComplete = nullptr);
+                          bool skipAnimation = false, std::function<void()> onComplete = nullptr,
+                          std::function<void()> onError = nullptr);
 
     // reserveScreenEdges() and unreserveScreenEdges() have been removed. The daemon
     // disables KWin Quick Tile via kwriteconfig6. Reserving edges would turn on the

--- a/kwin-effect/plasmazoneseffect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect/plasmazoneseffect.h
@@ -411,7 +411,13 @@ private:
      * window with no rule-matchable attributes at all falls through
      * to the filter.
      */
-    bool shouldAnimateWindow(KWin::EffectWindow* w) const;
+    /// @p sharedQuery (optional): a caller-owned memoisation slot. When the
+    /// gate has to build the per-window WindowQuery (~30 KWin accessors), it
+    /// stores it there so the caller's own resolver pass can reuse it instead
+    /// of building a second one — the drag chokepoint pays this per animated
+    /// apply. The slot is left disengaged when no rules forced a build.
+    bool shouldAnimateWindow(KWin::EffectWindow* w,
+                             std::optional<PhosphorRules::WindowQuery>* sharedQuery = nullptr) const;
 
     /**
      * @brief Per-window gate for the border / decoration pass.

--- a/kwin-effect/plasmazoneseffect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect/plasmazoneseffect.h
@@ -315,8 +315,12 @@ private:
      * @brief Push current metadata for a window to the daemon's WindowRegistry.
      *
      * Safe to call unconditionally on every observation — the daemon de-dupes.
-     * Called from slotWindowAdded for initial registration, and from
-     * windowClassChanged / desktopFileNameChanged handlers for live updates.
+     * Called from slotWindowAdded for initial registration; from the
+     * windowClassChanged / desktopFileNameChanged / desktops- and
+     * activities-changed handlers for identity/context updates; from the
+     * minimizedChanged handler (full snapshot — the daemon's mode-swap seed
+     * and capture guards consult the registry's LIVE isMinimized); and from
+     * the captionChanged handler (caption-only, includeExtended=false).
      *
      * @param includeExtended When false, the extended-property snapshot (the
      * trailing a{sv}: state flags, geometry, accessory flags) is NOT rebuilt

--- a/kwin-effect/plasmazoneseffect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect/plasmazoneseffect.h
@@ -319,11 +319,14 @@ private:
      * windowClassChanged / desktopFileNameChanged handlers for live updates.
      *
      * @param includeExtended When false, the extended-property snapshot (the
-     * trailing a{sv}: state flags, geometry, accessory flags, captionNormal) is
-     * NOT rebuilt or sent — the daemon preserves whatever it already has. Used by
+     * trailing a{sv}: state flags, geometry, accessory flags) is NOT rebuilt
+     * or sent — the daemon preserves whatever it already has. The one
+     * exception is captionNormal, which derives from the caption and is sent
+     * alone (the daemon treats a CaptionNormal-only map as a caption refresh,
+     * not a snapshot replace). Used by
      * the captionChanged handler: terminals/browsers rewrite their title every
-     * frame, and the rule-relevant extended fields don't change on a title tick,
-     * so rebuilding/marshalling a ~20-entry map per frame is pure waste. The
+     * frame, and the other rule-relevant extended fields don't change on a title
+     * tick, so rebuilding/marshalling a ~20-entry map per frame is pure waste. The
      * extended snapshot is captured at window-open and refreshed on identity
      * changes (class/desktop/activity), which is when it matters for the daemon's
      * open-path Float / RestorePosition resolvers.

--- a/kwin-effect/plasmazoneseffect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect/plasmazoneseffect.h
@@ -1,6 +1,13 @@
 // SPDX-FileCopyrightText: 2026 fuddlesworth
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+// FILE-SIZE EXCEPTION (sanctioned): PlasmaZonesEffect is the KWin plugin's
+// single entry class — the Effect interface overrides plus every handler
+// back-pointer surface the split-out implementation files
+// (plasmazoneseffect/*.cpp, handlers, autotilehandler) call back through.
+// The implementation is already partitioned; the class declaration is the
+// one place KWin's plugin contract requires to be whole.
+
 #pragma once
 
 #include <cstdint>

--- a/kwin-effect/plasmazoneseffect/rule_invalidation.cpp
+++ b/kwin-effect/plasmazoneseffect/rule_invalidation.cpp
@@ -66,6 +66,12 @@ void PlasmaZonesEffect::flushPendingRuleInvalidations()
     // placement-state change, so drop it once so border / opacity rules re-resolve
     // against the new snapped / floating / zone state.
     m_shaderManager.animationRuleEvaluator().clearCache();
+    // The exclusion verdicts (isExcludedBySnappingRule) are cached the same way
+    // and an Exclude rule can scope on the same placement fields — keep them in
+    // lockstep.
+    if (!m_snappingExclusionRuleSet.isEmpty()) {
+        m_snappingExclusionEvaluator.clearCache();
+    }
     for (const QString& windowId : windowIds) {
         KWin::EffectWindow* w = findWindowById(windowId);
         if (!w) {
@@ -135,6 +141,10 @@ void PlasmaZonesEffect::invalidateAllRuleCaches()
     // (clearAllDecorations), and the daemon-ready re-seeds schedule a border sweep to
     // re-fold every window against the fresh placement.
     m_shaderManager.animationRuleEvaluator().clearCache();
+    // Exclusion verdicts share the placement-scoped staleness — same sweep.
+    if (!m_snappingExclusionRuleSet.isEmpty()) {
+        m_snappingExclusionEvaluator.clearCache();
+    }
     // Window-layer rules need the same placement-scoped re-resolve, but they
     // are EVENT-driven (during normal operation only reconcileRuleWindowLayer
     // writes keepAbove/keepBelow; restoreAllRuleWindowLayers is

--- a/kwin-effect/plasmazoneseffect/window_connections.cpp
+++ b/kwin-effect/plasmazoneseffect/window_connections.cpp
@@ -666,8 +666,8 @@ void PlasmaZonesEffect::setupWindowConnections(KWin::EffectWindow* w)
             &AutotileHandler::slotWindowFrameGeometryChanged);
 
     // Single windowFrameGeometryChanged lambda combining the effect-side
-    // per-tick work — first-frame open suppression release AND debounced
-    // daemon push — into one connection. Keeping these as two separate
+    // per-tick work: deferred maximize completion, first-frame suppression
+    // release, and debounced daemon push. Keeping the latter two as separate
     // connections (which they were originally) doubled the per-geometry-
     // tick lambda dispatch cost without functional benefit; the bodies
     // are independent so collapsing them just runs one capture+vtable
@@ -766,8 +766,8 @@ void PlasmaZonesEffect::setupWindowConnections(KWin::EffectWindow* w)
     // Refresh the daemon's registry metadata on every minimize edge, and
     // BEFORE the handler connections below so the push is enqueued on the bus
     // ahead of any float traffic from the same edge. The daemon's mode-swap
-    // seed/restore decisions consult WindowMetadata::isMinimized, which is
-    // otherwise only snapshotted at window-open — a stale value lets a
+    // seed/restore decisions consult WindowMetadata::isMinimized, which can
+    // otherwise remain at its previous snapshot until an unrelated refresh. A stale value lets a
     // mode-swap seed tile a window that is minimized right now (the per-slot
     // floating check cannot cover this: it resolves via the screen's CURRENT
     // mode, which flips mid-toggle).

--- a/kwin-effect/plasmazoneseffect/window_connections.cpp
+++ b/kwin-effect/plasmazoneseffect/window_connections.cpp
@@ -25,6 +25,12 @@ namespace PlasmaZones {
 Q_DECLARE_LOGGING_CATEGORY(lcEffect)
 
 namespace {
+// A pending maximize morph whose size-landing commit arrives later than this
+// is considered stale (state flipped but the commit never came, e.g. an
+// occluded client under the lock screen) — the morph is skipped so a much
+// later unrelated resize cannot fire a bogus maximize animation.
+constexpr qint64 kPendingMaximizeMorphDeadlineMs = 1000;
+
 // Maximize-morph landing discriminator: has the frame SIZE actually moved
 // away from the departure rect? A maximize/restore always changes the frame
 // size, while a position-only change can apply early server-side, so the
@@ -727,7 +733,12 @@ void PlasmaZonesEffect::setupWindowConnections(KWin::EffectWindow* w)
                     const auto pending = pendingIt.value();
                     if (maximizeSizeLanded(safeW->frameGeometry(), pending.departureFrame)) {
                         m_shaderManager.m_pendingMaximizeMorph.remove(safeW.data());
-                        constexpr qint64 kPendingMaximizeMorphDeadlineMs = 1000;
+                        // The deadline SKIPS the morph for a stale entry; the
+                        // entry itself is consumed either way by the remove
+                        // above (only a size-landing geometry change reaches
+                        // this branch, so a never-landing entry lives until
+                        // the windowDeleted cleanup — bounded, and cheaper
+                        // than a timer per entry).
                         const bool stale =
                             ShaderInternal::shaderClockNowMs() - pending.armedAtMs > kPendingMaximizeMorphDeadlineMs;
                         // Same interactive guard as the arming site: a drag
@@ -738,9 +749,12 @@ void PlasmaZonesEffect::setupWindowConnections(KWin::EffectWindow* w)
                         }
                     }
                 }
-                // Body 1 — suppression release
+                // Body 1 — suppression release. Integer-aligned compare:
+                // fractional-scale outputs leave sub-pixel residue in
+                // frameGeometry(), and a bit-exact inequality released the
+                // suppression on jitter that moved nothing.
                 if (auto it = m_restoreSuppress.find(safeW.data()); it != m_restoreSuppress.end()
-                    && it->targetGeometry.isValid() && safeW->frameGeometry() != it->spawnGeometry) {
+                    && it->targetGeometry.isValid() && safeW->frameGeometry().toRect() != it->spawnGeometry.toRect()) {
                     endRestoreSuppression(safeW.data());
                 }
                 // Body 2 — debounced daemon shadow. Per tick this stashes the

--- a/kwin-effect/plasmazoneseffect/window_connections.cpp
+++ b/kwin-effect/plasmazoneseffect/window_connections.cpp
@@ -236,9 +236,21 @@ void PlasmaZonesEffect::setupWindowConnections(KWin::EffectWindow* w)
         // marshalling the ~20-entry a{sv} each frame. The daemon preserves the
         // existing extended fields when none are sent.
         auto pushCaptionOnly = [this, safeW]() {
-            if (safeW && !safeW->isDeleted()) {
-                pushWindowMetadata(safeW, /*includeExtended=*/false);
+            if (!safeW || safeW->isDeleted()) {
+                return;
             }
+            // Skip content-identical pushes: KWin can emit captionChanged
+            // without a net caption change, and the marshal (plus the
+            // daemon-side upsert) should not ride those. captionNormal
+            // derives from the caption, so an unchanged caption implies an
+            // unchanged push.
+            const QString caption = safeW->caption();
+            QString& last = m_lastPushedCaption[safeW.data()];
+            if (last == caption) {
+                return;
+            }
+            last = caption;
+            pushWindowMetadata(safeW, /*includeExtended=*/false);
         };
         // Class / desktop-file mutations invalidate the animation rule
         // evaluator's per-window match cache. The cache is keyed on the
@@ -603,6 +615,12 @@ void PlasmaZonesEffect::setupWindowConnections(KWin::EffectWindow* w)
     // the timer-driven teardown of the first racing the install of the
     // second. Track the last fully-maximized state per window and only
     // fire on actual edge transitions.
+    // Seed from the LIVE maximize mode: a window already fully maximized when
+    // the effect (re)loads has no entry, so its first RESTORE compared
+    // false==false, read as a no-edge, and played no morph.
+    if (KWin::Window* kwSeed = w->window()) {
+        m_shaderManager.m_lastFullyMaximized.insert(w, kwSeed->maximizeMode() == KWin::MaximizeFull);
+    }
     connect(w, &KWin::EffectWindow::windowMaximizedStateChanged, this,
             [this](KWin::EffectWindow* window, bool horizontal, bool vertical) {
                 if (!window) {
@@ -763,14 +781,18 @@ void PlasmaZonesEffect::setupWindowConnections(KWin::EffectWindow* w)
                 }
             });
 
-    // Refresh the daemon's registry metadata on every minimize edge, and
-    // BEFORE the handler connections below so the push is enqueued on the bus
-    // ahead of any float traffic from the same edge. The daemon's mode-swap
-    // seed/restore decisions consult WindowMetadata::isMinimized, which can
-    // otherwise remain at its previous snapshot until an unrelated refresh. A stale value lets a
-    // mode-swap seed tile a window that is minimized right now (the per-slot
-    // floating check cannot cover this: it resolves via the screen's CURRENT
-    // mode, which flips mid-toggle).
+    // Refresh the daemon's registry metadata on every minimize edge, connected
+    // BEFORE the handler connections below. For SNAP the ordering matters on
+    // the bus: the handler's float commit rides the same edge, and the push
+    // must land first so the daemon's suspension classification reads fresh
+    // minimize state. The AUTOTILE handler's float commit is debounced
+    // (kMinimizeFloatDebounceMs), so for it the ordering guarantee comes from
+    // that delay, not from connection order. The daemon's mode-swap
+    // seed/restore decisions consult WindowMetadata::isMinimized, which would
+    // otherwise remain at its previous snapshot until an unrelated refresh —
+    // a stale value lets a mode-swap seed tile a window that is minimized
+    // right now (the per-slot floating check cannot cover this: it resolves
+    // via the screen's CURRENT mode, which flips mid-toggle).
     // Liveness-guarded but deliberately NOT gated on shouldHandleWindow /
     // isTileableWindow: the open-time push in slotWindowAdded registers EVERY
     // window, and the daemon's rule predicates (IsMinimized) evaluate against

--- a/kwin-effect/plasmazoneseffect/window_connections.cpp
+++ b/kwin-effect/plasmazoneseffect/window_connections.cpp
@@ -763,6 +763,18 @@ void PlasmaZonesEffect::setupWindowConnections(KWin::EffectWindow* w)
                 }
             });
 
+    // Refresh the daemon's registry metadata on every minimize edge, and
+    // BEFORE the handler connections below so the push is enqueued on the bus
+    // ahead of any float traffic from the same edge. The daemon's mode-swap
+    // seed/restore decisions consult WindowMetadata::isMinimized, which is
+    // otherwise only snapshotted at window-open — a stale value lets a
+    // mode-swap seed tile a window that is minimized right now (the per-slot
+    // floating check cannot cover this: it resolves via the screen's CURRENT
+    // mode, which flips mid-toggle).
+    connect(w, &KWin::EffectWindow::minimizedChanged, this, [this, w]() {
+        pushWindowMetadata(w);
+    });
+
     // Autotile: track minimize/unminimize to remove/re-add windows from tiling
     connect(w, &KWin::EffectWindow::minimizedChanged, m_autotileHandler.get(),
             &AutotileHandler::slotWindowMinimizedChanged);

--- a/kwin-effect/plasmazoneseffect/window_connections.cpp
+++ b/kwin-effect/plasmazoneseffect/window_connections.cpp
@@ -269,7 +269,17 @@ void PlasmaZonesEffect::setupWindowConnections(KWin::EffectWindow* w)
         // desktops / activities / role changes don't feed the
         // WindowClass matcher so they don't need the cache drop.
         auto invalidateRuleCache = [this, safeW]() {
-            m_shaderManager.animationRuleEvaluator().clearCache();
+            // Gate each clear on its own rule set, mirroring the sibling
+            // invalidation in slotWindowActivated: the no-rules case pays
+            // nothing on a class swap.
+            if (!m_shaderManager.animationRuleSet().isEmpty()) {
+                m_shaderManager.animationRuleEvaluator().clearCache();
+            }
+            // The exclusion verdict cache keys on the same frozen id and the
+            // WindowClass matcher — a class swap can flip an Exclude verdict.
+            if (!m_snappingExclusionRuleSet.isEmpty()) {
+                m_snappingExclusionEvaluator.clearCache();
+            }
             // The cache drop alone revives nothing: appearance slots (opacity,
             // tint, border colour) bake into the decoration at
             // updateWindowDecoration time, and the stacking layer is

--- a/kwin-effect/plasmazoneseffect/window_connections.cpp
+++ b/kwin-effect/plasmazoneseffect/window_connections.cpp
@@ -771,8 +771,21 @@ void PlasmaZonesEffect::setupWindowConnections(KWin::EffectWindow* w)
     // mode-swap seed tile a window that is minimized right now (the per-slot
     // floating check cannot cover this: it resolves via the screen's CURRENT
     // mode, which flips mid-toggle).
-    connect(w, &KWin::EffectWindow::minimizedChanged, this, [this, w]() {
-        pushWindowMetadata(w);
+    // Liveness-guarded but deliberately NOT gated on shouldHandleWindow /
+    // isTileableWindow: the open-time push in slotWindowAdded registers EVERY
+    // window, and the daemon's rule predicates (IsMinimized) evaluate against
+    // that registry metadata for every window too — a tileable-only gate here
+    // would leave non-tileable windows' minimize state permanently stale.
+    // Spurious minimize pairs cost only the marshal: the registry upsert
+    // de-dupes content-identical pushes.
+    connect(w, &KWin::EffectWindow::minimizedChanged, this, [this, safeW = QPointer<KWin::EffectWindow>(w)]() {
+        // The minimize edge can race close teardown (the EffectWindow
+        // outlives the client as a Deleted shell); pushing metadata for it
+        // would resurrect a registry record the close path just removed.
+        if (!safeW || safeW->isDeleted()) {
+            return;
+        }
+        pushWindowMetadata(safeW.data());
     });
 
     // Autotile: track minimize/unminimize to remove/re-add windows from tiling

--- a/kwin-effect/plasmazoneseffect/window_filtering.cpp
+++ b/kwin-effect/plasmazoneseffect/window_filtering.cpp
@@ -342,16 +342,38 @@ bool PlasmaZonesEffect::shouldHandleWindow(KWin::EffectWindow* w, QString* rejec
     // must filter for drag operations and lifecycle reporting).
     // `m_snappingExclusionRuleSet` mirrors the Exclude-shaped slice of the
     // unified Rule store, refreshed on every rulesChanged via
-    // loadRuleAnimationsFromDbus (see shader_config_dbus.cpp). The
-    // `!isEmpty()` fast path keeps a no-exclusions user at two pointer
-    // reads — same cost as the prior list-derived check.
-    if (!m_snappingExclusionRuleSet.isEmpty()) {
-        if (m_snappingExclusionEvaluator.resolve(ruleQuery(w)).isExcluded()) {
-            return rejectedBecause(rejectReason, "user exclusion rule match");
-        }
+    // loadRuleAnimationsFromDbus (see shader_config_dbus.cpp).
+    if (isExcludedBySnappingRule(w)) {
+        return rejectedBecause(rejectReason, "user exclusion rule match");
     }
 
     return true;
+}
+
+bool PlasmaZonesEffect::isExcludedBySnappingRule(KWin::EffectWindow* w) const
+{
+    // The `isEmpty()` fast path keeps a no-exclusions user at two pointer
+    // reads — same cost as the prior list-derived check.
+    if (m_snappingExclusionRuleSet.isEmpty()) {
+        return false;
+    }
+    // Per-window verdict cache, mirroring resolveRuleActions: the hot callers
+    // (buildWindowMap per batch, hasOtherWindowOfClassWithDifferentPid's
+    // stacking-order sweep per open) would otherwise pay a full ~30-accessor
+    // ruleQuery build per window per consult — O(N^2) query builds across a
+    // login burst. Freshness matches the animation verdicts: the cache is
+    // revision-keyed for rule edits and cleared by the same placement /
+    // class-swap invalidation paths (flushPendingRuleInvalidations,
+    // invalidateAllRuleCaches, the metadataChanged lambda).
+    const QString windowId = getWindowId(w);
+    if (windowId.isEmpty()) {
+        return m_snappingExclusionEvaluator.resolve(ruleQuery(w)).isExcluded();
+    }
+    if (std::optional<PhosphorRules::ResolvedActions> cached =
+            m_snappingExclusionEvaluator.resolveCachedIfPresent(windowId)) {
+        return cached->isExcluded();
+    }
+    return m_snappingExclusionEvaluator.resolveCached(windowId, ruleQuery(w)).isExcluded();
 }
 
 bool PlasmaZonesEffect::shouldAnimateWindow(KWin::EffectWindow* w,
@@ -559,12 +581,9 @@ bool PlasmaZonesEffect::shouldDecorateWindow(KWin::EffectWindow* w) const
     // shouldHandleWindow gates on, so a window the user excluded from
     // management is not decorated either (preserves prior behavior, since the
     // decoration path used to run through shouldHandleWindow). No dedicated
-    // decoration rule slice, so no new rule action. The `!isEmpty()` fast path
-    // keeps a no-exclusions user at two pointer reads.
-    if (!m_snappingExclusionRuleSet.isEmpty()) {
-        if (m_snappingExclusionEvaluator.resolve(ruleQuery(w)).isExcluded()) {
-            return false;
-        }
+    // decoration rule slice, so no new rule action.
+    if (isExcludedBySnappingRule(w)) {
+        return false;
     }
 
     // Transient-window filter — dialogs / popups / tooltips / dropdowns /

--- a/kwin-effect/plasmazoneseffect/window_filtering.cpp
+++ b/kwin-effect/plasmazoneseffect/window_filtering.cpp
@@ -354,7 +354,8 @@ bool PlasmaZonesEffect::shouldHandleWindow(KWin::EffectWindow* w, QString* rejec
     return true;
 }
 
-bool PlasmaZonesEffect::shouldAnimateWindow(KWin::EffectWindow* w) const
+bool PlasmaZonesEffect::shouldAnimateWindow(KWin::EffectWindow* w,
+                                            std::optional<PhosphorRules::WindowQuery>* sharedQuery) const
 {
     if (!w) {
         return false;
@@ -403,10 +404,13 @@ bool PlasmaZonesEffect::shouldAnimateWindow(KWin::EffectWindow* w) const
     // two pointer reads (query never built).
     std::optional<PhosphorRules::WindowQuery> cachedQuery;
     auto query = [&]() -> const PhosphorRules::WindowQuery& {
-        if (!cachedQuery) {
-            cachedQuery = ruleQuery(w);
+        // Prefer the caller's memoisation slot (see the header doc) so the
+        // build survives this call for the caller's own resolver pass.
+        std::optional<PhosphorRules::WindowQuery>& slot = sharedQuery ? *sharedQuery : cachedQuery;
+        if (!slot) {
+            slot = ruleQuery(w);
         }
-        return *cachedQuery;
+        return *slot;
     };
 
     // Structural type exclusions (notification / OSD and the transient /

--- a/kwin-effect/plasmazoneseffect/window_identity.cpp
+++ b/kwin-effect/plasmazoneseffect/window_identity.cpp
@@ -159,6 +159,12 @@ void PlasmaZonesEffect::pushWindowMetadata(KWin::EffectWindow* w, bool includeEx
         // on exactly the chatty-title path. A single cheap direct read, no
         // query walk; the daemon treats a CaptionNormal-only map as a caption
         // refresh (carry-forward plus this field), not a snapshot replace.
+        // Known limitation: a captionNormal that transitions TO empty cannot
+        // be cleared through this route — inserting an empty value would make
+        // the map empty-or-caption-only ambiguous with "carry everything
+        // forward" on the daemon side, so the stale value persists until the
+        // next full snapshot. Full pushes re-derive it, so the staleness is
+        // bounded by the next includeExtended=true push.
         const QString captionNormal = window->captionNormal();
         if (!captionNormal.isEmpty()) {
             extended.insert(PhosphorProtocol::Service::WindowMetadataKey::CaptionNormal, captionNormal);

--- a/kwin-effect/plasmazoneseffect/window_identity.cpp
+++ b/kwin-effect/plasmazoneseffect/window_identity.cpp
@@ -152,6 +152,18 @@ void PlasmaZonesEffect::pushWindowMetadata(KWin::EffectWindow* w, bool includeEx
     // map stays empty and the daemon preserves the existing extended snapshot,
     // avoiding a per-frame query build + a{sv} marshal for chatty-title windows.
     QVariantMap extended;
+    if (!includeExtended && window) {
+        // captionNormal derives from the caption itself, so a caption tick
+        // changes it too — without this the daemon's CaptionNormal predicate
+        // matches a value frozen at the last full snapshot, permanently stale
+        // on exactly the chatty-title path. A single cheap direct read, no
+        // query walk; the daemon treats a CaptionNormal-only map as a caption
+        // refresh (carry-forward plus this field), not a snapshot replace.
+        const QString captionNormal = window->captionNormal();
+        if (!captionNormal.isEmpty()) {
+            extended.insert(PhosphorProtocol::Service::WindowMetadataKey::CaptionNormal, captionNormal);
+        }
+    }
     if (includeExtended) {
         PhosphorRules::WindowQuery props = ruleQueryFor(w, QString(), false, false, false, QString());
         // Report the window's OWN (pre-rule) keepAbove/keepBelow — the daemon

--- a/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
+++ b/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
@@ -68,6 +68,67 @@ void PlasmaZonesEffect::endRestoreSuppression(KWin::EffectWindow* window)
     }
 }
 
+bool PlasmaZonesEffect::tryInstantSnapRestore(KWin::EffectWindow* w, const QString& windowId, bool canSnapRestore)
+{
+    if (!canSnapRestore || !w || w->isDeleted() || m_snapHandler->restoreCacheEmpty()) {
+        return false;
+    }
+    const QString appId = ::PhosphorIdentity::WindowId::extractAppId(windowId);
+    // Single-shot semantics: takeRestore erases the entry on lookup, so any
+    // entry seen here is consumed regardless of which branch below runs (the
+    // entry has been considered for routing whether or not it was applied,
+    // so the next open of the same appId won't re-evaluate a dead entry).
+    // Shared by slotWindowAdded and the deferred-routing dispatch
+    // (completeDeferredWindowRoutes) — before the deferred path consumed the
+    // cache too, a deferred window left its entry alive for a later same-app
+    // sibling to claim.
+    const std::optional<CachedSnapRestore> cached = m_snapHandler->takeRestore(appId);
+    if (!cached) {
+        return false;
+    }
+    const bool savedScreenNowAutotile =
+        !cached->screenId.isEmpty() && m_autotileHandler->isAutotileScreen(cached->screenId);
+    if (cached->geometry.isValid() && !savedScreenNowAutotile) {
+        qCInfo(lcEffect) << "Instant snap restore for" << appId << "to:" << cached->geometry
+                         << "screen:" << cached->screenId;
+        // skipAnimation=true: teleport straight into the zone.
+        // First-frame open suppression (beginRestoreSuppression in
+        // slotWindowAdded) withholds the window from
+        // compositing until KWin's async moveResize commits, so
+        // by the time paintWindow runs the live frameGeometry()
+        // already reports the resolved zone — the surface-extent
+        // open shader (bounce, fly-in) plays into the zone from
+        // the first painted frame without any anchor pinning.
+        applyWindowGeometry(w, cached->geometry, false, /*skipAnimation=*/true);
+        return true;
+    }
+    if (savedScreenNowAutotile) {
+        qCDebug(lcEffect) << "Skipping instant snap restore for" << appId
+                          << "- saved screen now autotile:" << cached->screenId;
+    } else {
+        // Cached geometry is invalid (corrupt / zero-size persisted
+        // rect on a snap-mode screen).
+        qCDebug(lcEffect) << "Discarding instant snap restore entry for" << appId
+                          << "- geometry invalid:" << cached->geometry << "screen:" << cached->screenId;
+    }
+    return false;
+}
+
+void PlasmaZonesEffect::refreshRestoreSuppressionDeadline(KWin::EffectWindow* window)
+{
+    // Deadline-only re-arm for an ALREADY-suppressed window; never suppresses
+    // a visible one (that would read as a flash to invisible). Used by the
+    // deferred-routing dispatch: the defer-time suppression is armed with the
+    // standard deadline, but the screen query it waits on can outlast it, and
+    // an expired deadline returns the window to compositing at its centred
+    // spawn placement mid-route. spawnGeometry is left untouched so the
+    // settle detection keeps its original reference.
+    const auto it = m_restoreSuppress.find(window);
+    if (it != m_restoreSuppress.end()) {
+        it->deadlineMs = ShaderInternal::shaderClockNowMs() + kRestoreSuppressDeadlineMs;
+    }
+}
+
 void PlasmaZonesEffect::slotWindowAdded(KWin::EffectWindow* w)
 {
     // Full property + filter-verdict dump for every window as it opens. Silent
@@ -151,6 +212,13 @@ void PlasmaZonesEffect::slotWindowAdded(KWin::EffectWindow* w)
 
     if (tileableWindow && m_autotileHandler->isScreenQueryPending()) {
         if (tileableAppWindow) {
+            // DELIBERATELY broader than the post-query gate below
+            // (canSnapRestore || onAutotileScreen): the screen's mode is
+            // exactly what the pending query will tell us, so it cannot
+            // discriminate here. The dispatch releases non-repositioned
+            // windows promptly and re-arms the deadline for the rest
+            // (refreshRestoreSuppressionDeadline), so the over-suppression
+            // costs at most the query latency.
             beginRestoreSuppression(w);
         }
         m_autotileHandler->deferWindowRouting(w, canSnapRestore);
@@ -192,41 +260,11 @@ void PlasmaZonesEffect::slotWindowAdded(KWin::EffectWindow* w)
     // Rare race: the saved screen may have flipped from snap→autotile between
     // when the cache was populated and when the window opens. Re-check the
     // entry's screen mode via the autotile handler before applying.
-    if (canSnapRestore && !m_snapHandler->restoreCacheEmpty()) {
-        const QString appId = ::PhosphorIdentity::WindowId::extractAppId(windowId);
-        // Single-shot semantics: takeRestore erases the entry on lookup, so any
-        // entry seen here is consumed regardless of which branch below runs (the
-        // entry has been considered for routing whether or not it was applied,
-        // so the next open of the same appId won't re-evaluate a dead entry).
-        if (const std::optional<CachedSnapRestore> cached = m_snapHandler->takeRestore(appId)) {
-            const bool savedScreenNowAutotile =
-                !cached->screenId.isEmpty() && m_autotileHandler->isAutotileScreen(cached->screenId);
-            if (cached->geometry.isValid() && !savedScreenNowAutotile) {
-                qCInfo(lcEffect) << "Instant snap restore for" << appId << "to:" << cached->geometry
-                                 << "screen:" << cached->screenId;
-                // skipAnimation=true: teleport straight into the zone.
-                // First-frame open suppression (beginRestoreSuppression
-                // above in slotWindowAdded) withholds the window from
-                // compositing until KWin's async moveResize commits, so
-                // by the time paintWindow runs the live frameGeometry()
-                // already reports the resolved zone — the surface-extent
-                // open shader (bounce, fly-in) plays into the zone from
-                // the first painted frame without any anchor pinning.
-                applyWindowGeometry(w, cached->geometry, false, /*skipAnimation=*/true);
-                // Re-evaluate screen after teleport — cross-VS/cross-monitor
-                // moveResize updates KWin's output assignment, so the window
-                // may no longer be on an autotile screen.
-                onAutotileScreen = m_autotileHandler->isAutotileScreen(getWindowScreenId(w));
-            } else if (savedScreenNowAutotile) {
-                qCDebug(lcEffect) << "Skipping instant snap restore for" << appId
-                                  << "- saved screen now autotile:" << cached->screenId;
-            } else {
-                // Cached geometry is invalid (corrupt / zero-size persisted
-                // rect on a snap-mode screen).
-                qCDebug(lcEffect) << "Discarding instant snap restore entry for" << appId
-                                  << "- geometry invalid:" << cached->geometry << "screen:" << cached->screenId;
-            }
-        }
+    if (tryInstantSnapRestore(w, windowId, canSnapRestore)) {
+        // Re-evaluate screen after teleport — cross-VS/cross-monitor
+        // moveResize updates KWin's output assignment, so the window
+        // may no longer be on an autotile screen.
+        onAutotileScreen = m_autotileHandler->isAutotileScreen(getWindowScreenId(w));
     }
 
     if (onAutotileScreen && canSnapRestore) {
@@ -247,13 +285,16 @@ void PlasmaZonesEffect::slotWindowAdded(KWin::EffectWindow* w)
         // rather than waiting for the 250ms deadline.
         m_snapHandler->callResolveWindowRestore(
             w,
-            [this, safeW]() {
+            [this, safeW](bool snapApplied) {
                 if (!safeW || safeW->isDeleted()) {
                     return;
                 }
                 // Snap restore either moved the window to a snap screen (no-op for
                 // autotile) or didn't apply (window genuinely belongs on autotile).
-                if (!m_autotileHandler->notifyWindowAdded(safeW, /*knownFreeFloating=*/true)) {
+                // knownFreeFloating only when it did NOT apply: a zone-placed
+                // window's live frame is the zone rect, and reporting it as a
+                // known free frame would persist the zone rect as float-back.
+                if (!m_autotileHandler->notifyWindowAdded(safeW, /*knownFreeFloating=*/!snapApplied)) {
                     endRestoreSuppression(safeW.data());
                 }
             },

--- a/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
+++ b/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
@@ -85,7 +85,8 @@ void PlasmaZonesEffect::slotWindowAdded(KWin::EffectWindow* w)
     // shader — that gates on the animation filter (see the window.open block),
     // so the user's "exclude transient windows" animation setting stays
     // authoritative for which windows animate on open.
-    const bool tileableAppWindow = shouldHandleWindow(w) && isTileableWindow(w) && !w->isMinimized();
+    const bool tileableWindow = shouldHandleWindow(w) && isTileableWindow(w);
+    const bool tileableAppWindow = tileableWindow && !w->isMinimized();
 
     // Whether this window is a snap-restore candidate — it may be
     // teleported into a saved zone moments after opening (instantly from
@@ -147,6 +148,14 @@ void PlasmaZonesEffect::slotWindowAdded(KWin::EffectWindow* w)
     // re-reconcile when the async float/zone syncs land, via the
     // placement-state flush.
     reconcileRuleWindowLayer(windowId, w);
+
+    if (tileableWindow && m_autotileHandler->isScreenQueryPending()) {
+        if (tileableAppWindow) {
+            beginRestoreSuppression(w);
+        }
+        m_autotileHandler->deferWindowRouting(w, canSnapRestore);
+        return;
+    }
 
     bool onAutotileScreen = m_autotileHandler->isAutotileScreen(getWindowScreenId(w));
 

--- a/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
+++ b/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
@@ -123,6 +123,10 @@ void PlasmaZonesEffect::refreshRestoreSuppressionDeadline(KWin::EffectWindow* wi
     // an expired deadline returns the window to compositing at its centred
     // spawn placement mid-route. spawnGeometry is left untouched so the
     // settle detection keeps its original reference.
+    if (!window) {
+        // Null-guard symmetry with begin/endRestoreSuppression.
+        return;
+    }
     const auto it = m_restoreSuppress.find(window);
     if (it != m_restoreSuppress.end()) {
         it->deadlineMs = ShaderInternal::shaderClockNowMs() + kRestoreSuppressDeadlineMs;
@@ -436,8 +440,9 @@ void PlasmaZonesEffect::slotWindowClosed(KWin::EffectWindow* w)
     // class), yielding a different or empty id — every lookup misses, the
     // fold never binds uSurfaceLayer, and the decoration vanishes at close
     // frame 1 even though its entries were deliberately preserved. Keep the
-    // frozen mapping for the animation's lifetime; endShaderTransition and
-    // the windowDeleted backstop both re-scrub on teardown.
+    // frozen mapping for the animation's lifetime; the windowDeleted backstop
+    // (lifecycle_wiring.cpp) is the re-scrub — windowDeleted always follows a
+    // close-grabbed window, so the mapping cannot outlive the animation.
     if (!m_shaderManager.hasTransition(w)) {
         m_idCaches.windowIdCache.remove(w);
         m_idCaches.windowIdReverse.remove(closedWindowId);

--- a/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
+++ b/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
@@ -244,7 +244,7 @@ void PlasmaZonesEffect::slotWindowAdded(KWin::EffectWindow* w)
                 }
                 // Snap restore either moved the window to a snap screen (no-op for
                 // autotile) or didn't apply (window genuinely belongs on autotile).
-                if (!m_autotileHandler->notifyWindowAdded(safeW)) {
+                if (!m_autotileHandler->notifyWindowAdded(safeW, /*knownFreeFloating=*/true)) {
                     endRestoreSuppression(safeW.data());
                 }
             },
@@ -257,7 +257,7 @@ void PlasmaZonesEffect::slotWindowAdded(KWin::EffectWindow* w)
     // filter, already-notified, etc.), and snap-restore won't run either
     // (the !onAutotileScreen guard below), nothing will move the window —
     // release suppression so it doesn't wait out the deadline.
-    const bool autotileTookOver = m_autotileHandler->notifyWindowAdded(w);
+    const bool autotileTookOver = m_autotileHandler->notifyWindowAdded(w, /*knownFreeFloating=*/true);
     if (!autotileTookOver && onAutotileScreen) {
         endRestoreSuppression(w);
     }
@@ -340,10 +340,7 @@ void PlasmaZonesEffect::slotWindowClosed(KWin::EffectWindow* w)
     m_dragActivation.floatedWindowIds.remove(closedWindowId);
 
     // Notify autotile handler for cleanup (tracking sets + autotile D-Bus).
-    // Genuine destruction also drops any desktop-move geometry stash —
-    // onWindowClosed itself must not (the desktop-move path creates the
-    // stash immediately before calling it).
-    m_autotileHandler->onWindowClosed(closedWindowId, closedScreenId, /*windowDestroyed=*/true);
+    m_autotileHandler->onWindowClosed(closedWindowId, closedScreenId);
     m_autotileHandler->clearDesktopMoveStash(closedWindowId);
 
     // Mirror that cleanup for snapping's own border set. Pure bookkeeping —

--- a/kwin-effect/transitions/shadertransitionmanager.h
+++ b/kwin-effect/transitions/shadertransitionmanager.h
@@ -414,7 +414,7 @@ private:
     // Installing the morph then would tween between two same-size rects
     // while the real resize lands as a raw snap mid-animation. Instead the
     // state edge arms this entry and the size-delivering
-    // windowFrameGeometryChanged completes the install (window_lifecycle.cpp),
+    // windowFrameGeometryChanged completes the install (window_connections.cpp),
     // so the animation starts exactly when the window visibly changes size.
     // Erased on completion, on windowDeleted, and on a stale-deadline check
     // at consumption time.

--- a/libs/phosphor-context-resolver/README.md
+++ b/libs/phosphor-context-resolver/README.md
@@ -8,10 +8,8 @@
 > daemon's navigation/start/osd paths and the three D-Bus adaptors
 > (SnapAdaptor, WindowDragAdaptor, WindowTrackingAdaptor) with one
 > resolver call. The KWin effect does not consume this library
-> (effect-side state has no disable/lock cascade). OverlayService is the
-> remaining unmigrated consumer in the daemon, still on the legacy
-> inline `isContextDisabled(...)` cascade. See the `src/daemon/daemon.h`
-> `contextResolver()` docstring.
+> (effect-side state has no disable/lock cascade). Every daemon
+> consumer, OverlayService included, now goes through the resolver.
 
 ## Responsibility
 

--- a/libs/phosphor-context-resolver/include/PhosphorContext/IContextResolver.h
+++ b/libs/phosphor-context-resolver/include/PhosphorContext/IContextResolver.h
@@ -133,7 +133,7 @@ public:
     /**
      * @brief Build a handle for a PERSISTED context (not "right now").
      *
-     * Specialised for `(WindowTrackingService::isPersistedContextDisabled)`-style
+     * Specialised for `(WindowTrackingAdaptor::isPersistedContextDisabled)`-style
      * checks where the desktop/activity come from a persisted entry on
      * disk, not the live workspace state. The screen's mode is still
      * resolved through the mode provider — the disable-list mode axis

--- a/libs/phosphor-context-resolver/include/PhosphorContext/IContextResolver.h
+++ b/libs/phosphor-context-resolver/include/PhosphorContext/IContextResolver.h
@@ -38,9 +38,8 @@ namespace PhosphorContext {
  * the lock key composition was tweaked. The cascade shape was
  * duplicated; the snapshot point was inconsistent (handlers could
  * read desktop N at line 5 and act on desktop N+1 at line 12 if the
- * user virtual-desktop-switched mid-handler). OverlayService is the
- * remaining consumer still on the legacy inline cascade — see
- * `src/daemon/daemon.h::contextResolver()` for the migration status.
+ * user virtual-desktop-switched mid-handler). Every daemon consumer,
+ * OverlayService included, now goes through the resolver.
  * The KWin effect does not have a cascade to migrate; effect-side
  * paint state has no disable/lock gate.
  *

--- a/libs/phosphor-engine/include/PhosphorEngine/IPlacementEngine.h
+++ b/libs/phosphor-engine/include/PhosphorEngine/IPlacementEngine.h
@@ -413,7 +413,6 @@ public:
                            ///< receiver places the window in the target desktop's
                            ///< state/layout, not the currently-visible one.
         QPoint dropPos; ///< cursor position at drop, or invalid for non-drag handoffs
-        QRect sourceGeometry; ///< window's frame at handoff time (for size preservation)
         QStringList sourceZoneIds; ///< zones the window held at source (empty if not snapped)
         bool wasFloating = false; ///< window was floating in source engine
         int insertIndex = -1; ///< autotile target: raw window-order index (position
@@ -431,7 +430,8 @@ public:
     /// - Decide placement (snap to zone / tile / float) using the context
     ///   and engine-local policy. Drag drops typically place at dropPos;
     ///   non-drag handoffs (cross-engine focus changes, programmatic moves)
-    ///   typically respect wasFloating + sourceGeometry.
+    ///   typically respect wasFloating (the window keeps its live frame, so
+    ///   no geometry is carried in the context).
     /// - Emit any `windowFloatingChanged` / placement signals their normal
     ///   placement paths emit, so downstream state stays consistent.
     ///

--- a/libs/phosphor-engine/include/PhosphorEngine/IPlacementEngine.h
+++ b/libs/phosphor-engine/include/PhosphorEngine/IPlacementEngine.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <phosphorengine_export.h>
+
 #include <PhosphorEngine/IPlacementState.h>
 #include <PhosphorEngine/NavigationContext.h>
 #include <PhosphorEngine/WindowPlacement.h>

--- a/libs/phosphor-engine/include/PhosphorEngine/IWindowRegistry.h
+++ b/libs/phosphor-engine/include/PhosphorEngine/IWindowRegistry.h
@@ -16,9 +16,6 @@ public:
     virtual QString canonicalizeWindowId(const QString& rawWindowId) = 0;
     virtual QString canonicalizeForLookup(const QString& rawWindowId) const = 0;
     virtual QString appIdFor(const QString& instanceId) const = 0;
-    /// Live compositor minimize state. Accepts either a bare instance id or a
-    /// composite appId|instanceId window id.
-    virtual bool isMinimized(const QString& windowId) const = 0;
 };
 
 } // namespace PhosphorEngine

--- a/libs/phosphor-engine/include/PhosphorEngine/IWindowRegistry.h
+++ b/libs/phosphor-engine/include/PhosphorEngine/IWindowRegistry.h
@@ -24,11 +24,16 @@ public:
      *
      * Engaged true/false when the compositor has reported the window's
      * minimize state; std::nullopt when it is UNKNOWN (no record for the
-     * window, or the metadata push never carried the field). Consumers that
-     * gate destructive or layout-affecting behaviour on "not minimized" must
-     * treat nullopt conservatively rather than as false — collapsing unknown
-     * into "not minimized" is the fail-open that seeds hidden windows into
-     * tiling layouts and persists minimize-suspension floats.
+     * window, or the metadata push never carried the field). SEEDING and
+     * TILING consumers — anything that would place, move, or count a window
+     * in a layout — must treat nullopt conservatively rather than as false:
+     * collapsing unknown into "not minimized" is the fail-open that seeds
+     * hidden windows into tiling layouts and persists minimize-suspension
+     * floats. CAPTURE-side consumers may deliberately require engaged-true
+     * (`.value_or(false)`) when their traffic is causally ordered after the
+     * minimize edge's metadata push (recordFreeGeometry / recordFloatingClose
+     * document this per site) — refusing a capture on unknown would lose
+     * genuine free positions, the opposite failure.
      *
      * Default implementation reports unknown so registry-less engines and
      * test fakes stay honest instead of claiming visibility.

--- a/libs/phosphor-engine/include/PhosphorEngine/IWindowRegistry.h
+++ b/libs/phosphor-engine/include/PhosphorEngine/IWindowRegistry.h
@@ -6,6 +6,8 @@
 #include <phosphorengine_export.h>
 #include <QString>
 
+#include <optional>
+
 namespace PhosphorEngine {
 
 class PHOSPHORENGINE_EXPORT IWindowRegistry
@@ -16,6 +18,26 @@ public:
     virtual QString canonicalizeWindowId(const QString& rawWindowId) = 0;
     virtual QString canonicalizeForLookup(const QString& rawWindowId) const = 0;
     virtual QString appIdFor(const QString& instanceId) const = 0;
+
+    /**
+     * @brief Tri-state compositor minimize state for @p windowId.
+     *
+     * Engaged true/false when the compositor has reported the window's
+     * minimize state; std::nullopt when it is UNKNOWN (no record for the
+     * window, or the metadata push never carried the field). Consumers that
+     * gate destructive or layout-affecting behaviour on "not minimized" must
+     * treat nullopt conservatively rather than as false — collapsing unknown
+     * into "not minimized" is the fail-open that seeds hidden windows into
+     * tiling layouts and persists minimize-suspension floats.
+     *
+     * Default implementation reports unknown so registry-less engines and
+     * test fakes stay honest instead of claiming visibility.
+     */
+    virtual std::optional<bool> minimizedState(const QString& windowId) const
+    {
+        Q_UNUSED(windowId)
+        return std::nullopt;
+    }
 };
 
 } // namespace PhosphorEngine

--- a/libs/phosphor-engine/include/PhosphorEngine/IWindowRegistry.h
+++ b/libs/phosphor-engine/include/PhosphorEngine/IWindowRegistry.h
@@ -16,6 +16,9 @@ public:
     virtual QString canonicalizeWindowId(const QString& rawWindowId) = 0;
     virtual QString canonicalizeForLookup(const QString& rawWindowId) const = 0;
     virtual QString appIdFor(const QString& instanceId) const = 0;
+    /// Live compositor minimize state. Accepts either a bare instance id or a
+    /// composite appId|instanceId window id.
+    virtual bool isMinimized(const QString& windowId) const = 0;
 };
 
 } // namespace PhosphorEngine

--- a/libs/phosphor-engine/include/PhosphorEngine/IWindowTrackingService.h
+++ b/libs/phosphor-engine/include/PhosphorEngine/IWindowTrackingService.h
@@ -162,6 +162,15 @@ public:
     /// leaving its engine slots intact. For the drag-out / layout-change consume
     /// paths that restore the float-back once and must not re-apply it.
     virtual void clearFreeGeometry(const QString& windowId) = 0;
+    /// Screen-scoped consume-once variant: clears only @p screenId's
+    /// remembered float-back, preserving other monitors' entries. Default
+    /// falls back to the all-screens form for implementations without
+    /// per-screen granularity.
+    virtual void clearFreeGeometry(const QString& windowId, const QString& screenId)
+    {
+        Q_UNUSED(screenId)
+        clearFreeGeometry(windowId);
+    }
     virtual QRect zoneGeometry(const QString& zoneId, const QString& screenId = QString()) const = 0;
     virtual QRect resolveZoneGeometry(const QStringList& zoneIds, const QString& screenId) const = 0;
     virtual QString resolveEffectiveScreenId(const QString& screenId) const = 0;

--- a/libs/phosphor-engine/include/PhosphorEngine/IWindowTrackingService.h
+++ b/libs/phosphor-engine/include/PhosphorEngine/IWindowTrackingService.h
@@ -89,6 +89,16 @@ public:
     // ═══════════════════════════════════════════════════════════════════════════
 
     virtual bool isWindowFloating(const QString& windowId) const = 0;
+    /// Whether the window's float is a MINIMIZE SUSPENSION rather than
+    /// placement intent. Outlives the live minimize bit through the
+    /// unminimize animation grace so capture paths can keep preserving the
+    /// pre-minimize record. Default false for implementations that do not
+    /// track the classification.
+    virtual bool isSuspensionFloat(const QString& windowId) const
+    {
+        Q_UNUSED(windowId)
+        return false;
+    }
     virtual void setWindowFloating(const QString& windowId, bool floating) = 0;
     virtual void unsnapForFloat(const QString& windowId) = 0;
     virtual bool clearFloatingForSnap(const QString& windowId) = 0;

--- a/libs/phosphor-engine/include/PhosphorEngine/WindowPlacement.h
+++ b/libs/phosphor-engine/include/PhosphorEngine/WindowPlacement.h
@@ -138,8 +138,9 @@ struct WindowPlacement
     /// window to `floating`, so this geometry-less floated residue is exactly the
     /// case that must be rejected: it must NOT be persisted, and the snap restore's
     /// accept predicate must never CONSUME it from the per-app FIFO. At MaxPerApp
-    /// entries per app, such residue would otherwise starve and even evict
-    /// (removeFirst) the window's real placement, silently breaking geometry restore.
+    /// entries per app, such residue would otherwise starve and even evict the
+    /// window's real placement (evictForCapacity prefers a contentless victim
+    /// but falls back to the FIFO head), silently breaking geometry restore.
     bool hasRestorableContent() const
     {
         if (anyFreeGeometry().isValid()) {

--- a/libs/phosphor-engine/include/PhosphorEngine/WindowPlacement.h
+++ b/libs/phosphor-engine/include/PhosphorEngine/WindowPlacement.h
@@ -102,18 +102,29 @@ struct WindowPlacement
         return freeGeometryByScreen.value(screenId);
     }
 
-    /// Any captured free/float geometry (the first valid rect in unspecified hash
-    /// order — there is no per-screen recency to pick a "newest"), used as a
-    /// cross-screen fallback when the exact screen has none. Returns an invalid
-    /// rect when the window has no free geometry on record at all.
-    QRect anyFreeGeometry() const
+    /// The screenId of the deterministic cross-screen fallback pick: the
+    /// lexicographically-smallest screenId holding a valid rect. There is no
+    /// per-screen recency to pick a "newest", and QHash iteration order is
+    /// unspecified — without a total order the fallback float-back screen
+    /// would differ run to run. Empty when no screen has a valid rect.
+    QString anyFreeGeometryScreenId() const
     {
+        QString best;
         for (auto it = freeGeometryByScreen.constBegin(); it != freeGeometryByScreen.constEnd(); ++it) {
-            if (it.value().isValid()) {
-                return it.value();
+            if (it.value().isValid() && (best.isEmpty() || it.key() < best)) {
+                best = it.key();
             }
         }
-        return QRect();
+        return best;
+    }
+
+    /// Any captured free/float geometry (the deterministic pick of
+    /// anyFreeGeometryScreenId()), used as a cross-screen fallback when the
+    /// exact screen has none. Returns an invalid rect when the window has no
+    /// free geometry on record at all.
+    QRect anyFreeGeometry() const
+    {
+        return freeGeometryByScreen.value(anyFreeGeometryScreenId());
     }
 
     /// Whether this record carries anything worth restoring. True when the window

--- a/libs/phosphor-engine/include/PhosphorEngine/WindowPlacementStore.h
+++ b/libs/phosphor-engine/include/PhosphorEngine/WindowPlacementStore.h
@@ -109,9 +109,12 @@ public:
     bool clear(const QString& windowId);
 
     /// Clear ONLY the shared free/float geometry for the same live instance, leaving the
-    /// engine slots and context intact. Returns true if anything was cleared. Used by
-    /// the drag-out / layout-change paths that consume the float-back once.
+    /// engine slots and context intact. Returns true if anything was cleared. The
+    /// all-screens form is for wholesale invalidation (virtual-screen remap); the
+    /// screen-scoped overload is for consume-once paths (drag-out, drop-snap), which
+    /// must not destroy the float-back remembered for other monitors.
     bool clearFreeGeometry(const QString& windowId);
+    bool clearFreeGeometry(const QString& windowId, const QString& screenId);
 
     /// Apply an in-place mutation to every record; @p fn returns true when it changed
     /// the record. Returns the number changed. For bulk rewrites that keep the appId
@@ -134,6 +137,10 @@ public:
     int size() const;
 
 private:
+    /// Capacity eviction preferring contentless residue over restorable
+    /// placements — see the implementation comment.
+    static void evictForCapacity(QList<WindowPlacement>& bucket);
+
     /// appId → FIFO list of records (preserves multi-instance + close/reopen order).
     QHash<QString, QList<WindowPlacement>> m_byApp;
     quint64 m_sequence = 0;

--- a/libs/phosphor-engine/include/PhosphorEngine/WindowPlacementStore.h
+++ b/libs/phosphor-engine/include/PhosphorEngine/WindowPlacementStore.h
@@ -141,11 +141,14 @@ private:
     /// placements — see the implementation comment.
     static void evictForCapacity(QList<WindowPlacement>& bucket);
 
+public:
+    /// Per-app record cap (public so tests can pin the eviction contract).
+    static constexpr int MaxPerApp = 16;
+
+private:
     /// appId → FIFO list of records (preserves multi-instance + close/reopen order).
     QHash<QString, QList<WindowPlacement>> m_byApp;
     quint64 m_sequence = 0;
-
-    static constexpr int MaxPerApp = 16;
 };
 
 } // namespace PhosphorEngine

--- a/libs/phosphor-engine/include/PhosphorEngine/WindowPlacementStore.h
+++ b/libs/phosphor-engine/include/PhosphorEngine/WindowPlacementStore.h
@@ -40,11 +40,12 @@ public:
     /// record for the same live instance already exists (in any appId bucket) the
     /// incoming engine slot(s) and free-geometry screen(s) are merged in, leaving
     /// the other engine's slot and other screens' free geometry intact. Otherwise
-    /// the record is appended to its appId's FIFO. Stamps a fresh monotonic
-    /// `sequence`. No-op on an invalid record. Returns true if the store actually
-    /// changed — false when the merge produced a content-identical record (sequence
-    /// aside), so callers can skip marking state dirty and avoid a self-perpetuating
-    /// save loop.
+    /// the record is appended to its appId's FIFO. No-op on an invalid record.
+    /// Returns true if the store actually changed — false when the merge produced
+    /// a content-identical record, so callers can skip marking state dirty and
+    /// avoid a self-perpetuating save loop. Stamps a fresh monotonic `sequence`
+    /// whenever it changes anything (the content-identical short-circuit leaves
+    /// the existing record, sequence included, untouched).
     bool record(WindowPlacement placement);
 
     /// Restore lookup: the first record whose `accept` predicate passes, trying

--- a/libs/phosphor-engine/include/PhosphorEngine/WindowPlacementStore.h
+++ b/libs/phosphor-engine/include/PhosphorEngine/WindowPlacementStore.h
@@ -18,13 +18,13 @@ namespace PhosphorEngine {
 
 /// The single source of truth for window restore state in the unified model.
 ///
-/// Holds AT MOST ONE WindowPlacement record PER WINDOW (not per engine), captured
-/// live by the engines. Records are keyed two ways so they survive both a daemon
-/// restart (full windowId / uuid is stable while the window stays open) and a
+/// Holds AT MOST ONE WindowPlacement record PER WINDOW INSTANCE (not per engine),
+/// captured live by the engines. Records are keyed two ways so they survive both a daemon
+/// restart (the instance component is stable while the window stays open) and a
 /// close→reopen (uuid changes, so the appId FIFO carries it).
 ///
-/// The core invariant — `record()` MERGES into the single record for the exact
-/// windowId — gives per-mode state independence with a shared free/float geometry:
+/// The core invariant — `record()` MERGES into the single record for the same
+/// instance — gives per-mode state independence with a shared free/float geometry:
 /// each engine updates only its OWN slot (in `engines`, keyed by engineId()) plus
 /// any free-geometry change, so a window may be `snapped` in the snap engine AND
 /// `floating` in the autotile engine at once, each engine remembering the window's
@@ -37,7 +37,7 @@ public:
 
     /// Record / MERGE this window's placement. The incoming record supplies only
     /// the calling engine's slot (in `engines`) and any free-geometry update; if a
-    /// record for the same exact windowId already exists (in any appId bucket) the
+    /// record for the same live instance already exists (in any appId bucket) the
     /// incoming engine slot(s) and free-geometry screen(s) are merged in, leaving
     /// the other engine's slot and other screens' free geometry intact. Otherwise
     /// the record is appended to its appId's FIFO. Stamps a fresh monotonic
@@ -48,14 +48,14 @@ public:
     bool record(WindowPlacement placement);
 
     /// Restore lookup: the first record whose `accept` predicate passes, trying
-    /// the exact-windowId match before the appId FIFO (oldest first). The matched
+    /// the same-instance match before the appId FIFO (oldest first). The matched
     /// record is REMOVED (consumed) and returned. `accept` lets the caller reject
     /// cross-screen / disabled-context / wrong-kind candidates.
     ///
     /// `preferred` (optional) ranks the appId-FIFO branch ONLY: when supplied, the
     /// oldest entry satisfying BOTH `accept` and `preferred` is consumed first, and
     /// only if none qualifies does the oldest merely-accepted entry win. The
-    /// exact-windowId match is unaffected — a window's own record is always used in
+    /// same-instance match is unaffected — a window's own record is always used in
     /// whatever state it holds. Lets a caller restore the most meaningful record
     /// (e.g. a snapped placement) ahead of a contentless free/floating sibling that
     /// is merely older in the FIFO.
@@ -63,25 +63,23 @@ public:
                                         const std::function<bool(const WindowPlacement&)>& accept = {},
                                         const std::function<bool(const WindowPlacement&)>& preferred = {});
 
-    /// Non-consuming lookup (unlike take): the record for the exact windowId, else
+    /// Non-consuming lookup (unlike take): the record for the same live instance, else
     /// the NEWEST record in the appId bucket whose `accept` passes. Leaves the
     /// store unchanged — for live reads such as the float-back geometry lookup,
     /// where the record must stay put for the eventual restore/capture.
     std::optional<WindowPlacement> peek(const QString& windowId, const QString& appId,
                                         const std::function<bool(const WindowPlacement&)>& accept = {}) const;
 
-    /// Exact-windowId peek: branch 1 of peek() only, never the appId-FIFO
-    /// fallback. For reads about a LIVE window mid-session (KWin uuids are
-    /// stable until logout), where a same-app sibling's record must not
-    /// answer for this window — the appId fallback exists for the relogin
-    /// re-bind paths (take()), not for live per-window state. An empty appId
-    /// disables peek's fallback branch structurally, so this cannot drift.
+    /// Same-instance peek: branch 1 of peek() only, never the appId-FIFO
+    /// fallback. The instance component remains stable if a live window's appId
+    /// prefix changes, while still distinguishing same-app siblings. The appId
+    /// fallback exists for close/reopen paths where the instance changes.
     std::optional<WindowPlacement> peekExact(const QString& windowId) const
     {
         return peek(windowId, QString());
     }
 
-    /// True if a record exists for the exact windowId, or (if @p appId non-empty)
+    /// True if a record exists for the same live instance, or (if @p appId non-empty)
     /// any record in that appId bucket.
     bool contains(const QString& windowId, const QString& appId = QString()) const;
 
@@ -106,11 +104,11 @@ public:
     /// would otherwise not reach disk until an incidental save.
     bool collapsePureFloatSiblings(const QString& appId, const QString& keepWindowId);
 
-    /// Drop any record for the exact windowId (and prune the empty bucket).
+    /// Drop any record for the same live instance (and prune the empty bucket).
     /// Returns true if a record was actually removed.
     bool clear(const QString& windowId);
 
-    /// Clear ONLY the shared free/float geometry for the exact windowId, leaving the
+    /// Clear ONLY the shared free/float geometry for the same live instance, leaving the
     /// engine slots and context intact. Returns true if anything was cleared. Used by
     /// the drag-out / layout-change paths that consume the float-back once.
     bool clearFreeGeometry(const QString& windowId);

--- a/libs/phosphor-engine/include/PhosphorEngine/WindowRegistry.h
+++ b/libs/phosphor-engine/include/PhosphorEngine/WindowRegistry.h
@@ -38,7 +38,9 @@ struct WindowMetadata
     // compositor could not report it — e.g. no underlying KWin::Window) leaves the
     // corresponding WindowQuery field disengaged, keeping a predicate over it inert,
     // mirroring window_query.cpp's engage-only-when-known contract. ──
-    std::optional<bool> isMinimized{};
+    std::optional<bool> isMinimized{}; ///< LIVE, unlike isFocused: the effect re-pushes metadata on every
+                                       ///< minimizedChanged edge, so mode-swap seed/restore decisions can
+                                       ///< rely on it reflecting the window's current minimize state.
     std::optional<bool> isFullscreen{};
     std::optional<bool> isSticky{}; ///< on all virtual desktops
     std::optional<bool> isMaximized{}; ///< MaximizeFull (both axes)
@@ -137,6 +139,7 @@ public:
     };
     std::optional<WindowContext> windowContext(const QString& instanceId) const;
     Q_INVOKABLE QString appIdFor(const QString& instanceId) const override;
+    bool isMinimized(const QString& windowId) const override;
     QStringList instancesWithAppId(const QString& appId) const;
     bool contains(const QString& instanceId) const;
     QStringList allInstances() const;

--- a/libs/phosphor-engine/include/PhosphorEngine/WindowRegistry.h
+++ b/libs/phosphor-engine/include/PhosphorEngine/WindowRegistry.h
@@ -96,6 +96,8 @@ public:
     ~WindowRegistry() override;
 
     void upsert(const QString& instanceId, const WindowMetadata& metadata);
+    /// Remove metadata and canonical state, emitting windowDisappeared exactly
+    /// once while the canonical mapping remains available to subscribers.
     void remove(const QString& instanceId);
 
     std::optional<WindowMetadata> metadata(const QString& instanceId) const;
@@ -159,8 +161,8 @@ public:
     /// (e.g. saved-autotile-order cleanup) drop their ghost state too. Returns
     /// the count removed. @p aliveInstanceIds are the uuid components
     /// (WindowId::extractInstanceId), matching this registry's keying. The
-    /// normal per-window path is remove() + releaseCanonical on windowClosed;
-    /// this is the batch backstop the WTA alive-ids report drives.
+    /// normal per-window path is remove() on windowClosed; this is the batch
+    /// backstop the WTA alive-ids report drives.
     int pruneStaleInstances(const QSet<QString>& aliveInstanceIds);
 
 Q_SIGNALS:
@@ -173,6 +175,8 @@ private:
     QHash<QString, WindowMetadata> m_records;
     QMultiHash<QString, QString> m_appIdIndex;
     QHash<QString, QString> m_canonicalByInstance;
+    QSet<QString> m_disappearingInstances;
+    QSet<QString> m_removeAfterDisappearance;
 
     void indexInsert(const QString& instanceId, const QString& appId);
     void indexRemove(const QString& instanceId, const QString& appId);

--- a/libs/phosphor-engine/include/PhosphorEngine/WindowRegistry.h
+++ b/libs/phosphor-engine/include/PhosphorEngine/WindowRegistry.h
@@ -139,7 +139,9 @@ public:
     };
     std::optional<WindowContext> windowContext(const QString& instanceId) const;
     Q_INVOKABLE QString appIdFor(const QString& instanceId) const override;
-    bool isMinimized(const QString& windowId) const override;
+    /// Live compositor minimize state. Accepts either a bare instance id or a
+    /// composite appId|instanceId window id.
+    bool isMinimized(const QString& windowId) const;
     QStringList instancesWithAppId(const QString& appId) const;
     bool contains(const QString& instanceId) const;
     QStringList allInstances() const;

--- a/libs/phosphor-engine/include/PhosphorEngine/WindowRegistry.h
+++ b/libs/phosphor-engine/include/PhosphorEngine/WindowRegistry.h
@@ -38,9 +38,12 @@ struct WindowMetadata
     // compositor could not report it — e.g. no underlying KWin::Window) leaves the
     // corresponding WindowQuery field disengaged, keeping a predicate over it inert,
     // mirroring window_query.cpp's engage-only-when-known contract. ──
-    std::optional<bool> isMinimized{}; ///< LIVE, unlike isFocused: the effect re-pushes metadata on every
-                                       ///< minimizedChanged edge, so mode-swap seed/restore decisions can
-                                       ///< rely on it reflecting the window's current minimize state.
+    std::optional<bool> isMinimized{}; ///< Kept current as of the LAST DELIVERED push, unlike isFocused:
+                                       ///< the effect re-pushes full metadata on every minimizedChanged
+                                       ///< edge, so mode-swap seed/restore decisions can rely on it —
+                                       ///< with the one-edge propagation delay that implies, and
+                                       ///< disengaged when the compositor never reported the field
+                                       ///< (consumers treat that as "cannot vouch", not "visible").
     std::optional<bool> isFullscreen{};
     std::optional<bool> isSticky{}; ///< on all virtual desktops
     std::optional<bool> isMaximized{}; ///< MaximizeFull (both axes)
@@ -153,8 +156,11 @@ public:
     std::optional<bool> minimizedState(const QString& windowId) const override;
     QStringList instancesWithAppId(const QString& appId) const;
     bool contains(const QString& instanceId) const;
-    QStringList allInstances() const;
     int size() const;
+    /// Remove every record and canonical mapping, firing windowDisappeared
+    /// for each. TEST SEAM: production tears windows down per-window
+    /// (remove() on windowClosed, pruneStaleInstances for missed closes);
+    /// only tests bulk-reset the registry.
     void clear();
 
     Q_INVOKABLE QString canonicalizeWindowId(const QString& rawWindowId) override;
@@ -187,6 +193,12 @@ private:
     /// and replayed after the removal completes.
     QSet<QString> m_disappearingInstances;
     QHash<QString, WindowMetadata> m_pendingUpserts;
+    /// Depth counter, non-zero while clear() drives a removal loop: remove()
+    /// then DROPS re-entrant pending upserts instead of replaying them, so a
+    /// subscriber re-inserting from windowDisappeared cannot make records
+    /// survive the bulk reset. A counter, not a bool — a NESTED clear() from
+    /// a subscriber must not un-flag the outer one on its way out.
+    int m_clearing = 0;
 
     void indexInsert(const QString& instanceId, const QString& appId);
     void indexRemove(const QString& instanceId, const QString& appId);

--- a/libs/phosphor-engine/include/PhosphorEngine/WindowRegistry.h
+++ b/libs/phosphor-engine/include/PhosphorEngine/WindowRegistry.h
@@ -195,9 +195,12 @@ private:
     QHash<QString, WindowMetadata> m_pendingUpserts;
     /// Depth counter, non-zero while clear() drives a removal loop: remove()
     /// then DROPS re-entrant pending upserts instead of replaying them, so a
-    /// subscriber re-inserting from windowDisappeared cannot make records
-    /// survive the bulk reset. A counter, not a bool — a NESTED clear() from
-    /// a subscriber must not un-flag the outer one on its way out.
+    /// subscriber re-inserting from windowDisappeared cannot make the INSTANCE
+    /// BEING REMOVED survive the bulk reset. (A subscriber upserting a
+    /// different, brand-new instance mid-clear does survive — clear() only
+    /// sweeps the ids snapshotted before its loop; acceptable for a test
+    /// seam.) A counter, not a bool — a NESTED clear() from a subscriber must
+    /// not un-flag the outer one on its way out.
     int m_clearing = 0;
 
     void indexInsert(const QString& instanceId, const QString& appId);

--- a/libs/phosphor-engine/include/PhosphorEngine/WindowRegistry.h
+++ b/libs/phosphor-engine/include/PhosphorEngine/WindowRegistry.h
@@ -141,9 +141,16 @@ public:
     };
     std::optional<WindowContext> windowContext(const QString& instanceId) const;
     Q_INVOKABLE QString appIdFor(const QString& instanceId) const override;
-    /// Live compositor minimize state. Accepts either a bare instance id or a
-    /// composite appId|instanceId window id.
+    /// Live compositor minimize state, collapsed to a bool: unknown reads as
+    /// false. Prefer minimizedState() wherever "unknown" must not be treated
+    /// as "not minimized" (seeding, capture guards). Accepts either a bare
+    /// instance id or a composite appId|instanceId window id.
     bool isMinimized(const QString& windowId) const;
+    /// Tri-state minimize state (IWindowRegistry contract): engaged when a
+    /// record exists AND the compositor reported the field; nullopt when the
+    /// window is unknown or the field was never delivered. Accepts either a
+    /// bare instance id or a composite appId|instanceId window id.
+    std::optional<bool> minimizedState(const QString& windowId) const override;
     QStringList instancesWithAppId(const QString& appId) const;
     bool contains(const QString& instanceId) const;
     QStringList allInstances() const;

--- a/libs/phosphor-engine/include/PhosphorEngine/WindowRegistry.h
+++ b/libs/phosphor-engine/include/PhosphorEngine/WindowRegistry.h
@@ -159,7 +159,6 @@ public:
 
     Q_INVOKABLE QString canonicalizeWindowId(const QString& rawWindowId) override;
     Q_INVOKABLE QString canonicalizeForLookup(const QString& rawWindowId) const override;
-    void releaseCanonical(const QString& anyWindowId);
 
     /// Defensive cleanup for windows that died WITHOUT a close signal reaching
     /// the registry (compositor crash, lost D-Bus call): drop every metadata
@@ -182,6 +181,12 @@ private:
     QHash<QString, WindowMetadata> m_records;
     QMultiHash<QString, QString> m_appIdIndex;
     QHash<QString, QString> m_canonicalByInstance;
+    /// Instances currently inside remove()'s windowDisappeared emit. A
+    /// re-entrant remove() of the same instance is a no-op (exactly-once
+    /// signal), and a re-entrant upsert() is deferred into m_pendingUpserts
+    /// and replayed after the removal completes.
+    QSet<QString> m_disappearingInstances;
+    QHash<QString, WindowMetadata> m_pendingUpserts;
 
     void indexInsert(const QString& instanceId, const QString& appId);
     void indexRemove(const QString& instanceId, const QString& appId);

--- a/libs/phosphor-engine/include/PhosphorEngine/WindowRegistry.h
+++ b/libs/phosphor-engine/include/PhosphorEngine/WindowRegistry.h
@@ -175,8 +175,6 @@ private:
     QHash<QString, WindowMetadata> m_records;
     QMultiHash<QString, QString> m_appIdIndex;
     QHash<QString, QString> m_canonicalByInstance;
-    QSet<QString> m_disappearingInstances;
-    QSet<QString> m_removeAfterDisappearance;
 
     void indexInsert(const QString& instanceId, const QString& appId);
     void indexRemove(const QString& instanceId, const QString& appId);

--- a/libs/phosphor-engine/src/WindowPlacementStore.cpp
+++ b/libs/phosphor-engine/src/WindowPlacementStore.cpp
@@ -49,8 +49,11 @@ bool WindowPlacementStore::record(WindowPlacement incoming)
     // screen's remembered free spot.
     //
     // Locate the existing record for the same live instance, wherever it lives.
-    // The instance is unique across buckets, so once found we stop — WITHOUT running the loop's
-    // `++it` after a possible erase(it) (would increment an invalidated iterator).
+    // Instance uniqueness holds for ids sameWindowInstance can relate (composite
+    // `app|uuid` forms) — two BARE-id entries under different buckets fall
+    // outside that guarantee (see clearFreeGeometry's all-bucket sweep) — so
+    // once found we stop, WITHOUT running the loop's `++it` after a possible
+    // erase(it) (would increment an invalidated iterator).
     for (auto it = m_byApp.begin(); it != m_byApp.end();) {
         QList<WindowPlacement>& bucket = it.value();
         for (int i = 0; i < bucket.size(); ++i) {
@@ -506,10 +509,20 @@ void WindowPlacementStore::deserialize(const QJsonObject& obj)
     m_byApp.clear();
     m_sequence = 0;
     QList<WindowPlacement> loaded;
+    // Persisted ARRAY positions, keyed per (bucket, instance) — NOT a global
+    // index into the flattened list: a renamed duplicate persisted under an
+    // old bucket would carry that bucket's low global index into its NEW
+    // bucket and sort ahead of the new bucket's genuinely older entries,
+    // inverting the FIFO head take() consumes. Per-bucket positions keep each
+    // bucket's order self-referential; a record merged in from ANOTHER bucket
+    // (rename with no entry in the destination) has no key here and sorts
+    // last, i.e. newest — matching the runtime rename-append behaviour.
+    QHash<QPair<QString, QString>, int> firstPersistedPos;
     for (auto it = obj.constBegin(); it != obj.constEnd(); ++it) {
         if (it.key().isEmpty() || it.key().contains(QLatin1Char('|'))) {
             continue;
         }
+        int posInBucket = 0;
         const QJsonArray arr = it->toArray();
         for (const QJsonValue& v : arr) {
             WindowPlacement p = WindowPlacement::fromJson(it.key(), v.toObject());
@@ -526,23 +539,19 @@ void WindowPlacementStore::deserialize(const QJsonObject& obj)
             if (!p.windowId.contains(QLatin1Char('|'))) {
                 continue;
             }
+            const QPair<QString, QString> posKey{it.key(), PhosphorIdentity::WindowId::extractInstanceId(p.windowId)};
+            if (!firstPersistedPos.contains(posKey)) {
+                firstPersistedPos.insert(posKey, posInBucket);
+            }
+            ++posInBucket;
             loaded.append(p);
         }
     }
-
-    // Persisted ARRAY positions, first occurrence per instance: record()'s
-    // in-place merge keeps a record's bucket POSITION while restamping its
-    // sequence, so position order and sequence order legitimately diverge —
-    // replaying by sequence alone would reorder buckets across a reload,
-    // flipping take()'s oldest-first head and the eviction order the header
-    // documents as FIFO.
-    QHash<QString, int> firstPersistedPos;
-    for (int i = 0; i < loaded.size(); ++i) {
-        const QString instance = PhosphorIdentity::WindowId::extractInstanceId(loaded.at(i).windowId);
-        if (!firstPersistedPos.contains(instance)) {
-            firstPersistedPos.insert(instance, i);
-        }
-    }
+    // Positions exist because record()'s in-place merge keeps a record's
+    // bucket POSITION while restamping its sequence, so position order and
+    // sequence order legitimately diverge — replaying by sequence alone would
+    // reorder buckets across a reload, flipping take()'s oldest-first head and
+    // the eviction order the header documents as FIFO.
 
     // Replay oldest to newest through record() so persisted duplicates from an
     // appId-prefix mutation are merged into one live-instance record (sequence
@@ -556,16 +565,20 @@ void WindowPlacementStore::deserialize(const QJsonObject& obj)
     }
 
     // Restore each bucket to its persisted array order (merged duplicates sit
-    // at their earliest persisted position — FIFO semantics).
+    // at their earliest persisted position within THIS bucket — FIFO
+    // semantics; cross-bucket merge arrivals sort last, i.e. newest).
     for (auto it = m_byApp.begin(); it != m_byApp.end(); ++it) {
-        std::stable_sort(
-            it->begin(), it->end(), [&firstPersistedPos](const WindowPlacement& a, const WindowPlacement& b) {
-                const int pa = firstPersistedPos.value(PhosphorIdentity::WindowId::extractInstanceId(a.windowId),
-                                                       std::numeric_limits<int>::max());
-                const int pb = firstPersistedPos.value(PhosphorIdentity::WindowId::extractInstanceId(b.windowId),
-                                                       std::numeric_limits<int>::max());
-                return pa < pb;
-            });
+        const QString bucketKey = it.key();
+        std::stable_sort(it->begin(), it->end(),
+                         [&firstPersistedPos, &bucketKey](const WindowPlacement& a, const WindowPlacement& b) {
+                             const int pa = firstPersistedPos.value(
+                                 {bucketKey, PhosphorIdentity::WindowId::extractInstanceId(a.windowId)},
+                                 std::numeric_limits<int>::max());
+                             const int pb = firstPersistedPos.value(
+                                 {bucketKey, PhosphorIdentity::WindowId::extractInstanceId(b.windowId)},
+                                 std::numeric_limits<int>::max());
+                             return pa < pb;
+                         });
     }
 }
 

--- a/libs/phosphor-engine/src/WindowPlacementStore.cpp
+++ b/libs/phosphor-engine/src/WindowPlacementStore.cpp
@@ -8,6 +8,7 @@
 #include <QLatin1Char>
 
 #include <algorithm>
+#include <limits>
 #include <utility>
 
 namespace PhosphorEngine {
@@ -93,9 +94,7 @@ bool WindowPlacementStore::record(WindowPlacement incoming)
                 m_byApp.erase(it); // iterator consumed — do not ++it
             }
             QList<WindowPlacement>& dst = m_byApp[merged.appId];
-            while (dst.size() >= MaxPerApp) {
-                dst.removeFirst();
-            }
+            evictForCapacity(dst);
             dst.append(merged);
             return true;
         }
@@ -108,11 +107,28 @@ bool WindowPlacementStore::record(WindowPlacement incoming)
     // No existing record for this window — append a fresh one.
     incoming.sequence = ++m_sequence;
     QList<WindowPlacement>& bucket = m_byApp[incoming.appId];
-    while (bucket.size() >= MaxPerApp) {
-        bucket.removeFirst();
-    }
+    evictForCapacity(bucket);
     bucket.append(incoming);
     return true;
+}
+
+void WindowPlacementStore::evictForCapacity(QList<WindowPlacement>& bucket)
+{
+    // Evict contentless residue FIRST (oldest such entry), and only fall back
+    // to the positionally-oldest record when everything is restorable — a
+    // bare floating slot with no geometry must never push a real snapped or
+    // tiled placement out of the FIFO (WindowPlacement::hasRestorableContent
+    // documents this exact starvation hazard).
+    while (bucket.size() >= MaxPerApp) {
+        int victim = -1;
+        for (int i = 0; i < bucket.size(); ++i) {
+            if (!bucket.at(i).hasRestorableContent()) {
+                victim = i;
+                break;
+            }
+        }
+        bucket.removeAt(victim >= 0 ? victim : 0);
+    }
 }
 
 namespace {
@@ -122,8 +138,12 @@ namespace {
 /// placement and is never a collapse candidate.
 bool isPureFloatRecord(const WindowPlacement& p)
 {
+    // A slot-LESS record with remembered free geometry (the shape
+    // recordFreeGeometry produces) is the purest float duplicate there is —
+    // exactly what the collapse exists to converge. Only an empty record with
+    // neither slots nor geometry is excluded (nothing to keep or prune).
     if (p.engines.isEmpty()) {
-        return false;
+        return !p.freeGeometryByScreen.isEmpty();
     }
     for (auto it = p.engines.constBegin(); it != p.engines.constEnd(); ++it) {
         if (it.value().state == WindowPlacement::stateSnapped() || it.value().state == WindowPlacement::stateTiled()) {
@@ -147,7 +167,11 @@ bool WindowPlacementStore::collapsePureFloatSiblings(const QString& appId, const
 
     const auto findKeep = [&]() -> int {
         for (int i = 0; i < bucket.size(); ++i) {
-            if (bucket.at(i).windowId == keepWindowId) {
+            // Instance match, not exact-id: every other lookup in this file
+            // matches through sameWindowInstance so a live window whose appId
+            // prefix drifted still resolves — an exact compare here silently
+            // no-ops the collapse for exactly the renamed-window case.
+            if (sameWindowInstance(bucket.at(i).windowId, keepWindowId)) {
                 return i;
             }
         }
@@ -362,17 +386,42 @@ bool WindowPlacementStore::clearFreeGeometry(const QString& windowId)
     if (windowId.isEmpty()) {
         return false;
     }
-    // A live instance is unique across buckets (record() enforces this), so the first
-    // match is the only match — return as soon as it's cleared.
+    // Sweep ALL buckets rather than returning on the first hit: record()
+    // enforces instance uniqueness only for ids sameWindowInstance can relate,
+    // and two bare-id entries under different buckets fall outside that
+    // guarantee — an early return would leave the second one holding stale
+    // geometry.
+    bool cleared = false;
     for (auto it = m_byApp.begin(); it != m_byApp.end(); ++it) {
         for (WindowPlacement& p : it.value()) {
             if (sameWindowInstance(p.windowId, windowId) && !p.freeGeometryByScreen.isEmpty()) {
                 p.freeGeometryByScreen.clear();
-                return true;
+                cleared = true;
             }
         }
     }
-    return false;
+    return cleared;
+}
+
+bool WindowPlacementStore::clearFreeGeometry(const QString& windowId, const QString& screenId)
+{
+    if (windowId.isEmpty() || screenId.isEmpty()) {
+        return false;
+    }
+    // Screen-scoped consume: the drag-out/drop paths consume exactly one
+    // screen's float-back, and wiping the whole map would destroy the
+    // window's remembered free position on every OTHER monitor — the
+    // distinct-monitor float memory collapsePureFloatSiblings deliberately
+    // preserves.
+    bool cleared = false;
+    for (auto it = m_byApp.begin(); it != m_byApp.end(); ++it) {
+        for (WindowPlacement& p : it.value()) {
+            if (sameWindowInstance(p.windowId, windowId) && p.freeGeometryByScreen.remove(screenId) > 0) {
+                cleared = true;
+            }
+        }
+    }
+    return cleared;
 }
 
 int WindowPlacementStore::transform(const std::function<bool(WindowPlacement&)>& fn)
@@ -475,14 +524,42 @@ void WindowPlacementStore::deserialize(const QJsonObject& obj)
         }
     }
 
+    // Persisted ARRAY positions, first occurrence per instance: record()'s
+    // in-place merge keeps a record's bucket POSITION while restamping its
+    // sequence, so position order and sequence order legitimately diverge —
+    // replaying by sequence alone would reorder buckets across a reload,
+    // flipping take()'s oldest-first head and the eviction order the header
+    // documents as FIFO.
+    QHash<QString, int> firstPersistedPos;
+    for (int i = 0; i < loaded.size(); ++i) {
+        const QString instance = PhosphorIdentity::WindowId::extractInstanceId(loaded.at(i).windowId);
+        if (!firstPersistedPos.contains(instance)) {
+            firstPersistedPos.insert(instance, i);
+        }
+    }
+
     // Replay oldest to newest through record() so persisted duplicates from an
-    // appId-prefix mutation are merged into one live-instance record. This also
-    // applies the normal per-app cap in the same direction as runtime inserts.
+    // appId-prefix mutation are merged into one live-instance record (sequence
+    // decides MERGE precedence only). This also applies the normal per-app cap
+    // in the same direction as runtime inserts.
     std::stable_sort(loaded.begin(), loaded.end(), [](const WindowPlacement& lhs, const WindowPlacement& rhs) {
         return lhs.sequence < rhs.sequence;
     });
     for (WindowPlacement& placement : loaded) {
         record(std::move(placement));
+    }
+
+    // Restore each bucket to its persisted array order (merged duplicates sit
+    // at their earliest persisted position — FIFO semantics).
+    for (auto it = m_byApp.begin(); it != m_byApp.end(); ++it) {
+        std::stable_sort(
+            it->begin(), it->end(), [&firstPersistedPos](const WindowPlacement& a, const WindowPlacement& b) {
+                const int pa = firstPersistedPos.value(PhosphorIdentity::WindowId::extractInstanceId(a.windowId),
+                                                       std::numeric_limits<int>::max());
+                const int pb = firstPersistedPos.value(PhosphorIdentity::WindowId::extractInstanceId(b.windowId),
+                                                       std::numeric_limits<int>::max());
+                return pa < pb;
+            });
     }
 }
 

--- a/libs/phosphor-engine/src/WindowPlacementStore.cpp
+++ b/libs/phosphor-engine/src/WindowPlacementStore.cpp
@@ -2,11 +2,29 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 #include <PhosphorEngine/WindowPlacementStore.h>
+#include <PhosphorIdentity/WindowId.h>
 
 #include <QJsonArray>
 #include <QLatin1Char>
 
+#include <algorithm>
+#include <utility>
+
 namespace PhosphorEngine {
+
+namespace {
+bool sameWindowInstance(const QString& lhs, const QString& rhs)
+{
+    if (lhs == rhs) {
+        return true;
+    }
+    if (!lhs.contains(QLatin1Char('|')) || !rhs.contains(QLatin1Char('|'))) {
+        return false;
+    }
+    const QString lhsInstance = PhosphorIdentity::WindowId::extractInstanceId(lhs);
+    return !lhsInstance.isEmpty() && lhsInstance == PhosphorIdentity::WindowId::extractInstanceId(rhs);
+}
+} // namespace
 
 bool WindowPlacementStore::record(WindowPlacement incoming)
 {
@@ -23,13 +41,14 @@ bool WindowPlacementStore::record(WindowPlacement incoming)
     // slot, and updating the float position on one screen never drops another
     // screen's remembered free spot.
     //
-    // Locate the existing record for the EXACT windowId, wherever it lives. windowId
-    // is unique across buckets, so once found we stop — WITHOUT running the loop's
+    // Locate the existing record for the same live instance, wherever it lives.
+    // The instance is unique across buckets, so once found we stop — WITHOUT running the loop's
     // `++it` after a possible erase(it) (would increment an invalidated iterator).
     for (auto it = m_byApp.begin(); it != m_byApp.end();) {
         QList<WindowPlacement>& bucket = it.value();
         for (int i = 0; i < bucket.size(); ++i) {
-            if (bucket.at(i).windowId != incoming.windowId) {
+            const WindowPlacement& stored = bucket.at(i);
+            if (!sameWindowInstance(stored.windowId, incoming.windowId)) {
                 continue;
             }
             // Merge incoming into a copy of the existing record. Context (screen /
@@ -37,6 +56,7 @@ bool WindowPlacementStore::record(WindowPlacement incoming)
             // real engine capture updates it — a geometry-only write (no engine slot,
             // e.g. recordFreeGeometry) must NOT clobber the managed-context fields.
             WindowPlacement merged = bucket.at(i);
+            merged.windowId = incoming.windowId;
             if (!incoming.engines.isEmpty()) {
                 merged.screenId = incoming.screenId;
                 merged.virtualDesktop = incoming.virtualDesktop;
@@ -203,16 +223,16 @@ std::optional<WindowPlacement> WindowPlacementStore::take(const QString& windowI
         return !accept || accept(p);
     };
 
-    // 1. Exact-windowId match first (daemon restart, uuid stable). A record
+    // 1. Same-instance match first (daemon restart, uuid stable). A record
     //    whose windowId matches but whose `accept` predicate rejects it is NOT
     //    consumed here; the loop falls through to the appId FIFO below (the
     //    semantics are "consume the oldest restorable record", not "fail if the
-    //    exact record is unrestorable").
+    //    same-instance record is unrestorable").
     if (!windowId.isEmpty()) {
         for (auto it = m_byApp.begin(); it != m_byApp.end(); ++it) {
             QList<WindowPlacement>& bucket = it.value();
             for (int i = 0; i < bucket.size(); ++i) {
-                if (bucket.at(i).windowId == windowId && matches(bucket.at(i))) {
+                if (sameWindowInstance(bucket.at(i).windowId, windowId) && matches(bucket.at(i))) {
                     WindowPlacement p = bucket.takeAt(i);
                     if (bucket.isEmpty()) {
                         m_byApp.erase(it);
@@ -263,11 +283,11 @@ WindowPlacementStore::peek(const QString& windowId, const QString& appId,
         return !accept || accept(p);
     };
 
-    // 1. Exact-windowId match first (same window, daemon restart).
+    // 1. Same-instance match first (same window, daemon restart).
     if (!windowId.isEmpty()) {
         for (auto it = m_byApp.constBegin(); it != m_byApp.constEnd(); ++it) {
             for (const WindowPlacement& p : it.value()) {
-                if (p.windowId == windowId && matches(p)) {
+                if (sameWindowInstance(p.windowId, windowId) && matches(p)) {
                     return p;
                 }
             }
@@ -306,7 +326,7 @@ bool WindowPlacementStore::contains(const QString& windowId, const QString& appI
     }
     for (auto it = m_byApp.constBegin(); it != m_byApp.constEnd(); ++it) {
         for (const WindowPlacement& p : it.value()) {
-            if (p.windowId == windowId) {
+            if (sameWindowInstance(p.windowId, windowId)) {
                 return true;
             }
         }
@@ -323,7 +343,7 @@ bool WindowPlacementStore::clear(const QString& windowId)
     for (auto it = m_byApp.begin(); it != m_byApp.end();) {
         QList<WindowPlacement>& bucket = it.value();
         for (int i = bucket.size() - 1; i >= 0; --i) {
-            if (bucket.at(i).windowId == windowId) {
+            if (sameWindowInstance(bucket.at(i).windowId, windowId)) {
                 bucket.removeAt(i);
                 removed = true;
             }
@@ -342,11 +362,11 @@ bool WindowPlacementStore::clearFreeGeometry(const QString& windowId)
     if (windowId.isEmpty()) {
         return false;
     }
-    // windowId is unique across buckets (record() enforces this), so the first
+    // A live instance is unique across buckets (record() enforces this), so the first
     // match is the only match — return as soon as it's cleared.
     for (auto it = m_byApp.begin(); it != m_byApp.end(); ++it) {
         for (WindowPlacement& p : it.value()) {
-            if (p.windowId == windowId && !p.freeGeometryByScreen.isEmpty()) {
+            if (sameWindowInstance(p.windowId, windowId) && !p.freeGeometryByScreen.isEmpty()) {
                 p.freeGeometryByScreen.clear();
                 return true;
             }
@@ -429,11 +449,12 @@ QJsonObject WindowPlacementStore::serialize(const std::function<bool(const Windo
 void WindowPlacementStore::deserialize(const QJsonObject& obj)
 {
     m_byApp.clear();
+    m_sequence = 0;
+    QList<WindowPlacement> loaded;
     for (auto it = obj.constBegin(); it != obj.constEnd(); ++it) {
         if (it.key().isEmpty() || it.key().contains(QLatin1Char('|'))) {
             continue;
         }
-        QList<WindowPlacement> bucket;
         const QJsonArray arr = it->toArray();
         for (const QJsonValue& v : arr) {
             WindowPlacement p = WindowPlacement::fromJson(it.key(), v.toObject());
@@ -450,20 +471,18 @@ void WindowPlacementStore::deserialize(const QJsonObject& obj)
             if (!p.windowId.contains(QLatin1Char('|'))) {
                 continue;
             }
-            if (p.sequence > m_sequence) {
-                m_sequence = p.sequence;
-            }
-            bucket.append(p);
+            loaded.append(p);
         }
-        // Enforce the per-app cap by dropping the OLDEST (front) to keep the newest
-        // MaxPerApp — same direction as record()'s eviction (record() uses `>=`
-        // because it appends one afterward; here nothing is appended, so `>`).
-        while (bucket.size() > MaxPerApp) {
-            bucket.removeFirst();
-        }
-        if (!bucket.isEmpty()) {
-            m_byApp[it.key()] = bucket;
-        }
+    }
+
+    // Replay oldest to newest through record() so persisted duplicates from an
+    // appId-prefix mutation are merged into one live-instance record. This also
+    // applies the normal per-app cap in the same direction as runtime inserts.
+    std::stable_sort(loaded.begin(), loaded.end(), [](const WindowPlacement& lhs, const WindowPlacement& rhs) {
+        return lhs.sequence < rhs.sequence;
+    });
+    for (WindowPlacement& placement : loaded) {
+        record(std::move(placement));
     }
 }
 

--- a/libs/phosphor-engine/src/WindowPlacementStore.cpp
+++ b/libs/phosphor-engine/src/WindowPlacementStore.cpp
@@ -14,6 +14,12 @@
 namespace PhosphorEngine {
 
 namespace {
+// Instance-identity match for STORE keys. Contract note: ids without a '|'
+// separator only match EXACTLY here — unlike the registry's
+// extractInstanceId, which treats a bare string AS the instance id. The store
+// is only ever keyed with full appId|uuid composites (capture and restore
+// both build them), so a bare id reaching this predicate is foreign input
+// that must not fuzzy-match a composite's uuid component.
 bool sameWindowInstance(const QString& lhs, const QString& rhs)
 {
     if (lhs == rhs) {

--- a/libs/phosphor-engine/src/WindowRegistry.cpp
+++ b/libs/phosphor-engine/src/WindowRegistry.cpp
@@ -137,9 +137,17 @@ QString WindowRegistry::appIdFor(const QString& instanceId) const
 
 bool WindowRegistry::isMinimized(const QString& windowId) const
 {
+    return minimizedState(windowId).value_or(false);
+}
+
+std::optional<bool> WindowRegistry::minimizedState(const QString& windowId) const
+{
     const QString instanceId = PhosphorIdentity::WindowId::extractInstanceId(windowId);
     const auto it = m_records.constFind(instanceId);
-    return it != m_records.constEnd() && it->isMinimized.value_or(false);
+    if (it == m_records.constEnd()) {
+        return std::nullopt;
+    }
+    return it->isMinimized;
 }
 
 QStringList WindowRegistry::instancesWithAppId(const QString& appId) const

--- a/libs/phosphor-engine/src/WindowRegistry.cpp
+++ b/libs/phosphor-engine/src/WindowRegistry.cpp
@@ -8,32 +8,9 @@
 
 namespace PhosphorEngine {
 
-namespace {
-class WindowRegistryLifecycleState final : public QObject
-{
-public:
-    explicit WindowRegistryLifecycleState(QObject* parent)
-        : QObject(parent)
-    {
-        setObjectName(QStringLiteral("_plasmazones_window_registry_lifecycle"));
-    }
-
-    QSet<QString> disappearingInstances;
-    QHash<QString, WindowMetadata> pendingUpserts;
-};
-
-WindowRegistryLifecycleState* lifecycleState(const WindowRegistry* registry)
-{
-    QObject* state = registry->findChild<QObject*>(QStringLiteral("_plasmazones_window_registry_lifecycle"),
-                                                   Qt::FindDirectChildrenOnly);
-    return static_cast<WindowRegistryLifecycleState*>(state);
-}
-} // namespace
-
 WindowRegistry::WindowRegistry(QObject* parent)
     : QObject(parent)
 {
-    new WindowRegistryLifecycleState(this);
 }
 
 WindowRegistry::~WindowRegistry() = default;
@@ -45,9 +22,8 @@ void WindowRegistry::upsert(const QString& instanceId, const WindowMetadata& met
         return;
     }
 
-    WindowRegistryLifecycleState* lifecycle = lifecycleState(this);
-    if (lifecycle->disappearingInstances.contains(instanceId)) {
-        lifecycle->pendingUpserts.insert(instanceId, metadata);
+    if (m_disappearingInstances.contains(instanceId)) {
+        m_pendingUpserts.insert(instanceId, metadata);
         return;
     }
 
@@ -74,9 +50,8 @@ void WindowRegistry::upsert(const QString& instanceId, const WindowMetadata& met
 
 void WindowRegistry::remove(const QString& instanceId)
 {
-    WindowRegistryLifecycleState* lifecycle = lifecycleState(this);
-    if (lifecycle->disappearingInstances.contains(instanceId)) {
-        lifecycle->pendingUpserts.remove(instanceId);
+    if (m_disappearingInstances.contains(instanceId)) {
+        m_pendingUpserts.remove(instanceId);
         return;
     }
 
@@ -93,20 +68,27 @@ void WindowRegistry::remove(const QString& instanceId)
     // subscribers, then retire it. Canonical-only instances still represent a
     // lifecycle entry and therefore receive the same exactly-once signal.
     const QString canonical = m_canonicalByInstance.value(instanceId);
-    lifecycle->disappearingInstances.insert(instanceId);
+    m_disappearingInstances.insert(instanceId);
     QPointer<WindowRegistry> guard(this);
     Q_EMIT windowDisappeared(instanceId);
     if (!guard) {
         return;
     }
-    lifecycle->disappearingInstances.remove(instanceId);
-    const bool hasPendingUpsert = lifecycle->pendingUpserts.contains(instanceId);
-    const WindowMetadata pendingMetadata = lifecycle->pendingUpserts.take(instanceId);
-    m_canonicalByInstance.remove(instanceId);
-    if (hasPendingUpsert) {
-        if (!canonical.isEmpty()) {
+    m_disappearingInstances.remove(instanceId);
+    const bool hasPendingUpsert = m_pendingUpserts.contains(instanceId);
+    const WindowMetadata pendingMetadata = m_pendingUpserts.take(instanceId);
+    // Retire the mapping only if it still is the pre-emit one: a synchronous
+    // subscriber may have re-seeded a FRESH canonical for this instance during
+    // the emit (a re-announce racing the close), and clobbering that with a
+    // blind remove would strip the next lifecycle's identity translation.
+    const QString postEmit = m_canonicalByInstance.value(instanceId);
+    if (postEmit == canonical) {
+        m_canonicalByInstance.remove(instanceId);
+        if (hasPendingUpsert && !canonical.isEmpty()) {
             m_canonicalByInstance.insert(instanceId, canonical);
         }
+    }
+    if (hasPendingUpsert) {
         upsert(instanceId, pendingMetadata);
     }
 }
@@ -211,18 +193,6 @@ QString WindowRegistry::canonicalizeForLookup(const QString& rawWindowId) const
     const QString instanceId = PhosphorIdentity::WindowId::extractInstanceId(rawWindowId);
     auto it = m_canonicalByInstance.constFind(instanceId);
     return (it != m_canonicalByInstance.constEnd()) ? it.value() : rawWindowId;
-}
-
-void WindowRegistry::releaseCanonical(const QString& anyWindowId)
-{
-    if (anyWindowId.isEmpty()) {
-        return;
-    }
-    const QString instanceId = PhosphorIdentity::WindowId::extractInstanceId(anyWindowId);
-    if (lifecycleState(this)->disappearingInstances.contains(instanceId)) {
-        return;
-    }
-    m_canonicalByInstance.remove(instanceId);
 }
 
 int WindowRegistry::pruneStaleInstances(const QSet<QString>& aliveInstanceIds)

--- a/libs/phosphor-engine/src/WindowRegistry.cpp
+++ b/libs/phosphor-engine/src/WindowRegistry.cpp
@@ -227,6 +227,17 @@ void WindowRegistry::releaseCanonical(const QString& anyWindowId)
 
 int WindowRegistry::pruneStaleInstances(const QSet<QString>& aliveInstanceIds)
 {
+    // An EMPTY alive set means "wipe everything". The only legitimate empty
+    // case (user closed every window) is already covered by per-window
+    // remove() on windowClosed — while the illegitimate one is very real: the
+    // effect's one-shot alive report at daemon-ready fires before
+    // session-restored apps have mapped their windows, and treating that as
+    // "all dead" destroys the whole registry. Fail closed.
+    if (aliveInstanceIds.isEmpty() && !(m_records.isEmpty() && m_canonicalByInstance.isEmpty())) {
+        qWarning("WindowRegistry::pruneStaleInstances: refusing empty alive set with %d records tracked",
+                 int(m_records.size()));
+        return 0;
+    }
     // Union of both maps' keys — a window may carry a canonical entry without
     // a metadata record (or vice versa) depending on which signals it received
     // before dying. Collect first, then mutate (remove() invalidates iterators
@@ -243,13 +254,20 @@ int WindowRegistry::pruneStaleInstances(const QSet<QString>& aliveInstanceIds)
         }
     }
     QPointer<WindowRegistry> guard(this);
+    // Count actual removals, not intent: a windowDisappeared subscriber can
+    // re-upsert an instance (leaving it present) or destroy the registry
+    // mid-sweep, and the return value is documented as "count removed".
+    int removed = 0;
     for (const QString& instanceId : std::as_const(stale)) {
         remove(instanceId);
         if (!guard) {
             break;
         }
+        if (!m_records.contains(instanceId) && !m_canonicalByInstance.contains(instanceId)) {
+            ++removed;
+        }
     }
-    return stale.size();
+    return removed;
 }
 
 void WindowRegistry::indexInsert(const QString& instanceId, const QString& appId)

--- a/libs/phosphor-engine/src/WindowRegistry.cpp
+++ b/libs/phosphor-engine/src/WindowRegistry.cpp
@@ -4,7 +4,12 @@
 #include <PhosphorEngine/WindowRegistry.h>
 #include <PhosphorIdentity/WindowId.h>
 
+#include <QLoggingCategory>
 #include <QPointer>
+
+namespace {
+Q_LOGGING_CATEGORY(lcWindowRegistry, "org.phosphor.engine.windowregistry")
+} // namespace
 
 namespace PhosphorEngine {
 
@@ -18,7 +23,7 @@ WindowRegistry::~WindowRegistry() = default;
 void WindowRegistry::upsert(const QString& instanceId, const WindowMetadata& metadata)
 {
     if (instanceId.isEmpty()) {
-        qWarning("WindowRegistry::upsert: rejecting empty instance id");
+        qCWarning(lcWindowRegistry, "WindowRegistry::upsert: rejecting empty instance id");
         return;
     }
 
@@ -158,6 +163,9 @@ void WindowRegistry::clear()
     if (m_records.isEmpty() && m_canonicalByInstance.isEmpty()) {
         return;
     }
+    // Emission ORDER across the set is unspecified (QSet iteration) — every
+    // subscriber handles windowDisappeared per-window with no cross-window
+    // ordering assumption, so imposing one would buy nothing.
     QSet<QString> ids(m_records.keyBegin(), m_records.keyEnd());
     ids.unite(QSet<QString>(m_canonicalByInstance.keyBegin(), m_canonicalByInstance.keyEnd()));
     QPointer<WindowRegistry> guard(this);
@@ -207,8 +215,9 @@ int WindowRegistry::pruneStaleInstances(const QSet<QString>& aliveInstanceIds)
     // session-restored apps have mapped their windows, and treating that as
     // "all dead" destroys the whole registry. Fail closed.
     if (aliveInstanceIds.isEmpty() && !(m_records.isEmpty() && m_canonicalByInstance.isEmpty())) {
-        qWarning("WindowRegistry::pruneStaleInstances: refusing empty alive set with %d records tracked",
-                 int(m_records.size()));
+        qCWarning(lcWindowRegistry,
+                  "WindowRegistry::pruneStaleInstances: refusing empty alive set with %d records tracked",
+                  int(m_records.size()));
         return 0;
     }
     // Union of both maps' keys — a window may carry a canonical entry without
@@ -230,6 +239,9 @@ int WindowRegistry::pruneStaleInstances(const QSet<QString>& aliveInstanceIds)
     // Count actual removals, not intent: a windowDisappeared subscriber can
     // re-upsert an instance (leaving it present) or destroy the registry
     // mid-sweep, and the return value is documented as "count removed".
+    // Mid-sweep destruction returns the PARTIAL count of the removals whose
+    // post-checks completed — the final in-flight removal is deliberately
+    // uncounted (its post-check would read the freed object).
     int removed = 0;
     for (const QString& instanceId : std::as_const(stale)) {
         remove(instanceId);

--- a/libs/phosphor-engine/src/WindowRegistry.cpp
+++ b/libs/phosphor-engine/src/WindowRegistry.cpp
@@ -171,8 +171,14 @@ int WindowRegistry::pruneStaleInstances(const QSet<QString>& aliveInstanceIds)
         }
     }
     for (const QString& instanceId : std::as_const(stale)) {
+        const bool hadRecord = m_records.contains(instanceId);
         remove(instanceId); // fires windowDisappeared + drops m_records / appId index
         m_canonicalByInstance.remove(instanceId);
+        if (!hadRecord) {
+            // Canonical-only entries bypass remove()'s record-backed signal,
+            // but subscribers still need the stale instance notification.
+            Q_EMIT windowDisappeared(instanceId);
+        }
     }
     return stale.size();
 }

--- a/libs/phosphor-engine/src/WindowRegistry.cpp
+++ b/libs/phosphor-engine/src/WindowRegistry.cpp
@@ -76,6 +76,13 @@ QString WindowRegistry::appIdFor(const QString& instanceId) const
     return it != m_records.constEnd() ? it.value().appId : QString();
 }
 
+bool WindowRegistry::isMinimized(const QString& windowId) const
+{
+    const QString instanceId = PhosphorIdentity::WindowId::extractInstanceId(windowId);
+    const auto it = m_records.constFind(instanceId);
+    return it != m_records.constEnd() && it->isMinimized.value_or(false);
+}
+
 QStringList WindowRegistry::instancesWithAppId(const QString& appId) const
 {
     if (appId.isEmpty()) {

--- a/libs/phosphor-engine/src/WindowRegistry.cpp
+++ b/libs/phosphor-engine/src/WindowRegistry.cpp
@@ -88,9 +88,12 @@ void WindowRegistry::remove(const QString& instanceId)
             m_canonicalByInstance.insert(instanceId, canonical);
         }
     }
-    if (hasPendingUpsert) {
+    if (hasPendingUpsert && m_clearing == 0) {
         upsert(instanceId, pendingMetadata);
     }
+    // While clear() drives this removal, a re-entrant upsert is dropped: the
+    // bulk reset supersedes it, and replaying would let records survive the
+    // clear.
 }
 
 std::optional<WindowMetadata> WindowRegistry::metadata(const QString& instanceId) const
@@ -145,11 +148,6 @@ bool WindowRegistry::contains(const QString& instanceId) const
     return m_records.contains(instanceId);
 }
 
-QStringList WindowRegistry::allInstances() const
-{
-    return m_records.keys();
-}
-
 int WindowRegistry::size() const
 {
     return m_records.size();
@@ -163,12 +161,17 @@ void WindowRegistry::clear()
     QSet<QString> ids(m_records.keyBegin(), m_records.keyEnd());
     ids.unite(QSet<QString>(m_canonicalByInstance.keyBegin(), m_canonicalByInstance.keyEnd()));
     QPointer<WindowRegistry> guard(this);
+    // No scope guard for the counter: a subscriber may destroy the registry
+    // mid-loop, and a guard running against the freed object would be UB —
+    // decrement manually on the surviving path only.
+    ++m_clearing;
     for (const QString& id : ids) {
         remove(id);
         if (!guard) {
             return;
         }
     }
+    --m_clearing;
 }
 
 QString WindowRegistry::canonicalizeWindowId(const QString& rawWindowId)

--- a/libs/phosphor-engine/src/WindowRegistry.cpp
+++ b/libs/phosphor-engine/src/WindowRegistry.cpp
@@ -8,9 +8,32 @@
 
 namespace PhosphorEngine {
 
+namespace {
+class WindowRegistryLifecycleState final : public QObject
+{
+public:
+    explicit WindowRegistryLifecycleState(QObject* parent)
+        : QObject(parent)
+    {
+        setObjectName(QStringLiteral("_plasmazones_window_registry_lifecycle"));
+    }
+
+    QSet<QString> disappearingInstances;
+    QHash<QString, WindowMetadata> pendingUpserts;
+};
+
+WindowRegistryLifecycleState* lifecycleState(const WindowRegistry* registry)
+{
+    QObject* state = registry->findChild<QObject*>(QStringLiteral("_plasmazones_window_registry_lifecycle"),
+                                                   Qt::FindDirectChildrenOnly);
+    return static_cast<WindowRegistryLifecycleState*>(state);
+}
+} // namespace
+
 WindowRegistry::WindowRegistry(QObject* parent)
     : QObject(parent)
 {
+    new WindowRegistryLifecycleState(this);
 }
 
 WindowRegistry::~WindowRegistry() = default;
@@ -19,6 +42,12 @@ void WindowRegistry::upsert(const QString& instanceId, const WindowMetadata& met
 {
     if (instanceId.isEmpty()) {
         qWarning("WindowRegistry::upsert: rejecting empty instance id");
+        return;
+    }
+
+    WindowRegistryLifecycleState* lifecycle = lifecycleState(this);
+    if (lifecycle->disappearingInstances.contains(instanceId)) {
+        lifecycle->pendingUpserts.insert(instanceId, metadata);
         return;
     }
 
@@ -45,10 +74,9 @@ void WindowRegistry::upsert(const QString& instanceId, const WindowMetadata& met
 
 void WindowRegistry::remove(const QString& instanceId)
 {
-    if (m_disappearingInstances.contains(instanceId)) {
-        if (m_records.contains(instanceId)) {
-            m_removeAfterDisappearance.insert(instanceId);
-        }
+    WindowRegistryLifecycleState* lifecycle = lifecycleState(this);
+    if (lifecycle->disappearingInstances.contains(instanceId)) {
+        lifecycle->pendingUpserts.remove(instanceId);
         return;
     }
 
@@ -64,19 +92,22 @@ void WindowRegistry::remove(const QString& instanceId)
     // Emit while the canonical mapping is still available to synchronous
     // subscribers, then retire it. Canonical-only instances still represent a
     // lifecycle entry and therefore receive the same exactly-once signal.
-    m_disappearingInstances.insert(instanceId);
+    const QString canonical = m_canonicalByInstance.value(instanceId);
+    lifecycle->disappearingInstances.insert(instanceId);
     QPointer<WindowRegistry> guard(this);
     Q_EMIT windowDisappeared(instanceId);
     if (!guard) {
         return;
     }
-    m_disappearingInstances.remove(instanceId);
-    if (m_removeAfterDisappearance.remove(instanceId)) {
-        remove(instanceId);
-        return;
-    }
-    if (!m_records.contains(instanceId)) {
-        m_canonicalByInstance.remove(instanceId);
+    lifecycle->disappearingInstances.remove(instanceId);
+    const bool hasPendingUpsert = lifecycle->pendingUpserts.contains(instanceId);
+    const WindowMetadata pendingMetadata = lifecycle->pendingUpserts.take(instanceId);
+    m_canonicalByInstance.remove(instanceId);
+    if (hasPendingUpsert) {
+        if (!canonical.isEmpty()) {
+            m_canonicalByInstance.insert(instanceId, canonical);
+        }
+        upsert(instanceId, pendingMetadata);
     }
 }
 
@@ -141,8 +172,12 @@ void WindowRegistry::clear()
     }
     QSet<QString> ids(m_records.keyBegin(), m_records.keyEnd());
     ids.unite(QSet<QString>(m_canonicalByInstance.keyBegin(), m_canonicalByInstance.keyEnd()));
+    QPointer<WindowRegistry> guard(this);
     for (const QString& id : ids) {
         remove(id);
+        if (!guard) {
+            return;
+        }
     }
 }
 
@@ -176,6 +211,9 @@ void WindowRegistry::releaseCanonical(const QString& anyWindowId)
         return;
     }
     const QString instanceId = PhosphorIdentity::WindowId::extractInstanceId(anyWindowId);
+    if (lifecycleState(this)->disappearingInstances.contains(instanceId)) {
+        return;
+    }
     m_canonicalByInstance.remove(instanceId);
 }
 
@@ -196,8 +234,12 @@ int WindowRegistry::pruneStaleInstances(const QSet<QString>& aliveInstanceIds)
             stale.insert(it.key());
         }
     }
+    QPointer<WindowRegistry> guard(this);
     for (const QString& instanceId : std::as_const(stale)) {
         remove(instanceId);
+        if (!guard) {
+            break;
+        }
     }
     return stale.size();
 }

--- a/libs/phosphor-engine/src/WindowRegistry.cpp
+++ b/libs/phosphor-engine/src/WindowRegistry.cpp
@@ -4,6 +4,8 @@
 #include <PhosphorEngine/WindowRegistry.h>
 #include <PhosphorIdentity/WindowId.h>
 
+#include <QPointer>
+
 namespace PhosphorEngine {
 
 WindowRegistry::WindowRegistry(QObject* parent)
@@ -43,13 +45,39 @@ void WindowRegistry::upsert(const QString& instanceId, const WindowMetadata& met
 
 void WindowRegistry::remove(const QString& instanceId)
 {
-    auto it = m_records.find(instanceId);
-    if (it == m_records.end()) {
+    if (m_disappearingInstances.contains(instanceId)) {
+        if (m_records.contains(instanceId)) {
+            m_removeAfterDisappearance.insert(instanceId);
+        }
         return;
     }
-    indexRemove(instanceId, it.value().appId);
-    m_records.erase(it);
+
+    auto it = m_records.find(instanceId);
+    const bool hasCanonical = m_canonicalByInstance.contains(instanceId);
+    if (it == m_records.end() && !hasCanonical) {
+        return;
+    }
+    if (it != m_records.end()) {
+        indexRemove(instanceId, it.value().appId);
+        m_records.erase(it);
+    }
+    // Emit while the canonical mapping is still available to synchronous
+    // subscribers, then retire it. Canonical-only instances still represent a
+    // lifecycle entry and therefore receive the same exactly-once signal.
+    m_disappearingInstances.insert(instanceId);
+    QPointer<WindowRegistry> guard(this);
     Q_EMIT windowDisappeared(instanceId);
+    if (!guard) {
+        return;
+    }
+    m_disappearingInstances.remove(instanceId);
+    if (m_removeAfterDisappearance.remove(instanceId)) {
+        remove(instanceId);
+        return;
+    }
+    if (!m_records.contains(instanceId)) {
+        m_canonicalByInstance.remove(instanceId);
+    }
 }
 
 std::optional<WindowMetadata> WindowRegistry::metadata(const QString& instanceId) const
@@ -111,12 +139,10 @@ void WindowRegistry::clear()
     if (m_records.isEmpty() && m_canonicalByInstance.isEmpty()) {
         return;
     }
-    const QStringList ids = m_records.keys();
-    m_records.clear();
-    m_appIdIndex.clear();
-    m_canonicalByInstance.clear();
+    QSet<QString> ids(m_records.keyBegin(), m_records.keyEnd());
+    ids.unite(QSet<QString>(m_canonicalByInstance.keyBegin(), m_canonicalByInstance.keyEnd()));
     for (const QString& id : ids) {
-        Q_EMIT windowDisappeared(id);
+        remove(id);
     }
 }
 
@@ -171,14 +197,7 @@ int WindowRegistry::pruneStaleInstances(const QSet<QString>& aliveInstanceIds)
         }
     }
     for (const QString& instanceId : std::as_const(stale)) {
-        const bool hadRecord = m_records.contains(instanceId);
-        remove(instanceId); // fires windowDisappeared + drops m_records / appId index
-        m_canonicalByInstance.remove(instanceId);
-        if (!hadRecord) {
-            // Canonical-only entries bypass remove()'s record-backed signal,
-            // but subscribers still need the stale instance notification.
-            Q_EMIT windowDisappeared(instanceId);
-        }
+        remove(instanceId);
     }
     return stale.size();
 }

--- a/libs/phosphor-placement/include/PhosphorPlacement/WindowTrackingService.h
+++ b/libs/phosphor-placement/include/PhosphorPlacement/WindowTrackingService.h
@@ -1085,16 +1085,18 @@ private:
 
     // Dependencies
     PhosphorZones::LayoutRegistry* m_layoutManager;
-    PhosphorZones::IZoneDetector* m_zoneDetector;
     SnapStateResolver m_snapResolver;
     PhosphorEngine::WindowPlacementStore m_placementStore;
     IGeometryResolver* m_geometryResolver;
     PlacementConfig m_config;
     PhosphorWorkspaces::VirtualDesktopManager* m_virtualDesktopManager;
     // Shared registry for current-class queries and canonical key translation.
-    // Not owned. Null in unit tests.
-    PhosphorEngine::WindowRegistry* m_windowRegistry = nullptr;
-    PhosphorScreens::ScreenManager* m_screenManager = nullptr;
+    // Not owned. Null in unit tests. QPointer (not raw): both are Daemon
+    // children whose destruction order relative to this service is not
+    // contractual — a raw borrow dangled during Daemon child teardown, while
+    // the QPointer auto-nulls and every use site already null-guards.
+    QPointer<PhosphorEngine::WindowRegistry> m_windowRegistry;
+    QPointer<PhosphorScreens::ScreenManager> m_screenManager;
     QPointer<PhosphorEngine::PlacementEngineBase> m_snapEngine;
     AutotileModePredicate m_autotileModePredicate{};
     AutotileTiledPredicate m_autotileTiledPredicate{};

--- a/libs/phosphor-placement/include/PhosphorPlacement/WindowTrackingService.h
+++ b/libs/phosphor-placement/include/PhosphorPlacement/WindowTrackingService.h
@@ -40,10 +40,6 @@ namespace PhosphorSnapEngine {
 class SnapState;
 }
 
-namespace PhosphorEngine {
-class WindowRegistry;
-}
-
 namespace PhosphorWorkspaces {
 class VirtualDesktopManager;
 }
@@ -417,7 +413,10 @@ public:
      * after the animation grace — a placement capture landing inside that
      * window would otherwise persist the suspension float as a genuine user
      * float. Marked by the adaptor at the float WRITE (where minimize state is
-     * still fresh), cleared on unfloat and on windowClosed.
+     * still fresh), and cleared BY THE ADAPTOR on unfloat and on windowClosed
+     * (WindowTrackingService::windowClosed itself does not touch the set — a
+     * direct WTS caller must clear it explicitly). The prune backstop sweeps
+     * it for windows that die without a close signal.
      */
     bool isSuspensionFloat(const QString& windowId) const override;
     void markSuspensionFloat(const QString& windowId);

--- a/libs/phosphor-placement/include/PhosphorPlacement/WindowTrackingService.h
+++ b/libs/phosphor-placement/include/PhosphorPlacement/WindowTrackingService.h
@@ -407,6 +407,22 @@ public:
     bool isWindowFloating(const QString& windowId) const override;
 
     /**
+     * @brief Suspension-float classification (minimize-floats).
+     *
+     * A float applied while the compositor reported the window MINIMIZED is a
+     * suspension, not placement intent, and the classification must OUTLIVE
+     * the live minimize bit: on the unminimize edge the effect's metadata push
+     * flips isMinimized to false immediately, while the unfloat only commits
+     * after the animation grace — a placement capture landing inside that
+     * window would otherwise persist the suspension float as a genuine user
+     * float. Marked by the adaptor at the float WRITE (where minimize state is
+     * still fresh), cleared on unfloat and on windowClosed.
+     */
+    bool isSuspensionFloat(const QString& windowId) const override;
+    void markSuspensionFloat(const QString& windowId);
+    void clearSuspensionFloat(const QString& windowId);
+
+    /**
      * @brief Set window floating state
      *
      * Routes to the engine owning the window's current screen mode via the
@@ -1090,6 +1106,11 @@ private:
     // m_engineFloatResolver / m_engineFloatWriter and this set is never read or
     // written by isWindowFloating / setWindowFloating.
     QSet<QString> m_floatingWindows;
+
+    // Suspension-float classification — see isSuspensionFloat(). Canonical-
+    // keyed. Session-transient (never persisted): a restart's restored floats
+    // are re-classified when their windows re-report minimize state.
+    QSet<QString> m_suspensionFloats;
 
     // Daemon-injected per-engine float reader/writer/lister. See setEngineFloatResolver.
     EngineFloatResolver m_engineFloatResolver{};

--- a/libs/phosphor-placement/include/PhosphorPlacement/WindowTrackingService.h
+++ b/libs/phosphor-placement/include/PhosphorPlacement/WindowTrackingService.h
@@ -469,15 +469,15 @@ public:
 
     /**
      * @brief Clear pre-float zone after restore (both windowId and appId keys)
+     *
+     * Always clears the appId alias alongside the windowId key: the pre-float
+     * readers fall back to the alias, so a windowId-only clear (the former
+     * clearPreFloatZoneForWindow) still resolved the stale zone for the very
+     * window it targeted. The alias is a single last-writer slot per app, so
+     * "protecting sibling data" by keeping it only preserved whichever
+     * instance unsnapped last.
      */
     void clearPreFloatZone(const QString& windowId) override;
-
-    /**
-     * @brief Clear pre-float zone for a specific window only (not appId)
-     *
-     * Used by autotile float sync to avoid destroying sibling instances' data.
-     */
-    void clearPreFloatZoneForWindow(const QString& windowId);
 
     /**
      * @brief Clear floating state when snapping a floating window

--- a/libs/phosphor-placement/include/PhosphorPlacement/WindowTrackingService.h
+++ b/libs/phosphor-placement/include/PhosphorPlacement/WindowTrackingService.h
@@ -368,6 +368,7 @@ public:
     /// Clear a window's shared free/float geometry from the record. See
     /// IWindowTrackingService::clearFreeGeometry.
     void clearFreeGeometry(const QString& windowId) override;
+    void clearFreeGeometry(const QString& windowId, const QString& screenId) override;
 
     // ═══════════════════════════════════════════════════════════════════════════
     // Floating Window State

--- a/libs/phosphor-placement/src/WindowTrackingService.cpp
+++ b/libs/phosphor-placement/src/WindowTrackingService.cpp
@@ -30,14 +30,16 @@ WindowTrackingService::WindowTrackingService(PhosphorZones::LayoutRegistry* layo
                                              QObject* parent)
     : QObject(parent)
     , m_layoutManager(layoutManager)
-    , m_zoneDetector(zoneDetector)
     , m_geometryResolver(geometryResolver)
     , m_config(config)
     , m_virtualDesktopManager(vdm)
     , m_screenManager(screenManager)
 {
     Q_ASSERT(layoutManager);
+    // The detector parameter is a wiring sanity check only — zone resolution
+    // moved into the engines, so the service keeps no member for it.
     Q_ASSERT(zoneDetector);
+    Q_UNUSED(zoneDetector)
 
     // No save timer here: the service is an in-memory state manager whose
     // persistence is driven by the WindowTrackingAdaptor's dirty-mask
@@ -344,7 +346,7 @@ std::optional<QRect> WindowTrackingService::validateGeometryForScreen(const QRec
     //    — the virtual screens have different geometry bounds, so coordinates are wrong.
     if (!savedScreen.isEmpty() && !currentScreenName.isEmpty()
         && !PhosphorScreens::ScreenIdentity::screensMatch(savedScreen, currentScreenName)) {
-        auto* mgr = m_screenManager;
+        PhosphorScreens::ScreenManager* mgr = m_screenManager;
         QRect available;
         bool haveTarget = false;
         if (mgr) {

--- a/libs/phosphor-placement/src/WindowTrackingService.cpp
+++ b/libs/phosphor-placement/src/WindowTrackingService.cpp
@@ -577,6 +577,20 @@ void WindowTrackingService::clearFreeGeometry(const QString& windowId)
     }
 }
 
+void WindowTrackingService::clearFreeGeometry(const QString& windowId, const QString& screenId)
+{
+    if (windowId.isEmpty()) {
+        return;
+    }
+    if (screenId.isEmpty()) {
+        clearFreeGeometry(windowId);
+        return;
+    }
+    if (m_placementStore.clearFreeGeometry(windowId, screenId)) {
+        markDirty(DirtyWindowPlacements);
+    }
+}
+
 // ═══════════════════════════════════════════════════════════════════════════════
 // Floating Window State
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/libs/phosphor-placement/src/WindowTrackingService.cpp
+++ b/libs/phosphor-placement/src/WindowTrackingService.cpp
@@ -39,22 +39,20 @@ WindowTrackingService::WindowTrackingService(PhosphorZones::LayoutRegistry* layo
     Q_ASSERT(layoutManager);
     Q_ASSERT(zoneDetector);
 
-    // Note: No save timer needed - persistence handled by WindowTrackingAdaptor via KConfig
-    // Service just emits stateChanged() signal when state changes
+    // No save timer here: the service is an in-memory state manager whose
+    // persistence is driven by the WindowTrackingAdaptor's dirty-mask
+    // save/load (WindowTrackingAdaptor::saveState/loadState, debounced via
+    // scheduleSaveState). The service only tracks the dirty mask (markDirty)
+    // and emits stateChanged.
     //
     // PhosphorZones::Layout change handling: WindowTrackingAdaptor connects to activeLayoutChanged and calls
     // onLayoutChanged(). Do NOT connect here - duplicate invocation would clear m_resnapBuffer
     // on the second run (after assignments were already removed), causing no_windows_to_resnap.
-
-    // Note: Persistence is handled by WindowTrackingAdaptor via KConfig.
-    // The service is a pure in-memory state manager - adaptor calls
-    // populateState() after loading from KConfig.
 }
 
 WindowTrackingService::~WindowTrackingService()
 {
-    // Note: Persistence is handled by WindowTrackingAdaptor via KConfig
-    // Service is purely in-memory state management
+    // In-memory only; the adaptor owns persistence (see the ctor note).
 }
 
 QString WindowTrackingService::currentAppIdFor(const QString& anyWindowId) const
@@ -146,14 +144,14 @@ void WindowTrackingService::assignWindowToZones(const QString& windowId, const Q
     // shadowing is fragile and the explicit sync here makes the cross-layer
     // contract robust.
     //
-    // Remove BOTH the windowId AND the appId entry unconditionally — the
-    // post-session-restore case has the appId entry present without the
-    // windowId one (see m_floatingWindows comments in WindowTrackingService.h),
-    // so gating the appId removal on the windowId removal succeeding would
-    // miss exactly the case the comment block above describes. QSet::remove
-    // on a missing key is a documented no-op so the unconditional form is
-    // cost-equivalent in the no-op path.
-    m_floatingWindows.remove(windowId);
+    // Remove BOTH the windowId AND the appId entry unconditionally. The
+    // appId-keyed entry only arises through the legacy bulk seeder
+    // (setFloatingWindows — unit tests and the pre-engine init window; no
+    // production restore path feeds it any more), but gating the appId
+    // removal on the windowId removal succeeding would miss exactly that
+    // shape. QSet::remove on a missing key is a documented no-op so the
+    // unconditional form is cost-equivalent in the no-op path.
+    m_floatingWindows.remove(canonicalizeForLookup(windowId));
     const QString appId = currentAppIdFor(windowId);
     if (appId != windowId) {
         m_floatingWindows.remove(appId);
@@ -495,7 +493,10 @@ void WindowTrackingService::recordFreeGeometry(const QString& windowId, const QS
     }
     // A geometry-only partial: no engine slot, so record()'s merge leaves the
     // managed context (screen/desktop/activity) untouched and only updates this
-    // screen's free geometry.
+    // screen's free geometry. For a FRESH record (no prior entry) the float
+    // screen becomes the record's screenId by construction — deliberate: it
+    // is the only screen the store knows for the window, and the first
+    // managed capture overwrites it with the real managed context.
     PhosphorEngine::WindowPlacement p;
     p.windowId = windowId;
     p.appId = appId;
@@ -653,11 +654,15 @@ bool WindowTrackingService::isWindowFloating(const QString& windowId) const
     }
 
     // Legacy fallback (unit tests / early init before engines are wired):
-    // Try full window ID first (runtime - distinguishes multiple instances)
-    if (m_floatingWindows.contains(windowId)) {
+    // Try full window ID first (runtime - distinguishes multiple instances).
+    // Canonical key, like the sticky map: a class-mutating window (issue
+    // #628) must resolve — and be prunable — under one composite.
+    if (m_floatingWindows.contains(canonicalizeForLookup(windowId))) {
         return true;
     }
-    // Fall back to app ID (session restore - pointer addresses change across restarts)
+    // appId fallback: only the legacy bulk seeder (setFloatingWindows — unit
+    // tests / pre-engine init) writes bare-appId entries; no production
+    // restore path feeds this any more.
     QString appId = currentAppIdFor(windowId);
     return (appId != windowId && m_floatingWindows.contains(appId));
 }
@@ -696,11 +701,12 @@ void WindowTrackingService::setWindowFloating(const QString& windowId, bool floa
     }
 
     // Legacy fallback (unit tests / early init before engines are wired):
-    // maintain the shared set + snap state directly.
+    // maintain the shared set + snap state directly. Canonical keys
+    // throughout (see isWindowFloating's lookup).
     if (floating) {
-        m_floatingWindows.insert(windowId);
+        m_floatingWindows.insert(canonicalizeForLookup(windowId));
     } else {
-        m_floatingWindows.remove(windowId);
+        m_floatingWindows.remove(canonicalizeForLookup(windowId));
         // Also remove app ID entry (session-restored entries)
         QString appId = currentAppIdFor(windowId);
         if (appId != windowId) {
@@ -832,11 +838,18 @@ void WindowTrackingService::clearPreFloatZone(const QString& windowId)
     const QString appId = currentAppIdFor(windowId);
     // Remove by full window ID (runtime entries) and by app ID (session-restored
     // entries) across every store — the alias may live in the window's owning store.
+    bool removed = false;
     for (PhosphorSnapEngine::SnapState* state : snapAllStates()) {
-        state->clearPreFloatZone(windowId);
+        removed = state->clearPreFloatZone(windowId) || removed;
         if (appId != windowId) {
-            state->clearPreFloatZone(appId);
+            removed = state->clearPreFloatZone(appId) || removed;
         }
+    }
+    // Mark dirty on a real removal so the cleared zone does not resurrect
+    // from disk on the next restart (the autotile float-sync clear path has
+    // no other persistence trigger).
+    if (removed) {
+        markDirty(DirtyPreFloatZones | DirtyPreFloatScreens);
     }
 }
 

--- a/libs/phosphor-placement/src/WindowTrackingService.cpp
+++ b/libs/phosphor-placement/src/WindowTrackingService.cpp
@@ -362,7 +362,11 @@ std::optional<QRect> WindowTrackingService::validateGeometryForScreen(const QRec
             haveTarget = true;
             available = target->availableGeometry();
         }
-        if (haveTarget) {
+        // A resolved target with an EMPTY available rect (mid-hotplug, a VS
+        // whose geometry has not landed yet) must not produce a degenerate 0x0
+        // "success" — fall through to the generic on-screen validation below,
+        // same as when the target cannot be resolved at all.
+        if (haveTarget && available.isValid()) {
             // Clamp size to fit within the target screen (the window may have been
             // larger than the target VS when captured on a wider screen/physical monitor).
             int w = qMin(geo.width(), available.width());
@@ -397,8 +401,17 @@ std::optional<QRect> WindowTrackingService::validatedUnmanagedGeometry(const QSt
     // The non-exact default is DELIBERATE cross-instance float-back sharing
     // (free positions only, never zone/tile slots — those reads are exact-only
     // via peekExact); callers with a per-window contract pass exactOnly.
+    // Accept only records that can actually answer: peek's same-instance branch
+    // honours the predicate too, so a window whose OWN record is free-geometry-less
+    // (a bare engine-slot partial) falls through to the appId bucket instead of
+    // shadowing a sibling's usable float-back — the cross-instance sharing the
+    // non-exact default documents. exactOnly passes an empty appId, so for those
+    // callers the predicate only turns a contentless own-record hit into the
+    // same nullopt it produced before.
     const QString appId = exactOnly ? QString() : currentAppIdFor(windowId);
-    const auto rec = m_placementStore.peek(windowId, appId);
+    const auto rec = m_placementStore.peek(windowId, appId, [](const PhosphorEngine::WindowPlacement& p) {
+        return p.anyFreeGeometry().isValid();
+    });
     if (!rec) {
         return std::nullopt;
     }
@@ -406,10 +419,11 @@ std::optional<QRect> WindowTrackingService::validatedUnmanagedGeometry(const QSt
     if (exact.isValid()) {
         return validateGeometryForScreen(exact, screenId, screenId);
     }
-    for (auto it = rec->freeGeometryByScreen.constBegin(); it != rec->freeGeometryByScreen.constEnd(); ++it) {
-        if (it.value().isValid()) {
-            return validateGeometryForScreen(it.value(), it.key(), screenId);
-        }
+    // Deterministic cross-screen fallback (shared with anyFreeGeometry()) — a
+    // raw QHash walk here picked a different float-back screen run to run.
+    const QString fallbackScreen = rec->anyFreeGeometryScreenId();
+    if (!fallbackScreen.isEmpty()) {
+        return validateGeometryForScreen(rec->freeGeometryFor(fallbackScreen), fallbackScreen, screenId);
     }
     return std::nullopt;
 }
@@ -543,6 +557,23 @@ void WindowTrackingService::recordFloatingClose(const QString& windowId, const Q
         p.activity = existing->activity;
         p.kind = existing->kind;
         p.engines = existing->engines;
+        // The merge adopts THIS close's screenId as the managed context, but a
+        // managed slot inherited from a DIFFERENT screen references that
+        // screen's zones/tile order — restoring it under the new screenId
+        // would land the window in another screen's zone ids. Downgrade
+        // mismatched managed slots to plain floating (the state the window
+        // actually closed in); same-screen slots pass through untouched.
+        if (!existing->screenId.isEmpty()
+            && !PhosphorScreens::ScreenIdentity::screensMatch(existing->screenId, screenId)) {
+            for (auto it = p.engines.begin(); it != p.engines.end(); ++it) {
+                if (it->state == PhosphorEngine::WindowPlacement::stateSnapped()
+                    || it->state == PhosphorEngine::WindowPlacement::stateTiled()) {
+                    it->state = PhosphorEngine::WindowPlacement::stateFloating();
+                    it->zoneIds.clear();
+                    it->order = -1;
+                }
+            }
+        }
     }
     if (p.engines.isEmpty()) {
         // No prior record, or a geometry-only record with no engine slot (the
@@ -793,19 +824,11 @@ QString WindowTrackingService::preFloatScreen(const QString& windowId) const
     });
 }
 
-void WindowTrackingService::clearPreFloatZoneForWindow(const QString& windowId)
+void WindowTrackingService::clearPreFloatZone(const QString& windowId)
 {
     if (windowId.isEmpty()) {
         return;
     }
-    // Clear from whichever store holds the entry (owning store for the live id).
-    for (PhosphorSnapEngine::SnapState* state : snapAllStates()) {
-        state->clearPreFloatZone(windowId);
-    }
-}
-
-void WindowTrackingService::clearPreFloatZone(const QString& windowId)
-{
     const QString appId = currentAppIdFor(windowId);
     // Remove by full window ID (runtime entries) and by app ID (session-restored
     // entries) across every store — the alias may live in the window's owning store.

--- a/libs/phosphor-placement/src/WindowTrackingService.cpp
+++ b/libs/phosphor-placement/src/WindowTrackingService.cpp
@@ -492,7 +492,7 @@ void WindowTrackingService::recordFloatingClose(const QString& windowId, const Q
     // non-empty engine map is what makes the store merge adopt the new screenId
     // (a geometry-only partial, like recordFreeGeometry, would leave the stale
     // managed screen in place — exactly the bug this fixes).
-    // Exact record only: inheriting a same-app SIBLING's engine slots would
+    // Same-instance record only: inheriting a same-app SIBLING's engine slots would
     // graft its snapped/tiled placement under THIS windowId — a reopen then
     // restores two windows into the sibling's zone and corrupts the per-app
     // FIFO distribution. A window with no record of its own takes the

--- a/libs/phosphor-placement/src/WindowTrackingService.cpp
+++ b/libs/phosphor-placement/src/WindowTrackingService.cpp
@@ -425,9 +425,25 @@ void WindowTrackingService::recordFreeGeometry(const QString& windowId, const QS
     // free frame, and "autotile mode + not floating" cannot tell that apart from a
     // tiled window. The effect's saveAndRecordPreAutotileGeometry guards the tiled
     // case at capture time instead.)
-    if (isWindowSnapped(windowId) && !isWindowFloating(windowId)) {
+    // The float bit here must be the SNAP ENGINE'S OWN, not the mode-routed
+    // isWindowFloating(): the resolver answers via the screen's CURRENT mode,
+    // so on an autotile-mode screen a still-snapped window would read its
+    // float bit from the autotile engine (true when untracked), the AND would
+    // fail, and the zone rect would be written as the float-back — the guard
+    // failing open on exactly the mode-swap path it protects.
+    const PhosphorSnapEngine::SnapState* snapState = snapForWindow(windowId);
+    const bool snapFloating = snapState && snapState->isFloating(windowId);
+    if (isWindowSnapped(windowId) && !snapFloating) {
         qCDebug(lcPlacement) << "recordFreeGeometry: refusing snapped frame for" << windowId
                              << "— float-back stays frozen while it occupies a zone";
+        return;
+    }
+    // A minimized window's frame is never a genuine free position: it is
+    // whatever rect the window held when it was hidden (typically a zone or
+    // tile rect on managed screens). Engaged-true only — the minimize edge
+    // pushes fresh metadata before any capture traffic it triggers.
+    if (m_windowRegistry && m_windowRegistry->minimizedState(windowId).value_or(false)) {
+        qCDebug(lcPlacement) << "recordFreeGeometry: refusing minimized frame for" << windowId;
         return;
     }
     // Same invariant for the tiled case: an actively-tiled window's frame IS
@@ -479,6 +495,23 @@ void WindowTrackingService::recordFloatingClose(const QString& windowId, const Q
     if (isWindowAutotileTiled(windowId)) {
         return;
     }
+    // Same snapped-frame guard as recordFreeGeometry (mode-independent snap
+    // float bit): a window closing while it actually occupies a zone must not
+    // write the zone rect into the shared free geometry.
+    {
+        const PhosphorSnapEngine::SnapState* snapState = snapForWindow(windowId);
+        const bool snapFloating = snapState && snapState->isFloating(windowId);
+        if (isWindowSnapped(windowId) && !snapFloating) {
+            qCDebug(lcPlacement) << "recordFloatingClose: refusing snapped frame for" << windowId;
+            return;
+        }
+    }
+    // And the minimized guard: a minimized close's frame is the hidden rect,
+    // not a free position.
+    if (m_windowRegistry && m_windowRegistry->minimizedState(windowId).value_or(false)) {
+        qCDebug(lcPlacement) << "recordFloatingClose: refusing minimized frame for" << windowId;
+        return;
+    }
     const QString appId = currentAppIdFor(windowId);
     if (appId.isEmpty()) {
         return;
@@ -504,8 +537,9 @@ void WindowTrackingService::recordFloatingClose(const QString& windowId, const Q
         p.engines = existing->engines;
     }
     if (p.engines.isEmpty()) {
-        // No prior record (first close after a cross-screen drag): synthesize a
-        // floating slot so the merge still adopts the screen. A floated restore
+        // No prior record, or a geometry-only record with no engine slot (the
+        // shape recordFreeGeometry produces): synthesize a floating slot so
+        // the merge still adopts the screen. A floated restore
         // keys off screenId + freeGeometryByScreen, not the slot's engine id, so
         // the slot id is not load-bearing here.
         PhosphorEngine::EngineSlot slot;

--- a/libs/phosphor-placement/src/WindowTrackingService.cpp
+++ b/libs/phosphor-placement/src/WindowTrackingService.cpp
@@ -308,6 +308,25 @@ int WindowTrackingService::pruneStaleAssignments(const QSet<QString>& rawAliveWi
     // per-engine float resolver/writer are wired (the engines own float state), so
     // this is a no-op there; kept for the unwired / unit-test path.
     removeSet(m_floatingWindows);
+    // Suspension classification: cleared per-window by the adaptor on unfloat
+    // and windowClosed, but a window that dies WITHOUT a close signal — the
+    // case this backstop exists for — would leak its entry and hand a later
+    // same-canonical window a stale suspension classification. The set is
+    // CANONICAL-keyed, so canonicalize the alive ids before comparing (a live
+    // class-renamed window's current composite differs from its canonical).
+    QSet<QString> canonicalAlive;
+    canonicalAlive.reserve(aliveWindowIds.size());
+    for (const QString& id : aliveWindowIds) {
+        canonicalAlive.insert(canonicalizeForLookup(id));
+    }
+    for (auto it = m_suspensionFloats.begin(); it != m_suspensionFloats.end();) {
+        if (!canonicalAlive.contains(*it)) {
+            it = m_suspensionFloats.erase(it);
+            ++wtsCleaned;
+        } else {
+            ++it;
+        }
+    }
 
     if (m_snapEngine) {
         wtsCleaned += m_snapEngine->pruneStaleWindows(aliveWindowIds);

--- a/libs/phosphor-placement/src/WindowTrackingService.cpp
+++ b/libs/phosphor-placement/src/WindowTrackingService.cpp
@@ -581,6 +581,21 @@ void WindowTrackingService::clearFreeGeometry(const QString& windowId)
 // Floating Window State
 // ═══════════════════════════════════════════════════════════════════════════════
 
+bool WindowTrackingService::isSuspensionFloat(const QString& windowId) const
+{
+    return m_suspensionFloats.contains(canonicalizeForLookup(windowId));
+}
+
+void WindowTrackingService::markSuspensionFloat(const QString& windowId)
+{
+    m_suspensionFloats.insert(canonicalizeForLookup(windowId));
+}
+
+void WindowTrackingService::clearSuspensionFloat(const QString& windowId)
+{
+    m_suspensionFloats.remove(canonicalizeForLookup(windowId));
+}
+
 bool WindowTrackingService::isWindowFloating(const QString& windowId) const
 {
     // Per-engine answer: when the daemon has wired the resolver, the float bit

--- a/libs/phosphor-placement/src/WindowTrackingService.cpp
+++ b/libs/phosphor-placement/src/WindowTrackingService.cpp
@@ -257,6 +257,14 @@ int WindowTrackingService::pruneStaleAssignments(const QSet<QString>& rawAliveWi
     Q_ASSERT(hasSnapState());
     if (!hasSnapState())
         return 0;
+    // Fail closed on an empty alive set (the WindowRegistry twin carries the
+    // full rationale): a premature one-shot alive report at login must not
+    // wipe every persisted assignment; genuinely-closed windows are pruned
+    // per-window on windowClosed.
+    if (rawAliveWindowIds.isEmpty()) {
+        qCWarning(lcPlacement) << "pruneStaleAssignments: refusing empty alive set";
+        return 0;
+    }
     // Canonicalize the alive set so it compares like-for-like against the
     // canonical-keyed stores (the WTS-owned sticky / legacy-float sets below, and
     // SnapState's maps). Otherwise a window still alive under a mutated-class

--- a/libs/phosphor-placement/src/lifecycle.cpp
+++ b/libs/phosphor-placement/src/lifecycle.cpp
@@ -544,7 +544,7 @@ bool WindowTrackingService::isGeometryOnScreen(const QRect& geometry) const
     // Check virtual screens first (covers both virtual and non-subdivided physical screens).
     // Use area-overlap semantics (not center-point containment) so windows on virtual
     // screen boundaries are handled consistently with the physical-screen fallback path.
-    auto* mgr = m_screenManager;
+    PhosphorScreens::ScreenManager* mgr = m_screenManager;
     if (mgr) {
         const QStringList ids = mgr->effectiveScreenIds();
         for (const QString& id : ids) {
@@ -573,7 +573,7 @@ bool WindowTrackingService::isGeometryOnScreen(const QRect& geometry) const
 QRect WindowTrackingService::adjustGeometryToScreen(const QRect& geometry) const
 {
     // Try virtual/effective screens first via PhosphorScreens::ScreenManager
-    auto* mgr = m_screenManager;
+    PhosphorScreens::ScreenManager* mgr = m_screenManager;
     if (mgr) {
         const QStringList ids = mgr->effectiveScreenIds();
         const QPoint center = geometry.center();
@@ -653,7 +653,7 @@ QString WindowTrackingService::resolveEffectiveScreenId(const QString& screenId)
         return screenId;
     }
 
-    auto* smgr = m_screenManager;
+    PhosphorScreens::ScreenManager* smgr = m_screenManager;
     if (!smgr) {
         return screenId;
     }

--- a/libs/phosphor-placement/src/lifecycle.cpp
+++ b/libs/phosphor-placement/src/lifecycle.cpp
@@ -67,7 +67,9 @@ void WindowTrackingService::windowClosed(const QString& windowId, PhosphorEngine
     // and not be auto-snapped when reopened.
     QStringList zoneIds = snapState ? snapState->zonesForWindow(windowId) : QStringList{};
     QString zoneId = zoneIds.isEmpty() ? QString() : zoneIds.first();
-    // Check floating with full windowId first, fallback to appId
+    // With the engine resolver wired (production) this is the engine's answer
+    // directly; the full-windowId-then-appId fallback applies only to the
+    // legacy unwired path inside isWindowFloating.
     bool isFloating = isWindowFloating(windowId);
     if (!zoneId.isEmpty() && !zoneId.startsWith(kZoneSelectorIdPrefix)
         && !isFloating
@@ -478,6 +480,15 @@ void WindowTrackingService::onLayoutChanged()
         unassignWindow(windowId);
     }
     for (auto it = toRewrite.constBegin(); it != toRewrite.constEnd(); ++it) {
+        // Skip floating windows: assignWindowToZones unconditionally strips
+        // the legacy float bit, and a floating-with-preserved-zone window must
+        // not lose it to a bookkeeping rewrite — matching the migration
+        // siblings in virtualscreenmigration.cpp, which skip floating windows
+        // in their prune passes. (Production float state lives in the engines;
+        // this protects the unwired/test fallback path.)
+        if (isWindowFloating(it.key())) {
+            continue;
+        }
         const RewriteTarget& target = it.value();
         assignWindowToZones(it.key(), target.zones, target.screenId, target.desktop);
     }

--- a/libs/phosphor-placement/src/lifecycle.cpp
+++ b/libs/phosphor-placement/src/lifecycle.cpp
@@ -163,7 +163,7 @@ void WindowTrackingService::windowClosed(const QString& windowId, PhosphorEngine
     // the window is reopened. Without this, closing a floated window and
     // reopening it would inherit the float state (via appId fallback), causing
     // a spurious "floated" OSD and preventing auto-snap.
-    m_floatingWindows.remove(windowId);
+    m_floatingWindows.remove(canonicalizeForLookup(windowId));
     if (appId != windowId) {
         m_floatingWindows.remove(appId);
     }

--- a/libs/phosphor-placement/src/virtualscreenmigration.cpp
+++ b/libs/phosphor-placement/src/virtualscreenmigration.cpp
@@ -537,7 +537,7 @@ bool WindowTrackingService::pruneMigratedWindows(const QStringList& windowsToRem
             lastUsedCleared |= clearGlobalLastUsedIfRemoved(removedZones, store);
         }
         clearFreeGeometry(wId); // drop the record's shared free geometry
-        clearPreFloatZoneForWindow(wId);
+        clearPreFloatZone(wId);
         // Canonical key, as windowClosed does: the sticky map is keyed on the
         // first-seen composite (issue #628), so a window that renamed itself
         // (Electron/CEF) would leak its entry if removed under the raw id.

--- a/libs/phosphor-placement/src/virtualscreenmigration.cpp
+++ b/libs/phosphor-placement/src/virtualscreenmigration.cpp
@@ -22,6 +22,7 @@
 #include "placementlogging.h"
 #include <QScreen>
 #include <QUuid>
+#include <algorithm>
 #include <climits>
 
 namespace PhosphorPlacement {

--- a/libs/phosphor-snap-engine/include/PhosphorSnapEngine/SnapEngine.h
+++ b/libs/phosphor-snap-engine/include/PhosphorSnapEngine/SnapEngine.h
@@ -959,6 +959,11 @@ private:
 
     bool unfloatToZone(const QString& windowId, const QString& screenId);
     bool applyGeometryForFloat(const QString& windowId, const QString& screenId);
+    /// Float-path wrapper around applyGeometryForFloat that suppresses the
+    /// geometry apply for minimize-suspension floats (registry reports the
+    /// window minimized): a hidden window's frame must stay put so the
+    /// unminimize restore lands where the window really was.
+    void applyFloatGeometryUnlessMinimized(const QString& windowId, const QString& screenId);
 
     /// Lazy-constructs m_targetResolver on first call. Returns nullptr if
     /// the service or layout manager is missing (unit tests with stub

--- a/libs/phosphor-snap-engine/include/PhosphorSnapEngine/SnapEngine.h
+++ b/libs/phosphor-snap-engine/include/PhosphorSnapEngine/SnapEngine.h
@@ -957,7 +957,10 @@ private:
     // removed — all snap commits now route through commitSnapImpl.
     // ═══════════════════════════════════════════════════════════════════════════
 
-    bool unfloatToZone(const QString& windowId, const QString& screenId);
+    /// @p allowRuleTarget gates the SnapToZone-rule tier: true for user float
+    /// toggles (rule stays authoritative), false for suspension (minimize)
+    /// unfloats, which must restore the pre-float zone.
+    bool unfloatToZone(const QString& windowId, const QString& screenId, bool allowRuleTarget = true);
     bool applyGeometryForFloat(const QString& windowId, const QString& screenId);
     /// Float-path wrapper around applyGeometryForFloat that suppresses the
     /// geometry apply for minimize-suspension floats (registry reports the

--- a/libs/phosphor-snap-engine/include/PhosphorSnapEngine/SnapState.h
+++ b/libs/phosphor-snap-engine/include/PhosphorSnapEngine/SnapState.h
@@ -142,7 +142,9 @@ public:
     QString preFloatZone(const QString& windowId) const;
     QStringList preFloatZones(const QString& windowId) const;
     QString preFloatScreen(const QString& windowId) const;
-    void clearPreFloatZone(const QString& windowId);
+    /// Returns true when an entry was actually removed, so callers can gate
+    /// their dirty-marking on a real mutation.
+    bool clearPreFloatZone(const QString& windowId);
     void addPreFloatZone(const QString& windowId, const QStringList& zoneIds);
     void addPreFloatScreen(const QString& windowId, const QString& screenId);
 

--- a/libs/phosphor-snap-engine/src/SnapState.cpp
+++ b/libs/phosphor-snap-engine/src/SnapState.cpp
@@ -143,6 +143,13 @@ void SnapState::assignWindowToZones(const QString& rawWindowId, const QStringLis
     if (zoneChanged) {
         Q_EMIT windowAssigned(windowId, validZoneIds.first());
     }
+    if (wasFloating) {
+        // Snapping clears the float bit; the dedicated signal must fire like
+        // setFloating/setFloatingOnScreen do, or an exported-API subscriber
+        // tracking float state via floatingChanged misses every
+        // snap-clears-float transition.
+        Q_EMIT floatingChanged(windowId, false);
+    }
     if (zoneChanged || screenChanged || desktopChanged || wasFloating) {
         Q_EMIT stateChanged();
     }

--- a/libs/phosphor-snap-engine/src/SnapState.cpp
+++ b/libs/phosphor-snap-engine/src/SnapState.cpp
@@ -353,7 +353,7 @@ QStringList SnapState::preFloatZones(const QString& rawWindowId) const
     return m_preFloatZoneAssignments.value(windowId);
 }
 
-void SnapState::clearPreFloatZone(const QString& rawWindowId)
+bool SnapState::clearPreFloatZone(const QString& rawWindowId)
 {
     const QString windowId = canonicalizeForLookup(rawWindowId);
     // Emit only when an entry actually went away, matching this class's uniform
@@ -366,6 +366,7 @@ void SnapState::clearPreFloatZone(const QString& rawWindowId)
     if (removed > 0) {
         Q_EMIT stateChanged();
     }
+    return removed > 0;
 }
 
 void SnapState::addPreFloatZone(const QString& rawWindowId, const QStringList& zoneIds)

--- a/libs/phosphor-snap-engine/src/float.cpp
+++ b/libs/phosphor-snap-engine/src/float.cpp
@@ -205,62 +205,33 @@ bool SnapEngine::unfloatToZone(const QString& windowId, const QString& screenId)
 
 bool SnapEngine::applyGeometryForFloat(const QString& windowId, const QString& screenId)
 {
-    // Prefer the unified placement record's float-back geometry. It is the single
-    // source of truth: appId-keyed (survives the uuid change on logout/login),
-    // one-record-per-window, and — unlike the legacy m_unmanagedGeometries store —
-    // not silently dropped on load by the disabled-context gate when the user has
-    // toggled snapping off/on. The legacy store is consulted only as a fallback
-    // for windows with no record yet (pre-migration / first float of the session).
+    if (!m_windowTracker) {
+        return false;
+    }
+    // ONE resolver, shared with the WTA twin (WindowTrackingAdaptor::
+    // applyGeometryForFloat): validatedUnmanagedGeometry reads the unified
+    // placement record — this screen's remembered spot first, then the
+    // deterministic cross-screen fallback — and cross-screen-validates the
+    // rect. The previous open-coded peek here skipped that validation, so a
+    // rect captured on another monitor was applied with raw coordinates.
     //
-    // The appId-FIFO fallback here is DELIBERATE (unlike the exact-only pre-float
-    // zone read in resolveUnfloatGeometry): a record-less instance floating for
-    // the first time restores to where its app last floated — the cross-instance
-    // float-back share that collapsePureFloatSiblings manages. A shared free
-    // position is a sensible default; a shared ZONE assignment is not.
-    if (m_windowTracker) {
-        const QString appId = m_windowTracker->currentAppIdFor(windowId);
-        auto rec = m_windowTracker->placementStore().peek(windowId, appId);
-        if (rec) {
-            // The shared free/float geometry, per screen — never a zone/tile rect by
-            // construction. Prefer this screen's remembered spot, else any captured
-            // free spot.
-            QRect g = rec->freeGeometryFor(screenId);
-            if (!g.isValid()) {
-                g = rec->anyFreeGeometry();
-            }
-            if (g.isValid()) {
-                qCInfo(PhosphorSnapEngine::lcSnapEngine)
-                    << "applyGeometryForFloat:" << windowId << "restoring to" << g << "(placement record)";
-                Q_EMIT applyGeometryRequested(windowId, g.x(), g.y(), g.width(), g.height(), QString(), screenId,
-                                              false);
-                return true;
-            }
-            // A record exists but the window has no genuine free geometry yet (it has
-            // only ever been snapped/tiled). Do NOT fall back to the legacy unmanaged
-            // store — that may still hold a stale zone rect, which is exactly the
-            // geometry leak this model removes. Leave the window where it is; the next
-            // move while floating captures a real free position into the record.
-            qCInfo(PhosphorSnapEngine::lcSnapEngine)
-                << "applyGeometryForFloat:" << windowId << "no free geometry on record — leaving in place";
-            return false;
-        }
+    // The resolver's appId-FIFO fallback is DELIBERATE (unlike the exact-only
+    // pre-float zone read in resolveUnfloatGeometry): a record-less instance
+    // floating for the first time restores to where its app last floated — the
+    // cross-instance float-back share that collapsePureFloatSiblings manages.
+    // A shared free position is a sensible default; a shared ZONE assignment
+    // is not. A window with no free geometry on record anywhere simply stays
+    // where it is; the next move while floating captures a real free position.
+    const auto geo = m_windowTracker->validatedUnmanagedGeometry(windowId, screenId);
+    if (geo) {
+        qCInfo(PhosphorSnapEngine::lcSnapEngine)
+            << "applyGeometryForFloat:" << windowId << "restoring to" << *geo << "(placement record)";
+        Q_EMIT applyGeometryRequested(windowId, geo->x(), geo->y(), geo->width(), geo->height(), QString(), screenId,
+                                      false);
+        return true;
     }
-
-    // Legacy-store fallback (no placement record yet). Guard m_windowTracker:
-    // the placement-record block above is itself gated on a non-null tracker, so
-    // a null tracker falls straight here — deref it unconditionally and a
-    // headless-test engine (nullptr tracker) would crash.
-    if (m_windowTracker) {
-        auto geo = m_windowTracker->validatedUnmanagedGeometry(windowId, screenId);
-        if (geo) {
-            qCInfo(PhosphorSnapEngine::lcSnapEngine)
-                << "applyGeometryForFloat:" << windowId << "restoring to" << *geo << "(legacy unmanaged store)";
-            Q_EMIT applyGeometryRequested(windowId, geo->x(), geo->y(), geo->width(), geo->height(), QString(),
-                                          screenId, false);
-            return true;
-        }
-    }
-    qCWarning(PhosphorSnapEngine::lcSnapEngine) << "applyGeometryForFloat:" << windowId << "no pre-tile geometry found";
+    qCInfo(PhosphorSnapEngine::lcSnapEngine)
+        << "applyGeometryForFloat:" << windowId << "no free geometry on record — leaving in place";
     return false;
 }
 

--- a/libs/phosphor-snap-engine/src/float.cpp
+++ b/libs/phosphor-snap-engine/src/float.cpp
@@ -27,6 +27,11 @@ void SnapEngine::toggleWindowFloat(const QString& windowId, const QString& scree
     const bool currentlySnapped = state && state->isWindowSnapped(windowId);
 
     if (!currentlyFloating && !currentlySnapped) {
+        // Report instead of absorbing the press silently: every other
+        // navigation shortcut produces feedback, and a silent shortcut reads
+        // as broken (mirrors the autotile facade's not_managed report).
+        Q_EMIT navigationFeedback(false, QStringLiteral("float"), QStringLiteral("not_managed"), QString(), QString(),
+                                  screenId);
         return;
     }
 
@@ -42,10 +47,29 @@ void SnapEngine::toggleWindowFloat(const QString& windowId, const QString& scree
         m_windowTracker->unsnapForFloat(windowId);
         m_windowTracker->setWindowFloating(windowId, true);
         Q_EMIT windowFloatingChanged(windowId, true, screenId);
-        applyGeometryForFloat(windowId, screenId);
+        applyFloatGeometryUnlessMinimized(windowId, screenId);
         Q_EMIT navigationFeedback(true, QStringLiteral("float"), QStringLiteral("floated"), QString(), QString(),
                                   screenId);
     }
+}
+
+void SnapEngine::applyFloatGeometryUnlessMinimized(const QString& windowId, const QString& screenId)
+{
+    // A minimize-suspension float must NOT move the frame: the window is
+    // hidden, and applying the remembered float-back rect here would park it
+    // at a stale position that KWin then restores to on unminimize, before
+    // the unfloat re-snaps it (the "wrong geometry first, then resnaps"
+    // defect). The autotile engine documents and guards the identical hazard
+    // in float_handoff.cpp; this is the snap-side twin. The guard fires only
+    // on ENGAGED true: the effect pushes fresh metadata on the minimize edge
+    // BEFORE any float traffic from that edge (same ordered D-Bus stream), so
+    // a genuine minimize-float always arrives with the state engaged, while
+    // an unknown reading means a visible-window float whose float-back
+    // reposition must not be dropped.
+    if (m_windowRegistry && m_windowRegistry->minimizedState(windowId).value_or(false)) {
+        return;
+    }
+    applyGeometryForFloat(windowId, screenId);
 }
 
 void SnapEngine::setWindowFloat(const QString& windowId, bool shouldFloat, const QString& callerScreenId)
@@ -79,7 +103,9 @@ void SnapEngine::setWindowFloat(const QString& windowId, bool shouldFloat, const
         m_windowTracker->unsnapForFloat(windowId);
         m_windowTracker->setWindowFloating(windowId, true);
         Q_EMIT windowFloatingChanged(windowId, true, screenId);
-        applyGeometryForFloat(windowId, screenId);
+        // Guarded: the minimize path reaches here via setWindowFloatingForScreen
+        // and must not teleport the hidden frame (see the helper's comment).
+        applyFloatGeometryUnlessMinimized(windowId, screenId);
     } else {
         if (!unfloatToZone(windowId, screenId)) {
             // No pre-float zone to restore to — keep the window floating rather than

--- a/libs/phosphor-snap-engine/src/float.cpp
+++ b/libs/phosphor-snap-engine/src/float.cpp
@@ -107,7 +107,10 @@ void SnapEngine::setWindowFloat(const QString& windowId, bool shouldFloat, const
         // and must not teleport the hidden frame (see the helper's comment).
         applyFloatGeometryUnlessMinimized(windowId, screenId);
     } else {
-        if (!unfloatToZone(windowId, screenId)) {
+        // Suspension (minimize-as-float) unfloats restore the pre-float zone,
+        // never a SnapToZone rule target — see unfloatToZone's gate.
+        const bool suspension = m_windowTracker && m_windowTracker->isSuspensionFloat(windowId);
+        if (!unfloatToZone(windowId, screenId, /*allowRuleTarget=*/!suspension)) {
             // No pre-float zone to restore to — keep the window floating rather than
             // leaving it in a limbo state (not floating, not snapped to any zone).
             qCDebug(PhosphorSnapEngine::lcSnapEngine)
@@ -121,13 +124,17 @@ void SnapEngine::setWindowFloat(const QString& windowId, bool shouldFloat, const
 // Private helpers
 // ═══════════════════════════════════════════════════════════════════════════════
 
-bool SnapEngine::unfloatToZone(const QString& windowId, const QString& screenId)
+bool SnapEngine::unfloatToZone(const QString& windowId, const QString& screenId, bool allowRuleTarget)
 {
     // Highest-priority un-float target: a matched SnapToZone rule. Toggling a
     // window out of float lands it in the rule's zones, not a stale pre-float
     // zone, so the rule stays authoritative for both open and Meta+F. Falls
     // through to the pre-float / fallback zone when no rule matches.
-    {
+    // Gated on @p allowRuleTarget: a SUSPENSION (minimize) unfloat is not a
+    // user float toggle — the round trip exists to put the window back where
+    // it was, and letting the rule tier win would yank a manually re-snapped
+    // window back to the rule's zone on every minimize/unminimize.
+    if (allowRuleTarget) {
         const PhosphorEngine::SnapResult ruleSnap =
             calculateSnapToPlacementRule(windowId, screenId, /*isSticky=*/false);
         if (ruleSnap.shouldSnap && !ruleSnap.zoneIds.isEmpty()) {
@@ -422,6 +429,19 @@ void SnapEngine::handoffReceive(const HandoffContext& ctx)
     qCInfo(PhosphorSnapEngine::lcSnapEngine) << "SnapEngine::handoffReceive:" << ctx.windowId << "to" << ctx.toScreenId
                                              << "from" << ctx.fromEngineId << "wasFloating=" << ctx.wasFloating;
 
+    // Re-home FIRST, on every path: a window already tracked here under a
+    // different (screen, desktop, activity) key keeps its old owning SnapState
+    // otherwise — stateForWindowOnScreen deliberately does not re-home, and the
+    // zone-resolved branches below place through it — so
+    // pruneStatesForRemovedScreen / pruneStatesForDesktop on the SOURCE context
+    // would silently drop a snap that now lives on the destination. A
+    // documented no-op when the key is unchanged or the window is being
+    // adopted fresh from another engine (untracked here). This also moves the
+    // per-window state (floating bit, live screen rewritten to the
+    // destination) so screenForTrackedWindow reflects the new monitor (#724);
+    // the pre-float zone rides along UNCHANGED (behaviour A).
+    migrateWindowToScreen(ctx.windowId, ctx.toScreenId);
+
     if (!ctx.sourceZoneIds.isEmpty()) {
         QRect zoneGeo = m_windowTracker->resolveZoneGeometry(ctx.sourceZoneIds, ctx.toScreenId);
         if (zoneGeo.isValid()) {
@@ -484,16 +504,9 @@ void SnapEngine::handoffReceive(const HandoffContext& ctx)
     }
 
     const int currentDesktop = ctx.toDesktop > 0 ? ctx.toDesktop : currentVirtualDesktopForScreen(ctx.toScreenId);
-    // Re-home the window onto the destination monitor's per-key store when it is
-    // already tracked here (same-engine cross-screen float drift). This moves its
-    // per-window state (including the floating bit and the live screen, rewritten to
-    // the destination) so screenForTrackedWindow reflects the new monitor (#724). The
-    // pre-float zone rides along UNCHANGED (behaviour A): an unfloat on any monitor
-    // restores the home zone, and cross-monitor restore is allowed (there is no
-    // refusal guard). A no-op when the window is being
-    // adopted fresh from another engine (untracked here); stateForWindowOnScreen then
-    // registers it under the destination key below.
-    migrateWindowToScreen(ctx.windowId, ctx.toScreenId);
+    // Re-homing already happened at the top of the function (it must cover the
+    // zone-resolved branches too); an unfloat on any monitor restores the home
+    // zone, and cross-monitor restore is allowed (there is no refusal guard).
     if (!ctx.wasFloating) {
         // Explicit cross-mode MOVE of a MANAGED window whose source zones did
         // not resolve on this screen (foreign zone ids after a layout change).

--- a/libs/phosphor-snap-engine/src/float.cpp
+++ b/libs/phosphor-snap-engine/src/float.cpp
@@ -279,8 +279,8 @@ UnfloatResult SnapEngine::resolveUnfloatGeometry(const QString& windowId, const 
         // restart dead-ends ("no pre-float zone, keeping floating") with no way
         // out short of re-snapping by hand.
         using PhosphorEngine::WindowPlacement;
-        // Exact-windowId records ONLY: a daemon restart keeps KWin uuids, so the
-        // window's own record always exact-matches. The appId-FIFO fallback
+        // Same-instance records ONLY: a daemon restart keeps KWin uuids, so the
+        // window's own record always matches. The appId-FIFO fallback
         // would hand a record-less floating window a SIBLING's home zone (same
         // app, different instance) and unfloat-snap it there — cross-window
         // zone bleed. Logout/login (new uuids) restores through

--- a/libs/phosphor-snap-engine/src/float.cpp
+++ b/libs/phosphor-snap-engine/src/float.cpp
@@ -429,9 +429,11 @@ void SnapEngine::handoffReceive(const HandoffContext& ctx)
                 // snap-state resolver (Daemon wires setSnapStateResolver()), so zoneForWindow et al.
                 // see this assignment; the snap chrome is applied below via the
                 // non-empty-zoneId applyGeometryRequested (→ markWindowSnapped); and
-                // persistence flows through the placement-store record. The only
-                // caller, handleCrossModeMove, always passes wasFloating==false, so
-                // there is no floating flag to clear.
+                // persistence flows through the placement-store record. Every
+                // caller that sets toDesktop (the cross-desktop move paths)
+                // passes wasFloating==false, so there is no floating flag to
+                // clear in THIS branch; other handoffReceive callers land in
+                // the tail below.
                 SnapState* targetState = stateForWindowOnScreen(ctx.windowId, ctx.toScreenId);
                 if (ctx.sourceZoneIds.size() > 1) {
                     targetState->assignWindowToZones(ctx.windowId, ctx.sourceZoneIds, ctx.toScreenId, ctx.toDesktop);
@@ -474,6 +476,18 @@ void SnapEngine::handoffReceive(const HandoffContext& ctx)
     // adopted fresh from another engine (untracked here); stateForWindowOnScreen then
     // registers it under the destination key below.
     migrateWindowToScreen(ctx.windowId, ctx.toScreenId);
+    if (!ctx.wasFloating) {
+        // Explicit cross-mode MOVE of a MANAGED window whose source zones did
+        // not resolve on this screen (foreign zone ids after a layout change).
+        // Floating it here converted the user's move into a float toggle. It
+        // arrives as a plain FREE window instead — snapping's default for
+        // unmanaged windows — keeping its live frame. Broadcast not-floating
+        // so subscribers that last heard the source mode's state converge
+        // (the adaptor's last-broadcast gate dedups when they already agree).
+        m_windowTracker->setWindowFloating(ctx.windowId, false);
+        Q_EMIT windowFloatingChanged(ctx.windowId, false, ctx.toScreenId);
+        return;
+    }
     stateForWindowOnScreen(ctx.windowId, ctx.toScreenId)
         ->setFloatingOnScreen(ctx.windowId, ctx.toScreenId, currentDesktop);
     m_windowTracker->setWindowFloating(ctx.windowId, true);

--- a/libs/phosphor-snap-engine/src/float.cpp
+++ b/libs/phosphor-snap-engine/src/float.cpp
@@ -358,9 +358,9 @@ UnfloatResult SnapEngine::resolveFallbackUnfloatGeometry(const QString& windowId
     // caller's fallback. A tracked screen that no longer exists (output unplugged)
     // is discarded in favour of the caller's fallback. Zone geometry is resolved on
     // the resulting screen so the fallback lands where the window currently is.
-    const SnapState* trackedState = stateForWindow(windowId);
-    const QString screen =
-        resolveUnfloatScreen(trackedState ? trackedState->screenForWindow(windowId) : QString(), fallbackScreen);
+    // stateForWindow is never null; an untracked window yields an empty
+    // tracked screen and the caller's fallback wins.
+    const QString screen = resolveUnfloatScreen(stateForWindow(windowId)->screenForWindow(windowId), fallbackScreen);
     if (screen.isEmpty() || !m_layoutManager) {
         return result;
     }
@@ -532,31 +532,33 @@ void SnapEngine::handoffRelease(const QString& windowId)
     }
     qCInfo(PhosphorSnapEngine::lcSnapEngine) << "SnapEngine::handoffRelease:" << windowId;
 
-    if (SnapState* state = stateForWindow(windowId)) {
-        if (state->isWindowSnapped(windowId)) {
-            const QStringList removedZones = state->zonesForWindow(windowId);
-            state->unassignWindow(windowId);
-            syncGlobalLastUsedForRemovedZones(removedZones);
-        }
-        if (state->isFloating(windowId)) {
-            state->setFloating(windowId, false);
-        }
-        // The destination engine now owns the window. unassignWindow / setFloating
-        // above cleared its zone/screen/desktop and floating bit — but NOT the
-        // pre-float capture, which is deliberately PRESERVED (see
-        // testHandoffRelease_preservesPreFloatCapture): a future return handoff may
-        // consult it for size restoration. Finally drop the reverse-map ownership
-        // record so this engine no longer claims the window.
-        forgetWindow(windowId);
+    // Plain statement, no conditional: stateForWindow is NEVER null (the
+    // globals holder is constructed in the ctor — see the accessor's
+    // contract), and every query below answers empty/false for an untracked
+    // window, so the operations no-op harmlessly.
+    SnapState* state = stateForWindow(windowId);
+    if (state->isWindowSnapped(windowId)) {
+        const QStringList removedZones = state->zonesForWindow(windowId);
+        state->unassignWindow(windowId);
+        syncGlobalLastUsedForRemovedZones(removedZones);
     }
+    if (state->isFloating(windowId)) {
+        state->setFloating(windowId, false);
+    }
+    // The destination engine now owns the window. unassignWindow / setFloating
+    // above cleared its zone/screen/desktop and floating bit — but NOT the
+    // pre-float capture, which is deliberately PRESERVED (see
+    // testHandoffRelease_preservesPreFloatCapture): a future return handoff may
+    // consult it for size restoration. Finally drop the reverse-map ownership
+    // record so this engine no longer claims the window.
+    forgetWindow(windowId);
 }
 
 QString SnapEngine::screenForTrackedWindow(const QString& windowId) const
 {
-    if (const SnapState* state = stateForWindow(windowId)) {
-        return state->screenForWindow(windowId);
-    }
-    return {};
+    // stateForWindow is never null (ctor-constructed globals holder); an
+    // untracked window resolves to an empty screen.
+    return stateForWindow(windowId)->screenForWindow(windowId);
 }
 
 bool SnapEngine::isWindowTracked(const QString& windowId) const

--- a/libs/phosphor-snap-engine/src/float.cpp
+++ b/libs/phosphor-snap-engine/src/float.cpp
@@ -203,6 +203,13 @@ bool SnapEngine::unfloatToZone(const QString& windowId, const QString& screenId)
     return true;
 }
 
+// TRACKER CONTRACT for this file: every float/unfloat/handoff entry point
+// derefs m_windowTracker WITHOUT a null guard. The daemon always constructs
+// the engine with a live WindowTrackingService, and the reduced test wirings
+// that pass a null tracker (screen-mode routing, exclude rules) never call
+// into these paths. applyGeometryForFloat below is the one deliberate
+// exception — it is reachable from D-Bus relays in reduced wirings, so it
+// keeps its guard.
 bool SnapEngine::applyGeometryForFloat(const QString& windowId, const QString& screenId)
 {
     if (!m_windowTracker) {
@@ -434,6 +441,17 @@ void SnapEngine::handoffReceive(const HandoffContext& ctx)
                 // passes wasFloating==false, so there is no floating flag to
                 // clear in THIS branch; other handoffReceive callers land in
                 // the tail below.
+                // The cross-desktop callers' wasFloating==false invariant,
+                // enforced rather than comment-only: debug asserts, release
+                // clears the flag so a violating caller cannot leave a
+                // floating bit dangling behind the direct slot assignment.
+                Q_ASSERT(!ctx.wasFloating);
+                if (Q_UNLIKELY(ctx.wasFloating)) {
+                    qCWarning(PhosphorSnapEngine::lcSnapEngine)
+                        << "handoffReceive: cross-desktop handoff with wasFloating=true for" << ctx.windowId
+                        << "— clearing the float before the slot assignment";
+                    m_windowTracker->setWindowFloating(ctx.windowId, false);
+                }
                 SnapState* targetState = stateForWindowOnScreen(ctx.windowId, ctx.toScreenId);
                 if (ctx.sourceZoneIds.size() > 1) {
                     targetState->assignWindowToZones(ctx.windowId, ctx.sourceZoneIds, ctx.toScreenId, ctx.toDesktop);

--- a/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
+++ b/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
@@ -1339,6 +1339,7 @@ private:
      * @return true if the pending order was fully resolved and removed
      */
     bool cleanupPendingOrderIfResolved(const QString& screenId);
+    void schedulePendingOrderTimeout(const QString& screenId, uint64_t generation);
 
     /**
      * @brief Validate that a windowId is not empty, logging a warning if it is

--- a/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
+++ b/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
@@ -574,6 +574,15 @@ public:
     PhosphorTiles::TilingAlgorithm* effectiveAlgorithm(const QString& screenId) const;
 
     /**
+     * @brief Drop every per-screen SCHEDULING entry for @p screenId: pending
+     * retiles, retile retry state, and the deferred post-retile focus.
+     * Shared by the toggle-off removal loop and the orphaned-virtual-screen
+     * teardown — a stale entry keyed to a vs:N id would fire against the
+     * RECREATED id of a later re-subdivision.
+     */
+    void clearScreenScheduling(const QString& screenId);
+
+    /**
      * @brief Purge @p windowId from every pending initial order, with full
      * bookkeeping: empty orders drop their generation/strict entries, and
      * surviving orders are re-checked for resolution. The single purge used

--- a/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
+++ b/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
@@ -1609,6 +1609,12 @@ private:
     // removeWindow() if a pre-seeded window closes before arriving.
     QHash<QString, QStringList> m_pendingInitialOrders;
     QHash<QString, uint64_t> m_pendingOrderGeneration;
+    /// Engine-wide monotonic source for m_pendingOrderGeneration values. Per-screen
+    /// counters restarted at 1 after their map entry was removed, so a stale
+    /// timeout from a previous order epoch could match a fresh order's
+    /// generation and reap it. Serials never repeat, so a stale timer can only
+    /// miss.
+    uint64_t m_pendingOrderSerial = 0;
     // Screens whose pendingInitialOrders entry is "strict" — saved order
     // wins even when arrival order differs. Set by setInitialWindowOrder
     // (mode transition: the daemon intentionally pre-computed an order from

--- a/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
+++ b/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
@@ -1,5 +1,13 @@
 // SPDX-FileCopyrightText: 2026 fuddlesworth
 // SPDX-License-Identifier: LGPL-2.1-or-later
+//
+// FILE-SIZE EXCEPTION (sanctioned): AutotileEngine is one class — the tiling
+// engine's whole public and internal surface — and C++ cannot split a class
+// declaration across headers. The IMPLEMENTATION is already partitioned by
+// concern under src/autotileengine/; shrinking this header means extracting
+// collaborator classes (drag preview, script-state stash, per-screen config),
+// which is a deliberate refactor, not a mechanical file split. Same rationale
+// as plasmazoneseffect.h / daemon.h / windowtrackingadaptor.h.
 
 #pragma once
 
@@ -1475,6 +1483,10 @@ private:
     /// layout boundary instead of crossing surfaces.
     PhosphorEngine::ICrossSurfaceResolver* m_crossSurfaceResolver = nullptr;
     PhosphorEngine::IWindowRegistry* m_windowRegistry = nullptr;
+    /// Handle for the algorithmRegistered → setAppIdResolver hook installed by
+    /// setWindowRegistry(). Stored so a re-wire replaces the hook instead of
+    /// stacking a duplicate (Qt::UniqueConnection does not apply to lambdas).
+    QMetaObject::Connection m_appIdResolverHook;
     PhosphorTiles::ITileAlgorithmRegistry* m_algorithmRegistry = nullptr; ///< Borrowed; outlives engine
     std::unique_ptr<AutotileConfig> m_config;
     std::unique_ptr<PerScreenConfigResolver> m_configResolver;

--- a/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
+++ b/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
@@ -1213,8 +1213,9 @@ private:
      *        desktop/activity context); the overflow bucket is keyed per
      *        screenId only, so the caller must drain once per screen AFTER
      *        all of that screen's states are captured.
+     * @return Whether the state released any managed windows.
      */
-    void releaseScreenStateForTeardown(const QString& screenId, PhosphorTiles::TilingState* state,
+    bool releaseScreenStateForTeardown(const QString& screenId, PhosphorTiles::TilingState* state,
                                        QStringList& releasedWindows, bool drainOverflow = true);
 
     /**

--- a/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
+++ b/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
@@ -574,6 +574,18 @@ public:
     PhosphorTiles::TilingAlgorithm* effectiveAlgorithm(const QString& screenId) const;
 
     /**
+     * @brief Run the algorithm's onWindowAdded lifecycle hook for a just-inserted window
+     *
+     * Shared by every insert site (onWindowAdded, handoffReceive, the
+     * strict-initial-order seed in setAutotileScreens) so a memory algorithm's
+     * bookkeeping (e.g. dwindle-memory's split tree) sees every arrival.
+     * Floating arrivals are not in tiledWindows(), so indexOf misses and the
+     * hook is correctly skipped.
+     */
+    void notifyAlgorithmWindowAdded(PhosphorTiles::TilingState* state, const QString& screenId,
+                                    const QString& windowId);
+
+    /**
      * @brief Request that a window is activated after the given screen's next applyTiling
      *
      * Stored in m_pendingFocusByScreen and emitted as activateWindowRequested

--- a/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
+++ b/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
@@ -349,6 +349,18 @@ public:
     void pruneStatesForActivities(const QStringList& validActivities) override;
 
     /**
+     * @brief Prune PhosphorTiles::TilingState entries for a permanently removed monitor
+     *
+     * Removes every state whose key.screenId belongs to the removed physical
+     * monitor (including its virtual sub-screens), plus their tuned-flag /
+     * script-stash / scheduling / context residue. updateAutotileScreens only
+     * tears down the CURRENT (desktop, activity) context, so without this the
+     * removed monitor's other contexts' states leak for the session. Mirrors
+     * SnapEngine::pruneStatesForRemovedScreen.
+     */
+    void pruneStatesForRemovedScreen(const QString& physicalScreenId) override;
+
+    /**
      * @brief Get the current virtual desktop tracked by the engine
      */
     int currentDesktop() const noexcept

--- a/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
+++ b/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
@@ -202,10 +202,18 @@ public:
     {
         setAutotileScreens(screens);
     }
+    /// Capture-on-leave order: the tiled order PLUS minimize-floated windows
+    /// at their windowOrder positions. A minimize-float is a suspension, not
+    /// intent — dropping it here (as a bare tiledWindows() read would) makes
+    /// the window's position vanish from the saved order, so a
+    /// tiled→minimize→mode-round-trip loses its slot even though the seed
+    /// filter deliberately keeps minimized windows as placeholders. Genuine
+    /// (non-minimized) floats stay excluded.
     QStringList managedWindowOrder(const QString& screenId) const override
     {
-        return tiledWindowOrder(screenId);
+        return capturedWindowOrder(screenId);
     }
+    QStringList capturedWindowOrder(const QString& screenId) const;
     bool isModeSpecificFloated(const QString& windowId) const override
     {
         return isAutotileFloated(windowId);

--- a/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
+++ b/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
@@ -1614,8 +1614,12 @@ private:
 
     // Pre-seeded window order for snapping → autotile transitions.
     // Keyed by stable EDID-based screen ID (PhosphorScreens::ScreenIdentity::identifierFor).
-    // Consumed by insertWindow() as windows arrive; also cleaned up by
-    // removeWindow() if a pre-seeded window closes before arriving.
+    // Consumed by the strict seed in setAutotileScreens() (visible windows,
+    // eagerly) and by insertWindow() as remaining windows arrive; purged
+    // per-window via purgeFromPendingOrders (close, cap rejection), swept
+    // by pruneStaleWindows, and reaped by the pending-order timeout — which
+    // deliberately RETAINS an order holding live minimized placeholders, so
+    // those entries persist until the window opens or closes.
     QHash<QString, QStringList> m_pendingInitialOrders;
     QHash<QString, uint64_t> m_pendingOrderGeneration;
     /// Engine-wide monotonic source for m_pendingOrderGeneration values. Per-screen
@@ -1628,7 +1632,10 @@ private:
     // wins even when arrival order differs. Set by setInitialWindowOrder
     // (mode transition: the daemon intentionally pre-computed an order from
     // the previous mode's zones, and that order MUST be preserved).
-    // Cleared after the order is fully consumed. Entries seeded by
+    // Lifetime is TIED to the pending order's own: cleared wherever the
+    // order is removed (full consumption, per-window purge emptying it,
+    // stale-window sweep, timeout reap, screen teardown) — an order retained
+    // for a minimized placeholder keeps its strict flag with it. Entries seeded by
     // setInitialWindowOrder (mode transition) are the strict ones; advisory
     // entries reconstructed per-window from the placement store are NOT in this
     // set — for those the saved position is honored only when it appends at the

--- a/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
+++ b/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
@@ -574,6 +574,15 @@ public:
     PhosphorTiles::TilingAlgorithm* effectiveAlgorithm(const QString& screenId) const;
 
     /**
+     * @brief Purge @p windowId from every pending initial order, with full
+     * bookkeeping: empty orders drop their generation/strict entries, and
+     * surviving orders are re-checked for resolution. The single purge used
+     * by close, cap-rejection, and any other per-window drop — a bare
+     * removeAll leaves an empty order's timeout re-arm chain alive.
+     */
+    void purgeFromPendingOrders(const QString& windowId);
+
+    /**
      * @brief Run the algorithm's onWindowAdded lifecycle hook for a just-inserted window
      *
      * Shared by every insert site (onWindowAdded, handoffReceive, the

--- a/libs/phosphor-tile-engine/src/autotileengine/algorithm_state.cpp
+++ b/libs/phosphor-tile-engine/src/autotileengine/algorithm_state.cpp
@@ -31,6 +31,7 @@
 #include <PhosphorZones/Layout.h>
 #include <PhosphorZones/LayoutRegistry.h>
 #include "tileenginelogging.h"
+#include <PhosphorIdentity/VirtualScreenId.h>
 #include <PhosphorIdentity/WindowId.h>
 #include <PhosphorScreens/Manager.h>
 #include <PhosphorScreens/VirtualScreen.h>
@@ -538,6 +539,61 @@ void AutotileEngine::pruneStatesForDesktop(int removedDesktop)
     if (pruned > 0) {
         qCInfo(PhosphorTileEngine::lcTileEngine)
             << "Pruned" << pruned << "TilingStates for removed desktop" << removedDesktop;
+    }
+}
+
+void AutotileEngine::pruneStatesForRemovedScreen(const QString& physicalScreenId)
+{
+    if (physicalScreenId.isEmpty()) {
+        return;
+    }
+    // Match every virtual sub-screen of the removed physical monitor:
+    // samePhysical strips the "/vs:N" suffix before comparing.
+    const auto matches = [&physicalScreenId](const QString& screenId) {
+        return !screenId.isEmpty() && PhosphorIdentity::VirtualScreenId::samePhysical(screenId, physicalScreenId);
+    };
+    int pruned = 0;
+    QSet<QString> removedScreenIds;
+    m_states.removeStatesIf(
+        [&](const TilingStateKey& key, PhosphorTiles::TilingState*) {
+            return matches(key.screenId);
+        },
+        [&](const TilingStateKey& key, PhosphorTiles::TilingState* state) {
+            // Tuned flags go with the state, exactly as in the desktop /
+            // activity prunes — a reconnected monitor reusing this id must
+            // not inherit a stale "tuned" skip in propagateGlobal*.
+            m_userTunedSplitRatio.remove(key);
+            m_userTunedMasterCount.remove(key);
+            removedScreenIds.insert(key.screenId);
+            state->deleteLater();
+            ++pruned;
+        });
+    m_states.removeWindowsIf([&](const QString&, const TilingStateKey& key) {
+        return matches(key.screenId);
+    });
+    std::erase_if(m_scriptStateStash, [&](const auto& entry) {
+        return matches(entry.first.screenId);
+    });
+    // Per-screen scheduling can hold ids with no surviving state (a pending
+    // initial order for a context never materialised) — sweep by id, not just
+    // the removed states' keys.
+    for (const QString& sid : std::as_const(removedScreenIds)) {
+        clearScreenScheduling(sid);
+    }
+    const QStringList pendingOrderScreens = m_pendingInitialOrders.keys();
+    for (const QString& sid : pendingOrderScreens) {
+        if (matches(sid)) {
+            m_pendingInitialOrders.remove(sid);
+            m_pendingOrderGeneration.remove(sid);
+            m_strictInitialOrderScreens.remove(sid);
+            clearScreenScheduling(sid);
+        }
+    }
+    // Drop the per-output desktop entry / sticky pin for the dead screen ids.
+    m_context.removeScreensIf(matches);
+    if (pruned > 0) {
+        qCInfo(PhosphorTileEngine::lcTileEngine)
+            << "Pruned" << pruned << "TilingStates for removed screen" << physicalScreenId;
     }
 }
 

--- a/libs/phosphor-tile-engine/src/autotileengine/config.cpp
+++ b/libs/phosphor-tile-engine/src/autotileengine/config.cpp
@@ -102,7 +102,14 @@ void AutotileEngine::setInitialWindowOrder(const QString& screenId, const QStrin
                                                   << state->windowCount() << "windows, ignoring pre-seeded order";
         return;
     }
-    // Warn (but allow) if overwriting a pending order that hasn't been fully consumed
+    // The explicit mode-toggle path seeds before the assignment flips and
+    // updateAutotileScreens repeats the same seed after it flips. Keep that
+    // two-phase safety without warning, replacing generations, or scheduling
+    // another timeout when the effective order is unchanged.
+    if (m_pendingInitialOrders.value(screenId) == windowIds) {
+        return;
+    }
+    // Warn (but allow) if overwriting a genuinely different pending order.
     if (m_pendingInitialOrders.contains(screenId)) {
         qCWarning(PhosphorTileEngine::lcTileEngine)
             << "setInitialWindowOrder: overwriting existing pending order for" << screenId;

--- a/libs/phosphor-tile-engine/src/autotileengine/config.cpp
+++ b/libs/phosphor-tile-engine/src/autotileengine/config.cpp
@@ -42,9 +42,11 @@
 namespace PhosphorTileEngine {
 
 namespace {
-// Safety timeout for pending initial window orders that never arrive via D-Bus.
-// If windows fail to open (e.g., app crash during startup), this prevents
-// m_pendingInitialOrders from leaking state indefinitely.
+// Safety timeout for pending initial window orders that never arrive via
+// D-Bus (e.g. an app crash during startup). NOT an unconditional reaper: an
+// order holding a LIVE minimized placeholder is deliberately retained past
+// the timeout (the re-arm in schedulePendingOrderTimeout) and is cleaned up
+// by the window's own open/close instead.
 constexpr int PendingOrderTimeoutMs = 10000;
 
 // Filter a per-algorithm settings map down to the entries worth persisting:

--- a/libs/phosphor-tile-engine/src/autotileengine/config.cpp
+++ b/libs/phosphor-tile-engine/src/autotileengine/config.cpp
@@ -27,7 +27,6 @@
 #include <PhosphorTiles/TilingState.h>
 #include <PhosphorTiles/SplitTree.h>
 #include <PhosphorEngine/PerScreenKeys.h>
-#include <PhosphorEngine/WindowRegistry.h>
 #include <PhosphorTiles/AutotileConstants.h>
 #include <PhosphorZones/Layout.h>
 #include <PhosphorZones/LayoutRegistry.h>

--- a/libs/phosphor-tile-engine/src/autotileengine/config.cpp
+++ b/libs/phosphor-tile-engine/src/autotileengine/config.cpp
@@ -47,25 +47,49 @@ namespace {
 // m_pendingInitialOrders from leaking state indefinitely.
 constexpr int PendingOrderTimeoutMs = 10000;
 
-// Filter a per-algorithm settings map down to the entries worth persisting: those
-// that actually deviate from the algorithm's own defaults. A slot that merely
-// echoes the defaults carries no user intent, so writing it would surface as a
-// spurious "you changed this" row in the config profile diff. Both the
-// save-before-switch block and the no-slot fallback in setAlgorithm() can leave
-// such default-valued slots in the live map; filtering at write-back is the single
-// choke point that keeps them off disk. Entries whose algorithm is unknown to the
-// registry (e.g. an uninstalled scripted algorithm) are kept verbatim — they
-// cannot be compared to defaults, and dropping them would lose the user's tuning.
+// Filter a per-algorithm settings map down to the entries worth persisting:
+// those that deviate from what the no-slot READ fallback in
+// refreshConfigFromSettings would reconstruct anyway. Dropping only
+// reconstruction-identical slots keeps the write filter and the read fallback
+// symmetric — the round trip is lossless by construction. (The previous filter
+// compared against the algorithm's own defaults unconditionally, so an explicit
+// per-algo cap that happened to equal the algo default was dropped and then
+// NOT reconstructed when the global held a non-default value.) A slot that
+// merely echoes the reconstruction carries no user intent, so writing it would
+// surface as a spurious "you changed this" row in the config profile diff.
+// Entries whose algorithm is unknown to the registry (e.g. an uninstalled
+// scripted algorithm) are kept verbatim — they cannot be compared, and
+// dropping them would lose the user's tuning.
+//
+// The globals are the values the NEXT refresh will read back: maxWindows from
+// the settings key (write-back never touches it), splitRatio/masterCount from
+// the engine scalars writeBackTuning writes to the settings just before this
+// filter runs.
 QHash<QString, AlgorithmSettings> persistablePerAlgoSettings(const QHash<QString, AlgorithmSettings>& saved,
-                                                             PhosphorTiles::ITileAlgorithmRegistry* registry)
+                                                             PhosphorTiles::ITileAlgorithmRegistry* registry,
+                                                             int globalMaxWindows, qreal globalSplitRatio,
+                                                             int globalMasterCount)
 {
     QHash<QString, AlgorithmSettings> result;
     for (auto it = saved.constBegin(); it != saved.constEnd(); ++it) {
         auto* algo = registry ? registry->algorithm(it.key()) : nullptr;
-        const bool matchesDefaults = algo && qFuzzyCompare(1.0 + it->splitRatio, 1.0 + algo->defaultSplitRatio())
-            && it->masterCount == PhosphorTiles::AutotileDefaults::DefaultMasterCount
-            && it->maxWindows == algo->defaultMaxWindows() && it->customParams.isEmpty();
-        if (!matchesDefaults) {
+        bool matchesReconstruction = false;
+        if (algo) {
+            // Mirror of the read fallback: a schema-default global is ambient,
+            // so the algorithm's own default applies; a non-default global is
+            // an explicit override. masterCount has no per-algorithm default,
+            // so its reconstruction is always the global.
+            const int fallbackMax = globalMaxWindows == PhosphorTiles::AutotileDefaults::DefaultMaxWindows
+                ? algo->defaultMaxWindows()
+                : globalMaxWindows;
+            const qreal fallbackRatio =
+                qFuzzyCompare(1.0 + globalSplitRatio, 1.0 + PhosphorTiles::AutotileDefaults::DefaultSplitRatio)
+                ? algo->defaultSplitRatio()
+                : globalSplitRatio;
+            matchesReconstruction = qFuzzyCompare(1.0 + it->splitRatio, 1.0 + fallbackRatio)
+                && it->masterCount == globalMasterCount && it->maxWindows == fallbackMax && it->customParams.isEmpty();
+        }
+        if (!matchesReconstruction) {
             result.insert(it.key(), it.value());
         }
     }
@@ -120,7 +144,7 @@ void AutotileEngine::setInitialWindowOrder(const QString& screenId, const QStrin
     // order it wants preserved (zone order from the previous mode). Even if
     // windows arrive in a different sequence, the saved positions win.
     m_strictInitialOrderScreens.insert(screenId);
-    uint64_t gen = ++m_pendingOrderGeneration[screenId];
+    const uint64_t gen = m_pendingOrderGeneration[screenId] = ++m_pendingOrderSerial;
     qCInfo(PhosphorTileEngine::lcTileEngine)
         << "Pre-seeded window order for screen=" << screenId << "windows=" << windowIds;
 
@@ -137,13 +161,21 @@ void AutotileEngine::schedulePendingOrderTimeout(const QString& screenId, uint64
         if (m_windowRegistry) {
             const QStringList pending = m_pendingInitialOrders.value(screenId);
             for (const QString& windowId : pending) {
-                // value_or(true): unknown state defers like minimized, matching
-                // the strict-seed deferral so the timeout cannot reap a
-                // placeholder the seed deliberately retained.
-                if (m_windowRegistry->minimizedState(windowId).value_or(true)) {
+                // Engaged-true ONLY, unlike the strict seed's conservative
+                // value_or(true): the seed runs at the transition instant when
+                // the registry may not have caught up, but by timeout time the
+                // effect's daemon-ready metadata push has long landed, so a
+                // window the registry cannot vouch for here is dead (missed
+                // close) and its placeholder is exactly what this reaper
+                // exists to collect — deferring on unknown kept the order (and
+                // this chain) alive forever.
+                if (m_windowRegistry->minimizedState(windowId).value_or(false)) {
                     // A minimized live window can remain hidden indefinitely. Keep
                     // its positional placeholder, but re-arm cleanup so a later
-                    // metadata change or missed close cannot leak the order forever.
+                    // metadata change or missed close cannot leak the order
+                    // forever. The chain is bounded: one outstanding timer per
+                    // generation, and superseded generations die at their first
+                    // fire (serials are monotonic and never reused).
                     schedulePendingOrderTimeout(screenId, generation);
                     return;
                 }
@@ -214,7 +246,8 @@ void AutotileEngine::writeBackTuning()
         s->setAutotileSplitRatio(m_config->splitRatio);
         s->setAutotileMasterCount(m_config->masterCount);
         s->setAutotilePerAlgorithmSettings(AutotileConfig::perAlgoToVariantMap(
-            persistablePerAlgoSettings(m_config->savedAlgorithmSettings, m_algorithmRegistry)));
+            persistablePerAlgoSettings(m_config->savedAlgorithmSettings, m_algorithmRegistry, s->autotileMaxWindows(),
+                                       m_config->splitRatio, m_config->masterCount)));
     }
 }
 
@@ -354,11 +387,17 @@ void AutotileEngine::refreshConfigFromSettings()
             // silently clamp it to the global default on the next routine refresh.
             // Default-valued slots are no longer persisted (see
             // persistablePerAlgoSettings), so this on-demand fallback is what keeps
-            // an untouched algorithm at its intended cap. splitRatio/masterCount are
-            // left as the SYNC'd global values — those globals are real user
-            // settings, unlike the legacy per-algorithm maxWindows global.
+            // an untouched algorithm at its intended cap. splitRatio follows the
+            // same ambient-vs-override rule with the algorithm's own default
+            // ratio (a scripted algorithm shipping 0.6 must not be clamped to
+            // the schema 0.5 by every routine refresh). masterCount has no
+            // per-algorithm default, so the SYNC'd global stands for it.
             if (s->autotileMaxWindows() == PhosphorTiles::AutotileDefaults::DefaultMaxWindows) {
                 m_config->maxWindows = algo->defaultMaxWindows();
+            }
+            if (qFuzzyCompare(1.0 + s->autotileSplitRatio(),
+                              1.0 + PhosphorTiles::AutotileDefaults::DefaultSplitRatio)) {
+                m_config->splitRatio = algo->defaultSplitRatio();
             }
         }
     }

--- a/libs/phosphor-tile-engine/src/autotileengine/config.cpp
+++ b/libs/phosphor-tile-engine/src/autotileengine/config.cpp
@@ -169,6 +169,31 @@ QStringList AutotileEngine::tiledWindowOrder(const QString& screenId) const
     return state->tiledWindows();
 }
 
+QStringList AutotileEngine::capturedWindowOrder(const QString& screenId) const
+{
+    const TilingStateKey key = currentKeyForScreen(screenId);
+    PhosphorTiles::TilingState* state = m_states.stateForKey(key);
+    if (!state) {
+        return {};
+    }
+    // Full order minus GENUINE floats: a floating window whose registry
+    // state says minimized is a suspension float and keeps its position in
+    // the captured order (see managedWindowOrder's doc).
+    QStringList order;
+    const QStringList full = state->windowOrder();
+    order.reserve(full.size());
+    for (const QString& windowId : full) {
+        if (state->isFloating(windowId)) {
+            const bool minimized = m_windowRegistry && m_windowRegistry->minimizedState(windowId).value_or(false);
+            if (!minimized) {
+                continue;
+            }
+        }
+        order.append(windowId);
+    }
+    return order;
+}
+
 // ═══════════════════════════════════════════════════════════════════════════════
 // Settings synchronization
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/libs/phosphor-tile-engine/src/autotileengine/config.cpp
+++ b/libs/phosphor-tile-engine/src/autotileengine/config.cpp
@@ -134,10 +134,13 @@ void AutotileEngine::schedulePendingOrderTimeout(const QString& screenId, uint64
         if (m_pendingOrderGeneration.value(screenId) != generation) {
             return;
         }
-        if (const auto* registry = dynamic_cast<const PhosphorEngine::WindowRegistry*>(m_windowRegistry)) {
+        if (m_windowRegistry) {
             const QStringList pending = m_pendingInitialOrders.value(screenId);
             for (const QString& windowId : pending) {
-                if (registry->isMinimized(windowId)) {
+                // value_or(true): unknown state defers like minimized, matching
+                // the strict-seed deferral so the timeout cannot reap a
+                // placeholder the seed deliberately retained.
+                if (m_windowRegistry->minimizedState(windowId).value_or(true)) {
                     // A minimized live window can remain hidden indefinitely. Keep
                     // its positional placeholder, but re-arm cleanup so a later
                     // metadata change or missed close cannot leak the order forever.

--- a/libs/phosphor-tile-engine/src/autotileengine/config.cpp
+++ b/libs/phosphor-tile-engine/src/autotileengine/config.cpp
@@ -122,8 +122,11 @@ void AutotileEngine::setInitialWindowOrder(const QString& screenId, const QStrin
     }
     // Only take effect when the screen's PhosphorTiles::TilingState is empty (no prior windows —
     // including floating — from session restore). Uses windowCount() instead of
-    // tiledWindows() to also detect floating-only states.
-    PhosphorTiles::TilingState* state = tilingStateForScreen(screenId);
+    // tiledWindows() to also detect floating-only states. NON-CREATING lookup:
+    // this is a read-only emptiness probe, and the creating
+    // tilingStateForScreen would leave a persistent empty TilingState behind
+    // for a screen whose windows never arrive.
+    PhosphorTiles::TilingState* state = m_states.stateForKey(currentKeyForScreen(screenId));
     if (state && state->windowCount() > 0) {
         qCDebug(PhosphorTileEngine::lcTileEngine) << "setInitialWindowOrder: screen" << screenId << "already has"
                                                   << state->windowCount() << "windows, ignoring pre-seeded order";

--- a/libs/phosphor-tile-engine/src/autotileengine/config.cpp
+++ b/libs/phosphor-tile-engine/src/autotileengine/config.cpp
@@ -27,6 +27,7 @@
 #include <PhosphorTiles/TilingState.h>
 #include <PhosphorTiles/SplitTree.h>
 #include <PhosphorEngine/PerScreenKeys.h>
+#include <PhosphorEngine/WindowRegistry.h>
 #include <PhosphorTiles/AutotileConstants.h>
 #include <PhosphorZones/Layout.h>
 #include <PhosphorZones/LayoutRegistry.h>
@@ -123,11 +124,27 @@ void AutotileEngine::setInitialWindowOrder(const QString& screenId, const QStrin
     qCInfo(PhosphorTileEngine::lcTileEngine)
         << "Pre-seeded window order for screen=" << screenId << "windows=" << windowIds;
 
-    // Safety timeout: clean up if windows never arrive (e.g., app crash during startup).
-    // Use a generation counter so that stale timers from overwritten calls become no-ops.
-    QTimer::singleShot(PendingOrderTimeoutMs, this, [this, screenId, gen]() {
-        if (m_pendingOrderGeneration.value(screenId) != gen) {
-            return; // superseded by a newer setInitialWindowOrder call
+    schedulePendingOrderTimeout(screenId, gen);
+}
+
+void AutotileEngine::schedulePendingOrderTimeout(const QString& screenId, uint64_t generation)
+{
+    // Use a generation counter so stale timers from overwritten calls become no-ops.
+    QTimer::singleShot(PendingOrderTimeoutMs, this, [this, screenId, generation]() {
+        if (m_pendingOrderGeneration.value(screenId) != generation) {
+            return;
+        }
+        if (const auto* registry = dynamic_cast<const PhosphorEngine::WindowRegistry*>(m_windowRegistry)) {
+            const QStringList pending = m_pendingInitialOrders.value(screenId);
+            for (const QString& windowId : pending) {
+                if (registry->isMinimized(windowId)) {
+                    // A minimized live window can remain hidden indefinitely. Keep
+                    // its positional placeholder, but re-arm cleanup so a later
+                    // metadata change or missed close cannot leak the order forever.
+                    schedulePendingOrderTimeout(screenId, generation);
+                    return;
+                }
+            }
         }
         if (m_pendingInitialOrders.remove(screenId)) {
             m_pendingOrderGeneration.remove(screenId);

--- a/libs/phosphor-tile-engine/src/autotileengine/context.cpp
+++ b/libs/phosphor-tile-engine/src/autotileengine/context.cpp
@@ -508,7 +508,7 @@ void AutotileEngine::setAutotileScreens(const QSet<QString>& screens)
 
     // Only prune states for the CURRENT desktop/activity. States belonging to
     // other desktops are preserved so desktop switching is a fast state swap
-    // (no window release/re-add). windowsReleasedFromTiling MUST NOT fire
+    // (no window release/re-add). windowsReleased MUST NOT fire
     // for desktop/activity transitions — only for true autotile disable.
     QStringList releasedWindows;
     QSet<QString> placementChangedScreens;
@@ -545,7 +545,7 @@ void AutotileEngine::setAutotileScreens(const QSet<QString>& screens)
             m_userTunedMasterCount.remove(key);
         });
     // Clean up reverse-map entries for released windows BEFORE emitting the
-    // signal. Signal handlers (signals.cpp windowsReleasedFromTiling) check zone
+    // signal. Signal handlers (the daemon's windowsReleased lambda) check zone
     // assignments and floating state — stale mappings would cause them to see
     // phantom candidates.
     for (const QString& windowId : std::as_const(releasedWindows)) {
@@ -611,6 +611,10 @@ void AutotileEngine::setAutotileScreens(const QSet<QString>& screens)
         Q_EMIT enabledChanged(nowEnabled);
     }
 
+    // DELIBERATE ORDER: autotileScreensChanged first, placementChanged after.
+    // The screens signal drives the effect's mode-transition pass; the
+    // placement signals only schedule the daemon's debounced save, which must
+    // snapshot state AFTER the transition's releases are all in place.
     Q_EMIT autotileScreensChanged(QStringList(m_autotileScreens.begin(), m_autotileScreens.end()), wasDesktopSwitch);
     for (const QString& screenId : std::as_const(placementChangedScreens)) {
         Q_EMIT placementChanged(screenId);

--- a/libs/phosphor-tile-engine/src/autotileengine/context.cpp
+++ b/libs/phosphor-tile-engine/src/autotileengine/context.cpp
@@ -426,6 +426,7 @@ void AutotileEngine::setAutotileScreens(const QSet<QString>& screens)
     // (no window release/re-add). windowsReleasedFromTiling MUST NOT fire
     // for desktop/activity transitions — only for true autotile disable.
     QStringList releasedWindows;
+    QSet<QString> placementChangedScreens;
     // Only prune states that match the current desktop/activity AND whose screen
     // is no longer in the autotile set. States for other contexts are left
     // untouched here — by the time their desktop becomes current the screen is
@@ -445,7 +446,9 @@ void AutotileEngine::setAutotileScreens(const QSet<QString>& screens)
             // toggle-off/on round trip keeps the user's manual tile adjustments
             // instead of laying out from scratch.
             stashScriptState(key, state);
-            releaseScreenStateForTeardown(key.screenId, state, releasedWindows);
+            if (releaseScreenStateForTeardown(key.screenId, state, releasedWindows)) {
+                placementChangedScreens.insert(key.screenId);
+            }
             // Toggle-off drops only the resolver's IN-MEMORY overrides (they are
             // re-derived from settings on re-enable); the persisted per-screen
             // settings deliberately survive — a user toggling autotile off must
@@ -530,6 +533,9 @@ void AutotileEngine::setAutotileScreens(const QSet<QString>& screens)
     }
 
     Q_EMIT autotileScreensChanged(QStringList(m_autotileScreens.begin(), m_autotileScreens.end()), wasDesktopSwitch);
+    for (const QString& screenId : std::as_const(placementChangedScreens)) {
+        Q_EMIT placementChanged(screenId);
+    }
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/libs/phosphor-tile-engine/src/autotileengine/context.cpp
+++ b/libs/phosphor-tile-engine/src/autotileengine/context.cpp
@@ -142,6 +142,18 @@ void AutotileEngine::clearCurrentDesktopForScreen(const QString& screenId)
     m_context.clearCurrentDesktopForScreen(screenId);
 }
 
+void AutotileEngine::clearScreenScheduling(const QString& screenId)
+{
+    m_pendingRetileScreens.remove(screenId);
+    m_retileRetryScreens.remove(screenId);
+    m_retileRetryCount.remove(screenId);
+    // A deferred focus request stranded by a no-op retile must not survive
+    // the screen's removal: if the same screenId reconnects (re-subdivision
+    // recreates vs:N ids), its first applyTiling would consume the stale
+    // entry and activate a window from the previous session of that screen.
+    m_pendingFocusByScreen.remove(screenId);
+}
+
 void AutotileEngine::setCurrentActivity(const QString& activity)
 {
     // The established-flag (owned by the tracker, not a bare empty-string
@@ -584,13 +596,7 @@ void AutotileEngine::setAutotileScreens(const QSet<QString>& screens)
         }
     }
     for (const QString& screenId : removed) {
-        m_retileRetryScreens.remove(screenId);
-        m_retileRetryCount.remove(screenId);
-        // A deferred focus request stranded by a no-op retile must not
-        // survive the screen's removal: if the same screenId reconnects,
-        // its first applyTiling would consume the stale entry and activate
-        // a window from the previous session of that screen.
-        m_pendingFocusByScreen.remove(screenId);
+        clearScreenScheduling(screenId);
     }
 
     const bool nowEnabled = !m_autotileScreens.isEmpty();

--- a/libs/phosphor-tile-engine/src/autotileengine/context.cpp
+++ b/libs/phosphor-tile-engine/src/autotileengine/context.cpp
@@ -27,7 +27,6 @@
 #include <PhosphorTiles/TilingState.h>
 #include <PhosphorTiles/SplitTree.h>
 #include <PhosphorEngine/PerScreenKeys.h>
-#include <PhosphorEngine/WindowRegistry.h>
 #include <PhosphorTiles/AutotileConstants.h>
 #include <PhosphorZones/Layout.h>
 #include <PhosphorZones/LayoutRegistry.h>

--- a/libs/phosphor-tile-engine/src/autotileengine/context.cpp
+++ b/libs/phosphor-tile-engine/src/autotileengine/context.cpp
@@ -525,9 +525,9 @@ void AutotileEngine::setAutotileScreens(const QSet<QString>& screens)
             // Toggle-off drops only the resolver's IN-MEMORY overrides (they are
             // re-derived from settings on re-enable); the persisted per-screen
             // settings deliberately survive — a user toggling autotile off must
-            // not lose their per-monitor configuration. Contrast with the
-            // orphaned-virtual-screen teardown, which purges both layers because
-            // a dead VS id is never reused.
+            // not lose their per-monitor configuration. The orphaned-virtual-
+            // screen teardown follows the same rule: vs:N ids are recreated by
+            // a later re-subdivision, so its persisted layer survives too.
             m_configResolver->removeOverridesForScreen(key.screenId);
             m_userTunedSplitRatio.remove(key);
             m_userTunedMasterCount.remove(key);

--- a/libs/phosphor-tile-engine/src/autotileengine/context.cpp
+++ b/libs/phosphor-tile-engine/src/autotileengine/context.cpp
@@ -27,6 +27,7 @@
 #include <PhosphorTiles/TilingState.h>
 #include <PhosphorTiles/SplitTree.h>
 #include <PhosphorEngine/PerScreenKeys.h>
+#include <PhosphorEngine/WindowRegistry.h>
 #include <PhosphorTiles/AutotileConstants.h>
 #include <PhosphorZones/Layout.h>
 #include <PhosphorZones/LayoutRegistry.h>
@@ -375,13 +376,17 @@ void AutotileEngine::setAutotileScreens(const QSet<QString>& screens)
         // when the windows actually do open. Leave the advisory order in
         // pendingInitialOrders for insertWindow() to consult on arrival.
         if (m_pendingInitialOrders.contains(screenId) && m_strictInitialOrderScreens.contains(screenId)) {
-            const QStringList order = m_pendingInitialOrders.take(screenId);
-            m_pendingOrderGeneration.remove(screenId);
-            m_strictInitialOrderScreens.remove(screenId);
+            const QStringList order = m_pendingInitialOrders.value(screenId);
+            const auto* registry = dynamic_cast<const PhosphorEngine::WindowRegistry*>(m_windowRegistry);
+            bool hasDeferredMinimizedWindow = false;
             PhosphorTiles::TilingState* ts = tilingStateForScreen(screenId);
             if (ts) {
                 const TilingStateKey stateKey = currentKeyForScreen(screenId);
                 for (const QString& windowId : order) {
+                    if (registry && registry->isMinimized(windowId)) {
+                        hasDeferredMinimizedWindow = true;
+                        continue;
+                    }
                     if (!ts->containsWindow(windowId)) {
                         ts->addWindow(windowId);
                         // Register engine tracking immediately — without the
@@ -394,7 +399,7 @@ void AutotileEngine::setAutotileScreens(const QSet<QString>& screens)
                         // of truth). Without this, windows added from pending orders lose
                         // their floating state because windowOpened's floating restore is
                         // skipped when the window already exists in the PhosphorTiles::TilingState.
-                        // Exact record only: pending orders are built from LIVE session
+                        // Same-instance record only: pending orders are built from LIVE session
                         // ids, so a same-app sibling's floating record must not float
                         // this window (relogin restores go through insertWindow's take()).
                         if (m_windowTracker) {
@@ -416,6 +421,11 @@ void AutotileEngine::setAutotileScreens(const QSet<QString>& screens)
                         emitInsertFloatStateSync(windowId, screenId);
                     }
                 }
+            }
+            if (!hasDeferredMinimizedWindow) {
+                m_pendingInitialOrders.remove(screenId);
+                m_pendingOrderGeneration.remove(screenId);
+                m_strictInitialOrderScreens.remove(screenId);
             }
         }
         scheduleRetileForScreen(screenId);

--- a/libs/phosphor-tile-engine/src/autotileengine/context.cpp
+++ b/libs/phosphor-tile-engine/src/autotileengine/context.cpp
@@ -377,13 +377,26 @@ void AutotileEngine::setAutotileScreens(const QSet<QString>& screens)
         // pendingInitialOrders for insertWindow() to consult on arrival.
         if (m_pendingInitialOrders.contains(screenId) && m_strictInitialOrderScreens.contains(screenId)) {
             const QStringList order = m_pendingInitialOrders.value(screenId);
-            const auto* registry = dynamic_cast<const PhosphorEngine::WindowRegistry*>(m_windowRegistry);
+            if (!m_windowRegistry) {
+                // Without a registry the seed cannot distinguish minimized
+                // windows and will tile every seeded entry — visible in
+                // production as a hidden window holding a layout slot. Warn
+                // loudly; headless/test engines legitimately run without one.
+                qCWarning(PhosphorTileEngine::lcTileEngine)
+                    << "setAutotileScreens: strict seed for" << screenId
+                    << "has no window registry — minimized windows cannot be deferred";
+            }
             bool hasDeferredMinimizedWindow = false;
             PhosphorTiles::TilingState* ts = tilingStateForScreen(screenId);
             if (ts) {
                 const TilingStateKey stateKey = currentKeyForScreen(screenId);
                 for (const QString& windowId : order) {
-                    if (registry && registry->isMinimized(windowId)) {
+                    // Defer on engaged-true AND on unknown (record missing):
+                    // a window the registry cannot vouch for must not claim a
+                    // tile — the deferral self-heals when the effect's
+                    // windowOpened re-announce (sent only for visible
+                    // windows) consumes the pending slot at its seeded index.
+                    if (m_windowRegistry && m_windowRegistry->minimizedState(windowId).value_or(true)) {
                         hasDeferredMinimizedWindow = true;
                         continue;
                     }

--- a/libs/phosphor-tile-engine/src/autotileengine/context.cpp
+++ b/libs/phosphor-tile-engine/src/autotileengine/context.cpp
@@ -390,6 +390,7 @@ void AutotileEngine::setAutotileScreens(const QSet<QString>& screens)
             PhosphorTiles::TilingState* ts = tilingStateForScreen(screenId);
             if (ts) {
                 const TilingStateKey stateKey = currentKeyForScreen(screenId);
+                QStringList notTileable;
                 for (const QString& windowId : order) {
                     // Defer on engaged-true AND on unknown (record missing):
                     // a window the registry cannot vouch for must not claim a
@@ -400,7 +401,32 @@ void AutotileEngine::setAutotileScreens(const QSet<QString>& screens)
                         hasDeferredMinimizedWindow = true;
                         continue;
                     }
+                    // Same admission gate windowOpened applies: a window the
+                    // daemon's order names but that must not tile (excluded
+                    // app, special window type) would otherwise be seeded
+                    // into the layout and — containsWindow short-circuiting
+                    // its later re-announce — could never self-heal. Dropped
+                    // from the pending order below so a retained order (a
+                    // deferred minimized sibling) cannot wedge on it.
+                    if (!shouldTileWindow(windowId)) {
+                        notTileable.append(windowId);
+                        continue;
+                    }
                     if (!ts->containsWindow(windowId)) {
+                        // Single-owner guard: a mode transition can seed a
+                        // window that another context's state still owns
+                        // (e.g. tracked on a different desktop by a
+                        // catch-scan race). Release the old owner first —
+                        // same primitive handoffReceive uses — or
+                        // setKeyForWindow below re-points the reverse map
+                        // and leaves a permanent ghost in the old state.
+                        const TilingStateKey oldKey = m_states.keyForWindow(windowId);
+                        if (!oldKey.screenId.isEmpty() && oldKey != stateKey) {
+                            handoffRelease(windowId);
+                            if (oldKey.screenId != screenId) {
+                                scheduleRetileForScreen(oldKey.screenId);
+                            }
+                        }
                         ts->addWindow(windowId);
                         // Register engine tracking immediately — without the
                         // key entry, a window closing before the effect's
@@ -422,6 +448,19 @@ void AutotileEngine::setAutotileScreens(const QSet<QString>& screens)
                                 ts->setFloating(windowId, true);
                             }
                         }
+                        // Same "Float this app" admission insertWindow applies
+                        // at line ~292: a float-ruled window seeded tiled would
+                        // hold a tile its open-time rule says it must not, and
+                        // the containsWindow short-circuit on its re-announce
+                        // means nothing later corrects it.
+                        if (!ts->isFloating(windowId) && insertShouldFloat(windowId)) {
+                            ts->setFloating(windowId, true);
+                        }
+                        // Same lifecycle hook every other insert site runs — a
+                        // memory algorithm (dwindle-memory's split tree) must
+                        // see seeded arrivals or its bookkeeping goes blind to
+                        // them.
+                        notifyAlgorithmWindowAdded(ts, screenId, windowId);
                         // Announce on the passive channel via the canonical
                         // insert-time sync (both directions: restored-floating
                         // OR seeded-tiled-over-a-stale-WTS-float-bit). The
@@ -434,11 +473,22 @@ void AutotileEngine::setAutotileScreens(const QSet<QString>& screens)
                         emitInsertFloatStateSync(windowId, screenId);
                     }
                 }
-            }
-            if (!hasDeferredMinimizedWindow) {
-                m_pendingInitialOrders.remove(screenId);
-                m_pendingOrderGeneration.remove(screenId);
-                m_strictInitialOrderScreens.remove(screenId);
+                for (const QString& windowId : std::as_const(notTileable)) {
+                    m_pendingInitialOrders[screenId].removeAll(windowId);
+                }
+                if (!hasDeferredMinimizedWindow) {
+                    m_pendingInitialOrders.remove(screenId);
+                    m_pendingOrderGeneration.remove(screenId);
+                    m_strictInitialOrderScreens.remove(screenId);
+                }
+            } else {
+                // Null state — the screen is known to autotile but the state
+                // factory refused (virtual-screen teardown race). RETAIN the
+                // pending order rather than silently discarding the computed
+                // seed: insertWindow consumes it entry-by-entry when the
+                // effect's windowOpened announcements land.
+                qCWarning(PhosphorTileEngine::lcTileEngine) << "setAutotileScreens: no tiling state for" << screenId
+                                                            << "— strict seed retained for insert-time consumption";
             }
         }
         scheduleRetileForScreen(screenId);

--- a/libs/phosphor-tile-engine/src/autotileengine/core.cpp
+++ b/libs/phosphor-tile-engine/src/autotileengine/core.cpp
@@ -220,6 +220,7 @@ void AutotileEngine::connectSignals()
                     // Find and release orphaned virtual screen states for this physical screen
                     QStringList releasedWindows;
                     QSet<QString> orphanedVsIds;
+                    QSet<QString> placementChangedScreens;
                     m_states.removeStatesIf(
                         [&](const TilingStateKey& key, PhosphorTiles::TilingState*) {
                             const QString& sid = key.screenId;
@@ -241,8 +242,10 @@ void AutotileEngine::connectSignals()
                             // would blind capturePlacement's overflow
                             // discriminator for the remaining contexts.
                             orphanedVsIds.insert(sid);
-                            releaseScreenStateForTeardown(sid, state, releasedWindows,
-                                                          /*drainOverflow=*/false);
+                            if (releaseScreenStateForTeardown(sid, state, releasedWindows,
+                                                              /*drainOverflow=*/false)) {
+                                placementChangedScreens.insert(sid);
+                            }
                             // forgetScreen, not removeOverridesForScreen: this id
                             // is never reused, so remembering the algorithm it
                             // was on would strand a string for the session.
@@ -300,6 +303,9 @@ void AutotileEngine::connectSignals()
                     // Retile the new virtual screens
                     for (const QString& vsId : newVsIds) {
                         onScreenGeometryChanged(vsId);
+                    }
+                    for (const QString& sid : std::as_const(placementChangedScreens)) {
+                        Q_EMIT placementChanged(sid);
                     }
                 });
 

--- a/libs/phosphor-tile-engine/src/autotileengine/core.cpp
+++ b/libs/phosphor-tile-engine/src/autotileengine/core.cpp
@@ -289,6 +289,11 @@ void AutotileEngine::connectSignals()
                         });
                     for (const QString& sid : std::as_const(orphanedVsIds)) {
                         m_overflow.takeForScreen(sid);
+                        // Same per-screen scheduling cleanup the toggle-off
+                        // path runs — a stale deferred focus/retile keyed to
+                        // this vs:N id would fire against the RECREATED id of
+                        // a later re-subdivision.
+                        clearScreenScheduling(sid);
                     }
                     // Drop stashed bags for every orphaned VS id. Driven off the
                     // same predicate the removal used rather than off

--- a/libs/phosphor-tile-engine/src/autotileengine/core.cpp
+++ b/libs/phosphor-tile-engine/src/autotileengine/core.cpp
@@ -127,6 +127,7 @@ int AutotileEngine::pruneStaleWindows(const QSet<QString>& aliveWindowIds)
     // would otherwise keep its pending order (and the timeout's re-arm chain)
     // alive for the session. Same purge removeWindow applies on a signalled
     // close, batched.
+    QStringList survivingOrderScreens;
     for (auto pit = m_pendingInitialOrders.begin(); pit != m_pendingInitialOrders.end();) {
         QStringList& order = pit.value();
         const int before = order.size();
@@ -139,10 +140,14 @@ int AutotileEngine::pruneStaleWindows(const QSet<QString>& aliveWindowIds)
             m_strictInitialOrderScreens.remove(pit.key());
             pit = m_pendingInitialOrders.erase(pit);
         } else {
-            const QString screen = pit.key();
-            ++pit; // advance before potential erase by helper
-            cleanupPendingOrderIfResolved(screen);
+            survivingOrderScreens.append(pit.key());
+            ++pit;
         }
+    }
+    // After the walk — see purgeFromPendingOrders for why the resolution
+    // re-check must not erase other entries mid-iteration.
+    for (const QString& screen : std::as_const(survivingOrderScreens)) {
+        cleanupPendingOrderIfResolved(screen);
     }
     return pruned;
 }

--- a/libs/phosphor-tile-engine/src/autotileengine/core.cpp
+++ b/libs/phosphor-tile-engine/src/autotileengine/core.cpp
@@ -66,6 +66,11 @@ QRect AutotileEngine::lastManagedRect(const QString& rawWindowId) const
 
 int AutotileEngine::pruneStaleWindows(const QSet<QString>& aliveWindowIds)
 {
+    // The returned count tallies ENTRY removals, not distinct windows: one dead
+    // window present in the base store, the float set, engine tracking, and a
+    // pending order contributes up to four. Callers only log it as sweep
+    // activity, so the overlap is deliberate; don't repurpose it as a window
+    // count.
     int pruned = PlacementEngineBase::pruneStaleWindows(aliveWindowIds);
     for (auto it = m_autotileFloatedWindows.begin(); it != m_autotileFloatedWindows.end();) {
         if (!aliveWindowIds.contains(*it)) {

--- a/libs/phosphor-tile-engine/src/autotileengine/core.cpp
+++ b/libs/phosphor-tile-engine/src/autotileengine/core.cpp
@@ -122,6 +122,28 @@ int AutotileEngine::pruneStaleWindows(const QSet<QString>& aliveWindowIds)
             ++it;
         }
     }
+    // Pending initial orders: a minimized strict-order placeholder has no key
+    // entry, so the tracking sweep above cannot reach it — a dead placeholder
+    // would otherwise keep its pending order (and the timeout's re-arm chain)
+    // alive for the session. Same purge removeWindow applies on a signalled
+    // close, batched.
+    for (auto pit = m_pendingInitialOrders.begin(); pit != m_pendingInitialOrders.end();) {
+        QStringList& order = pit.value();
+        const int before = order.size();
+        order.removeIf([&aliveWindowIds](const QString& id) {
+            return !aliveWindowIds.contains(id);
+        });
+        pruned += before - order.size();
+        if (order.isEmpty()) {
+            m_pendingOrderGeneration.remove(pit.key());
+            m_strictInitialOrderScreens.remove(pit.key());
+            pit = m_pendingInitialOrders.erase(pit);
+        } else {
+            const QString screen = pit.key();
+            ++pit; // advance before potential erase by helper
+            cleanupPendingOrderIfResolved(screen);
+        }
+    }
     return pruned;
 }
 
@@ -138,12 +160,15 @@ void AutotileEngine::onWindowZoneChanged(const QString& rawWindowId, const QStri
     // and hand onWindowRemoved() an id no state tracks.
     const QString windowId = canonicalizeWindowId(rawWindowId);
     if (zoneId.isEmpty()) {
-        for (auto it = m_states.states().constBegin(); it != m_states.states().constEnd(); ++it) {
-            if (it.key().desktop != currentKeyForScreen(it.key().screenId).desktop
-                || it.key().activity != m_context.currentActivity()) {
-                continue;
-            }
-            if (it.value() && it.value()->isFloating(windowId)) {
+        // Guard on the OWNING state's float bit, keyed through the reverse
+        // map — onWindowRemoved below acts on that same stored key, which can
+        // belong to another desktop/activity context. A current-context-only
+        // scan missed an off-context floating window, so a stray zone-clear
+        // untracked it.
+        const TilingStateKey key = m_states.keyForWindow(windowId);
+        if (!key.screenId.isEmpty()) {
+            const PhosphorTiles::TilingState* owner = m_states.stateForKey(key);
+            if (owner && owner->isFloating(windowId)) {
                 return;
             }
         }
@@ -231,11 +256,14 @@ void AutotileEngine::connectSignals()
                         [&](const TilingStateKey& key, PhosphorTiles::TilingState* state) {
                             const QString sid = key.screenId;
                             // This virtual screen no longer exists — release its
-                            // windows via the shared teardown body. Unlike the
-                            // toggle-off path, an orphaned VS id is never reused,
-                            // so BOTH override layers go: the resolver's
-                            // in-memory map here, the persisted settings below
-                            // (clearPerScreenAutotileSettings). drainOverflow is
+                            // windows via the shared teardown body. Only the
+                            // IN-MEMORY layers are dropped here; the persisted
+                            // per-screen settings survive, exactly as on the
+                            // toggle-off path, because vs:N ids ARE recreated —
+                            // a later re-subdivision of the same physical
+                            // screen mints vs:0, vs:1... again and the user's
+                            // per-monitor configuration must come back with
+                            // them. drainOverflow is
                             // deferred to the per-screen loop below: this loop
                             // visits EVERY desktop/activity context of the same
                             // VS id, and an in-helper drain on the first context
@@ -246,9 +274,10 @@ void AutotileEngine::connectSignals()
                                                               /*drainOverflow=*/false)) {
                                 placementChangedScreens.insert(sid);
                             }
-                            // forgetScreen, not removeOverridesForScreen: this id
-                            // is never reused, so remembering the algorithm it
-                            // was on would strand a string for the session.
+                            // forgetScreen, not removeOverridesForScreen: both
+                            // are in-memory, and the remembered "built under"
+                            // algorithm is re-derived from the persisted
+                            // settings if a re-subdivision recreates this id.
                             m_configResolver->forgetScreen(sid);
                             m_userTunedSplitRatio.remove(key);
                             m_userTunedMasterCount.remove(key);
@@ -261,9 +290,9 @@ void AutotileEngine::connectSignals()
                     // orphanedVsIds, because that set is built inside the removal
                     // callback and so only holds ids that still had a live state.
                     // A VS toggled off earlier has no state, would be missing from
-                    // it, and its bag is exactly the "sits in the stash forever"
-                    // case this exists to prevent: the id is gone for good and is
-                    // never reused, so nothing will ever harvest or match it again.
+                    // it, and its bag would otherwise sit in the stash until
+                    // shutdown. Session-scoped manual-adjustment state; if a
+                    // re-subdivision recreates the id, the layout starts fresh.
                     std::erase_if(m_scriptStateStash, [&](const auto& entry) {
                         const QString& sid = entry.first.screenId;
                         return PhosphorIdentity::VirtualScreenId::isVirtual(sid)
@@ -277,17 +306,14 @@ void AutotileEngine::connectSignals()
                         Q_EMIT windowsReleased(releasedWindows, orphanedVsIds);
                     }
 
-                    // Clean up per-screen autotile settings for removed virtual screens.
-                    // Orphaned AutotileScreen: groups would otherwise accumulate indefinitely
-                    // as virtual screen IDs are never reused after reconfiguration.
-                    if (!orphanedVsIds.isEmpty()) {
-                        const QSignalBlocker blocker(engineSettings());
-                        if (auto* s = autotileSettings()) {
-                            for (const QString& orphanId : orphanedVsIds)
-                                s->clearPerScreenAutotileSettings(orphanId);
-                        }
-                        Q_EMIT settingsPersistRequested();
-                    }
+                    // The PERSISTED per-screen autotile settings are deliberately
+                    // NOT cleared for orphaned virtual screens. vs:N ids are
+                    // index-based and recreated by a later re-subdivision of the
+                    // same physical screen, so purging here permanently deleted
+                    // the user's per-monitor configuration on a simple
+                    // remove-then-re-add round trip. The groups are bounded by
+                    // the largest subdivision count the user has ever configured,
+                    // not unbounded growth.
 
                     // Clean up per-screen desktop maps for removed virtual screens on this
                     // physical screen — BOTH the sticky-pin override and the per-output-VD

--- a/libs/phosphor-tile-engine/src/autotileengine/facade.cpp
+++ b/libs/phosphor-tile-engine/src/autotileengine/facade.cpp
@@ -322,7 +322,12 @@ std::optional<PhosphorEngine::WindowPlacement> AutotileEngine::capturePlacement(
     // preserve branch fires only on ENGAGED true — the capture must not
     // preserve-and-freeze a visible window's slot just because its record is
     // missing.
-    const bool minimized = m_windowRegistry && m_windowRegistry->minimizedState(wid).value_or(false);
+    // isSuspensionFloat covers the unminimize grace: the live minimize bit
+    // flips false at the edge while the window is still suspension-floated
+    // until the deferred unfloat commits, and a capture in that window must
+    // still preserve rather than record the float.
+    const bool minimized = (m_windowRegistry && m_windowRegistry->minimizedState(wid).value_or(false))
+        || (m_windowTracker && m_windowTracker->isSuspensionFloat(wid));
     if (minimized && m_windowTracker) {
         const auto existing = m_windowTracker->placementStore().peekExact(wid);
         if (existing && !existing->slotFor(engineId()).isEmpty()) {
@@ -331,8 +336,18 @@ std::optional<PhosphorEngine::WindowPlacement> AutotileEngine::capturePlacement(
             // its order and context from the retained live TilingState so a
             // recent swap or migration is not reverted by a stale store entry.
             PhosphorEngine::EngineSlot slot = existing->slotFor(engineId());
-            if (slot.state == WindowPlacement::stateTiled()) {
-                slot.order = state->windowOrder().indexOf(wid);
+            // Refresh the order ONLY when the live state still contains the
+            // window as a non-floating member: a minimize-floated window's
+            // position in windowOrder() is the artifact of the suspension
+            // (handoffReceive inserts at the insert-position index), not the
+            // pre-minimize position this branch exists to preserve. And never
+            // write indexOf's -1 over a valid persisted order — a keyed-but-
+            // unmembered window (mid-migration) must keep its stored slot.
+            if (slot.state == WindowPlacement::stateTiled() && !state->isFloating(wid)) {
+                const int liveIdx = state->windowOrder().indexOf(wid);
+                if (liveIdx >= 0) {
+                    slot.order = liveIdx;
+                }
             }
             WindowPlacement preserved;
             preserved.windowId = wid;
@@ -371,8 +386,14 @@ std::optional<PhosphorEngine::WindowPlacement> AutotileEngine::capturePlacement(
     if (minimized) {
         // No prior autotile slot exists yet. The temporary minimize float was
         // entered before the first persistence sweep, so reconstruct the
-        // durable pre-minimize state from the retained window order.
-        slot.state = WindowPlacement::stateTiled();
+        // durable pre-minimize state from the retained window order. The
+        // explicit user-float MARKER survives the suspension (only the float
+        // shortcut paths set it), so an explicitly floated window keeps its
+        // float intent instead of being flattened to tiled; a drag-float
+        // minimized before any sweep is indistinguishable here and
+        // reconstructs as tiled (accepted residual).
+        slot.state =
+            isAutotileFloated(wid) ? QString(WindowPlacement::stateFloating()) : QString(WindowPlacement::stateTiled());
         slot.order = state->windowOrder().indexOf(wid);
     } else if (state->isFloating(wid) && !m_overflow.isOverflow(wid)) {
         slot.state = WindowPlacement::stateFloating();

--- a/libs/phosphor-tile-engine/src/autotileengine/facade.cpp
+++ b/libs/phosphor-tile-engine/src/autotileengine/facade.cpp
@@ -53,6 +53,13 @@ void AutotileEngine::setWindowRegistry(QObject* registry)
 {
     m_windowRegistry = dynamic_cast<PhosphorEngine::IWindowRegistry*>(registry);
     if (!m_windowRegistry) {
+        if (registry) {
+            // A non-null object of the wrong type is a WIRING BUG, not the
+            // legitimate registry-less test configuration — degrade loudly.
+            qCWarning(PhosphorTileEngine::lcTileEngine)
+                << "setWindowRegistry: object does not implement IWindowRegistry — registry-dependent"
+                << "behaviour (minimize deferral, appId resolution) disabled";
+        }
         return;
     }
     const QPointer<AutotileEngine> self(this);

--- a/libs/phosphor-tile-engine/src/autotileengine/facade.cpp
+++ b/libs/phosphor-tile-engine/src/autotileengine/facade.cpp
@@ -27,6 +27,7 @@
 #include <PhosphorTiles/TilingState.h>
 #include <PhosphorTiles/SplitTree.h>
 #include <PhosphorEngine/PerScreenKeys.h>
+#include <PhosphorEngine/WindowRegistry.h>
 #include <PhosphorTiles/AutotileConstants.h>
 #include <PhosphorZones/Layout.h>
 #include <PhosphorZones/LayoutRegistry.h>
@@ -316,13 +317,18 @@ std::optional<PhosphorEngine::WindowPlacement> AutotileEngine::capturePlacement(
     if (!state) {
         return std::nullopt;
     }
-    // A minimized window is temporarily represented as floating so it leaves
-    // tiledWindows() and the remaining windows reflow. Do not turn that runtime
-    // suspension into durable user-float intent. This guard is required here,
-    // not only in WindowTrackingAdaptor's capture funnel, because screen
-    // teardown captures the autotile slot directly before destroying the state.
-    if (m_windowRegistry && m_windowRegistry->isMinimized(wid)) {
-        return std::nullopt;
+    // Keep the canonicalization interface ABI-stable: live minimize metadata
+    // is an additive capability of the concrete production registry, not a new
+    // virtual in IWindowRegistry's exported vtable.
+    const auto* registry = dynamic_cast<const PhosphorEngine::WindowRegistry*>(m_windowRegistry);
+    const bool minimized = registry && registry->isMinimized(wid);
+    if (minimized && m_windowTracker) {
+        const auto existing = m_windowTracker->placementStore().peekExact(wid);
+        if (existing && !existing->slotFor(engineId()).isEmpty()) {
+            // A minimized window is temporarily represented as floating so it
+            // leaves tiledWindows(). Preserve an existing durable slot exactly.
+            return std::nullopt;
+        }
     }
 
     WindowPlacement p;
@@ -347,7 +353,13 @@ std::optional<PhosphorEngine::WindowPlacement> AutotileEngine::capturePlacement(
     // is recorded as tiled so it re-tiles — and overflows again if it still doesn't
     // fit — on restore, rather than sticking as a phantom user float.
     PhosphorEngine::EngineSlot slot;
-    if (state->isFloating(wid) && !m_overflow.isOverflow(wid)) {
+    if (minimized) {
+        // No prior autotile slot exists yet. The temporary minimize float was
+        // entered before the first persistence sweep, so reconstruct the
+        // durable pre-minimize state from the retained window order.
+        slot.state = WindowPlacement::stateTiled();
+        slot.order = state->windowOrder().indexOf(wid);
+    } else if (state->isFloating(wid) && !m_overflow.isOverflow(wid)) {
         slot.state = WindowPlacement::stateFloating();
     } else {
         slot.state = WindowPlacement::stateTiled();

--- a/libs/phosphor-tile-engine/src/autotileengine/facade.cpp
+++ b/libs/phosphor-tile-engine/src/autotileengine/facade.cpp
@@ -317,11 +317,12 @@ std::optional<PhosphorEngine::WindowPlacement> AutotileEngine::capturePlacement(
     if (!state) {
         return std::nullopt;
     }
-    // Keep the canonicalization interface ABI-stable: live minimize metadata
-    // is an additive capability of the concrete production registry, not a new
-    // virtual in IWindowRegistry's exported vtable.
-    const auto* registry = dynamic_cast<const PhosphorEngine::WindowRegistry*>(m_windowRegistry);
-    const bool minimized = registry && registry->isMinimized(wid);
+    // Live minimize state via the IWindowRegistry contract (defaulted virtual
+    // reporting unknown), so no per-window RTTI on the capture sweeps. The
+    // preserve branch fires only on ENGAGED true — the capture must not
+    // preserve-and-freeze a visible window's slot just because its record is
+    // missing.
+    const bool minimized = m_windowRegistry && m_windowRegistry->minimizedState(wid).value_or(false);
     if (minimized && m_windowTracker) {
         const auto existing = m_windowTracker->placementStore().peekExact(wid);
         if (existing && !existing->slotFor(engineId()).isEmpty()) {

--- a/libs/phosphor-tile-engine/src/autotileengine/facade.cpp
+++ b/libs/phosphor-tile-engine/src/autotileengine/facade.cpp
@@ -26,7 +26,6 @@
 #include <PhosphorTiles/TilingState.h>
 #include <PhosphorTiles/SplitTree.h>
 #include <PhosphorEngine/PerScreenKeys.h>
-#include <PhosphorEngine/WindowRegistry.h>
 #include <PhosphorTiles/AutotileConstants.h>
 #include <PhosphorZones/Layout.h>
 #include <PhosphorZones/LayoutRegistry.h>
@@ -68,6 +67,11 @@ void AutotileEngine::setWindowRegistry(QObject* registry)
     };
     auto* algoRegistry = m_algorithmRegistry;
     if (!algoRegistry) {
+        // Symmetric loud degrade with the wrong-type branch above: without an
+        // algorithm registry neither the existing-algorithm resolver sweep nor
+        // the registered-hook can be installed.
+        qCWarning(PhosphorTileEngine::lcTileEngine)
+            << "setWindowRegistry: no algorithm registry attached — appId resolvers not installed";
         return;
     }
     for (PhosphorTiles::TilingAlgorithm* algo : algoRegistry->allAlgorithms()) {
@@ -75,16 +79,20 @@ void AutotileEngine::setWindowRegistry(QObject* registry)
             algo->setAppIdResolver(resolver);
         }
     }
-    connect(algoRegistry, &PhosphorTiles::ITileAlgorithmRegistry::algorithmRegistered, this,
-            [this, resolver](const QString& id) {
-                auto* reg = m_algorithmRegistry;
-                if (!reg) {
-                    return;
-                }
-                if (auto* algo = reg->algorithm(id)) {
-                    algo->setAppIdResolver(resolver);
-                }
-            });
+    // Drop the previous invocation's hook first: setWindowRegistry is a public
+    // re-wireable seam, and stacking a second identical lambda would call
+    // setAppIdResolver N times per hot-reloaded algorithm.
+    disconnect(m_appIdResolverHook);
+    m_appIdResolverHook = connect(algoRegistry, &PhosphorTiles::ITileAlgorithmRegistry::algorithmRegistered, this,
+                                  [this, resolver](const QString& id) {
+                                      auto* reg = m_algorithmRegistry;
+                                      if (!reg) {
+                                          return;
+                                      }
+                                      if (auto* algo = reg->algorithm(id)) {
+                                          algo->setAppIdResolver(resolver);
+                                      }
+                                  });
 }
 
 QString AutotileEngine::canonicalizeWindowId(const QString& rawWindowId)

--- a/libs/phosphor-tile-engine/src/autotileengine/facade.cpp
+++ b/libs/phosphor-tile-engine/src/autotileengine/facade.cpp
@@ -1,31 +1,9 @@
 // SPDX-FileCopyrightText: 2026 fuddlesworth
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#include <PhosphorTileEngine/AutotileEngine.h>
-#include "engine_internal.h"
-#include "tileenginelogging.h"
-
-#include <PhosphorEngine/PerScreenKeys.h>
-#include <PhosphorEngine/WindowRegistry.h>
-#include <PhosphorGeometry/GeometryUtils.h>
-#include <PhosphorIdentity/WindowId.h>
-#include <PhosphorScreens/Manager.h>
-#include <PhosphorScreens/ScreenIdentity.h>
-#include <PhosphorScreens/VirtualScreen.h>
-#include <PhosphorTileEngine/AutotileConfig.h>
-#include <PhosphorTileEngine/NavigationController.h>
-#include <PhosphorTileEngine/PerScreenConfigResolver.h>
-#include <PhosphorTiles/AlgorithmPreviewParams.h>
-#include <PhosphorTiles/AlgorithmRegistry.h>
-#include <PhosphorTiles/AutotileConstants.h>
-#include <PhosphorTiles/ITileAlgorithmRegistry.h>
-#include <PhosphorTiles/SplitTree.h>
-#include <PhosphorTiles/TilingAlgorithm.h>
-#include <PhosphorTiles/TilingState.h>
-#include <PhosphorZones/Layout.h>
-#include <PhosphorZones/LayoutRegistry.h>
-#include <PhosphorZones/Zone.h>
-
+// Qt headers
+#include <algorithm>
+#include <cmath>
 #include <QDebug>
 #include <QJsonArray>
 #include <QJsonDocument>
@@ -35,8 +13,30 @@
 #include <QTimer>
 #include <QVarLengthArray>
 
-#include <algorithm>
-#include <cmath>
+// Project headers
+#include <PhosphorTileEngine/AutotileEngine.h>
+#include <PhosphorTiles/AlgorithmRegistry.h>
+#include <PhosphorTiles/ITileAlgorithmRegistry.h>
+#include <PhosphorGeometry/GeometryUtils.h>
+#include <PhosphorTileEngine/AutotileConfig.h>
+#include <PhosphorTileEngine/NavigationController.h>
+#include <PhosphorTileEngine/PerScreenConfigResolver.h>
+#include <PhosphorTiles/AlgorithmPreviewParams.h>
+#include <PhosphorTiles/TilingAlgorithm.h>
+#include <PhosphorTiles/TilingState.h>
+#include <PhosphorTiles/SplitTree.h>
+#include <PhosphorEngine/PerScreenKeys.h>
+#include <PhosphorEngine/WindowRegistry.h>
+#include <PhosphorTiles/AutotileConstants.h>
+#include <PhosphorZones/Layout.h>
+#include <PhosphorZones/LayoutRegistry.h>
+#include "tileenginelogging.h"
+#include <PhosphorIdentity/WindowId.h>
+#include <PhosphorScreens/Manager.h>
+#include <PhosphorScreens/VirtualScreen.h>
+#include <PhosphorZones/Zone.h>
+#include <PhosphorScreens/ScreenIdentity.h>
+#include "engine_internal.h"
 
 namespace PhosphorTileEngine {
 
@@ -337,12 +337,12 @@ std::optional<PhosphorEngine::WindowPlacement> AutotileEngine::capturePlacement(
         || (m_windowTracker && m_windowTracker->isSuspensionFloat(wid));
     if (minimized && m_windowTracker) {
         const auto existing = m_windowTracker->placementStore().peekExact(wid);
-        if (existing && !existing->slotFor(engineId()).isEmpty()) {
+        PhosphorEngine::EngineSlot slot = existing ? existing->slotFor(engineId()) : PhosphorEngine::EngineSlot{};
+        if (existing && !slot.isEmpty()) {
             // A minimized window is temporarily represented as floating so it
             // leaves tiledWindows(). Preserve the durable state, but refresh
             // its order and context from the retained live TilingState so a
             // recent swap or migration is not reverted by a stale store entry.
-            PhosphorEngine::EngineSlot slot = existing->slotFor(engineId());
             // Refresh the order ONLY when the live state still contains the
             // window as a non-floating member: a minimize-floated window's
             // position in windowOrder() is the artifact of the suspension

--- a/libs/phosphor-tile-engine/src/autotileengine/facade.cpp
+++ b/libs/phosphor-tile-engine/src/autotileengine/facade.cpp
@@ -1,9 +1,31 @@
 // SPDX-FileCopyrightText: 2026 fuddlesworth
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-// Qt headers
-#include <algorithm>
-#include <cmath>
+#include <PhosphorTileEngine/AutotileEngine.h>
+#include "engine_internal.h"
+#include "tileenginelogging.h"
+
+#include <PhosphorEngine/PerScreenKeys.h>
+#include <PhosphorEngine/WindowRegistry.h>
+#include <PhosphorGeometry/GeometryUtils.h>
+#include <PhosphorIdentity/WindowId.h>
+#include <PhosphorScreens/Manager.h>
+#include <PhosphorScreens/ScreenIdentity.h>
+#include <PhosphorScreens/VirtualScreen.h>
+#include <PhosphorTileEngine/AutotileConfig.h>
+#include <PhosphorTileEngine/NavigationController.h>
+#include <PhosphorTileEngine/PerScreenConfigResolver.h>
+#include <PhosphorTiles/AlgorithmPreviewParams.h>
+#include <PhosphorTiles/AlgorithmRegistry.h>
+#include <PhosphorTiles/AutotileConstants.h>
+#include <PhosphorTiles/ITileAlgorithmRegistry.h>
+#include <PhosphorTiles/SplitTree.h>
+#include <PhosphorTiles/TilingAlgorithm.h>
+#include <PhosphorTiles/TilingState.h>
+#include <PhosphorZones/Layout.h>
+#include <PhosphorZones/LayoutRegistry.h>
+#include <PhosphorZones/Zone.h>
+
 #include <QDebug>
 #include <QJsonArray>
 #include <QJsonDocument>
@@ -13,31 +35,8 @@
 #include <QTimer>
 #include <QVarLengthArray>
 
-// Project headers
-#include <PhosphorTileEngine/AutotileEngine.h>
-#include <PhosphorTiles/AlgorithmRegistry.h>
-#include <PhosphorTiles/ITileAlgorithmRegistry.h>
-#include <PhosphorGeometry/GeometryUtils.h>
-#include <PhosphorTileEngine/AutotileConfig.h>
-#include <PhosphorTileEngine/NavigationController.h>
-#include <PhosphorTileEngine/PerScreenConfigResolver.h>
-#include <PhosphorTiles/AlgorithmPreviewParams.h>
-#include <PhosphorTiles/TilingAlgorithm.h>
-// DwindleMemoryAlgorithm.h no longer needed — prepareTilingState() is virtual on PhosphorTiles::TilingAlgorithm
-#include <PhosphorTiles/TilingState.h>
-#include <PhosphorTiles/SplitTree.h>
-#include <PhosphorEngine/PerScreenKeys.h>
-#include <PhosphorEngine/WindowRegistry.h>
-#include <PhosphorTiles/AutotileConstants.h>
-#include <PhosphorZones/Layout.h>
-#include <PhosphorZones/LayoutRegistry.h>
-#include "tileenginelogging.h"
-#include <PhosphorIdentity/WindowId.h>
-#include <PhosphorScreens/Manager.h>
-#include <PhosphorScreens/VirtualScreen.h>
-#include <PhosphorZones/Zone.h>
-#include <PhosphorScreens/ScreenIdentity.h>
-#include "engine_internal.h"
+#include <algorithm>
+#include <cmath>
 
 namespace PhosphorTileEngine {
 
@@ -56,8 +55,9 @@ void AutotileEngine::setWindowRegistry(QObject* registry)
     if (!m_windowRegistry) {
         return;
     }
-    auto resolver = [this](const QString& windowId) {
-        return currentAppIdFor(windowId);
+    const QPointer<AutotileEngine> self(this);
+    auto resolver = [self](const QString& windowId) {
+        return self ? self->currentAppIdFor(windowId) : QString();
     };
     auto* algoRegistry = m_algorithmRegistry;
     if (!algoRegistry) {
@@ -326,8 +326,22 @@ std::optional<PhosphorEngine::WindowPlacement> AutotileEngine::capturePlacement(
         const auto existing = m_windowTracker->placementStore().peekExact(wid);
         if (existing && !existing->slotFor(engineId()).isEmpty()) {
             // A minimized window is temporarily represented as floating so it
-            // leaves tiledWindows(). Preserve an existing durable slot exactly.
-            return std::nullopt;
+            // leaves tiledWindows(). Preserve the durable state, but refresh
+            // its order and context from the retained live TilingState so a
+            // recent swap or migration is not reverted by a stale store entry.
+            PhosphorEngine::EngineSlot slot = existing->slotFor(engineId());
+            if (slot.state == WindowPlacement::stateTiled()) {
+                slot.order = state->windowOrder().indexOf(wid);
+            }
+            WindowPlacement preserved;
+            preserved.windowId = wid;
+            preserved.appId = currentAppIdFor(windowId);
+            preserved.screenId = key.screenId;
+            preserved.virtualDesktop = key.desktop;
+            preserved.activity = key.activity;
+            preserved.kind = existing->kind;
+            preserved.engines.insert(engineId(), slot);
+            return preserved;
         }
     }
 

--- a/libs/phosphor-tile-engine/src/autotileengine/facade.cpp
+++ b/libs/phosphor-tile-engine/src/autotileengine/facade.cpp
@@ -316,6 +316,14 @@ std::optional<PhosphorEngine::WindowPlacement> AutotileEngine::capturePlacement(
     if (!state) {
         return std::nullopt;
     }
+    // A minimized window is temporarily represented as floating so it leaves
+    // tiledWindows() and the remaining windows reflow. Do not turn that runtime
+    // suspension into durable user-float intent. This guard is required here,
+    // not only in WindowTrackingAdaptor's capture funnel, because screen
+    // teardown captures the autotile slot directly before destroying the state.
+    if (m_windowRegistry && m_windowRegistry->isMinimized(wid)) {
+        return std::nullopt;
+    }
 
     WindowPlacement p;
     // Canonical id, not the raw argument: every engine map is keyed on the

--- a/libs/phosphor-tile-engine/src/autotileengine/facade.cpp
+++ b/libs/phosphor-tile-engine/src/autotileengine/facade.cpp
@@ -375,6 +375,11 @@ std::optional<PhosphorEngine::WindowPlacement> AutotileEngine::capturePlacement(
         slot.order = state->windowOrder().indexOf(wid);
     } else if (state->isFloating(wid) && !m_overflow.isOverflow(wid)) {
         slot.state = WindowPlacement::stateFloating();
+        // Retain the live order as a stable slot reference even when the
+        // frame is still on its former tile and free geometry cannot yet be
+        // captured. This preserves genuine float intent through an immediate
+        // minimize/teardown without making geometry-less unmanaged residue.
+        slot.order = state->windowOrder().indexOf(wid);
     } else {
         slot.state = WindowPlacement::stateTiled();
         slot.order = state->windowOrder().indexOf(wid);

--- a/libs/phosphor-tile-engine/src/autotileengine/float_handoff.cpp
+++ b/libs/phosphor-tile-engine/src/autotileengine/float_handoff.cpp
@@ -230,16 +230,8 @@ void AutotileEngine::handoffReceive(const HandoffContext& ctx)
     // — drag-from-another-autotile-screen typically falls here.
     state->setFloating(windowId, ctx.wasFloating);
     // Keep the memory algorithm's bookkeeping consistent for a non-floating
-    // arrival — symmetric with the removal hook in handoffRelease. Floating
-    // arrivals are not in tiledWindows(), so indexOf misses and the hook is
-    // correctly skipped.
-    PhosphorTiles::TilingAlgorithm* algo = effectiveAlgorithm(ctx.toScreenId);
-    if (algo && algo->supportsLifecycleHooks()) {
-        const int idx = state->tiledWindows().indexOf(windowId);
-        if (idx >= 0) {
-            algo->onWindowAdded(state, idx);
-        }
-    }
+    // arrival — symmetric with the removal hook in handoffRelease.
+    notifyAlgorithmWindowAdded(state, ctx.toScreenId, windowId);
     m_states.setKeyForWindow(windowId, destKey);
 
     // Announce the received float bit on the passive channel (the snap twin

--- a/libs/phosphor-tile-engine/src/autotileengine/insert.cpp
+++ b/libs/phosphor-tile-engine/src/autotileengine/insert.cpp
@@ -354,6 +354,7 @@ void AutotileEngine::insertWindowByConfigOrder(PhosphorTiles::TilingState* state
 
 void AutotileEngine::purgeFromPendingOrders(const QString& windowId)
 {
+    QStringList survivingScreens;
     for (auto pit = m_pendingInitialOrders.begin(); pit != m_pendingInitialOrders.end();) {
         pit.value().removeAll(windowId);
         if (pit.value().isEmpty()) {
@@ -361,10 +362,15 @@ void AutotileEngine::purgeFromPendingOrders(const QString& windowId)
             m_strictInitialOrderScreens.remove(pit.key());
             pit = m_pendingInitialOrders.erase(pit);
         } else {
-            const QString screen = pit.key();
-            ++pit; // advance before potential erase by helper
-            cleanupPendingOrderIfResolved(screen);
+            survivingScreens.append(pit.key());
+            ++pit;
         }
+    }
+    // Resolution re-check AFTER the walk: cleanupPendingOrderIfResolved can
+    // erase OTHER map entries, and erasing anything but the iterator's own
+    // element mid-iteration relies on undocumented QHash rehash behaviour.
+    for (const QString& screen : std::as_const(survivingScreens)) {
+        cleanupPendingOrderIfResolved(screen);
     }
 }
 

--- a/libs/phosphor-tile-engine/src/autotileengine/insert.cpp
+++ b/libs/phosphor-tile-engine/src/autotileengine/insert.cpp
@@ -234,6 +234,19 @@ bool AutotileEngine::insertWindow(const QString& windowId, const QString& screen
         auto rec = m_windowTracker->placementStore().take(windowId, appId, [&](const WindowPlacement& p) {
             const PhosphorEngine::EngineSlot s = p.slotFor(engineId());
             if (s.state == WindowPlacement::stateFloating()) {
+                // A geometry-less floating record (the order-only slot the
+                // capture writes to preserve float intent through an
+                // immediate minimize/teardown) is meaningful for the SAME
+                // instance — restore floating in place — but consumed by a
+                // FIFO sibling it floats a fresh window at its spawn rect
+                // for no user-visible reason while burning a slot a real
+                // placement may need. Same-instance restores stay
+                // unconditional; FIFO consumption requires a real float-back.
+                const bool sameInstance = ::PhosphorIdentity::WindowId::extractInstanceId(p.windowId)
+                    == ::PhosphorIdentity::WindowId::extractInstanceId(windowId);
+                if (!sameInstance && !p.anyFreeGeometry().isValid()) {
+                    return false;
+                }
                 return p.screenId.isEmpty() || p.screenId == screenId;
             }
             if (s.state == WindowPlacement::stateTiled()) {

--- a/libs/phosphor-tile-engine/src/autotileengine/insert.cpp
+++ b/libs/phosphor-tile-engine/src/autotileengine/insert.cpp
@@ -68,6 +68,18 @@ void AutotileEngine::emitInsertFloatStateSync(const QString& windowId, const QSt
     }
 }
 
+void AutotileEngine::notifyAlgorithmWindowAdded(PhosphorTiles::TilingState* state, const QString& screenId,
+                                                const QString& windowId)
+{
+    PhosphorTiles::TilingAlgorithm* algo = effectiveAlgorithm(screenId);
+    if (algo && algo->supportsLifecycleHooks() && state) {
+        const int idx = state->tiledWindows().indexOf(windowId);
+        if (idx >= 0) {
+            algo->onWindowAdded(state, idx);
+        }
+    }
+}
+
 bool AutotileEngine::insertShouldFloat(const QString& windowId) const
 {
     // A window ARRIVING from another state was already managed, so the open-time
@@ -126,6 +138,14 @@ bool AutotileEngine::insertWindow(const QString& windowId, const QString& screen
         // prevents multi-instance apps from all matching the first entry.
         if (desiredPos < 0 && hasStableAppId) {
             for (int i = 0; i < pendingOrder.size(); ++i) {
+                // An entry whose saved id the registry still vouches for is a
+                // LIVE window (typically a minimized placeholder deferred by
+                // the strict seed) that will claim its own slot on arrival —
+                // an unrelated same-app sibling must not consume it and
+                // overwrite its id (which would strand the real window).
+                if (m_windowRegistry && m_windowRegistry->minimizedState(pendingOrder.at(i)).has_value()) {
+                    continue;
+                }
                 // Compare using currentAppIdFor so both sides resolve to the
                 // latest class — an entry saved before a rename still matches.
                 if (currentAppIdFor(pendingOrder.at(i)) == appId && !state->containsWindow(pendingOrder.at(i))) {

--- a/libs/phosphor-tile-engine/src/autotileengine/insert.cpp
+++ b/libs/phosphor-tile-engine/src/autotileengine/insert.cpp
@@ -323,6 +323,22 @@ void AutotileEngine::removeWindow(const QString& windowId)
 {
     m_windowMinSizes.remove(windowId);
     m_overflow.clearOverflow(windowId);
+
+    // Purge a closed window from pending initial orders even when it was a
+    // minimized placeholder and therefore never received an engine key.
+    for (auto pit = m_pendingInitialOrders.begin(); pit != m_pendingInitialOrders.end();) {
+        pit.value().removeAll(windowId);
+        if (pit.value().isEmpty()) {
+            m_pendingOrderGeneration.remove(pit.key());
+            m_strictInitialOrderScreens.remove(pit.key());
+            pit = m_pendingInitialOrders.erase(pit);
+        } else {
+            const QString screen = pit.key();
+            ++pit; // advance before potential erase by helper
+            cleanupPendingOrderIfResolved(screen);
+        }
+    }
+
     const TilingStateKey key = m_states.takeWindow(windowId);
     if (key.screenId.isEmpty()) {
         return;
@@ -336,22 +352,6 @@ void AutotileEngine::removeWindow(const QString& windowId)
         // removal runs, and by the save-time snapshot for still-open windows. The
         // reopen consumes that record in insertWindow().
         state->removeWindow(windowId);
-    }
-
-    // Purge closed window from pending initial orders.
-    // If a pre-seeded window closes before arriving at the autotile engine,
-    // the pending order would leak indefinitely without this cleanup.
-    for (auto pit = m_pendingInitialOrders.begin(); pit != m_pendingInitialOrders.end();) {
-        pit.value().removeAll(windowId);
-        if (pit.value().isEmpty()) {
-            m_pendingOrderGeneration.remove(pit.key());
-            m_strictInitialOrderScreens.remove(pit.key());
-            pit = m_pendingInitialOrders.erase(pit);
-        } else {
-            const QString screen = pit.key();
-            ++pit; // advance before potential erase by helper
-            cleanupPendingOrderIfResolved(screen);
-        }
     }
 }
 

--- a/libs/phosphor-tile-engine/src/autotileengine/insert.cpp
+++ b/libs/phosphor-tile-engine/src/autotileengine/insert.cpp
@@ -352,13 +352,8 @@ void AutotileEngine::insertWindowByConfigOrder(PhosphorTiles::TilingState* state
     }
 }
 
-void AutotileEngine::removeWindow(const QString& windowId)
+void AutotileEngine::purgeFromPendingOrders(const QString& windowId)
 {
-    m_windowMinSizes.remove(windowId);
-    m_overflow.clearOverflow(windowId);
-
-    // Purge a closed window from pending initial orders even when it was a
-    // minimized placeholder and therefore never received an engine key.
     for (auto pit = m_pendingInitialOrders.begin(); pit != m_pendingInitialOrders.end();) {
         pit.value().removeAll(windowId);
         if (pit.value().isEmpty()) {
@@ -369,6 +364,25 @@ void AutotileEngine::removeWindow(const QString& windowId)
             const QString screen = pit.key();
             ++pit; // advance before potential erase by helper
             cleanupPendingOrderIfResolved(screen);
+        }
+    }
+}
+
+void AutotileEngine::removeWindow(const QString& windowId)
+{
+    m_windowMinSizes.remove(windowId);
+    m_overflow.clearOverflow(windowId);
+
+    // Purge a closed window from pending initial orders even when it was a
+    // minimized placeholder and therefore never received an engine key.
+    purgeFromPendingOrders(windowId);
+    // A pending post-retile focus for a window that just closed must not
+    // survive to activate a dead id on its screen's next retile.
+    for (auto fit = m_pendingFocusByScreen.begin(); fit != m_pendingFocusByScreen.end();) {
+        if (fit.value() == windowId) {
+            fit = m_pendingFocusByScreen.erase(fit);
+        } else {
+            ++fit;
         }
     }
 

--- a/libs/phosphor-tile-engine/src/autotileengine/insert.cpp
+++ b/libs/phosphor-tile-engine/src/autotileengine/insert.cpp
@@ -191,6 +191,13 @@ bool AutotileEngine::insertWindow(const QString& windowId, const QString& screen
             // through to insertPosition so the user's "After existing" /
             // "After focused" / "As main window" setting wins for new
             // arrivals.
+            // NOTE: the advisory (non-strict) branch below is currently
+            // unreachable by construction — setInitialWindowOrder is the sole
+            // pending-order producer and always marks its screen strict, and
+            // the strict flag's lifetime is lockstep with the order's. The
+            // branch is retained as the documented CONTRACT for any future
+            // producer of advisory (hint-only) orders; do not delete it as
+            // dead code without also collapsing that contract.
             const bool strict = m_strictInitialOrderScreens.contains(screenId) || exactWindowIdMatch;
             if (strict || insertAt >= state->windowCount()) {
                 state->addWindow(windowId, insertAt);

--- a/libs/phosphor-tile-engine/src/autotileengine/window_lifecycle.cpp
+++ b/libs/phosphor-tile-engine/src/autotileengine/window_lifecycle.cpp
@@ -107,6 +107,8 @@ void AutotileEngine::windowOpened(const QString& rawWindowId, const QString& scr
     // VS2 to VS1), remove it from the old screen's PhosphorTiles::TilingState first. Without this,
     // the window remains in the old PhosphorTiles::TilingState as a ghost entry — the old screen
     // retiles around a window that's no longer there, and zone assignments stay stale.
+    bool crossScreenMigration = false;
+    bool wasFloating = false;
     if (!screenId.isEmpty()) {
         const TilingStateKey newKey = currentKeyForScreen(screenId);
         auto existingIt = m_states.windowKeys().constFind(windowId);
@@ -114,8 +116,10 @@ void AutotileEngine::windowOpened(const QString& rawWindowId, const QString& scr
             const TilingStateKey oldKey = existingIt.value();
             PhosphorTiles::TilingState* oldState = m_states.stateForKey(oldKey);
             if (oldState && oldState->containsWindow(windowId)) {
-                // Use the algorithm's lifecycle hook for clean removal
-                // (e.g., dwindle-memory needs to update its split tree).
+                // Mirror migrateWindowBetweenKeys: capture the live float
+                // state before the source drops the window, run the clean
+                // removal hook, and keep the overflow bookkeeping coherent.
+                wasFloating = oldState->isFloating(windowId);
                 PhosphorTiles::TilingAlgorithm* oldAlgo = effectiveAlgorithm(oldKey.screenId);
                 if (oldAlgo && oldAlgo->supportsLifecycleHooks()) {
                     const int idx = oldState->tiledWindows().indexOf(windowId);
@@ -124,6 +128,8 @@ void AutotileEngine::windowOpened(const QString& rawWindowId, const QString& scr
                     }
                 }
                 oldState->removeWindow(windowId);
+                m_overflow.migrateWindow(windowId);
+                crossScreenMigration = true;
                 qCInfo(PhosphorTileEngine::lcTileEngine) << "windowOpened: removed" << windowId << "from old screen"
                                                          << oldKey.screenId << "before adding to" << screenId;
                 scheduleRetileForScreen(oldKey.screenId);
@@ -137,6 +143,18 @@ void AutotileEngine::windowOpened(const QString& rawWindowId, const QString& scr
         storeWindowMinSize(windowId, minWidth, minHeight);
     }
 
+    if (crossScreenMigration) {
+        // Migration ARRIVAL, same as migrateWindowBetweenKeys: without the
+        // marker, a FLOATING window's re-add re-derived its state from the
+        // open-time float rule and got tiled on the new screen, silently
+        // dropping the user's float.
+        QScopeGuard clearArrival([this] {
+            m_migrationArrival.reset();
+        });
+        m_migrationArrival = MigrationArrival{windowId, wasFloating};
+        onWindowAdded(windowId);
+        return;
+    }
     onWindowAdded(windowId);
 }
 
@@ -356,6 +374,12 @@ bool AutotileEngine::releaseScreenStateForTeardown(const QString& screenId, Phos
     // rides from the engine's own float-back cache.
     const QStringList tiled = state->tiledWindows();
     const QStringList floated = state->floatingWindows();
+    // The return feeds the callers' placementChanged emission. That signal
+    // describes the LIVE OCCUPANCY release (windows leaving the tiling), so
+    // it is membership-based BY CONTRACT — it must fire even when the durable
+    // record is already content-identical (pinned by
+    // testMinimizedFloatDoesNotReplaceTiledPlacementOnTeardown), and a
+    // tracker-less engine still released its windows.
     const bool releasedAny = !tiled.isEmpty() || !floated.isEmpty();
     if (m_windowTracker) {
         // Two passes instead of `floated + tiled` — this runs once per
@@ -545,10 +569,10 @@ void AutotileEngine::onWindowAdded(const QString& windowId)
         qCDebug(PhosphorTileEngine::lcTileEngine)
             << "Max window limit reached for screen" << screenId << "(max=" << maxWin << ")";
         // Purge this window from pending initial orders so the order doesn't
-        // leak waiting for a window that will never be inserted.
-        for (auto pit = m_pendingInitialOrders.begin(); pit != m_pendingInitialOrders.end(); ++pit) {
-            pit.value().removeAll(windowId);
-        }
+        // leak waiting for a window that will never be inserted. Shared
+        // helper, not a bare removeAll: an order emptied here must also drop
+        // its generation/strict entries or its timeout chain stays armed.
+        purgeFromPendingOrders(windowId);
         return;
     }
 
@@ -592,6 +616,9 @@ QString AutotileEngine::removeTrackedWindowNoRetile(const QString& windowId)
     if (screenId.isEmpty()) {
         // A minimized strict-order placeholder is intentionally absent from
         // m_states, but its close still has to remove the pending-order entry.
+        // DELIBERATELY no release/retile signalling on this path: the window
+        // never occupied a tile, so there is nothing for subscribers to
+        // reflow — the pending-order purge is the whole cleanup.
         removeWindow(windowId);
         return {};
     }

--- a/libs/phosphor-tile-engine/src/autotileengine/window_lifecycle.cpp
+++ b/libs/phosphor-tile-engine/src/autotileengine/window_lifecycle.cpp
@@ -596,6 +596,9 @@ QString AutotileEngine::removeTrackedWindowNoRetile(const QString& windowId)
 {
     const QString screenId = m_states.keyForWindow(windowId).screenId;
     if (screenId.isEmpty()) {
+        // A minimized strict-order placeholder is intentionally absent from
+        // m_states, but its close still has to remove the pending-order entry.
+        removeWindow(windowId);
         return {};
     }
 

--- a/libs/phosphor-tile-engine/src/autotileengine/window_lifecycle.cpp
+++ b/libs/phosphor-tile-engine/src/autotileengine/window_lifecycle.cpp
@@ -581,13 +581,7 @@ void AutotileEngine::onWindowAdded(const QString& windowId)
 
     if (inserted) {
         // Notify algorithm via lifecycle hook before retile
-        PhosphorTiles::TilingAlgorithm* algo = effectiveAlgorithm(screenId);
-        if (algo && algo->supportsLifecycleHooks() && state) {
-            const int idx = state->tiledWindows().indexOf(windowId);
-            if (idx >= 0) {
-                algo->onWindowAdded(state, idx);
-            }
-        }
+        notifyAlgorithmWindowAdded(state, screenId, windowId);
         scheduleRetileForScreen(screenId);
     }
 }

--- a/libs/phosphor-tile-engine/src/autotileengine/window_lifecycle.cpp
+++ b/libs/phosphor-tile-engine/src/autotileengine/window_lifecycle.cpp
@@ -345,7 +345,7 @@ void AutotileEngine::windowFocused(const QString& rawWindowId, const QString& sc
     onWindowFocused(windowId);
 }
 
-void AutotileEngine::releaseScreenStateForTeardown(const QString& screenId, PhosphorTiles::TilingState* state,
+bool AutotileEngine::releaseScreenStateForTeardown(const QString& screenId, PhosphorTiles::TilingState* state,
                                                    QStringList& releasedWindows, bool drainOverflow)
 {
     // Snapshot each window's autotile slot into the unified record BEFORE the
@@ -356,6 +356,7 @@ void AutotileEngine::releaseScreenStateForTeardown(const QString& screenId, Phos
     // rides from the engine's own float-back cache.
     const QStringList tiled = state->tiledWindows();
     const QStringList floated = state->floatingWindows();
+    const bool releasedAny = !tiled.isEmpty() || !floated.isEmpty();
     if (m_windowTracker) {
         // Two passes instead of `floated + tiled` — this runs once per
         // context in the orphaned-VS teardown loop and the concatenation
@@ -390,6 +391,7 @@ void AutotileEngine::releaseScreenStateForTeardown(const QString& screenId, Phos
     m_pendingOrderGeneration.remove(screenId);
     m_strictInitialOrderScreens.remove(screenId);
     state->deleteLater();
+    return releasedAny;
 }
 
 void AutotileEngine::migrateWindowBetweenKeys(const QString& windowId, const TilingStateKey& oldKey,

--- a/libs/phosphor-zones/include/PhosphorZones/Layout.h
+++ b/libs/phosphor-zones/include/PhosphorZones/Layout.h
@@ -362,6 +362,25 @@ public:
     {
         m_lastRecalcGeometry = geom;
     }
+    /// The complete staleness predicate recalculateZoneGeometries() gates on:
+    /// the screen rect changed OR the zone set was edited since the last pass
+    /// (m_zoneGeometryDirty). Callers that skip work when a recalc "already
+    /// happened" MUST use this, not a bare lastRecalcGeometry() comparison —
+    /// the rect alone reads as fresh after a zone add/remove at unchanged
+    /// screen geometry, leaving the new zones with no absolute geometry.
+    bool needsRecalc(const QRectF& screenGeometry) const
+    {
+        return screenGeometry != m_lastRecalcGeometry || m_zoneGeometryDirty;
+    }
+    /// Full-recalc bookkeeping for external appliers (the async worker path):
+    /// stamps the rect AND clears the zone-set dirty bit, exactly as
+    /// recalculateZoneGeometries() does internally. Use only when the applied
+    /// result covered the layout's current zone set.
+    void markRecalculated(const QRectF& geom)
+    {
+        m_lastRecalcGeometry = geom;
+        m_zoneGeometryDirty = false;
+    }
 
     // Serialization
     QJsonObject toJson() const;

--- a/libs/phosphor-zones/include/PhosphorZones/LayoutComputeService.h
+++ b/libs/phosphor-zones/include/PhosphorZones/LayoutComputeService.h
@@ -33,7 +33,6 @@ public:
     static void recalculateSync(Layout* layout, const QRectF& screenGeometry);
 
 Q_SIGNALS:
-    void geometriesComputed(const QString& screenId, const QUuid& layoutId, PhosphorZones::Layout* layout);
     void requestCompute(const PhosphorZones::LayoutSnapshot& snapshot, uint64_t generation);
     void geometriesComputedForGeneration(const QString& screenId, const QUuid& layoutId, PhosphorZones::Layout* layout,
                                          uint64_t generation);

--- a/libs/phosphor-zones/include/PhosphorZones/LayoutComputeService.h
+++ b/libs/phosphor-zones/include/PhosphorZones/LayoutComputeService.h
@@ -28,17 +28,21 @@ public:
     void setLayoutManager(LayoutRegistry* manager);
 
     bool requestRecalculate(Layout* layout, const QString& screenId, const QRectF& screenGeometry);
+    uint64_t currentGeneration(const QString& screenId) const;
 
     static void recalculateSync(Layout* layout, const QRectF& screenGeometry);
 
 Q_SIGNALS:
     void geometriesComputed(const QString& screenId, const QUuid& layoutId, PhosphorZones::Layout* layout);
     void requestCompute(const PhosphorZones::LayoutSnapshot& snapshot, uint64_t generation);
+    void geometriesComputedForGeneration(const QString& screenId, const QUuid& layoutId, PhosphorZones::Layout* layout,
+                                         uint64_t generation);
 
 private:
     static LayoutSnapshot buildSnapshot(Layout* layout, const QString& screenId, const QRectF& screenGeometry);
     void applyResult(const LayoutComputeResult& result);
     void onLayoutRemoved(const QUuid& layoutId);
+    void publishResult(const QString& screenId, const QUuid& layoutId, Layout* layout, uint64_t generation);
 
     QHash<QUuid, QPointer<Layout>> m_trackedLayouts;
     QHash<QString, uint64_t> m_screenGeneration;

--- a/libs/phosphor-zones/include/PhosphorZones/LayoutComputeService.h
+++ b/libs/phosphor-zones/include/PhosphorZones/LayoutComputeService.h
@@ -44,6 +44,10 @@ private:
     void publishResult(const QString& screenId, const QUuid& layoutId, Layout* layout, uint64_t generation);
 
     QHash<QUuid, QPointer<Layout>> m_trackedLayouts;
+    /// Per-screen request generation. Never pruned — entries are one integer
+    /// per screenId ever requested, bounded by session screen/VS churn, and
+    /// pruning would reset a returning screen's counter under any in-flight
+    /// stale result.
     QHash<QString, uint64_t> m_screenGeneration;
     QPointer<LayoutRegistry> m_layoutManager;
     QThread* m_thread = nullptr;

--- a/libs/phosphor-zones/src/layoutcomputeservice.cpp
+++ b/libs/phosphor-zones/src/layoutcomputeservice.cpp
@@ -43,6 +43,11 @@ LayoutComputeService::~LayoutComputeService()
         qCWarning(lcLayoutLib) << "LayoutComputeService: worker thread did not quit within 5s — terminating";
         m_thread->terminate();
         m_thread->wait();
+        // The worker's deleteLater is posted into the terminated thread's
+        // event loop, which never runs again — reclaim it directly. Safe: the
+        // thread is fully stopped after wait(), so nothing races the delete.
+        delete m_worker;
+        m_worker = nullptr;
     }
 }
 
@@ -82,6 +87,12 @@ bool LayoutComputeService::requestRecalculate(Layout* layout, const QString& scr
         // never computed, satisfying the caller's barrier with nothing
         // applied. Publishing under the current generation keeps both the
         // barrier and any in-flight compute honest.
+        // Contract note: because the no-op path deliberately does NOT bump the
+        // generation, this queued publish can share a generation number with an
+        // in-flight worker compute (geometry flipped back to lastRecalcGeometry
+        // while the intermediate compute is still running) — two results at the
+        // same generation, the worker's second. Barriers must therefore settle
+        // on the LATEST result for a generation, not the first.
         const uint64_t gen = m_screenGeneration.value(screenId);
         const QString sid = screenId;
         const QUuid lid = layout->id();

--- a/libs/phosphor-zones/src/layoutcomputeservice.cpp
+++ b/libs/phosphor-zones/src/layoutcomputeservice.cpp
@@ -56,22 +56,23 @@ bool LayoutComputeService::requestRecalculate(Layout* layout, const QString& scr
         return false;
     }
 
+    const uint64_t gen = ++m_screenGeneration[screenId];
+
     if (screenGeometry == layout->lastRecalcGeometry()) {
         const QString sid = screenId;
         const QUuid lid = layout->id();
         QPointer<Layout> lp(layout);
         QMetaObject::invokeMethod(
             this,
-            [this, sid, lid, lp]() {
-                Q_EMIT geometriesComputed(sid, lid, lp.data());
+            [this, sid, lid, lp, gen]() {
+                const bool superseded = gen < m_screenGeneration.value(sid);
+                Q_EMIT geometriesComputed(sid, lid, superseded ? nullptr : lp.data());
             },
             Qt::QueuedConnection);
         return true;
     }
 
     m_trackedLayouts[layout->id()] = layout;
-
-    uint64_t gen = ++m_screenGeneration[screenId];
 
     LayoutSnapshot snapshot = buildSnapshot(layout, screenId, screenGeometry);
     Q_EMIT requestCompute(snapshot, gen);

--- a/libs/phosphor-zones/src/layoutcomputeservice.cpp
+++ b/libs/phosphor-zones/src/layoutcomputeservice.cpp
@@ -114,14 +114,9 @@ void LayoutComputeService::applyResult(const LayoutComputeResult& result)
     if (genIt != m_screenGeneration.constEnd() && result.generation < *genIt) {
         qCDebug(lcLayoutLib) << "LayoutComputeService: discarding stale result for" << result.screenId
                              << "gen=" << result.generation << "current=" << *genIt;
-        // Emit so async barriers (e.g. Daemon::processPendingGeometryUpdates) still
-        // drain for this (screenId, layoutId) pair. Without this, a burst of
-        // panel/screen events that bumps the generation faster than worker results
-        // arrive leaves every superseded barrier waiting forever, and the
-        // reapply-geometries timer that follows the barrier never starts. Pass
-        // nullptr because the layout's zone geometries do NOT reflect this
-        // generation — consumers that need fresh state will see the next
-        // non-stale emit for the same (screenId, layoutId) pair.
+        // Emit a null layout so screen-scoped async barriers know this result
+        // was superseded and must wait for the newest generation. The current
+        // result may belong to a different layout after an assignment change.
         Q_EMIT geometriesComputed(result.screenId, result.layoutId, nullptr);
         return;
     }

--- a/libs/phosphor-zones/src/layoutcomputeservice.cpp
+++ b/libs/phosphor-zones/src/layoutcomputeservice.cpp
@@ -66,7 +66,7 @@ bool LayoutComputeService::requestRecalculate(Layout* layout, const QString& scr
             this,
             [this, sid, lid, lp, gen]() {
                 const bool superseded = gen < m_screenGeneration.value(sid);
-                Q_EMIT geometriesComputed(sid, lid, superseded ? nullptr : lp.data());
+                publishResult(sid, lid, superseded ? nullptr : lp.data(), gen);
             },
             Qt::QueuedConnection);
         return true;
@@ -77,6 +77,11 @@ bool LayoutComputeService::requestRecalculate(Layout* layout, const QString& scr
     LayoutSnapshot snapshot = buildSnapshot(layout, screenId, screenGeometry);
     Q_EMIT requestCompute(snapshot, gen);
     return true;
+}
+
+uint64_t LayoutComputeService::currentGeneration(const QString& screenId) const
+{
+    return m_screenGeneration.value(screenId);
 }
 
 void LayoutComputeService::recalculateSync(Layout* layout, const QRectF& screenGeometry)
@@ -117,7 +122,7 @@ void LayoutComputeService::applyResult(const LayoutComputeResult& result)
         // Emit a null layout so screen-scoped async barriers know this result
         // was superseded and must wait for the newest generation. The current
         // result may belong to a different layout after an assignment change.
-        Q_EMIT geometriesComputed(result.screenId, result.layoutId, nullptr);
+        publishResult(result.screenId, result.layoutId, nullptr, result.generation);
         return;
     }
 
@@ -125,14 +130,14 @@ void LayoutComputeService::applyResult(const LayoutComputeResult& result)
     if (layoutIt == m_trackedLayouts.constEnd() || layoutIt->isNull()) {
         qCDebug(lcLayoutLib) << "LayoutComputeService: dropping result for destroyed layout"
                              << result.layoutId.toString();
-        Q_EMIT geometriesComputed(result.screenId, result.layoutId, nullptr);
+        publishResult(result.screenId, result.layoutId, nullptr, result.generation);
         return;
     }
     Layout* layout = layoutIt->data();
 
     if (layout->lastRecalcGeometry() == result.screenGeometry) {
         qCDebug(lcLayoutLib) << "LayoutComputeService: sync path already applied for" << result.screenId;
-        Q_EMIT geometriesComputed(result.screenId, result.layoutId, layout);
+        publishResult(result.screenId, result.layoutId, layout, result.generation);
         return;
     }
 
@@ -146,7 +151,18 @@ void LayoutComputeService::applyResult(const LayoutComputeResult& result)
     layout->setLastRecalcGeometry(result.screenGeometry);
     layout->endBatchModify();
 
-    Q_EMIT geometriesComputed(result.screenId, result.layoutId, layout);
+    publishResult(result.screenId, result.layoutId, layout, result.generation);
+}
+
+void LayoutComputeService::publishResult(const QString& screenId, const QUuid& layoutId, Layout* layout,
+                                         uint64_t generation)
+{
+    QPointer<LayoutComputeService> guard(this);
+    Q_EMIT geometriesComputed(screenId, layoutId, layout);
+    if (!guard) {
+        return;
+    }
+    Q_EMIT geometriesComputedForGeneration(screenId, layoutId, layout, generation);
 }
 
 void LayoutComputeService::onLayoutRemoved(const QUuid& layoutId)

--- a/libs/phosphor-zones/src/layoutcomputeservice.cpp
+++ b/libs/phosphor-zones/src/layoutcomputeservice.cpp
@@ -34,7 +34,16 @@ LayoutComputeService::LayoutComputeService(QObject* parent)
 LayoutComputeService::~LayoutComputeService()
 {
     m_thread->quit();
-    m_thread->wait(5000);
+    if (!m_thread->wait(5000)) {
+        // A wedged worker (runaway compute) must not let the parented QThread
+        // be destroyed while still running — Qt aborts the whole process on
+        // that. The worker only writes its own local result state, so a
+        // forced stop at teardown cannot corrupt anything the surviving
+        // process still reads.
+        qCWarning(lcLayoutLib) << "LayoutComputeService: worker thread did not quit within 5s — terminating";
+        m_thread->terminate();
+        m_thread->wait();
+    }
 }
 
 void LayoutComputeService::setLayoutManager(LayoutRegistry* manager)

--- a/libs/phosphor-zones/src/layoutcomputeservice.cpp
+++ b/libs/phosphor-zones/src/layoutcomputeservice.cpp
@@ -155,6 +155,11 @@ void LayoutComputeService::applyResult(const LayoutComputeResult& result)
     if (layoutIt == m_trackedLayouts.constEnd() || layoutIt->isNull()) {
         qCDebug(lcLayoutLib) << "LayoutComputeService: dropping result for destroyed layout"
                              << result.layoutId.toString();
+        if (layoutIt != m_trackedLayouts.constEnd()) {
+            // Reap the nulled QPointer so destroyed-without-layoutRemoved
+            // layouts don't accumulate tombstones for the session.
+            m_trackedLayouts.remove(result.layoutId);
+        }
         publishResult(result.screenId, result.layoutId, nullptr, result.generation);
         return;
     }

--- a/libs/phosphor-zones/src/layoutcomputeservice.cpp
+++ b/libs/phosphor-zones/src/layoutcomputeservice.cpp
@@ -48,6 +48,12 @@ LayoutComputeService::~LayoutComputeService()
 
 void LayoutComputeService::setLayoutManager(LayoutRegistry* manager)
 {
+    // Sever the previous manager's connection first: re-wiring would
+    // otherwise stack a second layoutRemoved handler, and setting null would
+    // leave the dead manager's connection live.
+    if (m_layoutManager) {
+        disconnect(m_layoutManager, nullptr, this, nullptr);
+    }
     m_layoutManager = manager;
     if (!manager) {
         return;
@@ -199,16 +205,7 @@ void LayoutComputeService::applyResult(const LayoutComputeResult& result)
 void LayoutComputeService::publishResult(const QString& screenId, const QUuid& layoutId, Layout* layout,
                                          uint64_t generation)
 {
-    QPointer<LayoutComputeService> guard(this);
-    // QPointer the layout across the first emit too: a subscriber that
-    // destroys the layout (layout removal) must not leave the second emit
-    // publishing a dangling pointer.
-    QPointer<Layout> layoutGuard(layout);
-    Q_EMIT geometriesComputed(screenId, layoutId, layout);
-    if (!guard) {
-        return;
-    }
-    Q_EMIT geometriesComputedForGeneration(screenId, layoutId, layoutGuard.data(), generation);
+    Q_EMIT geometriesComputedForGeneration(screenId, layoutId, layout, generation);
 }
 
 void LayoutComputeService::onLayoutRemoved(const QUuid& layoutId)

--- a/libs/phosphor-zones/src/layoutcomputeservice.cpp
+++ b/libs/phosphor-zones/src/layoutcomputeservice.cpp
@@ -56,9 +56,18 @@ bool LayoutComputeService::requestRecalculate(Layout* layout, const QString& scr
         return false;
     }
 
-    const uint64_t gen = ++m_screenGeneration[screenId];
-
-    if (screenGeometry == layout->lastRecalcGeometry()) {
+    // needsRecalc, not a bare rect comparison: a zone edit at unchanged
+    // screen geometry (m_zoneGeometryDirty) must take the worker path or the
+    // edited zones keep stale/absent absolute geometry.
+    if (!layout->needsRecalc(screenGeometry)) {
+        // NO generation bump for a no-op: bumping here would supersede an
+        // in-flight worker compute carrying a REAL geometry change — its
+        // result would be discarded as stale while this cached callback
+        // publishes a non-null layout for a generation whose geometry it
+        // never computed, satisfying the caller's barrier with nothing
+        // applied. Publishing under the current generation keeps both the
+        // barrier and any in-flight compute honest.
+        const uint64_t gen = m_screenGeneration.value(screenId);
         const QString sid = screenId;
         const QUuid lid = layout->id();
         QPointer<Layout> lp(layout);
@@ -72,6 +81,7 @@ bool LayoutComputeService::requestRecalculate(Layout* layout, const QString& scr
         return true;
     }
 
+    const uint64_t gen = ++m_screenGeneration[screenId];
     m_trackedLayouts[layout->id()] = layout;
 
     LayoutSnapshot snapshot = buildSnapshot(layout, screenId, screenGeometry);
@@ -135,7 +145,12 @@ void LayoutComputeService::applyResult(const LayoutComputeResult& result)
     }
     Layout* layout = layoutIt->data();
 
-    if (layout->lastRecalcGeometry() == result.screenGeometry) {
+    // needsRecalc, not a bare rect comparison: if zones were edited after the
+    // sync recalc stamped this rect, the worker's freshly computed geometries
+    // are exactly what the edited zones are missing — discarding them here
+    // would publish a non-null layout whose new zones have no absolute
+    // geometry.
+    if (!layout->needsRecalc(result.screenGeometry)) {
         qCDebug(lcLayoutLib) << "LayoutComputeService: sync path already applied for" << result.screenId;
         publishResult(result.screenId, result.layoutId, layout, result.generation);
         return;
@@ -148,7 +163,25 @@ void LayoutComputeService::applyResult(const LayoutComputeResult& result)
             zone->setGeometry(computed.absoluteGeometry);
         }
     }
-    layout->setLastRecalcGeometry(result.screenGeometry);
+    // Clear the zone-set dirty bit only when this result covered the layout's
+    // CURRENT zones. A zone edited mid-flight (snapshot taken before the
+    // edit) leaves the layout dirty so the next request recomputes it; the
+    // rect is still stamped either way, preserving the pre-existing
+    // rect-comparison behavior for that partial case.
+    bool coversCurrentZones = result.zones.size() == layout->zoneCount();
+    if (coversCurrentZones) {
+        for (const auto& computed : result.zones) {
+            if (!layout->zoneById(computed.zoneId)) {
+                coversCurrentZones = false;
+                break;
+            }
+        }
+    }
+    if (coversCurrentZones) {
+        layout->markRecalculated(result.screenGeometry);
+    } else {
+        layout->setLastRecalcGeometry(result.screenGeometry);
+    }
     layout->endBatchModify();
 
     publishResult(result.screenId, result.layoutId, layout, result.generation);
@@ -158,11 +191,15 @@ void LayoutComputeService::publishResult(const QString& screenId, const QUuid& l
                                          uint64_t generation)
 {
     QPointer<LayoutComputeService> guard(this);
+    // QPointer the layout across the first emit too: a subscriber that
+    // destroys the layout (layout removal) must not leave the second emit
+    // publishing a dangling pointer.
+    QPointer<Layout> layoutGuard(layout);
     Q_EMIT geometriesComputed(screenId, layoutId, layout);
     if (!guard) {
         return;
     }
-    Q_EMIT geometriesComputedForGeneration(screenId, layoutId, layout, generation);
+    Q_EMIT geometriesComputedForGeneration(screenId, layoutId, layoutGuard.data(), generation);
 }
 
 void LayoutComputeService::onLayoutRemoved(const QUuid& layoutId)

--- a/libs/phosphor-zones/src/layoutregistry_assignments.cpp
+++ b/libs/phosphor-zones/src/layoutregistry_assignments.cpp
@@ -209,6 +209,16 @@ bool LayoutRegistry::purgeSnappingLayoutFromAssignments(const QString& layoutId)
         // Shape 2: a window-property (or otherwise non-context) rule. Remove
         // only the SetSnappingLayout actions referencing the deleted layout;
         // every other action is preserved verbatim.
+        //
+        // A MIXED context rule (context-only match + assignment actions +
+        // some non-assignment action) lands here too — it fails
+        // isPureAssignmentRule but still carries a context whose observers
+        // must refresh, so record it in `affected` for the layoutAssigned
+        // emit below, exactly like the Shape-1 branch.
+        if (isContextAssignmentRule(rule)) {
+            const ContextDims dims = decodeDims(rule.match);
+            affected.insert(qMakePair(dims.screenId, dims.virtualDesktop));
+        }
         PWR::Rule trimmed = rule;
         trimmed.actions.erase(std::remove_if(trimmed.actions.begin(), trimmed.actions.end(),
                                              [&layoutId](const PWR::RuleAction& action) {

--- a/scripts/plasmazones-report.sh
+++ b/scripts/plasmazones-report.sh
@@ -371,6 +371,9 @@ echo "Support report archive created:"
 echo "  $ARCHIVE_PATH"
 echo ""
 echo "Contents:"
-tar -tzf "$ARCHIVE_PATH" | sed 's|^./||' | grep -v '^$' | sed 's/^/  /'
+# `|| true`: under pipefail an all-blank listing would make grep -v exit
+# non-zero and abort AFTER the archive was already written, losing the
+# attach instruction below for a report that succeeded.
+tar -tzf "$ARCHIVE_PATH" | sed 's|^./||' | grep -v '^$' | sed 's/^/  /' || true
 echo ""
 echo "Attach this file to your GitHub Issue or Discussion."

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -486,6 +486,8 @@ set(plasmazones_daemon_SRCS
     daemon/daemon/idle.cpp
     daemon/daemon/navigation.cpp
     daemon/daemon/autotile.cpp
+    daemon/daemon/seedorderfilter.cpp
+    daemon/daemon/seedorderfilter.h
     daemon/daemon/osd.cpp
     daemon/daemon.h
     daemon/daemon/helpers.h

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -1,6 +1,13 @@
 // SPDX-FileCopyrightText: 2026 fuddlesworth
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+// FILE-SIZE EXCEPTION (sanctioned): the Daemon class is the composition root
+// — every service, adaptor, engine, and timer member plus the phase-method
+// declarations their wiring documentation hangs off. The implementation is
+// already split across daemon/*.cpp by phase; splitting the class DECLARATION
+// would scatter the ownership/destruction-order contract the header's member
+// ordering encodes.
+
 #pragma once
 
 #include <QObject>
@@ -460,9 +467,13 @@ private:
     /**
      * @brief Pre-seed autotile engine with zone-ordered windows for one screen
      *
-     * Builds the zone-ordered window list from WTS and passes it to the autotile
-     * engine's setInitialWindowOrder(). Used by both per-screen toggle and global
-     * snapping→autotile transition.
+     * Prefers the SAVED order from the last mode toggle
+     * (m_lastAutotileOrders, deterministic re-entry) and only falls back to
+     * the zone-ordered window list from WTS. Live filters run before
+     * seeding (filterAutotileSeedOrder): user floats and durable snap-slot
+     * floats are dropped, minimized windows stay as positional placeholders.
+     * The result goes to the autotile engine's setInitialWindowOrder(). Used
+     * by both per-screen toggle and global snapping→autotile transition.
      *
      * @param screenId Screen identifier
      */

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -512,9 +512,14 @@ private:
      * `SnapEngine::emitBatchedResnap` — one batched signal per autotile
      * toggle instead of per-window D-Bus chatter. Zone-snapped windows are
      * already handled by `SnapAdaptor::resnapCurrentAssignments`.
+     *
+     * @param onlyScreenId When non-empty, restrict to that screen's saved
+     *        orders — the per-screen toggle must not emit restores for
+     *        windows still tiled on other screens.
      */
     QVector<ZoneAssignmentEntry> buildAutotileRestoreEntries(const QSet<QString>& excludeWindows = {}, int desktop = -1,
-                                                             const QString& activity = QString());
+                                                             const QString& activity = QString(),
+                                                             const QString& onlyScreenId = QString());
 
     /** @brief Show layout OSD deferred (avoids blocking on first-time QML compilation) */
     void showLayoutOsdDeferred(const QUuid& layoutId, const QString& screenId);

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -1136,7 +1136,7 @@ private:
     // assignment cascade.
     QHash<QString, int> m_lastTiledCountByScreen;
 
-    // Snap-float restore entries collected during windowsReleasedFromTiling.
+    // Snap-float restore entries collected by the windowsReleased handler.
     // Consumed by the toggle handler to batch geometry restores into the resnap signal.
     QVector<ZoneAssignmentEntry> m_pendingSnapFloatRestores;
 

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -486,10 +486,12 @@ private:
     /**
      * @brief Pre-save snap-mode floating state before entering autotile
      *
-     * Saves non-autotile-floated floating windows to WTS's savedSnapFloating set.
-     * When screenId is provided, only saves windows on that screen. When empty,
-     * saves all floating windows (used for global autotile enable).
-     * Idempotent (QSet::insert).
+     * Snapshots every non-autotile-floated floating window into the unified
+     * placement record via captureWindowPlacement (the record's snap slot +
+     * shared free geometry are the single source of truth; there is no
+     * parallel saved-float set). When screenId is provided, only windows on
+     * that screen are captured; when empty, all floating windows (global
+     * autotile enable). Idempotent — content-identical captures no-op.
      */
     void presaveSnapFloats(const QString& screenId = QString());
 

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -857,7 +857,7 @@ private:
     /// so a restart would stack duplicate handlers. We disconnect these exact
     /// handles on re-entry rather than the (sender, signal, receiver) triple:
     /// other call sites install their OWN handlers on the same signals — e.g.
-    /// initLayoutAndSettingsWiring() connects layoutAssigned from the ctor — and
+    /// initLayoutAndSettingsWiring() connects layoutAssigned from init() — and
     /// a triple-wide disconnect would silently delete those too. Qt::UniqueConnection
     /// is not an option here: it does not apply to lambda/functor connections.
     QList<QMetaObject::Connection> m_restartScopedConnections;
@@ -867,6 +867,14 @@ private:
     /// AFTER initializeAutotile() — sharing one list would drop these handles
     /// the moment after they were installed.
     QList<QMetaObject::Connection> m_autotileShortcutConnections;
+    /// Handles for every connection installed by initLayoutAndSettingsWiring().
+    /// The senders (m_settings, m_layoutManager, the three value-member
+    /// timers) all survive stop(), and init() CAN re-run (stop() -> init() ->
+    /// start()), so a bare re-wire would stack duplicate handlers — double
+    /// mode-transition passes and double gap resnaps per settings save. Exact
+    /// handles, not (sender, signal, receiver) triples, for the same reason
+    /// as m_restartScopedConnections.
+    QList<QMetaObject::Connection> m_layoutSettingsWiringConnections;
 
     std::unique_ptr<PhosphorWorkspaces::VirtualDesktopManager> m_virtualDesktopManager;
     std::unique_ptr<PhosphorWorkspaces::ActivityManager> m_activityManager;

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -198,19 +198,13 @@ public:
      *
      * Borrowed by the three D-Bus adaptors (SnapAdaptor,
      * WindowTrackingAdaptor, WindowDragAdaptor) and the daemon's own
-     * navigation / OSD paths so the cascade
+     * navigation / OSD / overlay paths so the cascade
      * `(modeFor → currentDesktop → currentActivity → isContextDisabled
      * → isContextLocked)` resolves through one call instead of being
-     * hand-stitched at each site. OverlayService is NOT yet a consumer —
-     * its disabled-context gates still call the legacy
-     * `isContextDisabled(m_settings, ...)` directly; migrating it is
-     * follow-up work. The pointer is non-null after `init()` and stays
-     * non-null until `stop()` runs to completion (which calls
-     * `m_contextResolver.reset()` in the teardown order documented at
-     * @ref m_contextResolver). Note that `stop()` returns early when
-     * `m_running` is false — the init-without-start teardown path
-     * therefore skips the explicit reset, and the resolver is destroyed
-     * later by `~Daemon` via the unique_ptr member dtor. See
+     * hand-stitched at each site. The pointer is non-null after `init()` and stays
+     * non-null until `stop()` runs. The init-without-start path detaches the
+     * overlay's borrow before its early return, while normal running teardown
+     * also clears every adaptor borrow before resetting the resolver. See
      * @ref m_contextResolver for the declaration-order invariant.
      */
     PhosphorContext::ContextResolver* contextResolver() const

--- a/src/daemon/daemon/autotile.cpp
+++ b/src/daemon/daemon/autotile.cpp
@@ -650,20 +650,17 @@ void Daemon::seedAutotileOrderForScreen(const QString& screenId)
         //   tiled — the strict seed in setAutotileScreens only restores
         //   floating from the AUTOTILE placement slot, so a float recorded by
         //   another mode would be tiled over.
-        // - Minimized: checked via the registry's live metadata, because the
-        //   floating check resolves through the screen's CURRENT mode slot.
-        //   The seed runs twice per toggle (mode-toggle handler, then
-        //   updateAutotileScreens after the assignment flip), and the second
-        //   pass reads the autotile slot where a snap-mode minimize-float is
-        //   invisible — the minimize check is mode-independent and holds on
-        //   both passes.
+        // Minimized windows remain in the order as placeholders. The engine's
+        // strict-seed path defers adding them until their windowOpened arrives,
+        // preserving position without making a hidden window occupy a tile.
         const PhosphorEngine::WindowRegistry* registry = wts->windowRegistry();
         order.removeIf([wts, registry](const QString& windowId) {
-            if (wts->isWindowFloating(windowId)) {
+            const bool minimized = registry && registry->isMinimized(windowId);
+            if (!minimized && wts->isWindowFloating(windowId)) {
                 return true;
             }
             // The mode flips before the second seed, so the live floating
-            // resolver then reads the empty autotile slot. The exact durable
+            // resolver then reads the empty autotile slot. The instance-exact durable
             // snap slot preserves the source-mode user float across that flip.
             const auto record = wts->placementStore().peekExact(windowId);
             if (record
@@ -671,7 +668,7 @@ void Daemon::seedAutotileOrderForScreen(const QString& screenId)
                     == PhosphorEngine::WindowPlacement::stateFloating()) {
                 return true;
             }
-            return registry && registry->isMinimized(windowId);
+            return false;
         });
     }
 
@@ -698,14 +695,14 @@ void Daemon::processPendingGeometryUpdates()
     const QString activity = currentActivity();
     const QStringList screenIds = m_screenManager->effectiveScreenIds();
 
-    auto pending = std::make_shared<QSet<QString>>();
+    auto pending = std::make_shared<QHash<QString, uint64_t>>();
 
     auto requestFor = [this, pending](PhosphorZones::Layout* layout, const QString& screenId, const QRectF& geom) {
         if (!layout) {
             return;
         }
         if (m_layoutComputeService->requestRecalculate(layout, screenId, geom)) {
-            pending->insert(screenId);
+            pending->insert(screenId, m_layoutComputeService->currentGeneration(screenId));
         }
     };
 
@@ -736,29 +733,31 @@ void Daemon::processPendingGeometryUpdates()
         return;
     }
 
-    // Completion barrier: a superseded result carries layout==nullptr while
-    // its layout still exists, so it cannot complete the screen. A successful
-    // newer result for the same screen may name a different layout after an
-    // assignment change and still correctly completes that screen. A destroyed
-    // layout is terminal and drains its screen.
+    // Completion barrier: only the service's current generation can complete a
+    // screen. If another request supersedes ours, advance the expected generation
+    // and wait for that result. A null result at the current generation is terminal
+    // because it means the associated layout was destroyed.
     auto conn = std::make_shared<QMetaObject::Connection>();
-    *conn =
-        connect(m_layoutComputeService.get(), &PhosphorZones::LayoutComputeService::geometriesComputed, this,
-                [this, pending, conn](const QString& screenId, const QUuid& layoutId, PhosphorZones::Layout* layout) {
-                    if (!pending->contains(screenId)) {
-                        return;
-                    }
-                    if (!layout && m_layoutManager && m_layoutManager->layoutById(layoutId)) {
-                        return; // superseded; wait for the current generation
-                    }
-                    pending->remove(screenId);
-                    if (pending->isEmpty()) {
-                        QObject::disconnect(*conn);
-                        m_overlayService->updateGeometries();
-                        m_reapplyGeometriesTimer.setInterval(REAPPLY_DELAY_MS);
-                        m_reapplyGeometriesTimer.start();
-                    }
-                });
+    *conn = connect(
+        m_layoutComputeService.get(), &PhosphorZones::LayoutComputeService::geometriesComputedForGeneration, this,
+        [this, pending, conn](const QString& screenId, const QUuid&, PhosphorZones::Layout*, uint64_t generation) {
+            auto expected = pending->find(screenId);
+            if (expected == pending->end() || generation < expected.value()) {
+                return;
+            }
+            const uint64_t currentGeneration = m_layoutComputeService->currentGeneration(screenId);
+            if (generation < currentGeneration) {
+                expected.value() = currentGeneration;
+                return;
+            }
+            pending->remove(screenId);
+            if (pending->isEmpty()) {
+                QObject::disconnect(*conn);
+                m_overlayService->updateGeometries();
+                m_reapplyGeometriesTimer.setInterval(REAPPLY_DELAY_MS);
+                m_reapplyGeometriesTimer.start();
+            }
+        });
 
     // Re-query panel geometry once after a delay to pick up settled state (e.g. panel editor close).
     // That completion emits availableGeometryChanged → debounce → processPendingGeometryUpdates → reapply.

--- a/src/daemon/daemon/autotile.cpp
+++ b/src/daemon/daemon/autotile.cpp
@@ -28,6 +28,7 @@
 #include <QScreen>
 #include <PhosphorScreens/ScreenIdentity.h>
 #include <PhosphorIdentity/VirtualScreenId.h>
+#include "seedorderfilter.h"
 
 namespace PlasmaZones {
 
@@ -39,6 +40,12 @@ namespace {
 constexpr int DELAYED_PANEL_REQUERY_MS = 400;
 // Reapply requested on next event loop (0); daemon state is already updated when we start the timer.
 constexpr int REAPPLY_DELAY_MS = 0;
+// Watchdog for the geometry-recalc completion barrier: a screen removed
+// (hot-unplug, VS teardown) after its recalc was requested never delivers a
+// result, which would leave the barrier's pending set non-empty forever and
+// the overlay refresh lost. Generous relative to a worker-thread recalc
+// (single-digit ms per layout).
+constexpr int COMPUTE_BARRIER_TIMEOUT_MS = 3000;
 } // anonymous namespace
 
 bool Daemon::isAnyScreenAutotile() const
@@ -117,6 +124,12 @@ void Daemon::updateAutotileScreens()
     for (const QString& screenId : removedScreens) {
         // Per-output virtual desktops (#648): each screen resolves its own desktop.
         const int desktop = currentDesktopForScreen(screenId);
+        // Stored unconditionally, INCLUDING an empty order: the capture is the
+        // authoritative "what was tiled at toggle-off", and an empty one must
+        // overwrite a stale non-empty entry from an earlier toggle so re-entry
+        // does not resurrect windows that have since closed or left the
+        // screen (seedAutotileOrderForScreen falls back to the zone-ordered
+        // list when the saved order is empty).
         QStringList order = m_autotileEngine->managedWindowOrder(screenId);
         m_lastAutotileOrders[TilingStateKey{screenId, desktop, activity}] = order;
     }
@@ -664,18 +677,6 @@ void Daemon::seedAutotileOrderForScreen(const QString& screenId)
         order = wts->buildZoneOrderedWindowList(screenId);
     }
     if (!order.isEmpty() && wts) {
-        // Order sources describe past arrangements (the tiled order captured
-        // at toggle-off, or zone assignments) and know nothing about what
-        // happened to those windows since. Two live checks before seeding:
-        //
-        // - Floating: a window floating NOW (e.g. floated by the snap handler
-        //   while the screen was in a manual mode) must not be seeded back as
-        //   tiled — the strict seed in setAutotileScreens only restores
-        //   floating from the AUTOTILE placement slot, so a float recorded by
-        //   another mode would be tiled over.
-        // Minimized windows remain in the order as placeholders. The engine's
-        // strict-seed path defers adding them until their windowOpened arrives,
-        // preserving position without making a hidden window occupy a tile.
         const PhosphorEngine::WindowRegistry* registry = wts->windowRegistry();
         if (!registry) {
             // Without the registry every minimized window reads as
@@ -686,22 +687,10 @@ void Daemon::seedAutotileOrderForScreen(const QString& screenId)
             qCWarning(lcDaemon) << "seedAutotileOrderForScreen: no window registry —"
                                 << "minimized windows cannot be filtered for" << screenId;
         }
-        order.removeIf([wts, registry](const QString& windowId) {
-            const bool minimized = registry && registry->isMinimized(windowId);
-            if (!minimized && wts->isWindowFloating(windowId)) {
-                return true;
-            }
-            // The mode flips before the second seed, so the live floating
-            // resolver then reads the empty autotile slot. The instance-exact durable
-            // snap slot preserves the source-mode user float across that flip.
-            const auto record = wts->placementStore().peekExact(windowId);
-            if (record
-                && record->slotFor(PhosphorEngine::WindowPlacement::snapEngineId()).state
-                    == PhosphorEngine::WindowPlacement::stateFloating()) {
-                return true;
-            }
-            return false;
-        });
+        // Drop entries that must not be seeded as tiled (live user floats,
+        // durable snap-slot floats); minimized windows stay as positional
+        // placeholders. See filterAutotileSeedOrder's doc for the rationale.
+        filterAutotileSeedOrder(order, wts, registry);
     }
 
     if (!order.isEmpty()) {
@@ -769,6 +758,16 @@ void Daemon::processPendingGeometryUpdates()
     // screen. If another request supersedes ours, advance the expected generation
     // and wait for that result. A null result at the current generation is terminal
     // because it means the associated layout was destroyed.
+    //
+    // Keyed by screenId ALONE, deliberately. The service's generation counter is
+    // per screen and bumped by every request, so the result carrying the
+    // screen's current generation IS the newest request for that screen —
+    // whatever layout it computed. A competing same-screen request for a
+    // DIFFERENT layout only exists when the screen's displayed layout changed
+    // mid-flight (activeLayoutChanged / layoutAssigned), and then ITS result is
+    // exactly the geometry the overlay refresh needs; re-keying by
+    // (screen, layout) would instead strand the barrier waiting for a
+    // generation that can never arrive.
     auto conn = std::make_shared<QMetaObject::Connection>();
     *conn = connect(
         m_layoutComputeService.get(), &PhosphorZones::LayoutComputeService::geometriesComputedForGeneration, this,
@@ -790,6 +789,23 @@ void Daemon::processPendingGeometryUpdates()
                 m_reapplyGeometriesTimer.start();
             }
         });
+    // Watchdog (see COMPUTE_BARRIER_TIMEOUT_MS): force-complete a barrier whose
+    // screen disappeared mid-flight so the overlay refresh still happens and
+    // the connection does not leak. A barrier that completed normally has an
+    // empty pending set and an already-disconnected conn — the timeout then
+    // no-ops.
+    QTimer::singleShot(COMPUTE_BARRIER_TIMEOUT_MS, this, [this, pending, conn]() {
+        if (pending->isEmpty()) {
+            return;
+        }
+        qCWarning(lcDaemon) << "Geometry recalc barrier timed out with screens still pending:" << pending->keys()
+                            << "— forcing overlay refresh";
+        pending->clear();
+        QObject::disconnect(*conn);
+        m_overlayService->updateGeometries();
+        m_reapplyGeometriesTimer.setInterval(REAPPLY_DELAY_MS);
+        m_reapplyGeometriesTimer.start();
+    });
 
     // Re-query panel geometry once after a delay to pick up settled state (e.g. panel editor close).
     // That completion emits availableGeometryChanged → debounce → processPendingGeometryUpdates → reapply.

--- a/src/daemon/daemon/autotile.cpp
+++ b/src/daemon/daemon/autotile.cpp
@@ -637,11 +637,34 @@ void Daemon::seedAutotileOrderForScreen(const QString& screenId)
     // activation, or windows changed between toggles).
     TilingStateKey orderKey{screenId, currentDesktopForScreen(screenId), currentActivity()};
     QStringList order = m_lastAutotileOrders.value(orderKey);
-    if (order.isEmpty()) {
-        PhosphorPlacement::WindowTrackingService* wts = m_windowTrackingAdaptor->service();
-        if (wts) {
-            order = wts->buildZoneOrderedWindowList(screenId);
-        }
+    PhosphorPlacement::WindowTrackingService* wts = m_windowTrackingAdaptor->service();
+    if (order.isEmpty() && wts) {
+        order = wts->buildZoneOrderedWindowList(screenId);
+    }
+    if (!order.isEmpty() && wts) {
+        // Order sources describe past arrangements (the tiled order captured
+        // at toggle-off, or zone assignments) and know nothing about what
+        // happened to those windows since. Two live checks before seeding:
+        //
+        // - Floating: a window floating NOW (e.g. floated by the snap handler
+        //   while the screen was in a manual mode) must not be seeded back as
+        //   tiled — the strict seed in setAutotileScreens only restores
+        //   floating from the AUTOTILE placement slot, so a float recorded by
+        //   another mode would be tiled over.
+        // - Minimized: checked via the registry's live metadata, because the
+        //   floating check resolves through the screen's CURRENT mode slot.
+        //   The seed runs twice per toggle (mode-toggle handler, then
+        //   updateAutotileScreens after the assignment flip), and the second
+        //   pass reads the autotile slot where a snap-mode minimize-float is
+        //   invisible — the minimize check is mode-independent and holds on
+        //   both passes.
+        const PhosphorEngine::WindowRegistry* registry = wts->windowRegistry();
+        order.removeIf([wts, registry](const QString& windowId) {
+            if (wts->isWindowFloating(windowId)) {
+                return true;
+            }
+            return registry && registry->isMinimized(windowId);
+        });
     }
 
     if (!order.isEmpty()) {

--- a/src/daemon/daemon/autotile.cpp
+++ b/src/daemon/daemon/autotile.cpp
@@ -67,7 +67,10 @@ bool Daemon::isAnyScreenAutotile() const
 
 void Daemon::updateAutotileScreens()
 {
-    if (!m_autotileEngine || !m_layoutManager || !m_screenManager) {
+    // m_algorithmRegistry joins the preamble: the per-screen override loop
+    // below derefs it for the algorithm-default MaxWindows injection, and a
+    // guard only on its siblings left that deref as the odd one out.
+    if (!m_autotileEngine || !m_layoutManager || !m_screenManager || !m_algorithmRegistry) {
         return;
     }
     // Every entry path into this function is wired in init() or later
@@ -649,7 +652,11 @@ void Daemon::presaveSnapFloats(const QString& screenId)
             continue;
         }
         // When scoped to a screen, only snapshot windows on that screen.
-        // Windows floating on other screens are not entering autotile.
+        // Windows floating on other screens are not entering autotile. A
+        // window with NO tracked screen is deliberately INCLUDED on every
+        // per-screen toggle: it might be on the toggling screen, and the
+        // capture is an idempotent record refresh — skipping on unknown would
+        // drop exactly the float this presave exists to preserve.
         if (!screenId.isEmpty()) {
             const QString windowScreen = wts->screenForWindow(fid);
             if (!windowScreen.isEmpty() && windowScreen != screenId) {
@@ -706,13 +713,19 @@ void Daemon::processPendingGeometryUpdates()
     if (!m_geometryUpdatePending) {
         return;
     }
+    // Timer-driven entry (the geometry debounce fires from the event loop),
+    // so unlike the signal-wired paths nothing upstream vouches for these
+    // members during a stop() teardown window.
+    if (!m_screenManager || !m_layoutManager || !m_layoutComputeService || !m_overlayService) {
+        return;
+    }
 
     // Recalculate zone geometries for each effective screen (virtual or physical)
     // so fixed-mode zones stay normalized correctly against the correct screen geometry.
     // Async: each screen's computation runs on the worker thread. A barrier
-    // tracks pending screens. LayoutComputeService reports superseded results
-    // with a null layout, which this barrier ignores until the newest result
-    // for that screen completes.
+    // tracks pending screens. Supersession is tracked by per-screen
+    // GENERATION (see the completion barrier below); a result below the
+    // screen's current generation just advances the expectation.
     const QString activity = currentActivity();
     const QStringList screenIds = m_screenManager->effectiveScreenIds();
 
@@ -756,8 +769,11 @@ void Daemon::processPendingGeometryUpdates()
 
     // Completion barrier: only the service's current generation can complete a
     // screen. If another request supersedes ours, advance the expected generation
-    // and wait for that result. A null result at the current generation is terminal
-    // because it means the associated layout was destroyed.
+    // and wait for that result. The layout pointer in the emission is NOT
+    // inspected — generation alone decides. A destroyed layout's result
+    // arrives null AT the current generation and completes the screen exactly
+    // like an applied one, which is the point: the barrier waits for the
+    // newest outcome, whatever it was.
     //
     // Keyed by screenId ALONE, deliberately. The service's generation counter is
     // per screen and bumped by every request, so the result carrying the

--- a/src/daemon/daemon/autotile.cpp
+++ b/src/daemon/daemon/autotile.cpp
@@ -118,9 +118,7 @@ void Daemon::updateAutotileScreens()
         // Per-output virtual desktops (#648): each screen resolves its own desktop.
         const int desktop = currentDesktopForScreen(screenId);
         QStringList order = m_autotileEngine->managedWindowOrder(screenId);
-        if (!order.isEmpty()) {
-            m_lastAutotileOrders[TilingStateKey{screenId, desktop, activity}] = order;
-        }
+        m_lastAutotileOrders[TilingStateKey{screenId, desktop, activity}] = order;
     }
 
     // Seed window order for screens ENTERING autotile from saved state.

--- a/src/daemon/daemon/autotile.cpp
+++ b/src/daemon/daemon/autotile.cpp
@@ -566,10 +566,10 @@ QVector<ZoneAssignmentEntry> Daemon::buildAutotileRestoreEntries(const QSet<QStr
     if (!m_windowTrackingAdaptor || m_lastAutotileOrders.isEmpty()) {
         return entries;
     }
+    // No null-check on service(): the adaptor constructs and owns its service
+    // (never null once the adaptor exists) — the sibling callers in this file
+    // rely on the same invariant.
     PhosphorPlacement::WindowTrackingService* wts = m_windowTrackingAdaptor->service();
-    if (!wts) {
-        return entries;
-    }
     for (auto it = m_lastAutotileOrders.constBegin(); it != m_lastAutotileOrders.constEnd(); ++it) {
         if (desktop >= 0 && (it.key().desktop != desktop || it.key().activity != activity)) {
             continue;

--- a/src/daemon/daemon/autotile.cpp
+++ b/src/daemon/daemon/autotile.cpp
@@ -544,7 +544,7 @@ QHash<TilingStateKey, QStringList> Daemon::captureAutotileOrders() const
 }
 
 QVector<ZoneAssignmentEntry> Daemon::buildAutotileRestoreEntries(const QSet<QString>& excludeWindows, int desktop,
-                                                                 const QString& activity)
+                                                                 const QString& activity, const QString& onlyScreenId)
 {
     QVector<ZoneAssignmentEntry> entries;
     if (!m_windowTrackingAdaptor || m_lastAutotileOrders.isEmpty()) {
@@ -558,13 +558,29 @@ QVector<ZoneAssignmentEntry> Daemon::buildAutotileRestoreEntries(const QSet<QStr
         if (desktop >= 0 && (it.key().desktop != desktop || it.key().activity != activity)) {
             continue;
         }
+        // Scope to the toggled screen when the caller says so. The per-screen
+        // mode toggle merges captured orders for EVERY active autotile screen
+        // into m_lastAutotileOrders, and two screens routinely share a
+        // (desktop, activity) pair — without this filter the toggle emits
+        // pre-tile restores for windows still happily tiled on OTHER screens
+        // and teleports them to their old float positions.
+        if (!onlyScreenId.isEmpty() && it.key().screenId != onlyScreenId) {
+            continue;
+        }
         const QString& screenId = it.key().screenId;
         for (const QString& windowId : it.value()) {
             if (excludeWindows.contains(windowId))
                 continue;
             if (wts->isWindowSnapped(windowId))
                 continue;
-            if (wts->isWindowFloating(windowId))
+            // Minimize exception, mirroring the seed/order-resnap filters: a
+            // minimized window reads as floating (suspension float) but must
+            // keep its restore entry — the effect skips the geometry apply
+            // for minimized windows and keeps only the bookkeeping, and the
+            // unminimize path re-resolves placement.
+            const bool minimized =
+                wts->windowRegistry() && wts->windowRegistry()->minimizedState(windowId).value_or(false);
+            if (wts->isWindowFloating(windowId) && !minimized)
                 continue;
             // Strict per-instance lookup — no appId fallback. A window that was
             // only ever auto-tiled (never explicitly snapped, never explicitly
@@ -599,6 +615,13 @@ void Daemon::presaveSnapFloats(const QString& screenId)
     // Runs while the screen is still in snapping mode, so captureWindowPlacement
     // routes to the snap engine and records the snap slot (= floating) plus the
     // shared free geometry from the live frame.
+    //
+    // MINIMIZED floating windows are a deliberate no-op inside
+    // captureWindowPlacement (its minimize guard): their record still holds
+    // the PRE-minimize state, which is exactly what the return path restores
+    // — windowsReleased's snapSnapped branch qualifies minimized windows via
+    // the registry, so a snapped-then-minimized window resnaps to its zone
+    // rather than needing a suspension-float slot written here.
     //
     // Reachable from `Settings::settingsChanged` (init_services.cpp) before the
     // engines exist — any synchronous re-entry into settingsChanged during the
@@ -654,6 +677,15 @@ void Daemon::seedAutotileOrderForScreen(const QString& screenId)
         // strict-seed path defers adding them until their windowOpened arrives,
         // preserving position without making a hidden window occupy a tile.
         const PhosphorEngine::WindowRegistry* registry = wts->windowRegistry();
+        if (!registry) {
+            // Without the registry every minimized window reads as
+            // not-minimized here AND the engine's own strict-seed deferral
+            // loses its second line of defence — the fail-open that seeds a
+            // hidden window into a tile. Loud, because in production the
+            // registry is always wired.
+            qCWarning(lcDaemon) << "seedAutotileOrderForScreen: no window registry —"
+                                << "minimized windows cannot be filtered for" << screenId;
+        }
         order.removeIf([wts, registry](const QString& windowId) {
             const bool minimized = registry && registry->isMinimized(windowId);
             if (!minimized && wts->isWindowFloating(windowId)) {

--- a/src/daemon/daemon/autotile.cpp
+++ b/src/daemon/daemon/autotile.cpp
@@ -20,6 +20,7 @@
 #include "dbus/windowtrackingadaptor/windowtrackingadaptor.h"
 #include <PhosphorEngine/PlacementEngineBase.h>
 #include <PhosphorEngine/IPlacementEngine.h>
+#include <PhosphorEngine/WindowPlacement.h>
 #include <PhosphorTiles/AlgorithmRegistry.h>
 #include <PhosphorTiles/TilingAlgorithm.h>
 #include <QGuiApplication>
@@ -601,7 +602,7 @@ void Daemon::presaveSnapFloats(const QString& screenId)
     // routes to the snap engine and records the snap slot (= floating) plus the
     // shared free geometry from the live frame.
     //
-    // Reachable from `Settings::settingsChanged` (daemon.cpp ~830) before the
+    // Reachable from `Settings::settingsChanged` (init_services.cpp) before the
     // engines exist — any synchronous re-entry into settingsChanged during the
     // D-Bus retry loop in init() would hit this path with null engine pointers.
     if (!m_windowTrackingAdaptor || !m_autotileEngine || !m_snapEngine) {
@@ -663,6 +664,15 @@ void Daemon::seedAutotileOrderForScreen(const QString& screenId)
             if (wts->isWindowFloating(windowId)) {
                 return true;
             }
+            // The mode flips before the second seed, so the live floating
+            // resolver then reads the empty autotile slot. The exact durable
+            // snap slot preserves the source-mode user float across that flip.
+            const auto record = wts->placementStore().peekExact(windowId);
+            if (record
+                && record->slotFor(PhosphorEngine::WindowPlacement::snapEngineId()).state
+                    == PhosphorEngine::WindowPlacement::stateFloating()) {
+                return true;
+            }
             return registry && registry->isMinimized(windowId);
         });
     }
@@ -684,22 +694,20 @@ void Daemon::processPendingGeometryUpdates()
     // Recalculate zone geometries for each effective screen (virtual or physical)
     // so fixed-mode zones stay normalized correctly against the correct screen geometry.
     // Async: each screen's computation runs on the worker thread. A barrier
-    // tracks pending (screenId, layoutId) pairs explicitly so unrelated
-    // geometriesComputed emissions (e.g. from an async layoutAssigned firing
-    // mid-barrier) cannot drain it prematurely.
+    // tracks pending screens. LayoutComputeService reports superseded results
+    // with a null layout, which this barrier ignores until the newest result
+    // for that screen completes.
     const QString activity = currentActivity();
     const QStringList screenIds = m_screenManager->effectiveScreenIds();
 
-    // Key = (screenId, layoutId). Matches what geometriesComputed carries.
-    using PendingKey = QPair<QString, QUuid>;
-    auto pending = std::make_shared<QSet<PendingKey>>();
+    auto pending = std::make_shared<QSet<QString>>();
 
     auto requestFor = [this, pending](PhosphorZones::Layout* layout, const QString& screenId, const QRectF& geom) {
         if (!layout) {
             return;
         }
         if (m_layoutComputeService->requestRecalculate(layout, screenId, geom)) {
-            pending->insert({screenId, layout->id()});
+            pending->insert(screenId);
         }
     };
 
@@ -730,28 +738,29 @@ void Daemon::processPendingGeometryUpdates()
         return;
     }
 
-    // Completion barrier: only fire the continuation once every pending
-    // (screen, layout) pair has reported back. Unrelated emissions for
-    // keys not in `pending` are ignored, so a concurrent async caller
-    // cannot drain our barrier prematurely. We key off the signal's
-    // `layoutId` (not `layout->id()`), so the barrier still drains when
-    // a tracked PhosphorZones::Layout is destroyed mid-compute — LayoutComputeService
-    // emits with layout==nullptr in that case.
+    // Completion barrier: a superseded result carries layout==nullptr while
+    // its layout still exists, so it cannot complete the screen. A successful
+    // newer result for the same screen may name a different layout after an
+    // assignment change and still correctly completes that screen. A destroyed
+    // layout is terminal and drains its screen.
     auto conn = std::make_shared<QMetaObject::Connection>();
-    *conn = connect(
-        m_layoutComputeService.get(), &PhosphorZones::LayoutComputeService::geometriesComputed, this,
-        [this, pending, conn](const QString& screenId, const QUuid& layoutId, PhosphorZones::Layout* /*layout*/) {
-            const PendingKey key{screenId, layoutId};
-            if (!pending->remove(key)) {
-                return; // not one of ours
-            }
-            if (pending->isEmpty()) {
-                QObject::disconnect(*conn);
-                m_overlayService->updateGeometries();
-                m_reapplyGeometriesTimer.setInterval(REAPPLY_DELAY_MS);
-                m_reapplyGeometriesTimer.start();
-            }
-        });
+    *conn =
+        connect(m_layoutComputeService.get(), &PhosphorZones::LayoutComputeService::geometriesComputed, this,
+                [this, pending, conn](const QString& screenId, const QUuid& layoutId, PhosphorZones::Layout* layout) {
+                    if (!pending->contains(screenId)) {
+                        return;
+                    }
+                    if (!layout && m_layoutManager && m_layoutManager->layoutById(layoutId)) {
+                        return; // superseded; wait for the current generation
+                    }
+                    pending->remove(screenId);
+                    if (pending->isEmpty()) {
+                        QObject::disconnect(*conn);
+                        m_overlayService->updateGeometries();
+                        m_reapplyGeometriesTimer.setInterval(REAPPLY_DELAY_MS);
+                        m_reapplyGeometriesTimer.start();
+                    }
+                });
 
     // Re-query panel geometry once after a delay to pick up settled state (e.g. panel editor close).
     // That completion emits availableGeometryChanged → debounce → processPendingGeometryUpdates → reapply.

--- a/src/daemon/daemon/autotile.cpp
+++ b/src/daemon/daemon/autotile.cpp
@@ -685,10 +685,20 @@ void Daemon::seedAutotileOrderForScreen(const QString& screenId)
     TilingStateKey orderKey{screenId, currentDesktopForScreen(screenId), currentActivity()};
     QStringList order = m_lastAutotileOrders.value(orderKey);
     PhosphorPlacement::WindowTrackingService* wts = m_windowTrackingAdaptor->service();
-    if (order.isEmpty() && wts) {
+    if (!wts) {
+        // Fail CLOSED: without the WTS the seed filter cannot drop live user
+        // floats or durable snap-slot floats, and seeding a saved order
+        // UNFILTERED would violate the contract in seedorderfilter.h.
+        // Unreachable under the "service() is never null once the adaptor
+        // exists" invariant, but the contract must not depend on it silently.
+        qCWarning(lcDaemon) << "seedAutotileOrderForScreen: no WindowTrackingService — refusing unfiltered seed for"
+                            << screenId;
+        return;
+    }
+    if (order.isEmpty()) {
         order = wts->buildZoneOrderedWindowList(screenId);
     }
-    if (!order.isEmpty() && wts) {
+    if (!order.isEmpty()) {
         const PhosphorEngine::WindowRegistry* registry = wts->windowRegistry();
         if (!registry) {
             // Without the registry every minimized window reads as

--- a/src/daemon/daemon/autotile.cpp
+++ b/src/daemon/daemon/autotile.cpp
@@ -163,8 +163,13 @@ void Daemon::updateAutotileScreens()
             // Resolve per-context tiling-parameter RULES up front — the effective
             // overflow behavior gates the algorithm-default MaxWindows injection
             // below (an Unlimited context must not receive a finite injected cap).
-            const int ctxDesktop = m_layoutManager->currentVirtualDesktopForScreen(screenId);
-            const QString ctxActivity = m_layoutManager->currentActivity();
+            // Same context sources as the disable/assignment checks in the first
+            // loop (VirtualDesktopManager + ActivityManager, not the registry's
+            // push-updated mirror): mixing sources inside one pass would let a
+            // mirror lag resolve a SetMaxWindows/SetSplitRatio rule against a
+            // different context than the assignment it layers onto.
+            const int ctxDesktop = currentDesktopForScreen(screenId);
+            const QString& ctxActivity = activity;
             const PhosphorZones::ContextTilingParams tilingParams =
                 m_layoutManager->resolveContextTilingParams(screenId, ctxDesktop, ctxActivity);
             // Effective overflow mirrors effectiveOverflowBehavior's cascade: a

--- a/src/daemon/daemon/autotile_init.cpp
+++ b/src/daemon/daemon/autotile_init.cpp
@@ -16,6 +16,7 @@
 #include "dbus/windowtrackingadaptor/windowtrackingadaptor.h"
 
 #include <PhosphorEngine/PlacementEngineBase.h>
+#include <PhosphorEngine/WindowPlacement.h>
 #include <PhosphorPlacement/WindowTrackingService.h>
 #include <PhosphorScreens/Manager.h>
 #include <PhosphorSnapEngine/SnapEngine.h>
@@ -125,6 +126,7 @@ void Daemon::initializeAutotile()
                     m_pendingSnapFloatRestores.clear();
                     if (m_windowTrackingAdaptor) {
                         PhosphorPlacement::WindowTrackingService* wts = m_windowTrackingAdaptor->service();
+                        const QString activity = currentActivity();
                         for (const QString& windowId : windowIds) {
                             // Only process windows whose current WTS screen is one of the
                             // screens being released. A window that moved to a different
@@ -181,11 +183,15 @@ void Daemon::initializeAutotile()
                             // never touched the snap slot). Restoring that stale
                             // float would both resurrect it and knock the window out
                             // of the order resnap, which skips floating windows.
-                            const bool tiledAtRelease = !windowScreen.isEmpty()
-                                && m_lastAutotileOrders
-                                       .value(TilingStateKey{windowScreen, currentDesktopForScreen(windowScreen),
-                                                             currentActivity()})
-                                       .contains(windowId);
+                            bool tiledAtRelease = false;
+                            for (const QString& releasedScreenId : releasedScreenIds) {
+                                const TilingStateKey key{releasedScreenId, currentDesktopForScreen(releasedScreenId),
+                                                         activity};
+                                if (m_lastAutotileOrders.value(key).contains(windowId)) {
+                                    tiledAtRelease = true;
+                                    break;
+                                }
+                            }
                             if (snapFloat && tiledAtRelease) {
                                 qCInfo(lcDaemon) << "windowsReleased: skipping stale snap-float for tiled window"
                                                  << windowId << "(order resnap re-snaps it)";
@@ -274,14 +280,8 @@ void Daemon::initializeAutotile()
                 // Note: intentionally shown regardless of showOsdOnLayoutSwitch — this is
                 // direct feedback to an explicit user action, not a passive layout-switch OSD.
                 const auto currentMode = currentModeFor(screenId);
-                // Legacy direct settings check — kept inline because the OSD
-                // surface needs the rich PlasmaZones::DisabledReason enum
-                // (which carries axis info for the user-facing message);
-                // PhosphorContext::DisabledReason in the LGPL lib is a
-                // narrower projection. Migrating this site requires a richer
-                // resolver API and is tracked as a follow-up.
-                const DisabledReason why =
-                    contextDisabledReason(m_settings.get(), currentMode, screenId, desktop, activity);
+                const DisabledReason why = toDaemonDisabledReason(
+                    m_contextResolver->disabledReason(m_contextResolver->handleForMode(screenId, currentMode)));
                 if (why != DisabledReason::NotDisabled) {
                     showContextDisabledOsd(screenId, desktop, activity, why);
                     return;

--- a/src/daemon/daemon/autotile_init.cpp
+++ b/src/daemon/daemon/autotile_init.cpp
@@ -266,6 +266,12 @@ void Daemon::initializeAutotile()
                 // mode the user is actually trying to interact with.
                 // Note: intentionally shown regardless of showOsdOnLayoutSwitch — this is
                 // direct feedback to an explicit user action, not a passive layout-switch OSD.
+                // Fail closed on a missing resolver, matching the sibling
+                // gates (isFocusedContextGated and friends): a toggle during
+                // the teardown window must not act ungated.
+                if (!m_contextResolver) {
+                    return;
+                }
                 const auto currentMode = currentModeFor(screenId);
                 const DisabledReason why = toDaemonDisabledReason(
                     m_contextResolver->disabledReason(m_contextResolver->handleForMode(screenId, currentMode)));
@@ -310,10 +316,13 @@ void Daemon::initializeAutotile()
                 // orders are preserved — a replace would discard them.
                 if (wasAutotile) {
                     auto currentOrders = captureAutotileOrders();
-                    for (const QString& activeScreenId : m_autotileEngine->activeScreens()) {
-                        m_lastAutotileOrders.remove(
-                            TilingStateKey{activeScreenId, currentDesktopForScreen(activeScreenId), activity});
-                    }
+                    // Pre-clear ONLY the toggled screen's context: this is a
+                    // per-screen toggle, and dropping every active screen's
+                    // saved order wiped remembered orders for screens the
+                    // capture below may not cover (their live state can be
+                    // empty right now while their saved order is still the
+                    // re-entry seed).
+                    m_lastAutotileOrders.remove(TilingStateKey{screenId, desktop, activity});
                     for (auto it = currentOrders.constBegin(); it != currentOrders.constEnd(); ++it) {
                         m_lastAutotileOrders[it.key()] = it.value();
                     }

--- a/src/daemon/daemon/autotile_init.cpp
+++ b/src/daemon/daemon/autotile_init.cpp
@@ -171,7 +171,25 @@ void Daemon::initializeAutotile()
                             const bool snapSnapped = wasAutotileFloated
                                 && snapSlot.state == PhosphorEngine::WindowPlacement::stateSnapped()
                                 && !snapSlot.zoneIds.isEmpty();
-                            if (snapFloat) {
+                            // A window that was TILED at release (present in the
+                            // autotile order captured just before this signal) is
+                            // resnapped by the order-driven path, whose commitSnap
+                            // rewrites the snap slot. Its snap slot may still say
+                            // floating from a minimize-float taken the last time the
+                            // screen was in snapping and dissolved during the
+                            // autotile session (the unfloat ran in autotile mode and
+                            // never touched the snap slot). Restoring that stale
+                            // float would both resurrect it and knock the window out
+                            // of the order resnap, which skips floating windows.
+                            const bool tiledAtRelease = !windowScreen.isEmpty()
+                                && m_lastAutotileOrders
+                                       .value(TilingStateKey{windowScreen, currentDesktopForScreen(windowScreen),
+                                                             currentActivity()})
+                                       .contains(windowId);
+                            if (snapFloat && tiledAtRelease) {
+                                qCInfo(lcDaemon) << "windowsReleased: skipping stale snap-float for tiled window"
+                                                 << windowId << "(order resnap re-snaps it)";
+                            } else if (snapFloat) {
                                 qCInfo(lcDaemon) << "windowsReleased: restoring snap-float for" << windowId;
                                 m_windowTrackingAdaptor->setWindowFloating(windowId, true);
                                 const QString screen = wts->screenForWindow(windowId);

--- a/src/daemon/daemon/autotile_init.cpp
+++ b/src/daemon/daemon/autotile_init.cpp
@@ -117,131 +117,128 @@ void Daemon::initializeAutotile()
         // 2. Restore snap-mode floats from each window's placement record (snap slot),
         //    captured when the screen last left snapping — the single source of truth.
         // Must check isModeSpecificFloated BEFORE clearing the marker.
-        connect(m_autotileEngine.get(), &PlacementEngineBase::windowsReleased, this,
-                [this](const QStringList& windowIds, const QSet<QString>& releasedScreenIds) {
-                    // Clear unconditionally: entries from a previous release
-                    // batch are stale the moment a new one arrives, and leaving
-                    // them behind because the adaptor happens to be null would
-                    // leak them into the next toggle.
-                    m_pendingSnapFloatRestores.clear();
-                    if (m_windowTrackingAdaptor) {
-                        PhosphorPlacement::WindowTrackingService* wts = m_windowTrackingAdaptor->service();
-                        const QString activity = currentActivity();
-                        for (const QString& windowId : windowIds) {
-                            // Only process windows whose current WTS screen is one of the
-                            // screens being released. A window that moved to a different
-                            // screen (e.g., dragged from autotile VS to snap VS and resnapped)
-                            // is no longer on the releasing screen — its state on the current
-                            // screen must not be disturbed.
-                            const QString windowScreen = wts->screenForWindow(windowId);
-                            if (!windowScreen.isEmpty() && !releasedScreenIds.contains(windowScreen)) {
-                                // Window is on a different screen — do NOT touch its state.
-                                // It may be on another autotile screen (flag still valid) or
-                                // a snap screen (flag already cleared by assignWindowToZones).
-                                qCDebug(lcDaemon) << "windowsReleased: skipping" << windowId << "on screen"
-                                                  << windowScreen << "(not in released set)";
-                                continue;
+        connect(
+            m_autotileEngine.get(), &PlacementEngineBase::windowsReleased, this,
+            [this](const QStringList& windowIds, const QSet<QString>& releasedScreenIds) {
+                // Clear unconditionally: entries from a previous release
+                // batch are stale the moment a new one arrives, and leaving
+                // them behind because the adaptor happens to be null would
+                // leak them into the next toggle.
+                m_pendingSnapFloatRestores.clear();
+                if (m_windowTrackingAdaptor) {
+                    PhosphorPlacement::WindowTrackingService* wts = m_windowTrackingAdaptor->service();
+                    QSet<QString> orderResnapWindows;
+                    const QString activity = currentActivity();
+                    for (const QString& releasedScreenId : releasedScreenIds) {
+                        const TilingStateKey key{releasedScreenId, currentDesktopForScreen(releasedScreenId), activity};
+                        const QStringList order = m_lastAutotileOrders.value(key);
+                        orderResnapWindows.unite(QSet<QString>(order.begin(), order.end()));
+                    }
+                    for (const QString& windowId : windowIds) {
+                        // Only process windows whose current WTS screen is one of the
+                        // screens being released. A window that moved to a different
+                        // screen (e.g., dragged from autotile VS to snap VS and resnapped)
+                        // is no longer on the releasing screen — its state on the current
+                        // screen must not be disturbed.
+                        const QString windowScreen = wts->screenForWindow(windowId);
+                        if (!windowScreen.isEmpty() && !releasedScreenIds.contains(windowScreen)) {
+                            // Window is on a different screen — do NOT touch its state.
+                            // It may be on another autotile screen (flag still valid) or
+                            // a snap screen (flag already cleared by assignWindowToZones).
+                            qCDebug(lcDaemon) << "windowsReleased: skipping" << windowId << "on screen" << windowScreen
+                                              << "(not in released set)";
+                            continue;
+                        }
+                        if (!m_autotileEngine || !m_snapEngine)
+                            continue;
+                        // Clear autotile-originated floats (they don't persist into snap mode)
+                        bool wasAutotileFloated = m_autotileEngine->isModeSpecificFloated(windowId);
+                        if (wasAutotileFloated) {
+                            m_windowTrackingAdaptor->setWindowFloating(windowId, false);
+                        }
+                        m_autotileEngine->clearModeSpecificFloatMarker(windowId);
+                        // Restore the snap-mode float from the SINGLE source of truth — the
+                        // window's placement record (its snap slot), captured when the screen
+                        // last left snapping. No parallel saved-float set. Float state is set
+                        // immediately; geometry restore is deferred to the batched resnap
+                        // signal to avoid individual D-Bus signals queuing behind the resnap.
+                        // Exact record only: this is a LIVE mid-session window (uuids stable),
+                        // so a same-app sibling's record must not float/zone-restore it.
+                        const auto rec = wts->placementStore().peekExact(windowId);
+                        const PhosphorEngine::EngineSlot snapSlot = rec
+                            ? rec->slotFor(PhosphorEngine::WindowPlacement::snapEngineId())
+                            : PhosphorEngine::EngineSlot{};
+                        const bool snapFloat = snapSlot.state == PhosphorEngine::WindowPlacement::stateFloating();
+                        // A window SNAPPED in snapping mode, then floated in autotile, keeps its
+                        // snap-engine state — float is PER ENGINE. Such a window is excluded from
+                        // the captured autotile tile order (floated windows aren't ordered), so the
+                        // order-driven resnap and buildAutotileRestoreEntries never see it; without
+                        // this branch it falls through every restore path and keeps its autotile-
+                        // float geometry on return to snapping (the "still floated" bug). Gated on
+                        // wasAutotileFloated so order-driven (tiled, non-floated) windows — which the
+                        // order-resnap path already handles — are not double-snapped here.
+                        const bool snapSnapped = wasAutotileFloated
+                            && snapSlot.state == PhosphorEngine::WindowPlacement::stateSnapped()
+                            && !snapSlot.zoneIds.isEmpty();
+                        // A window present in the exact order captured for this
+                        // release is resnapped by the order-driven path, whose
+                        // commitSnap rewrites the snap slot. Its snap slot may still say
+                        // floating from a minimize-float taken the last time the
+                        // screen was in snapping and dissolved during the
+                        // autotile session (the unfloat ran in autotile mode and
+                        // never touched the snap slot). Restoring that stale
+                        // float would both resurrect it and knock the window out
+                        // of the order resnap, which skips floating windows.
+                        if (snapFloat && orderResnapWindows.contains(windowId)) {
+                            qCInfo(lcDaemon) << "windowsReleased: skipping stale snap-float for order-resnapped window"
+                                             << windowId << "(order resnap re-snaps it)";
+                        } else if (snapFloat) {
+                            qCInfo(lcDaemon) << "windowsReleased: restoring snap-float for" << windowId;
+                            m_windowTrackingAdaptor->setWindowFloating(windowId, true);
+                            const QString screen = wts->screenForWindow(windowId);
+                            QRect g = rec->freeGeometryFor(screen.isEmpty() ? rec->screenId : screen);
+                            if (!g.isValid()) {
+                                g = rec->anyFreeGeometry();
                             }
-                            if (!m_autotileEngine || !m_snapEngine)
-                                continue;
-                            // Clear autotile-originated floats (they don't persist into snap mode)
-                            bool wasAutotileFloated = m_autotileEngine->isModeSpecificFloated(windowId);
-                            if (wasAutotileFloated) {
-                                m_windowTrackingAdaptor->setWindowFloating(windowId, false);
+                            if (g.isValid()) {
+                                ZoneAssignmentEntry entry;
+                                entry.windowId = windowId;
+                                entry.targetZoneId = RestoreSentinel;
+                                entry.targetGeometry = g;
+                                m_pendingSnapFloatRestores.append(entry);
                             }
-                            m_autotileEngine->clearModeSpecificFloatMarker(windowId);
-                            // Restore the snap-mode float from the SINGLE source of truth — the
-                            // window's placement record (its snap slot), captured when the screen
-                            // last left snapping. No parallel saved-float set. Float state is set
-                            // immediately; geometry restore is deferred to the batched resnap
-                            // signal to avoid individual D-Bus signals queuing behind the resnap.
-                            // Exact record only: this is a LIVE mid-session window (uuids stable),
-                            // so a same-app sibling's record must not float/zone-restore it.
-                            const auto rec = wts->placementStore().peekExact(windowId);
-                            const PhosphorEngine::EngineSlot snapSlot = rec
-                                ? rec->slotFor(PhosphorEngine::WindowPlacement::snapEngineId())
-                                : PhosphorEngine::EngineSlot{};
-                            const bool snapFloat = snapSlot.state == PhosphorEngine::WindowPlacement::stateFloating();
-                            // A window SNAPPED in snapping mode, then floated in autotile, keeps its
-                            // snap-engine state — float is PER ENGINE. Such a window is excluded from
-                            // the captured autotile tile order (floated windows aren't ordered), so the
-                            // order-driven resnap and buildAutotileRestoreEntries never see it; without
-                            // this branch it falls through every restore path and keeps its autotile-
-                            // float geometry on return to snapping (the "still floated" bug). Gated on
-                            // wasAutotileFloated so order-driven (tiled, non-floated) windows — which the
-                            // order-resnap path already handles — are not double-snapped here.
-                            const bool snapSnapped = wasAutotileFloated
-                                && snapSlot.state == PhosphorEngine::WindowPlacement::stateSnapped()
-                                && !snapSlot.zoneIds.isEmpty();
-                            // A window that was TILED at release (present in the
-                            // autotile order captured just before this signal) is
-                            // resnapped by the order-driven path, whose commitSnap
-                            // rewrites the snap slot. Its snap slot may still say
-                            // floating from a minimize-float taken the last time the
-                            // screen was in snapping and dissolved during the
-                            // autotile session (the unfloat ran in autotile mode and
-                            // never touched the snap slot). Restoring that stale
-                            // float would both resurrect it and knock the window out
-                            // of the order resnap, which skips floating windows.
-                            bool tiledAtRelease = false;
-                            for (const QString& releasedScreenId : releasedScreenIds) {
-                                const TilingStateKey key{releasedScreenId, currentDesktopForScreen(releasedScreenId),
-                                                         activity};
-                                if (m_lastAutotileOrders.value(key).contains(windowId)) {
-                                    tiledAtRelease = true;
-                                    break;
-                                }
-                            }
-                            if (snapFloat && tiledAtRelease) {
-                                qCInfo(lcDaemon) << "windowsReleased: skipping stale snap-float for tiled window"
-                                                 << windowId << "(order resnap re-snaps it)";
-                            } else if (snapFloat) {
-                                qCInfo(lcDaemon) << "windowsReleased: restoring snap-float for" << windowId;
-                                m_windowTrackingAdaptor->setWindowFloating(windowId, true);
-                                const QString screen = wts->screenForWindow(windowId);
-                                QRect g = rec->freeGeometryFor(screen.isEmpty() ? rec->screenId : screen);
-                                if (!g.isValid()) {
-                                    g = rec->anyFreeGeometry();
-                                }
-                                if (g.isValid()) {
-                                    ZoneAssignmentEntry entry;
-                                    entry.windowId = windowId;
-                                    entry.targetZoneId = RestoreSentinel;
-                                    entry.targetGeometry = g;
-                                    m_pendingSnapFloatRestores.append(entry);
-                                }
-                            } else if (snapSnapped) {
-                                const QString screen = wts->screenForWindow(windowId);
-                                const QString restoreScreen = screen.isEmpty() ? rec->screenId : screen;
-                                const QRect geo = wts->resolveZoneGeometry(snapSlot.zoneIds, restoreScreen);
-                                if (geo.isValid()) {
-                                    qCInfo(lcDaemon) << "windowsReleased: restoring snap-zone for" << windowId
-                                                     << "zones=" << snapSlot.zoneIds << "screen=" << restoreScreen;
-                                    // Float is already cleared above for autotile-floated windows; this
-                                    // window returns to its snapped state, not floating. Multiple windows
-                                    // may legitimately share a zone, so no cross-window zone dedup here.
-                                    ZoneAssignmentEntry entry;
-                                    entry.windowId = windowId;
-                                    entry.targetZoneId = snapSlot.zoneIds.first();
-                                    entry.targetZoneIds = snapSlot.zoneIds;
-                                    entry.targetGeometry = geo;
-                                    entry.targetScreenId = restoreScreen;
-                                    // The durable record knows which desktop this snap
-                                    // belongs to; carry it so the batch commit doesn't
-                                    // re-stamp the window onto the current desktop.
-                                    entry.virtualDesktop = rec->virtualDesktop;
-                                    m_pendingSnapFloatRestores.append(entry);
-                                } else {
-                                    qCWarning(lcDaemon) << "windowsReleased: snap-zone restore for" << windowId
-                                                        << "failed — zone geometry unresolved for" << snapSlot.zoneIds;
-                                }
+                        } else if (snapSnapped) {
+                            const QString screen = wts->screenForWindow(windowId);
+                            const QString restoreScreen = screen.isEmpty() ? rec->screenId : screen;
+                            const QRect geo = wts->resolveZoneGeometry(snapSlot.zoneIds, restoreScreen);
+                            if (geo.isValid()) {
+                                qCInfo(lcDaemon) << "windowsReleased: restoring snap-zone for" << windowId
+                                                 << "zones=" << snapSlot.zoneIds << "screen=" << restoreScreen;
+                                // Float is already cleared above for autotile-floated windows; this
+                                // window returns to its snapped state, not floating. Multiple windows
+                                // may legitimately share a zone, so no cross-window zone dedup here.
+                                ZoneAssignmentEntry entry;
+                                entry.windowId = windowId;
+                                entry.targetZoneId = snapSlot.zoneIds.first();
+                                entry.targetZoneIds = snapSlot.zoneIds;
+                                entry.targetGeometry = geo;
+                                entry.targetScreenId = restoreScreen;
+                                // The durable record knows which desktop this snap
+                                // belongs to; carry it so the batch commit doesn't
+                                // re-stamp the window onto the current desktop.
+                                entry.virtualDesktop = rec->virtualDesktop;
+                                m_pendingSnapFloatRestores.append(entry);
                             } else {
-                                qCDebug(lcDaemon) << "windowsReleased: no snap-float to restore for" << windowId
-                                                  << "wasAutotileFloated:" << wasAutotileFloated;
+                                qCWarning(lcDaemon) << "windowsReleased: snap-zone restore for" << windowId
+                                                    << "failed — zone geometry unresolved for" << snapSlot.zoneIds;
                             }
+                        } else {
+                            qCDebug(lcDaemon) << "windowsReleased: no snap-float to restore for" << windowId
+                                              << "wasAutotileFloated:" << wasAutotileFloated;
                         }
                     }
-                });
+                }
+            });
 
         // ═══════════════════════════════════════════════════════════════════════════
         // Autotile Shortcut Signals
@@ -323,6 +320,10 @@ void Daemon::initializeAutotile()
                 // orders are preserved — a replace would discard them.
                 if (wasAutotile) {
                     auto currentOrders = captureAutotileOrders();
+                    for (const QString& activeScreenId : m_autotileEngine->activeScreens()) {
+                        m_lastAutotileOrders.remove(
+                            TilingStateKey{activeScreenId, currentDesktopForScreen(activeScreenId), activity});
+                    }
                     for (auto it = currentOrders.constBegin(); it != currentOrders.constEnd(); ++it) {
                         m_lastAutotileOrders[it.key()] = it.value();
                     }

--- a/src/daemon/daemon/autotile_init.cpp
+++ b/src/daemon/daemon/autotile_init.cpp
@@ -266,10 +266,11 @@ void Daemon::initializeAutotile()
                 // mode the user is actually trying to interact with.
                 // Note: intentionally shown regardless of showOsdOnLayoutSwitch — this is
                 // direct feedback to an explicit user action, not a passive layout-switch OSD.
-                // Fail closed on a missing resolver, matching the sibling
-                // gates (isFocusedContextGated and friends): a toggle during
-                // the teardown window must not act ungated.
-                if (!m_contextResolver) {
+                // Fail closed on a missing resolver or engine, matching the
+                // sibling gates (isFocusedContextGated and friends): a toggle
+                // during the teardown window must not act ungated (the
+                // wasAutotile branch below derefs the engine).
+                if (!m_contextResolver || !m_autotileEngine) {
                     return;
                 }
                 const auto currentMode = currentModeFor(screenId);

--- a/src/daemon/daemon/autotile_init.cpp
+++ b/src/daemon/daemon/autotile_init.cpp
@@ -117,128 +117,108 @@ void Daemon::initializeAutotile()
         // 2. Restore snap-mode floats from each window's placement record (snap slot),
         //    captured when the screen last left snapping — the single source of truth.
         // Must check isModeSpecificFloated BEFORE clearing the marker.
-        connect(
-            m_autotileEngine.get(), &PlacementEngineBase::windowsReleased, this,
-            [this](const QStringList& windowIds, const QSet<QString>& releasedScreenIds) {
-                // Clear unconditionally: entries from a previous release
-                // batch are stale the moment a new one arrives, and leaving
-                // them behind because the adaptor happens to be null would
-                // leak them into the next toggle.
-                m_pendingSnapFloatRestores.clear();
-                if (m_windowTrackingAdaptor) {
-                    PhosphorPlacement::WindowTrackingService* wts = m_windowTrackingAdaptor->service();
-                    QSet<QString> orderResnapWindows;
-                    const QString activity = currentActivity();
-                    for (const QString& releasedScreenId : releasedScreenIds) {
-                        const TilingStateKey key{releasedScreenId, currentDesktopForScreen(releasedScreenId), activity};
-                        const QStringList order = m_lastAutotileOrders.value(key);
-                        orderResnapWindows.unite(QSet<QString>(order.begin(), order.end()));
-                    }
-                    for (const QString& windowId : windowIds) {
-                        // Only process windows whose current WTS screen is one of the
-                        // screens being released. A window that moved to a different
-                        // screen (e.g., dragged from autotile VS to snap VS and resnapped)
-                        // is no longer on the releasing screen — its state on the current
-                        // screen must not be disturbed.
-                        const QString windowScreen = wts->screenForWindow(windowId);
-                        if (!windowScreen.isEmpty() && !releasedScreenIds.contains(windowScreen)) {
-                            // Window is on a different screen — do NOT touch its state.
-                            // It may be on another autotile screen (flag still valid) or
-                            // a snap screen (flag already cleared by assignWindowToZones).
-                            qCDebug(lcDaemon) << "windowsReleased: skipping" << windowId << "on screen" << windowScreen
-                                              << "(not in released set)";
-                            continue;
-                        }
-                        if (!m_autotileEngine || !m_snapEngine)
-                            continue;
-                        // Clear autotile-originated floats (they don't persist into snap mode)
-                        bool wasAutotileFloated = m_autotileEngine->isModeSpecificFloated(windowId);
-                        if (wasAutotileFloated) {
-                            m_windowTrackingAdaptor->setWindowFloating(windowId, false);
-                        }
-                        m_autotileEngine->clearModeSpecificFloatMarker(windowId);
-                        // Restore the snap-mode float from the SINGLE source of truth — the
-                        // window's placement record (its snap slot), captured when the screen
-                        // last left snapping. No parallel saved-float set. Float state is set
-                        // immediately; geometry restore is deferred to the batched resnap
-                        // signal to avoid individual D-Bus signals queuing behind the resnap.
-                        // Exact record only: this is a LIVE mid-session window (uuids stable),
-                        // so a same-app sibling's record must not float/zone-restore it.
-                        const auto rec = wts->placementStore().peekExact(windowId);
-                        const PhosphorEngine::EngineSlot snapSlot = rec
-                            ? rec->slotFor(PhosphorEngine::WindowPlacement::snapEngineId())
-                            : PhosphorEngine::EngineSlot{};
-                        const bool snapFloat = snapSlot.state == PhosphorEngine::WindowPlacement::stateFloating();
-                        // A window SNAPPED in snapping mode, then floated in autotile, keeps its
-                        // snap-engine state — float is PER ENGINE. Such a window is excluded from
-                        // the captured autotile tile order (floated windows aren't ordered), so the
-                        // order-driven resnap and buildAutotileRestoreEntries never see it; without
-                        // this branch it falls through every restore path and keeps its autotile-
-                        // float geometry on return to snapping (the "still floated" bug). Gated on
-                        // wasAutotileFloated so order-driven (tiled, non-floated) windows — which the
-                        // order-resnap path already handles — are not double-snapped here.
-                        const bool snapSnapped = wasAutotileFloated
-                            && snapSlot.state == PhosphorEngine::WindowPlacement::stateSnapped()
-                            && !snapSlot.zoneIds.isEmpty();
-                        // A window present in the exact order captured for this
-                        // release is resnapped by the order-driven path, whose
-                        // commitSnap rewrites the snap slot. Its snap slot may still say
-                        // floating from a minimize-float taken the last time the
-                        // screen was in snapping and dissolved during the
-                        // autotile session (the unfloat ran in autotile mode and
-                        // never touched the snap slot). Restoring that stale
-                        // float would both resurrect it and knock the window out
-                        // of the order resnap, which skips floating windows.
-                        if (snapFloat && orderResnapWindows.contains(windowId)) {
-                            qCInfo(lcDaemon) << "windowsReleased: skipping stale snap-float for order-resnapped window"
-                                             << windowId << "(order resnap re-snaps it)";
-                        } else if (snapFloat) {
-                            qCInfo(lcDaemon) << "windowsReleased: restoring snap-float for" << windowId;
-                            m_windowTrackingAdaptor->setWindowFloating(windowId, true);
-                            const QString screen = wts->screenForWindow(windowId);
-                            QRect g = rec->freeGeometryFor(screen.isEmpty() ? rec->screenId : screen);
-                            if (!g.isValid()) {
-                                g = rec->anyFreeGeometry();
+        connect(m_autotileEngine.get(), &PlacementEngineBase::windowsReleased, this,
+                [this](const QStringList& windowIds, const QSet<QString>& releasedScreenIds) {
+                    // Clear unconditionally: entries from a previous release
+                    // batch are stale the moment a new one arrives, and leaving
+                    // them behind because the adaptor happens to be null would
+                    // leak them into the next toggle.
+                    m_pendingSnapFloatRestores.clear();
+                    if (m_windowTrackingAdaptor) {
+                        PhosphorPlacement::WindowTrackingService* wts = m_windowTrackingAdaptor->service();
+                        for (const QString& windowId : windowIds) {
+                            // Only process windows whose current WTS screen is one of the
+                            // screens being released. A window that moved to a different
+                            // screen (e.g., dragged from autotile VS to snap VS and resnapped)
+                            // is no longer on the releasing screen — its state on the current
+                            // screen must not be disturbed.
+                            const QString windowScreen = wts->screenForWindow(windowId);
+                            if (!windowScreen.isEmpty() && !releasedScreenIds.contains(windowScreen)) {
+                                // Window is on a different screen — do NOT touch its state.
+                                // It may be on another autotile screen (flag still valid) or
+                                // a snap screen (flag already cleared by assignWindowToZones).
+                                qCDebug(lcDaemon) << "windowsReleased: skipping" << windowId << "on screen"
+                                                  << windowScreen << "(not in released set)";
+                                continue;
                             }
-                            if (g.isValid()) {
-                                ZoneAssignmentEntry entry;
-                                entry.windowId = windowId;
-                                entry.targetZoneId = RestoreSentinel;
-                                entry.targetGeometry = g;
-                                m_pendingSnapFloatRestores.append(entry);
+                            if (!m_autotileEngine || !m_snapEngine)
+                                continue;
+                            // Clear autotile-originated floats (they don't persist into snap mode)
+                            bool wasAutotileFloated = m_autotileEngine->isModeSpecificFloated(windowId);
+                            if (wasAutotileFloated) {
+                                m_windowTrackingAdaptor->setWindowFloating(windowId, false);
                             }
-                        } else if (snapSnapped) {
-                            const QString screen = wts->screenForWindow(windowId);
-                            const QString restoreScreen = screen.isEmpty() ? rec->screenId : screen;
-                            const QRect geo = wts->resolveZoneGeometry(snapSlot.zoneIds, restoreScreen);
-                            if (geo.isValid()) {
-                                qCInfo(lcDaemon) << "windowsReleased: restoring snap-zone for" << windowId
-                                                 << "zones=" << snapSlot.zoneIds << "screen=" << restoreScreen;
-                                // Float is already cleared above for autotile-floated windows; this
-                                // window returns to its snapped state, not floating. Multiple windows
-                                // may legitimately share a zone, so no cross-window zone dedup here.
-                                ZoneAssignmentEntry entry;
-                                entry.windowId = windowId;
-                                entry.targetZoneId = snapSlot.zoneIds.first();
-                                entry.targetZoneIds = snapSlot.zoneIds;
-                                entry.targetGeometry = geo;
-                                entry.targetScreenId = restoreScreen;
-                                // The durable record knows which desktop this snap
-                                // belongs to; carry it so the batch commit doesn't
-                                // re-stamp the window onto the current desktop.
-                                entry.virtualDesktop = rec->virtualDesktop;
-                                m_pendingSnapFloatRestores.append(entry);
+                            m_autotileEngine->clearModeSpecificFloatMarker(windowId);
+                            // Restore the snap-mode float from the SINGLE source of truth — the
+                            // window's placement record (its snap slot), captured when the screen
+                            // last left snapping. No parallel saved-float set. Float state is set
+                            // immediately; geometry restore is deferred to the batched resnap
+                            // signal to avoid individual D-Bus signals queuing behind the resnap.
+                            // Same-instance record only: this is a LIVE mid-session window (uuids stable),
+                            // so a same-app sibling's record must not float/zone-restore it.
+                            const auto rec = wts->placementStore().peekExact(windowId);
+                            const PhosphorEngine::EngineSlot snapSlot = rec
+                                ? rec->slotFor(PhosphorEngine::WindowPlacement::snapEngineId())
+                                : PhosphorEngine::EngineSlot{};
+                            const bool snapFloat = snapSlot.state == PhosphorEngine::WindowPlacement::stateFloating();
+                            // A window SNAPPED in snapping mode, then floated in autotile, keeps its
+                            // snap-engine state — float is PER ENGINE. Such a window is excluded from
+                            // the captured autotile tile order (floated windows aren't ordered), so the
+                            // order-driven resnap and buildAutotileRestoreEntries never see it; without
+                            // this branch it falls through every restore path and keeps its autotile-
+                            // float geometry on return to snapping (the "still floated" bug). Gated on
+                            // wasAutotileFloated so order-driven (tiled, non-floated) windows — which the
+                            // order-resnap path already handles — are not double-snapped here.
+                            const bool snapSnapped = wasAutotileFloated
+                                && snapSlot.state == PhosphorEngine::WindowPlacement::stateSnapped()
+                                && !snapSlot.zoneIds.isEmpty();
+                            if (snapFloat) {
+                                qCInfo(lcDaemon) << "windowsReleased: restoring snap-float for" << windowId;
+                                m_windowTrackingAdaptor->setWindowFloating(windowId, true);
+                                const QString screen = wts->screenForWindow(windowId);
+                                QRect g = rec->freeGeometryFor(screen.isEmpty() ? rec->screenId : screen);
+                                if (!g.isValid()) {
+                                    g = rec->anyFreeGeometry();
+                                }
+                                if (g.isValid()) {
+                                    ZoneAssignmentEntry entry;
+                                    entry.windowId = windowId;
+                                    entry.targetZoneId = RestoreSentinel;
+                                    entry.targetGeometry = g;
+                                    m_pendingSnapFloatRestores.append(entry);
+                                }
+                            } else if (snapSnapped) {
+                                const QString screen = wts->screenForWindow(windowId);
+                                const QString restoreScreen = screen.isEmpty() ? rec->screenId : screen;
+                                const QRect geo = wts->resolveZoneGeometry(snapSlot.zoneIds, restoreScreen);
+                                if (geo.isValid()) {
+                                    qCInfo(lcDaemon) << "windowsReleased: restoring snap-zone for" << windowId
+                                                     << "zones=" << snapSlot.zoneIds << "screen=" << restoreScreen;
+                                    // Float is already cleared above for autotile-floated windows; this
+                                    // window returns to its snapped state, not floating. Multiple windows
+                                    // may legitimately share a zone, so no cross-window zone dedup here.
+                                    ZoneAssignmentEntry entry;
+                                    entry.windowId = windowId;
+                                    entry.targetZoneId = snapSlot.zoneIds.first();
+                                    entry.targetZoneIds = snapSlot.zoneIds;
+                                    entry.targetGeometry = geo;
+                                    entry.targetScreenId = restoreScreen;
+                                    // The durable record knows which desktop this snap
+                                    // belongs to; carry it so the batch commit doesn't
+                                    // re-stamp the window onto the current desktop.
+                                    entry.virtualDesktop = rec->virtualDesktop;
+                                    m_pendingSnapFloatRestores.append(entry);
+                                } else {
+                                    qCWarning(lcDaemon) << "windowsReleased: snap-zone restore for" << windowId
+                                                        << "failed — zone geometry unresolved for" << snapSlot.zoneIds;
+                                }
                             } else {
-                                qCWarning(lcDaemon) << "windowsReleased: snap-zone restore for" << windowId
-                                                    << "failed — zone geometry unresolved for" << snapSlot.zoneIds;
+                                qCDebug(lcDaemon) << "windowsReleased: no snap-float to restore for" << windowId
+                                                  << "wasAutotileFloated:" << wasAutotileFloated;
                             }
-                        } else {
-                            qCDebug(lcDaemon) << "windowsReleased: no snap-float to restore for" << windowId
-                                              << "wasAutotileFloated:" << wasAutotileFloated;
                         }
                     }
-                }
-            });
+                });
 
         // ═══════════════════════════════════════════════════════════════════════════
         // Autotile Shortcut Signals

--- a/src/daemon/daemon/autotile_init.cpp
+++ b/src/daemon/daemon/autotile_init.cpp
@@ -170,17 +170,26 @@ void Daemon::initializeAutotile()
                             // float geometry on return to snapping (the "still floated" bug). Gated on
                             // wasAutotileFloated so order-driven (tiled, non-floated) windows — which the
                             // order-resnap path already handles — are not double-snapped here.
-                            const bool snapSnapped = wasAutotileFloated
+                            //
+                            // A MINIMIZED window qualifies too: its autotile representation is a
+                            // suspension float that never sets the mode-specific marker, so a
+                            // snap-SNAPPED window that was autotiled and then minimized would
+                            // otherwise take no restore branch at all and unminimize at a stale
+                            // rect before anything resnaps it.
+                            const bool wasMinimized = wts->windowRegistry()
+                                && wts->windowRegistry()->minimizedState(windowId).value_or(false);
+                            const bool snapSnapped = (wasAutotileFloated || wasMinimized)
                                 && snapSlot.state == PhosphorEngine::WindowPlacement::stateSnapped()
                                 && !snapSlot.zoneIds.isEmpty();
                             if (snapFloat) {
                                 qCInfo(lcDaemon) << "windowsReleased: restoring snap-float for" << windowId;
                                 m_windowTrackingAdaptor->setWindowFloating(windowId, true);
                                 const QString screen = wts->screenForWindow(windowId);
-                                QRect g = rec->freeGeometryFor(screen.isEmpty() ? rec->screenId : screen);
-                                if (!g.isValid()) {
-                                    g = rec->anyFreeGeometry();
-                                }
+                                // Per-screen rect only. anyFreeGeometry() would return a rect
+                                // remembered for a DIFFERENT monitor and teleport the window
+                                // there on multi-monitor; with no rect for this screen the
+                                // window simply stays where it is.
+                                const QRect g = rec->freeGeometryFor(screen.isEmpty() ? rec->screenId : screen);
                                 if (g.isValid()) {
                                     ZoneAssignmentEntry entry;
                                     entry.windowId = windowId;
@@ -486,7 +495,13 @@ void Daemon::initializeAutotile()
                         // float-restore it instead of resnapping to its zone.
                         QStringList windowOrder;
                         for (const QString& windowId : fullOrder) {
-                            if (wts && wts->isWindowFloating(windowId)) {
+                            // Minimize exception, mirroring the seed filter: a minimized
+                            // window reads as floating (suspension float), but it must
+                            // still receive its resnap entry or it unminimizes at the
+                            // stale autotile rect before anything places it.
+                            const bool minimized = wts && wts->windowRegistry()
+                                && wts->windowRegistry()->minimizedState(windowId).value_or(false);
+                            if (wts && wts->isWindowFloating(windowId) && !minimized) {
                                 continue;
                             }
                             if (wts && wts->recordedSnapZones(windowId).isEmpty()) {
@@ -526,7 +541,7 @@ void Daemon::initializeAutotile()
                     allResnapEntries.append(m_pendingSnapFloatRestores);
                     m_pendingSnapFloatRestores.clear();
                     QVector<ZoneAssignmentEntry> restoreEntries =
-                        buildAutotileRestoreEntries(resnappedWindows, desktop, activity);
+                        buildAutotileRestoreEntries(resnappedWindows, desktop, activity, screenId);
                     allResnapEntries.append(restoreEntries);
 
                     // Emit ONE batched signal (suppresses one OSD regardless of screen count)

--- a/src/daemon/daemon/helpers.h
+++ b/src/daemon/daemon/helpers.h
@@ -9,12 +9,30 @@
 
 #include <QScreen>
 #include "core/platform/logging.h"
+#include "core/interfaces/settings_interfaces.h"
 #include "core/utils/utils.h"
 #include "dbus/windowtrackingadaptor/windowtrackingadaptor.h"
 #include <PhosphorScreens/Manager.h>
 #include <PhosphorScreens/ScreenIdentity.h>
+#include <PhosphorContext/DisabledReason.h>
 
 namespace PlasmaZones {
+
+inline DisabledReason toDaemonDisabledReason(PhosphorContext::DisabledReason reason)
+{
+    switch (reason) {
+    case PhosphorContext::DisabledReason::NotDisabled:
+        return DisabledReason::NotDisabled;
+    case PhosphorContext::DisabledReason::MonitorDisabled:
+        return DisabledReason::MonitorDisabled;
+    case PhosphorContext::DisabledReason::DesktopDisabled:
+        return DisabledReason::DesktopDisabled;
+    case PhosphorContext::DisabledReason::ActivityDisabled:
+        return DisabledReason::ActivityDisabled;
+    }
+    Q_UNREACHABLE();
+    return DisabledReason::NotDisabled;
+}
 
 /**
  * @brief Resolve a physical screen ID to a virtual screen ID if subdivisions exist.

--- a/src/daemon/daemon/helpers.h
+++ b/src/daemon/daemon/helpers.h
@@ -3,9 +3,10 @@
 
 #pragma once
 
-// Inline helpers shared across daemon TU files (daemon_start.cpp,
-// daemon_signals.cpp, daemon_navigation.cpp).  Defined inline to
-// avoid ODR issues in both unity and normal builds.
+// Inline helpers shared across the daemon TU files in this directory
+// (start.cpp, signals.cpp, navigation.cpp, osd.cpp, lifecycle.cpp, the
+// init_*.cpp trio, autotile_init.cpp).  Defined inline to avoid ODR
+// issues in both unity and normal builds.
 
 #include <QScreen>
 #include "core/platform/logging.h"
@@ -156,10 +157,16 @@ inline QString resolveShortcutScreenId(PhosphorScreens::ScreenManager* mgr,
  *
  * Falls back to focused-window screen, then primary screen.
  *
- * @p mgr is unused today (lastCursorScreenName is already virtual-screen
- * resolved at the WindowTrackingAdaptor source). Kept in the signature so
- * the call site mirrors @ref resolveShortcutScreenId and so a future
- * resolution policy that needs ScreenManager has a place to land.
+ * @p mgr is unused today: WindowTrackingAdaptor::cursorScreenChanged resolves
+ * m_lastCursorScreenId to a virtual ID at the source whenever the physical
+ * screen is split, so a physical ID from lastCursorScreenName means the
+ * screen has no virtual split and IS the effective ID — no further mapping
+ * needed. (resolveShortcutScreenId still re-resolves its inputs because its
+ * primary source, lastActiveScreenName, arrives from the effect and may be a
+ * raw physical ID on a split screen; the two helpers' assumptions differ
+ * because their sources do, not because either is wrong.) Kept in the
+ * signature so the call site mirrors @ref resolveShortcutScreenId and so a
+ * future resolution policy that needs ScreenManager has a place to land.
  */
 inline QString resolveCursorScreenId(PhosphorScreens::ScreenManager* /*mgr*/,
                                      const WindowTrackingAdaptor* trackingAdaptor)

--- a/src/daemon/daemon/helpers.h
+++ b/src/daemon/daemon/helpers.h
@@ -16,6 +16,8 @@
 #include <PhosphorScreens/ScreenIdentity.h>
 #include <PhosphorContext/DisabledReason.h>
 
+#include <optional>
+
 namespace PlasmaZones {
 
 inline DisabledReason toDaemonDisabledReason(PhosphorContext::DisabledReason reason)
@@ -39,16 +41,19 @@ inline DisabledReason toDaemonDisabledReason(PhosphorContext::DisabledReason rea
  *
  * When the KWin effect sends a physical screen ID (e.g., during daemon reconnect
  * before virtual screen configs are loaded), the daemon must resolve it to the
- * correct virtual screen.  Uses the focused window's geometry center as the
- * position hint (QCursor::pos() is unreliable on Wayland for background daemons).
- * Falls back to vs:0 (leftmost) if no better hint is available.
+ * correct virtual screen. Resolution cascade: the focused window's
+ * daemon-tracked screen assignment, then the effect-reported active screen,
+ * then the optional cursor-position hint, then vs:0 (leftmost).
  *
  * @p mgr is the injected ScreenManager (required — pass null only in tests
  * that don't exercise VS resolution; null is treated as "no subdivision").
+ * @p cursorPos optional cursor hint; disengaged by default. No production
+ * caller currently supplies one — the parameter is kept for shortcut paths
+ * that have an effect-reported cursor and no focused window.
  */
 inline QString resolveVirtualScreenId(PhosphorScreens::ScreenManager* mgr, const QString& physicalId,
                                       const WindowTrackingAdaptor* trackingAdaptor,
-                                      const QPoint& cursorPos = QPoint(-1, -1))
+                                      const std::optional<QPoint>& cursorPos = std::nullopt)
 {
     if (!mgr || !mgr->hasVirtualScreens(physicalId)) {
         return physicalId;
@@ -79,9 +84,12 @@ inline QString resolveVirtualScreenId(PhosphorScreens::ScreenManager* mgr, const
     }
 
     // Cursor position hint: when a keyboard shortcut fires with no focused window,
-    // the cursor position (from the effect) can resolve the correct virtual screen.
-    if (cursorPos.x() >= 0) {
-        const QString vsAtCursor = mgr->effectiveScreenAt(cursorPos);
+    // the cursor position (from the effect) can resolve the correct virtual
+    // screen. std::optional, not a negative-coord sentinel — multi-monitor
+    // layouts legitimately have negative coordinates, so (-1,-1) was a valid
+    // position masquerading as "absent".
+    if (cursorPos.has_value()) {
+        const QString vsAtCursor = mgr->effectiveScreenAt(*cursorPos);
         if (PhosphorIdentity::VirtualScreenId::isVirtual(vsAtCursor)
             && PhosphorIdentity::VirtualScreenId::extractPhysicalId(vsAtCursor) == physicalId) {
             return vsAtCursor;

--- a/src/daemon/daemon/init_adaptors.cpp
+++ b/src/daemon/daemon/init_adaptors.cpp
@@ -85,6 +85,44 @@ namespace PlasmaZones {
 
 void Daemon::initCoreAdaptors()
 {
+    // stop() -> init() re-entry: every adaptor below survives stop() (it only
+    // detaches / clears their borrows), so construct-over would leak one full
+    // adaptor set as QObject children per cycle, each still holding its
+    // init-time connections and D-Bus object registration. Delete the whole
+    // previous set first, borrowers before borrowed: ControlAdaptor (borrows
+    // snap/layout/WTA), then the engine adaptors (borrow the WTA), then the
+    // core adaptors in reverse creation order.
+    //
+    // Manual delete of Qt-parented QObjects is a deliberate carve-out from
+    // the never-manual-delete rule: init() runs before exec(), so no queued
+    // D-Bus dispatch or event can land mid-delete, and deleteLater() would
+    // NOT be processed before the new set registers over the same D-Bus
+    // paths.
+    delete m_controlAdaptor;
+    m_controlAdaptor = nullptr;
+    delete m_snapAdaptor;
+    m_snapAdaptor = nullptr;
+    delete m_autotileAdaptor;
+    m_autotileAdaptor = nullptr;
+    delete m_windowDragAdaptor;
+    m_windowDragAdaptor = nullptr;
+    delete m_windowTrackingAdaptor;
+    m_windowTrackingAdaptor = nullptr;
+    delete m_zoneDetectionAdaptor;
+    m_zoneDetectionAdaptor = nullptr;
+    delete m_overlayAdaptor;
+    m_overlayAdaptor = nullptr;
+    delete m_compositorBridge;
+    m_compositorBridge = nullptr;
+    delete m_ruleAdaptor;
+    m_ruleAdaptor = nullptr;
+    delete m_shaderAdaptor;
+    m_shaderAdaptor = nullptr;
+    delete m_settingsAdaptor;
+    m_settingsAdaptor = nullptr;
+    delete m_layoutAdaptor;
+    m_layoutAdaptor = nullptr;
+
     // Initialize domain-specific D-Bus adaptors
     // Each adaptor has its own D-Bus interface
     // D-Bus adaptors use raw new; Qt parent-child manages their lifetime.

--- a/src/daemon/daemon/init_engines.cpp
+++ b/src/daemon/daemon/init_engines.cpp
@@ -137,25 +137,26 @@ void Daemon::initEnginesAndWiring()
     // held as the base PlacementEngineBase. Use the derived `autotileEngine`
     // pointer captured above — the std::move into m_autotileEngine transferred
     // ownership but not the pointee, so it still points at the live engine.
-    if (autotileEngine) {
-        autotileEngine->setContextGapProvider([this](const QString& screenId) -> QVariantMap {
-            if (!m_layoutManager || screenId.isEmpty()) {
-                return {};
-            }
-            // This is the autotile gap path, so resolve against the "tiling"
-            // placement mode — a per-mode `Mode Equals "tiling"` gap rule then
-            // applies here and a "snapping" one stays inert. The same
-            // GeometryUtils::contextGapOverrideMap shaping the snap provider uses
-            // below keeps the two paths byte-identical (PerScreenKeys form, with
-            // the per-side toggle gating the per-side entries). The config per-
-            // monitor gap is merged UNDER the rule override so a user gap rule
-            // still wins per slot.
-            return GeometryUtils::mergeConfigPerScreenGaps(
-                GeometryUtils::contextGapOverrideMap(m_layoutManager->resolveContextGaps(
-                    screenId, currentDesktopForScreen(screenId), currentActivity(), QStringLiteral("tiling"))),
-                m_settings.get(), screenId);
-        });
-    }
+    // CONTRACT: createEngines() above always constructs both engines and
+    // initCoreAdaptors() ran first, so autotileEngine / snapEngine and the
+    // adaptor members are non-null throughout this method — no per-use guards.
+    autotileEngine->setContextGapProvider([this](const QString& screenId) -> QVariantMap {
+        if (!m_layoutManager || screenId.isEmpty()) {
+            return {};
+        }
+        // This is the autotile gap path, so resolve against the "tiling"
+        // placement mode — a per-mode `Mode Equals "tiling"` gap rule then
+        // applies here and a "snapping" one stays inert. The same
+        // GeometryUtils::contextGapOverrideMap shaping the snap provider uses
+        // below keeps the two paths byte-identical (PerScreenKeys form, with
+        // the per-side toggle gating the per-side entries). The config per-
+        // monitor gap is merged UNDER the rule override so a user gap rule
+        // still wins per slot.
+        return GeometryUtils::mergeConfigPerScreenGaps(
+            GeometryUtils::contextGapOverrideMap(m_layoutManager->resolveContextGaps(
+                screenId, currentDesktopForScreen(screenId), currentActivity(), QStringLiteral("tiling"))),
+            m_settings.get(), screenId);
+    });
 
     // Build the PhosphorContext::ContextResolver wiring NOW — after the
     // workspace managers, settings, and router exist; before any D-Bus
@@ -179,12 +180,8 @@ void Daemon::initEnginesAndWiring()
     // resolver only exists now. The setters mirror setAutotileEngine /
     // setShortcutRegistrar / setScreenModeRouter — same late-binding
     // pattern the daemon already uses for cross-cutting deps.
-    if (m_windowDragAdaptor) {
-        m_windowDragAdaptor->setContextResolver(m_contextResolver.get());
-    }
-    if (m_windowTrackingAdaptor) {
-        m_windowTrackingAdaptor->setContextResolver(m_contextResolver.get());
-    }
+    m_windowDragAdaptor->setContextResolver(m_contextResolver.get());
+    m_windowTrackingAdaptor->setContextResolver(m_contextResolver.get());
     // m_snapAdaptor is constructed below at the engine-adaptor block; its
     // contextResolver wire lives there.
 
@@ -312,6 +309,13 @@ void Daemon::initEnginesAndWiring()
                 PhosphorRules::ExclusionRules::applicationExcludePatternsFrom(m_excludeRuleSet));
         }
     };
+    // The rule store is constructed once in the Daemon ctor and SURVIVES a
+    // stop() → init() cycle, so re-wiring here would stack duplicates of the
+    // three rulesChanged subscriptions below (triple refilter/refresh/
+    // reconcile per edit after each cycle). Sever every rulesChanged
+    // connection targeting the daemon first; all of them are (re)established
+    // right here.
+    disconnect(m_ruleStore.get(), &PhosphorRules::RuleStore::rulesChanged, this, nullptr);
     connect(m_ruleStore.get(), &PhosphorRules::RuleStore::rulesChanged, this,
             [refilterExcludeRules](bool /*persisted*/) {
                 refilterExcludeRules();
@@ -600,7 +604,17 @@ void Daemon::initEnginesAndWiring()
         });
 
     // Create engine D-Bus adaptors — each engine has a dedicated adaptor that
-    // connects signals in its constructor (unified pattern for both engines)
+    // connects signals in its constructor (unified pattern for both engines).
+    // stop() → init() re-entry: the previous cycle's adaptors survive stop()
+    // (it only detaches / clears their engine borrows), so construct-over
+    // would accumulate one QObject child per cycle, each still holding
+    // cleared borrows and its D-Bus registration. Delete the old ones first.
+    delete m_controlAdaptor;
+    m_controlAdaptor = nullptr;
+    delete m_snapAdaptor;
+    m_snapAdaptor = nullptr;
+    delete m_autotileAdaptor;
+    m_autotileAdaptor = nullptr;
     m_snapAdaptor = new SnapAdaptor(snapEngine, m_windowTrackingAdaptor, m_settings.get(), this);
     m_snapAdaptor->setContextResolver(m_contextResolver.get());
     m_autotileAdaptor = new AutotileAdaptor(autotileEngine, m_screenManager.get(), m_algorithmRegistry.get(), this);

--- a/src/daemon/daemon/init_engines.cpp
+++ b/src/daemon/daemon/init_engines.cpp
@@ -605,16 +605,10 @@ void Daemon::initEnginesAndWiring()
 
     // Create engine D-Bus adaptors — each engine has a dedicated adaptor that
     // connects signals in its constructor (unified pattern for both engines).
-    // stop() → init() re-entry: the previous cycle's adaptors survive stop()
-    // (it only detaches / clears their engine borrows), so construct-over
-    // would accumulate one QObject child per cycle, each still holding
-    // cleared borrows and its D-Bus registration. Delete the old ones first.
-    delete m_controlAdaptor;
-    m_controlAdaptor = nullptr;
-    delete m_snapAdaptor;
-    m_snapAdaptor = nullptr;
-    delete m_autotileAdaptor;
-    m_autotileAdaptor = nullptr;
+    // stop() → init() re-entry: the previous cycle's WHOLE adaptor set
+    // (engine and core) is deleted in one dependency-ordered preamble at the
+    // top of initCoreAdaptors(), which init() always runs immediately before
+    // this function — so these members are null here on a re-cycle.
     m_snapAdaptor = new SnapAdaptor(snapEngine, m_windowTrackingAdaptor, m_settings.get(), this);
     m_snapAdaptor->setContextResolver(m_contextResolver.get());
     m_autotileAdaptor = new AutotileAdaptor(autotileEngine, m_screenManager.get(), m_algorithmRegistry.get(), this);
@@ -633,6 +627,13 @@ void Daemon::initEnginesAndWiring()
     // save completes (all setAssignmentEntry + notifyReload finished), so all
     // assignments and settings are fully committed. Separated from settingsChanged
     // handler to avoid feedback loops with autotile/snapping transitions.
+    //
+    // Disconnect-first: m_layoutAdaptor is created in initCoreAdaptors and,
+    // unlike the three engine adaptors deleted above, survives a
+    // stop() -> init() cycle — a bare connect would stack a second handler
+    // (double resnap + double OSD pass per KCM apply). Same rationale as the
+    // rulesChanged sweep earlier in this function.
+    disconnect(m_layoutAdaptor, &LayoutAdaptor::assignmentChangesApplied, this, nullptr);
     connect(
         m_layoutAdaptor, &LayoutAdaptor::assignmentChangesApplied, this,
         [this](const QStringList& changedScreenIdsList) {
@@ -808,6 +809,11 @@ bool Daemon::registerDBusService()
                      << "path=" << PhosphorProtocol::Service::ObjectPath;
 
     // Connect overlay adaptor signals to daemon overlay control
+    // Disconnect-first on both: the two adaptors are created in
+    // initCoreAdaptors and survive a stop() -> init() cycle, so bare
+    // connects here would stack duplicate show/hide + updateGeometries
+    // handlers per cycle (same rationale as the rulesChanged sweep).
+    disconnect(m_overlayAdaptor, &OverlayAdaptor::overlayVisibilityChanged, this, nullptr);
     connect(m_overlayAdaptor, &OverlayAdaptor::overlayVisibilityChanged, this, [this](bool visible) {
         if (visible) {
             showOverlay();
@@ -817,6 +823,7 @@ bool Daemon::registerDBusService()
     });
 
     // Connect zone detection to overlay updates
+    disconnect(m_zoneDetectionAdaptor, &ZoneDetectionAdaptor::zoneDetected, this, nullptr);
     connect(m_zoneDetectionAdaptor, &ZoneDetectionAdaptor::zoneDetected, this,
             [this](const QString& zoneId, const PhosphorProtocol::ZoneGeometryRect& geometry) {
                 Q_UNUSED(zoneId)

--- a/src/daemon/daemon/init_engines.cpp
+++ b/src/daemon/daemon/init_engines.cpp
@@ -169,8 +169,11 @@ void Daemon::initEnginesAndWiring()
     m_settingsGateAdapter = std::make_unique<DaemonSettingsGateAdapter>(m_settings.get(), m_layoutManager.get());
     m_contextResolver = std::make_unique<PhosphorContext::ContextResolver>(
         m_workspaceStateAdapter.get(), m_screenModeAdapter.get(), m_settingsGateAdapter.get());
+    if (m_overlayService) {
+        m_overlayService->setContextResolver(m_contextResolver.get());
+    }
 
-    // Late-bind the resolver into the D-Bus adaptors that gate their
+    // Late-bind the resolver into consumers that gate their
     // handlers on the disable/lock cascade. Each adaptor was constructed
     // earlier (before m_settings/m_screenModeRouter were ready); the
     // resolver only exists now. The setters mirror setAutotileEngine /

--- a/src/daemon/daemon/init_services.cpp
+++ b/src/daemon/daemon/init_services.cpp
@@ -111,6 +111,17 @@ namespace PlasmaZones {
 
 void Daemon::initLayoutAndSettingsWiring()
 {
+    // Every sender wired below (m_settings, m_layoutManager, the value-member
+    // timers) survives stop(), and init() can re-run — drop the handles we
+    // installed last time so a stop() -> init() -> start() cycle cannot stack
+    // duplicate handlers (double mode-transition + double gap resnap per
+    // save). Exact handles, not (sender, signal, receiver) sweeps: other call
+    // sites (connectLayoutSignals, overlayservice) own handlers on the same
+    // signals.
+    for (const QMetaObject::Connection& c : std::as_const(m_layoutSettingsWiringConnections)) {
+        disconnect(c);
+    }
+    m_layoutSettingsWiringConnections.clear();
     // Wire the level-1 (global) cascade tier as two pass-through
     // providers — snap default layout id and autotile default algorithm
     // id — symmetric in shape and each gated on its own enabled flag.
@@ -241,49 +252,51 @@ void Daemon::initLayoutAndSettingsWiring()
     // Connect layout changes to zone detector and overlay service
     // activeLayoutChanged fires when the global active layout changes; layoutAssigned
     // fires for per-screen assignments. We handle both but avoid redundant recalculations.
-    connect(m_layoutManager.get(), &PhosphorZones::LayoutRegistry::activeLayoutChanged, this,
-            [this](PhosphorZones::Layout* layout) {
-                if (layout) {
-                    // Recalculate zone geometries asynchronously using primary screen geometry.
-                    // Active layout is global; recalculating per-screen overwrites each
-                    // iteration (last-wins bug). The overlay computes per-screen geometry
-                    // on the fly via GeometryUtils::getZoneGeometryWithGaps(m_screenManager.get(), ).
-                    QScreen* primary = Utils::primaryScreen();
-                    if (primary) {
-                        QString screenId = PhosphorScreens::ScreenIdentity::identifierFor(primary);
-                        m_layoutComputeService->requestRecalculate(
-                            layout, screenId,
-                            GeometryUtils::effectiveScreenGeometry(m_screenManager.get(), layout, primary));
+    m_layoutSettingsWiringConnections.append(
+        connect(m_layoutManager.get(), &PhosphorZones::LayoutRegistry::activeLayoutChanged, this,
+                [this](PhosphorZones::Layout* layout) {
+                    if (layout) {
+                        // Recalculate zone geometries asynchronously using primary screen geometry.
+                        // Active layout is global; recalculating per-screen overwrites each
+                        // iteration (last-wins bug). The overlay computes per-screen geometry
+                        // on the fly via GeometryUtils::getZoneGeometryWithGaps(m_screenManager.get(), ).
+                        QScreen* primary = Utils::primaryScreen();
+                        if (primary) {
+                            QString screenId = PhosphorScreens::ScreenIdentity::identifierFor(primary);
+                            m_layoutComputeService->requestRecalculate(
+                                layout, screenId,
+                                GeometryUtils::effectiveScreenGeometry(m_screenManager.get(), layout, primary));
+                        }
                     }
-                }
-                m_zoneDetector->setLayout(layout);
-                m_overlayService->updateLayout(layout);
-            });
+                    m_zoneDetector->setLayout(layout);
+                    m_overlayService->updateLayout(layout);
+                }));
 
     // Connect per-screen layout assignments
     // Only update if this is a DIFFERENT layout than the active one
     // (to avoid double-processing when both signals fire for the same layout)
-    connect(m_layoutManager.get(), &PhosphorZones::LayoutRegistry::layoutAssigned, this,
-            [this](const QString& screenId, int /*virtualDesktop*/, PhosphorZones::Layout* layout) {
-                if (!layout) {
-                    return;
-                }
-                // Skip if this layout is already the active layout
-                // (activeLayoutChanged handler already processed it for all screens)
-                if (layout == m_layoutManager->activeLayout()) {
-                    return;
-                }
-                // This is a screen-specific layout different from the active one
-                // Only recalculate for the specific screen
-                const PhosphorScreens::PhysicalScreen screen = m_screenManager->screenByName(screenId);
-                if (screen.isValid() && screen.qscreen) {
-                    m_layoutComputeService->requestRecalculate(
-                        layout, screenId,
-                        GeometryUtils::effectiveScreenGeometry(m_screenManager.get(), layout, screen.qscreen));
-                }
-                // Note: We don't change zone detector or overlay here since
-                // they work with the active layout, not per-screen layouts
-            });
+    m_layoutSettingsWiringConnections.append(
+        connect(m_layoutManager.get(), &PhosphorZones::LayoutRegistry::layoutAssigned, this,
+                [this](const QString& screenId, int /*virtualDesktop*/, PhosphorZones::Layout* layout) {
+                    if (!layout) {
+                        return;
+                    }
+                    // Skip if this layout is already the active layout
+                    // (activeLayoutChanged handler already processed it for all screens)
+                    if (layout == m_layoutManager->activeLayout()) {
+                        return;
+                    }
+                    // This is a screen-specific layout different from the active one
+                    // Only recalculate for the specific screen
+                    const PhosphorScreens::PhysicalScreen screen = m_screenManager->screenByName(screenId);
+                    if (screen.isValid() && screen.qscreen) {
+                        m_layoutComputeService->requestRecalculate(
+                            layout, screenId,
+                            GeometryUtils::effectiveScreenGeometry(m_screenManager.get(), layout, screen.qscreen));
+                    }
+                    // Note: We don't change zone detector or overlay here since
+                    // they work with the active layout, not per-screen layouts
+                }));
 
     // Connect settings changes to overlay service and autotile engine.
     // This is the SINGLE comprehensive handler for batch config reloads (Settings::load()).
@@ -293,14 +306,21 @@ void Daemon::initLayoutAndSettingsWiring()
     m_prevAutotileEnabled = m_settings->autotileEnabled();
     m_previewNotifyTimer.setSingleShot(true);
     m_previewNotifyTimer.setInterval(100);
-    connect(&m_previewNotifyTimer, &QTimer::timeout, this, [this]() {
+    m_layoutSettingsWiringConnections.append(connect(&m_previewNotifyTimer, &QTimer::timeout, this, [this]() {
         if (m_algorithmRegistry && m_algorithmRegistry->previewParams() != m_preRetilePreviewParams
             && m_layoutAdaptor) {
             m_layoutAdaptor->notifyLayoutListChanged();
         }
-    });
+    }));
 
-    connect(m_settings.get(), &Settings::settingsChanged, this, [this]() {
+    // m_settings is ctor-owned and SURVIVES a stop() -> init() cycle, and
+    // stop()'s per-sender sweep deliberately excludes it — so re-wiring here
+    // would stack a second settingsChanged handler and run the whole
+    // mode-transition block twice per save (double resnap, double OSD arm,
+    // second pass against already-cleared pending restores). Sever every
+    // settingsChanged connection targeting the daemon first; they are all
+    // (re)established via the handle list dropped at the top of this function.
+    m_layoutSettingsWiringConnections.append(connect(m_settings.get(), &Settings::settingsChanged, this, [this]() {
         m_overlayService->updateSettings(m_settings.get());
 
         // Detect state transitions before syncing
@@ -398,7 +418,7 @@ void Daemon::initLayoutAndSettingsWiring()
         // Resnap/retile/OSD is triggered separately by applyAssignmentChanges()
         // after the KCM's batch save completes — NOT here in the settings handler.
         syncModeFromAssignments();
-    });
+    }));
 
     // Resnap currently-snapped windows when a snapping gap/padding setting
     // changes (global or per-screen) so the new spacing is visible immediately
@@ -413,30 +433,38 @@ void Daemon::initLayoutAndSettingsWiring()
     // Re-armed by armResnapOsdSuppression on every arm.
     m_suppressResnapOsdWatchdog.setSingleShot(true);
     m_suppressResnapOsdWatchdog.setInterval(2000);
-    connect(&m_suppressResnapOsdWatchdog, &QTimer::timeout, this, [this]() {
+    m_layoutSettingsWiringConnections.append(connect(&m_suppressResnapOsdWatchdog, &QTimer::timeout, this, [this]() {
         m_suppressResnapOsd = 0;
-    });
+    }));
 
     m_gapResnapTimer.setSingleShot(true);
     m_gapResnapTimer.setInterval(100);
-    connect(&m_gapResnapTimer, &QTimer::timeout, this, [this]() {
+    m_layoutSettingsWiringConnections.append(connect(&m_gapResnapTimer, &QTimer::timeout, this, [this]() {
         if (!m_snapAdaptor) {
             return;
         }
         armResnapOsdSuppression(1); // settings-driven reflow, not user navigation
         m_snapAdaptor->resnapCurrentAssignments();
-    });
+    }));
     const auto scheduleGapResnap = [this]() {
         m_gapResnapTimer.start();
     };
-    connect(m_settings.get(), &Settings::innerGapChanged, this, scheduleGapResnap);
-    connect(m_settings.get(), &Settings::outerGapChanged, this, scheduleGapResnap);
-    connect(m_settings.get(), &Settings::usePerSideOuterGapChanged, this, scheduleGapResnap);
-    connect(m_settings.get(), &Settings::outerGapTopChanged, this, scheduleGapResnap);
-    connect(m_settings.get(), &Settings::outerGapBottomChanged, this, scheduleGapResnap);
-    connect(m_settings.get(), &Settings::outerGapLeftChanged, this, scheduleGapResnap);
-    connect(m_settings.get(), &Settings::outerGapRightChanged, this, scheduleGapResnap);
-    connect(m_settings.get(), &Settings::perScreenSnappingSettingsChanged, this, scheduleGapResnap);
+    m_layoutSettingsWiringConnections.append(
+        connect(m_settings.get(), &Settings::innerGapChanged, this, scheduleGapResnap));
+    m_layoutSettingsWiringConnections.append(
+        connect(m_settings.get(), &Settings::outerGapChanged, this, scheduleGapResnap));
+    m_layoutSettingsWiringConnections.append(
+        connect(m_settings.get(), &Settings::usePerSideOuterGapChanged, this, scheduleGapResnap));
+    m_layoutSettingsWiringConnections.append(
+        connect(m_settings.get(), &Settings::outerGapTopChanged, this, scheduleGapResnap));
+    m_layoutSettingsWiringConnections.append(
+        connect(m_settings.get(), &Settings::outerGapBottomChanged, this, scheduleGapResnap));
+    m_layoutSettingsWiringConnections.append(
+        connect(m_settings.get(), &Settings::outerGapLeftChanged, this, scheduleGapResnap));
+    m_layoutSettingsWiringConnections.append(
+        connect(m_settings.get(), &Settings::outerGapRightChanged, this, scheduleGapResnap));
+    m_layoutSettingsWiringConnections.append(
+        connect(m_settings.get(), &Settings::perScreenSnappingSettingsChanged, this, scheduleGapResnap));
 }
 
 } // namespace PlasmaZones

--- a/src/daemon/daemon/init_services.cpp
+++ b/src/daemon/daemon/init_services.cpp
@@ -7,45 +7,24 @@
 #include <QGuiApplication>
 #include <QFutureWatcher>
 #include <QPointer>
-#include <QStandardPaths>
 #include <QtConcurrent>
 #include <QScreen>
 #include <QDBusConnection>
 #include <QDBusMessage>
-#include <QDBusObjectPath>
 #include <QDBusPendingCall>
-#include <QDBusPendingCallWatcher>
-#include <QDBusPendingReply>
-#include <QDBusError>
-#include <QDir>
-#include <QFile>
-#include <QFileInfo>
-#include <QPluginLoader>
-#include <QRegularExpression>
 #include <QSet>
-#include <QThread>
-#include <array>
 
-#include <PhosphorServiceIdle/IdleService.h>
-#include <PhosphorAnimation/CurveLoader.h>
 #include <PhosphorAnimation/CurveRegistry.h>
 #include <PhosphorAnimation/PhosphorProfileRegistry.h>
 #include <PhosphorAnimation/Profile.h>
-#include <PhosphorAnimation/ProfileLoader.h>
 #include <PhosphorAnimation/ProfilePaths.h>
 #include <PhosphorAnimation/PhosphorCurve.h>
-#include <PhosphorAnimation/QtQuickClockManager.h>
 #include <PhosphorAnimation/AnimationShaderRegistry.h>
 #include <PhosphorSurface/SurfaceShaderRegistry.h>
 
 #include "daemon/overlayservice.h"
 #include "daemon/controllers/unifiedlayoutcontroller.h"
 #include "daemon/controllers/shortcutmanager.h"
-#include "daemon/controllers/enginefactory.h"
-#include "daemon/controllers/contextresolverwiring.h"
-#include "daemon/rendering/surfaceshaderitem.h"
-#include "daemon/rendering/zoneentryscaffold.h"
-#include "daemon/rendering/zoneshadernoderhi.h"
 
 #include <PhosphorIdentity/VirtualScreenId.h>
 #include <PhosphorIdentity/WindowId.h>
@@ -64,11 +43,7 @@
 #include <PhosphorEngine/WindowRegistry.h>
 #include <PhosphorWorkspaces/VirtualDesktopManager.h>
 #include <PhosphorWorkspaces/ActivityManager.h>
-#include <PhosphorProtocol/ServiceConstants.h>
 #include <PhosphorContext/ContextResolver.h>
-#include <PhosphorScreens/DBusScreenAdaptor.h>
-#include <PhosphorScreens/Swapper.h>
-#include <PhosphorScreens/PlasmaPanelSource.h>
 #include <PhosphorScreens/ScreenIdentity.h>
 #include <PhosphorSnapEngine/SnapEngine.h>
 #include <PhosphorSnapEngine/SnapState.h>
@@ -82,30 +57,15 @@
 #include "config/configdefaults.h"
 #include "config/settingsconfigstore.h"
 #include "config/settings.h"
-#include "core/types/baselinecleanup.h"
 #include "core/types/constants.h"
-#include "core/resolve/crosssurfaceresolver.h"
-#include "core/resolve/animationbootstrap.h"
 #include "core/resolve/screenmoderouter.h"
 #include "core/utils/geometryutils.h"
 #include "core/utils/utils.h"
 #include "core/platform/logging.h"
 #include "core/interfaces/shaderregistry.h"
-#include "common/screenidresolver.h"
-#include "common/layoutbundlebuilder.h"
-#include "phosphor_i18n.h"
 #include "dbus/layoutadaptor/layoutadaptor.h"
-#include "dbus/settingsadaptor/settingsadaptor.h"
-#include "dbus/overlayadaptor.h"
-#include "dbus/zonedetectionadaptor.h"
 #include "dbus/windowtrackingadaptor/windowtrackingadaptor.h"
-#include "dbus/windowdragadaptor/windowdragadaptor.h"
-#include "dbus/autotileadaptor/autotileadaptor.h"
 #include "dbus/snapadaptor/snapadaptor.h"
-#include "dbus/shaderadaptor.h"
-#include "dbus/compositorbridgeadaptor.h"
-#include "dbus/controladaptor.h"
-#include "dbus/ruleadaptor.h"
 
 namespace PlasmaZones {
 

--- a/src/daemon/daemon/init_services.cpp
+++ b/src/daemon/daemon/init_services.cpp
@@ -322,8 +322,15 @@ void Daemon::initLayoutAndSettingsWiring()
 
         // Capture autotile window order BEFORE any mode switch destroys PhosphorTiles::TilingState.
         // Saved for deterministic re-seeding when autotile is re-enabled.
+        // MERGE, not replace: the capture only sees live states (the current
+        // context's screens), and a wholesale replace discarded the saved
+        // orders of every other desktop/activity — same merge the per-screen
+        // toggle path performs.
         if (autotileToggled && !autotileNow) {
-            m_lastAutotileOrders = captureAutotileOrders();
+            const auto captured = captureAutotileOrders();
+            for (auto it = captured.constBegin(); it != captured.constEnd(); ++it) {
+                m_lastAutotileOrders.insert(it.key(), it.value());
+            }
         }
 
         // Handle autotile feature gate toggle

--- a/src/daemon/daemon/lifecycle.cpp
+++ b/src/daemon/daemon/lifecycle.cpp
@@ -172,10 +172,12 @@ void Daemon::start()
     // name, and re-registering them lives in init(), not here. A restarted daemon therefore
     // has no bus presence, so nothing it publishes reaches the effect regardless. The
     // same asymmetry covers the autotile shortcuts: their grabs survive stop()
-    // while their handler connections are severed and only initAutotile (an
-    // init() phase) rewires them — with no bus presence nothing they would
-    // trigger reaches anyone, so re-wiring them here would repair a limb of a
-    // cycle that is degraded by design. The
+    // while their handler connections died with the engine, and although
+    // initializeAutotile() re-runs from start() below, it wires the handlers
+    // only when m_autotileEngine exists — which after a no-init stop() it does
+    // not (engines are rebuilt in init(), not here). With no bus presence
+    // nothing they would trigger reaches anyone anyway, so wiring them here
+    // would repair a limb of a cycle that is degraded by design. The
     // re-arm exists so the daemon's own state is consistent after the cycle (which the
     // repairs below also do), not because the cycle fully restores service.
     if (!m_idleService) {
@@ -611,17 +613,122 @@ void Daemon::stop()
         m_overlayService->setContextResolver(nullptr);
     }
 
+    // The borrow-severing blocks below are ALSO init-origin (initEnginesAndWiring
+    // wires them, and init() can complete without start() ever running), so they
+    // must sit ABOVE the running gate: on an init-without-start teardown (failed
+    // init, ~Daemon after init()) the captured `this` / raw-member closures would
+    // otherwise stay installed while member destruction frees what they deref.
+    // Every one of them is a null-safe idempotent clear, so running them on a
+    // never-inited daemon is a no-op.
+
+    // Clear adaptor engine pointers BEFORE destroying the engines.
+    // Adaptors are Qt children of the daemon (destroyed later); a D-Bus call
+    // arriving between engine destruction and adaptor destruction would otherwise
+    // access freed memory. After clearing, ensureEngine() returns false.
+    if (m_autotileAdaptor) {
+        m_autotileAdaptor->clearEngine();
+    }
+    if (m_snapAdaptor) {
+        m_snapAdaptor->clearEngine();
+    }
+
+    // Null the WindowDragAdaptor's engine pointer for the same reason.
+    // Clear engine references before destruction
+    if (m_windowTrackingAdaptor) {
+        m_windowTrackingAdaptor->setEngines(nullptr, nullptr);
+    }
+
+    // Clear the late-bound WTS float / mode callbacks that capture `this` (Daemon,
+    // via screenModeForWindow) — symmetric with the setShouldTrackPredicate /
+    // setShouldRestorePredicate clears, so the "every `this`-capturing predicate is
+    // cleared before teardown" contract stays grep-discoverable and survives a
+    // future ownership/order refactor.
+    if (m_windowTrackingAdaptor && m_windowTrackingAdaptor->service()) {
+        auto* wts = m_windowTrackingAdaptor->service();
+        wts->setEngineFloatResolver({});
+        wts->setEngineFloatWriter({});
+        wts->setEngineFloatLister({});
+        wts->setAutotileModePredicate({});
+        wts->setAutotileTiledPredicate({});
+        // Deliberately NOT cleared here: the snap-state resolver (setSnapStateResolver)
+        // and setSnapEngine both capture/store only QPointer(snapEngine), so they
+        // self-null when the engine is destroyed — there is no `this`/raw-pointer
+        // capture to invalidate, unlike the float callbacks above.
+    }
+
+    // Drop the D-Bus borrowers' non-owning resolver / router / WTA pointers.
+    // Explicit symmetric clear across all three borrowers — SnapAdaptor's
+    // resolver is also nulled defensively by clearEngine() above, but doing
+    // it here too keeps the teardown contract grep-discoverable and survives
+    // a future refactor of clearEngine() that might stop touching the
+    // resolver pointer.
+    if (m_snapAdaptor) {
+        m_snapAdaptor->setContextResolver(nullptr);
+    }
+    if (m_windowDragAdaptor) {
+        m_windowDragAdaptor->setContextResolver(nullptr);
+    }
+    if (m_windowTrackingAdaptor) {
+        m_windowTrackingAdaptor->setContextResolver(nullptr);
+        // m_screenModeRouter is destroyed on the running path below; null its
+        // WTA borrow before that reset so any D-Bus call landing in the gap
+        // between this teardown and the bus unregister can't deref
+        // a freed router pointer. SnapAdaptor's clearEngine() does
+        // the symmetric clear (snapadaptor.cpp).
+        m_windowTrackingAdaptor->setScreenModeRouter(nullptr);
+    }
+    if (m_autotileAdaptor) {
+        // Sever the autotile adaptor's post-construction borrow of the WTA (wired
+        // in init() so the autotile open path can resolve RouteToScreen /
+        // RouteToDesktop rules). The autotile open path no-ops on a null WTA, so
+        // a D-Bus open landing in the teardown gap can't drive routing against
+        // half-torn-down state. Symmetric with the resolver / router clears above
+        // and honours the shutdown-nullptr contract documented in autotileadaptor.h.
+        m_autotileAdaptor->setWindowTrackingAdaptor(nullptr);
+    }
+
+    // Sever SnapEngine's borrow of m_excludeRuleSet (a daemon-owned value
+    // member) BEFORE m_snapEngine.reset(). Declaration order currently
+    // guarantees lifetime, but a future reorder or ownership move could
+    // silently introduce a dangling pointer through isAppIdExcluded if
+    // a late shutdown call landed; the explicit clear here makes the
+    // teardown contract grep-discoverable and survives that refactor.
+    // `m_snapEngine` is base-typed `PlacementEngineBase*`; the setter
+    // lives on the concrete `SnapEngine`. qobject_cast mirrors the
+    // concreteAutotile narrowing a few lines below.
+    if (auto* concreteSnap = qobject_cast<PhosphorSnapEngine::SnapEngine*>(m_snapEngine.get())) {
+        concreteSnap->setExcludeRuleSet(nullptr);
+    }
+
+    // Likewise sever WindowTrackingAdaptor's borrow of m_ruleStore (used by
+    // its restore-position evaluator) before the store is destroyed. Same
+    // grep-discoverable teardown contract as the SnapEngine exclude borrow above.
+    if (m_windowTrackingAdaptor) {
+        m_windowTrackingAdaptor->setRuleStore(nullptr);
+    }
+
+    // Clear the autotile context-gap provider, which captures `this` (Daemon, via
+    // m_layoutManager / currentDesktopForScreen / currentActivity). No live deref
+    // can occur today — m_autotileEngine is destroyed on the running path below
+    // while `this` is still alive — but clearing it keeps the "every
+    // `this`-capturing closure is cleared before teardown" contract complete and
+    // grep-discoverable, exactly like the SnapEngine exclude-rule borrow above.
+    // `m_autotileEngine` is base-typed `PlacementEngineBase*`;
+    // setContextGapProvider lives on the concrete engine.
+    if (auto* concreteAutotile = qobject_cast<PhosphorTileEngine::AutotileEngine*>(m_autotileEngine.get())) {
+        concreteAutotile->setContextGapProvider({});
+    }
+
     // Everything ABOVE this gate is init/ctor-origin teardown that must run on
     // an init-without-start path (a failed init, a double-stop): the adaptor
     // detaches, the D-Bus unregister, the loader resets, the QML-static
-    // null-outs, and the shader-registry teardown — all of which either sever a
-    // BORROWED pointer a member destructor would otherwise deref, or are
-    // idempotent no-ops. Everything BELOW is start()-origin (the persistent
-    // sender reconnects and the engine/resolver/rule-store borrows established
-    // during a running session); those members' destructors deref no borrowed
-    // pointer, so skipping their explicit clears on the init-failure path is
-    // safe (verified per-adaptor), and running them without a prior start()
-    // could touch half-wired state. Hence the gate sits here.
+    // null-outs, the shader-registry teardown, and the borrow-severing clears
+    // just above — all of which either sever a BORROWED pointer a member
+    // destructor would otherwise deref, or are idempotent no-ops. Everything
+    // BELOW is start()-origin (the persistent sender reconnects, the state
+    // save, and the engine/resolver member RESETS established during a running
+    // session); running those without a prior start() could touch half-wired
+    // state. Hence the gate sits here.
     if (!m_running) {
         return;
     }
@@ -750,80 +857,11 @@ void Daemon::stop()
     // overwriting the correct WTS state saved above. The engine is destroyed
     // immediately after, so cleanup is unnecessary.
 
-    // Clear adaptor engine pointers BEFORE destroying the engines.
-    // Adaptors are Qt children of the daemon (destroyed later); a D-Bus call
-    // arriving between engine destruction and adaptor destruction would otherwise
-    // access freed memory. After clearing, ensureEngine() returns false.
-    if (m_autotileAdaptor) {
-        m_autotileAdaptor->clearEngine();
-    }
-    if (m_snapAdaptor) {
-        m_snapAdaptor->clearEngine();
-    }
-
-    // Null the WindowDragAdaptor's engine pointer for the same reason.
-    // Clear engine references before destruction
-    if (m_windowTrackingAdaptor) {
-        m_windowTrackingAdaptor->setEngines(nullptr, nullptr);
-    }
-
-    // Clear the late-bound WTS float / mode callbacks that capture `this` (Daemon,
-    // via screenModeForWindow) — symmetric with the setShouldTrackPredicate /
-    // setShouldRestorePredicate clears, so the "every `this`-capturing predicate is
-    // cleared before teardown" contract stays grep-discoverable and survives a
-    // future ownership/order refactor.
-    if (m_windowTrackingAdaptor && m_windowTrackingAdaptor->service()) {
-        auto* wts = m_windowTrackingAdaptor->service();
-        wts->setEngineFloatResolver({});
-        wts->setEngineFloatWriter({});
-        wts->setEngineFloatLister({});
-        wts->setAutotileModePredicate({});
-        wts->setAutotileTiledPredicate({});
-        // Deliberately NOT cleared here: the snap-state resolver (setSnapStateResolver)
-        // and setSnapEngine both capture/store only QPointer(snapEngine), so they
-        // self-null when the engine is destroyed — there is no `this`/raw-pointer
-        // capture to invalidate, unlike the float callbacks above.
-    }
-
-    // Tear down the context-resolver triple before destroying the
-    // services the adapters borrow from. Order: borrowers (D-Bus
-    // adaptors) drop their non-owning resolver pointer first, then the
-    // resolver and its three adapters die, then the underlying router
-    // / VirtualDesktopManager / ActivityManager / Settings can safely
-    // reset(). Without this, a queued D-Bus method that lands between
-    // here and ~Daemon (or a shortcut-manager signal still alive on the
-    // main thread) would deref an adapter whose backing service had
-    // already been freed by the existing engine-pointer teardown below.
-    //
-    // Explicit symmetric clear across all three borrowers — SnapAdaptor's
-    // resolver is also nulled defensively by clearEngine() above, but doing
-    // it here too keeps the teardown contract grep-discoverable and survives
-    // a future refactor of clearEngine() that might stop touching the
-    // resolver pointer.
-    if (m_snapAdaptor) {
-        m_snapAdaptor->setContextResolver(nullptr);
-    }
-    if (m_windowDragAdaptor) {
-        m_windowDragAdaptor->setContextResolver(nullptr);
-    }
-    if (m_windowTrackingAdaptor) {
-        m_windowTrackingAdaptor->setContextResolver(nullptr);
-        // m_screenModeRouter is destroyed below; null its WTA borrow
-        // before that reset so any D-Bus call landing in the gap
-        // between this teardown and the bus unregister can't deref
-        // a freed router pointer. SnapAdaptor's clearEngine() does
-        // the symmetric clear (snapadaptor.cpp).
-        m_windowTrackingAdaptor->setScreenModeRouter(nullptr);
-    }
-    if (m_autotileAdaptor) {
-        // Sever the autotile adaptor's post-construction borrow of the WTA (wired
-        // in init() so the autotile open path can resolve RouteToScreen /
-        // RouteToDesktop rules). The autotile open path no-ops on a null WTA, so
-        // a D-Bus open landing in the teardown gap can't drive routing against
-        // half-torn-down state. Symmetric with the resolver / router clears above
-        // and honours the shutdown-nullptr contract documented in autotileadaptor.h.
-        m_autotileAdaptor->setWindowTrackingAdaptor(nullptr);
-    }
+    // The engine borrows, WTS callbacks, and resolver/router/WTA borrower
+    // pointers were all severed ABOVE the running gate (they are init-origin);
+    // from here on only the member RESETS remain. Order: the resolver and its
+    // three adapters die first, then the underlying router /
+    // VirtualDesktopManager / ActivityManager / Settings can safely reset().
     m_contextResolver.reset();
     m_settingsGateAdapter.reset();
     m_screenModeAdapter.reset();
@@ -834,38 +872,9 @@ void Daemon::stop()
     // already captured before the router went away.
     m_screenModeRouter.reset();
 
-    // Sever SnapEngine's borrow of m_excludeRuleSet (a daemon-owned value
-    // member) BEFORE m_snapEngine.reset(). Declaration order currently
-    // guarantees lifetime, but a future reorder or ownership move could
-    // silently introduce a dangling pointer through isAppIdExcluded if
-    // a late shutdown call landed; the explicit clear here makes the
-    // teardown contract grep-discoverable and survives that refactor.
-    // `m_snapEngine` is base-typed `PlacementEngineBase*`; the setter
-    // lives on the concrete `SnapEngine`. qobject_cast mirrors the
-    // concreteAutotile narrowing a few lines below.
-    if (auto* concreteSnap = qobject_cast<PhosphorSnapEngine::SnapEngine*>(m_snapEngine.get())) {
-        concreteSnap->setExcludeRuleSet(nullptr);
-    }
-
-    // Likewise sever WindowTrackingAdaptor's borrow of m_ruleStore (used by
-    // its restore-position evaluator) before the store is destroyed. Same
-    // grep-discoverable teardown contract as the SnapEngine exclude borrow above.
-    if (m_windowTrackingAdaptor) {
-        m_windowTrackingAdaptor->setRuleStore(nullptr);
-    }
-
-    // Clear the autotile context-gap provider, which captures `this` (Daemon, via
-    // m_layoutManager / currentDesktopForScreen / currentActivity). No live deref
-    // can occur today — m_autotileEngine is destroyed below while `this` is still
-    // alive — but clearing it keeps the "every `this`-capturing closure is cleared
-    // before teardown" contract complete and grep-discoverable, exactly like the
-    // SnapEngine exclude-rule borrow above. `m_autotileEngine` is base-typed
-    // `PlacementEngineBase*`; setContextGapProvider lives on the concrete engine.
-    if (auto* concreteAutotile = qobject_cast<PhosphorTileEngine::AutotileEngine*>(m_autotileEngine.get())) {
-        concreteAutotile->setContextGapProvider({});
-    }
-
     // Destroy engines now (during stop(), before Qt child destruction order).
+    // Their exclude-rule / rule-store / context-gap borrows were severed
+    // above the running gate.
     m_snapEngine.reset();
     m_autotileEngine.reset();
 

--- a/src/daemon/daemon/lifecycle.cpp
+++ b/src/daemon/daemon/lifecycle.cpp
@@ -598,6 +598,14 @@ void Daemon::stop()
     // across cycles.
     m_scheduledBakeFingerprints.clear();
 
+    // initEnginesAndWiring lends the resolver to OverlayService before
+    // start() marks the daemon running. Detach it above the running gate so a
+    // failed init cannot leave ~OverlayService pumping deferred deletes with a
+    // resolver that reverse member destruction has already freed.
+    if (m_overlayService) {
+        m_overlayService->setContextResolver(nullptr);
+    }
+
     // Everything ABOVE this gate is init/ctor-origin teardown that must run on
     // an init-without-start path (a failed init, a double-stop): the adaptor
     // detaches, the D-Bus unregister, the loader resets, the QML-static

--- a/src/daemon/daemon/lifecycle.cpp
+++ b/src/daemon/daemon/lifecycle.cpp
@@ -673,6 +673,9 @@ void Daemon::stop()
     // first placementChanged of the next init/start cycle read as "unchanged"
     // and silently skip its save trigger.
     m_lastTiledCountByScreen.clear();
+    // Per-session restore staging: entries computed against the pre-stop
+    // window set must not feed a post-restart KCM apply with dead geometry.
+    m_pendingSnapFloatRestores.clear();
 
     // Release the shortcut grabs and the Portal session with the connections:
     // registerShortcuts() on the next start() lazily recreates the registry

--- a/src/daemon/daemon/lifecycle.cpp
+++ b/src/daemon/daemon/lifecycle.cpp
@@ -217,6 +217,8 @@ void Daemon::start()
     // setDefaultShortcut stores defaults synchronously (fast, no key grabbing),
     // then key grabs are activated via async D-Bus calls so the event loop
     // stays responsive for Wayland protocol events during login.
+    // Unguarded deref: m_shortcutManager is ctor-owned and never reset
+    // (stop()'s guard is defensive teardown symmetry, not a live invariant).
     m_shortcutManager->registerShortcuts();
     connectShortcutSignals();
     initializeAutotile();

--- a/src/daemon/daemon/lifecycle.cpp
+++ b/src/daemon/daemon/lifecycle.cpp
@@ -171,6 +171,11 @@ void Daemon::start()
     // Note what this does NOT fix: stop() also unregisters the D-Bus object and the service
     // name, and re-registering them lives in init(), not here. A restarted daemon therefore
     // has no bus presence, so nothing it publishes reaches the effect regardless. The
+    // same asymmetry covers the autotile shortcuts: their grabs survive stop()
+    // while their handler connections are severed and only initAutotile (an
+    // init() phase) rewires them — with no bus presence nothing they would
+    // trigger reaches anyone, so re-wiring them here would repair a limb of a
+    // cycle that is degraded by design. The
     // re-arm exists so the daemon's own state is consistent after the cycle (which the
     // repairs below also do), not because the cycle fully restores service.
     if (!m_idleService) {
@@ -663,6 +668,11 @@ void Daemon::stop()
         disconnect(conn);
     }
     m_perStartConnections.clear();
+
+    // Per-session change-gate state: a stale tiled-count entry would make the
+    // first placementChanged of the next init/start cycle read as "unchanged"
+    // and silently skip its save trigger.
+    m_lastTiledCountByScreen.clear();
 
     // Release the shortcut grabs and the Portal session with the connections:
     // registerShortcuts() on the next start() lazily recreates the registry

--- a/src/daemon/daemon/osd.cpp
+++ b/src/daemon/daemon/osd.cpp
@@ -571,9 +571,11 @@ void Daemon::showOsdForScreens(const QStringList& screenIds, const QString& acti
         }
         for (const QString& screenId : screenIds) {
             // Each screen reports against its OWN current virtual desktop
-            // (Plasma 6.7 per-output virtual desktops, #648).
-            const int desktop =
-                m_virtualDesktopManager ? m_virtualDesktopManager->currentDesktopForScreen(screenId) : currentDesktop();
+            // (Plasma 6.7 per-output virtual desktops, #648) — via the shared
+            // helper so the null-manager fallback cannot drift from every
+            // other resolution site (the open-coded form fell back to the
+            // global current desktop while the helper reports 0/unknown).
+            const int desktop = currentDesktopForScreen(screenId);
             // Route the disabled-context probe through the resolver so this
             // OSD pass uses the same single snapshot façade as every other
             // call site — the prior hand-stitched (modeFor → settings →

--- a/src/daemon/daemon/osd.cpp
+++ b/src/daemon/daemon/osd.cpp
@@ -481,9 +481,10 @@ void Daemon::syncModeFromAssignments()
                 }
             }
         }
-        // Per-output virtual desktops (#648): each screen resolves its own desktop.
-        const int desktop = currentDesktopForScreen(focusedScreenId);
         if (!focusedScreenId.isEmpty()) {
+            // Per-output virtual desktops (#648): each screen resolves its own
+            // desktop. Inside the guard — a lookup for an empty id is dead work.
+            const int desktop = currentDesktopForScreen(focusedScreenId);
             const QString focusedAssignmentId =
                 m_layoutManager->assignmentIdForScreen(focusedScreenId, desktop, activity);
             m_unifiedLayoutController->setCurrentScreenName(focusedScreenId);

--- a/src/daemon/daemon/osd.cpp
+++ b/src/daemon/daemon/osd.cpp
@@ -67,23 +67,29 @@ void Daemon::showOverlay()
     }
     // Per-screen autotile exclusion is handled by OverlayService::initializeOverlay()
     // via m_excludedScreens (set in updateAutotileScreens)
-    m_overlayService->show();
+    if (m_overlayService) {
+        m_overlayService->show();
+    }
 }
 
 void Daemon::hideOverlay()
 {
     clearHighlight();
-    m_overlayService->hide();
+    if (m_overlayService) {
+        m_overlayService->hide();
+    }
 }
 
 bool Daemon::isOverlayVisible() const
 {
-    return m_overlayService->isVisible();
+    return m_overlayService && m_overlayService->isVisible();
 }
 
 void Daemon::clearHighlight()
 {
-    m_zoneDetector->clearHighlights();
+    if (m_zoneDetector) {
+        m_zoneDetector->clearHighlights();
+    }
 }
 
 void Daemon::armResnapOsdSuppression(int count)

--- a/src/daemon/daemon/osd.cpp
+++ b/src/daemon/daemon/osd.cpp
@@ -579,28 +579,8 @@ void Daemon::showOsdForScreens(const QStringList& screenIds, const QString& acti
             // reports against, while the screen's mode stays live.
             DisabledReason why = DisabledReason::NotDisabled;
             if (m_contextResolver) {
-                // Map PhosphorContext::DisabledReason → PlasmaZones::DisabledReason.
-                // The two enums are value-identical by intent (the LGPL lib's
-                // DisabledReason.h documents it mirrors the GPL daemon's),
-                // but the conversion is written as a switch so a future enum
-                // value added on one side surfaces here as a compile-time
-                // -Wswitch warning rather than a silent value coercion.
-                const auto reason = m_contextResolver->disabledReason(
-                    m_contextResolver->handleForPersisted(screenId, desktop, activity));
-                switch (reason) {
-                case PhosphorContext::DisabledReason::NotDisabled:
-                    why = DisabledReason::NotDisabled;
-                    break;
-                case PhosphorContext::DisabledReason::MonitorDisabled:
-                    why = DisabledReason::MonitorDisabled;
-                    break;
-                case PhosphorContext::DisabledReason::DesktopDisabled:
-                    why = DisabledReason::DesktopDisabled;
-                    break;
-                case PhosphorContext::DisabledReason::ActivityDisabled:
-                    why = DisabledReason::ActivityDisabled;
-                    break;
-                }
+                why = toDaemonDisabledReason(m_contextResolver->disabledReason(
+                    m_contextResolver->handleForPersisted(screenId, desktop, activity)));
             }
             if (why != DisabledReason::NotDisabled) {
                 showContextDisabledOsd(screenId, desktop, activity, why);

--- a/src/daemon/daemon/osd.cpp
+++ b/src/daemon/daemon/osd.cpp
@@ -405,22 +405,27 @@ void Daemon::updateLayoutFilterForScreen(const QString& focusedScreenId)
     bool manualActive = false;
 
     if (m_settings->autotileEnabled() && m_layoutManager && m_screenManager) {
-        const int desktop = currentDesktopForScreen(focusedScreenId);
         const QString activity = currentActivity();
 
         if (!focusedScreenId.isEmpty()) {
             // Per-screen filter: only check the focused screen's mode
-            const QString assignmentId = m_layoutManager->assignmentIdForScreen(focusedScreenId, desktop, activity);
+            const QString assignmentId = m_layoutManager->assignmentIdForScreen(
+                focusedScreenId, currentDesktopForScreen(focusedScreenId), activity);
             if (PhosphorLayout::LayoutId::isAutotile(assignmentId)) {
                 autotileActive = true;
             } else {
                 manualActive = true;
             }
         } else {
-            // Global filter: union of all effective screens (includes virtual screens)
+            // Global filter: union of all effective screens (includes virtual
+            // screens). Each screen resolves its OWN desktop (#648 per-output
+            // virtual desktops) — a desktop hoisted from the empty focused id
+            // is the global current desktop and misresolves per-output
+            // screens showing a different one.
             const QStringList effectiveIds = m_screenManager->effectiveScreenIds();
             for (const QString& screenId : effectiveIds) {
-                const QString assignmentId = m_layoutManager->assignmentIdForScreen(screenId, desktop, activity);
+                const QString assignmentId =
+                    m_layoutManager->assignmentIdForScreen(screenId, currentDesktopForScreen(screenId), activity);
                 if (PhosphorLayout::LayoutId::isAutotile(assignmentId)) {
                     autotileActive = true;
                 } else {

--- a/src/daemon/daemon/seedorderfilter.cpp
+++ b/src/daemon/daemon/seedorderfilter.cpp
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "seedorderfilter.h"
+
+#include <PhosphorEngine/WindowPlacement.h>
+#include <PhosphorEngine/WindowRegistry.h>
+#include <PhosphorPlacement/WindowTrackingService.h>
+
+namespace PlasmaZones {
+
+void filterAutotileSeedOrder(QStringList& order, PhosphorPlacement::WindowTrackingService* wts,
+                             const PhosphorEngine::WindowRegistry* registry)
+{
+    if (order.isEmpty() || !wts) {
+        return;
+    }
+    order.removeIf([wts, registry](const QString& windowId) {
+        const bool minimized = registry && registry->isMinimized(windowId);
+        if (!minimized && wts->isWindowFloating(windowId)) {
+            return true;
+        }
+        const auto record = wts->placementStore().peekExact(windowId);
+        if (record
+            && record->slotFor(PhosphorEngine::WindowPlacement::snapEngineId()).state
+                == PhosphorEngine::WindowPlacement::stateFloating()) {
+            return true;
+        }
+        return false;
+    });
+}
+
+} // namespace PlasmaZones

--- a/src/daemon/daemon/seedorderfilter.cpp
+++ b/src/daemon/daemon/seedorderfilter.cpp
@@ -16,7 +16,11 @@ void filterAutotileSeedOrder(QStringList& order, PhosphorPlacement::WindowTracki
         return;
     }
     order.removeIf([wts, registry](const QString& windowId) {
-        const bool minimized = registry && registry->isMinimized(windowId);
+        // minimizedState().value_or(false), not isMinimized(): keeps this
+        // filter's unknown-handling in lockstep with the resnap-order and
+        // restore-entry filters (autotile.cpp / autotile_init.cpp), which the
+        // registry doc steers toward the tri-state accessor.
+        const bool minimized = registry && registry->minimizedState(windowId).value_or(false);
         if (!minimized && wts->isWindowFloating(windowId)) {
             return true;
         }

--- a/src/daemon/daemon/seedorderfilter.h
+++ b/src/daemon/daemon/seedorderfilter.h
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <QStringList>
+
+namespace PhosphorEngine {
+class WindowRegistry;
+}
+namespace PhosphorPlacement {
+class WindowTrackingService;
+}
+
+namespace PlasmaZones {
+
+/**
+ * @brief Filter an autotile seed order's entries against live window state.
+ *
+ * Order sources describe past arrangements (the tiled order captured at
+ * toggle-off, or zone assignments) and know nothing about what happened to
+ * those windows since. Entries are DROPPED when the window must not be seeded
+ * back as tiled:
+ *  - it is floating NOW and not minimized (a float set by another mode would
+ *    be tiled over — the strict seed only restores floating from the AUTOTILE
+ *    placement slot);
+ *  - its instance-exact durable placement record carries a floating snap slot
+ *    (the mode flips before the second seed, so the live floating resolver
+ *    then reads the empty autotile slot; the record preserves the source-mode
+ *    user float across that flip).
+ * Minimized windows are KEPT as positional placeholders — the engine's
+ * strict-seed path defers adding them until their windowOpened arrives,
+ * preserving position without a hidden window occupying a tile.
+ *
+ * Extracted from Daemon::seedAutotileOrderForScreen so the predicate is unit
+ * testable without a full daemon.
+ */
+void filterAutotileSeedOrder(QStringList& order, PhosphorPlacement::WindowTrackingService* wts,
+                             const PhosphorEngine::WindowRegistry* registry);
+
+} // namespace PlasmaZones

--- a/src/daemon/daemon/signals.cpp
+++ b/src/daemon/daemon/signals.cpp
@@ -120,7 +120,8 @@ void Daemon::connectLayoutSignals()
     // handler below runs twice. Drop exactly the handles WE installed last
     // time: a (sender, signal, receiver) disconnect would also delete other
     // call sites' handlers on the same signals (initLayoutAndSettingsWiring()
-    // connects layoutAssigned from the ctor, and that never re-runs), and
+    // connects layoutAssigned from init(), which CAN re-run and drops its own
+    // tracked handles the same way), and
     // Qt::UniqueConnection does not apply to lambda/functor connections.
     // start() calls this one FIRST (lifecycle.cpp), so the clear lives here
     // and connectOverlaySignals() only appends.

--- a/src/daemon/daemon/signals.cpp
+++ b/src/daemon/daemon/signals.cpp
@@ -523,7 +523,7 @@ void Daemon::syncAutotileFloatState(const QString& windowId, bool floating, cons
             // needed to restore the snap zone when the window returns to vs:0.
             const QString preFloatScreen = wts->preFloatScreen(windowId);
             if (preFloatScreen.isEmpty() || preFloatScreen == screenId) {
-                wts->clearPreFloatZoneForWindow(windowId);
+                wts->clearPreFloatZone(windowId);
             }
         } else {
             // The window's snap-mode float (if any) already lives in its placement
@@ -593,7 +593,7 @@ void Daemon::syncAutotileFloatStatePassive(const QString& windowId, bool floatin
         // zone-restore on return to the snap VS still works.
         const QString preFloatScreen = wts->preFloatScreen(windowId);
         if (preFloatScreen.isEmpty() || preFloatScreen == screenId) {
-            wts->clearPreFloatZoneForWindow(windowId);
+            wts->clearPreFloatZone(windowId);
         }
     } else {
         // Snap-mode float persists in the placement record's snap slot (single
@@ -635,7 +635,7 @@ void Daemon::syncAutotileBatchFloatState(const QStringList& windowIds, const QSt
         // Same cross-VS preservation logic as the single-window handler
         const QString preFloatScreen = wts->preFloatScreen(windowId);
         if (preFloatScreen.isEmpty() || preFloatScreen == screenId) {
-            wts->clearPreFloatZoneForWindow(windowId);
+            wts->clearPreFloatZone(windowId);
         }
     }
     if (m_settings && m_settings->showNavigationOsd() && m_overlayService && !windowIds.isEmpty()) {

--- a/src/daemon/daemon/start.cpp
+++ b/src/daemon/daemon/start.cpp
@@ -262,7 +262,7 @@ void Daemon::connectDesktopActivity()
                 // [SEQ B] Pin screens where all autotiled windows are sticky BEFORE
                 // changing the desktop context, so currentKeyForScreen() still
                 // resolves existing TilingStates ("virtualdesktopsonlyonprimary").
-                if (m_autotileEngine && m_windowTrackingAdaptor) {
+                if (m_autotileEngine && m_windowTrackingAdaptor && m_windowTrackingAdaptor->service()) {
                     auto* service = m_windowTrackingAdaptor->service();
                     m_autotileEngine->updateStickyScreenPins([service](const QString& windowId) {
                         return service->isWindowSticky(windowId);
@@ -426,7 +426,7 @@ void Daemon::connectDesktopActivity()
                         m_autotileEngine->cancelDragInsertPreview();
                     }
                     // Pin sticky screens before changing activity context
-                    if (m_autotileEngine && m_windowTrackingAdaptor) {
+                    if (m_autotileEngine && m_windowTrackingAdaptor && m_windowTrackingAdaptor->service()) {
                         auto* service = m_windowTrackingAdaptor->service();
                         m_autotileEngine->updateStickyScreenPins([service](const QString& windowId) {
                             return service->isWindowSticky(windowId);
@@ -888,7 +888,10 @@ void Daemon::handleCycleLayout(const QString& screenId, bool forward)
 
 void Daemon::migrateStartupScreenAssignments()
 {
-    if (!m_windowTrackingAdaptor || !m_screenManager) {
+    // m_settings and service() are unguarded below by the same invariant the
+    // rest of the file relies on: both are ctor-owned / adaptor-constructed
+    // and never null while the adaptor exists (autotile.cpp documents it).
+    if (!m_windowTrackingAdaptor || !m_screenManager || !m_windowTrackingAdaptor->service()) {
         return;
     }
     const auto vsConfigs = m_settings->virtualScreenConfigs();

--- a/src/daemon/daemon/start.cpp
+++ b/src/daemon/daemon/start.cpp
@@ -392,10 +392,13 @@ void Daemon::connectDesktopActivity()
             pruneContextMapsForActivities(validSet);
         });
 
-        // Set initial activity on components that maintain their own copy
+        // Set initial activity on components that maintain their own copy.
+        // Layout registry FIRST: the overlay's setter runs a refresh pass
+        // that resolves assignments through the registry, so updating the
+        // overlay first would render one pass against the old activity.
         const QString initialActivity = m_activityManager->currentActivity();
-        m_overlayService->setCurrentActivity(initialActivity);
         m_layoutManager->setCurrentActivity(initialActivity);
+        m_overlayService->setCurrentActivity(initialActivity);
         if (m_autotileEngine) {
             m_autotileEngine->setCurrentActivity(initialActivity);
         }
@@ -406,8 +409,10 @@ void Daemon::connectDesktopActivity()
         // Connect activity changes: update all components
         connect(m_activityManager.get(), &PhosphorWorkspaces::ActivityManager::currentActivityChanged, this,
                 [this](const QString& activityId) {
-                    m_overlayService->setCurrentActivity(activityId);
+                    // Registry before overlay — see the initial-activity note
+                    // above (the overlay's refresh resolves via the registry).
                     m_layoutManager->setCurrentActivity(activityId);
+                    m_overlayService->setCurrentActivity(activityId);
                     if (m_unifiedLayoutController) {
                         m_unifiedLayoutController->setCurrentActivity(activityId);
                     }

--- a/src/daemon/daemon/start.cpp
+++ b/src/daemon/daemon/start.cpp
@@ -167,13 +167,17 @@ void Daemon::connectScreenSignals()
                     m_layoutManager->clearCurrentVirtualDesktopForScreen(removedScreenId);
                 }
 
-                // The snap engine's per-(screen,desktop,activity) stores are created
-                // lazily on placement, not from an autotile-screens set, so the removed
-                // output's stores must be pruned explicitly here (autotile self-prunes
-                // via updateAutotileScreens). Matches every virtual sub-screen of the
-                // removed physical id.
+                // Both engines' per-(screen,desktop,activity) stores must be
+                // pruned explicitly here; each matches every virtual sub-screen
+                // of the removed physical id. Autotile's updateAutotileScreens
+                // self-prune covers only the CURRENT (desktop, activity)
+                // context — the removed monitor's other contexts' TilingStates
+                // would otherwise leak for the session.
                 if (m_snapEngine) {
                     m_snapEngine->pruneStatesForRemovedScreen(removedScreenId);
+                }
+                if (m_autotileEngine) {
+                    m_autotileEngine->pruneStatesForRemovedScreen(removedScreenId);
                 }
 
                 // Invalidate cached EDID serial so a different monitor on this connector is detected

--- a/src/daemon/overlayservice.cpp
+++ b/src/daemon/overlayservice.cpp
@@ -15,6 +15,7 @@
 #include <PhosphorZones/Layout.h>
 #include <PhosphorZones/LayoutRegistry.h>
 #include <PhosphorZones/Zone.h>
+#include <PhosphorContext/IContextResolver.h>
 #include <PhosphorZones/LayoutUtils.h>
 #include "common/layoutpreviewserialize.h"
 #include "core/utils/unifiedlayoutlist.h"
@@ -553,6 +554,21 @@ void OverlayService::setLayout(PhosphorZones::Layout* layout)
     }
 }
 
+void OverlayService::setContextResolver(PhosphorContext::IContextResolver* resolver)
+{
+    m_contextResolver = resolver;
+}
+
+bool OverlayService::isSnappingContextDisabled(const QString& screenId) const
+{
+    if (!m_contextResolver || screenId.isEmpty()) {
+        return false;
+    }
+    const auto handle =
+        m_contextResolver->handleForPersisted(screenId, currentVirtualDesktopForScreen(screenId), m_currentActivity);
+    return m_contextResolver->isDisabled(handle);
+}
+
 PhosphorZones::Layout* OverlayService::resolveScreenLayout(QScreen* screen) const
 {
     // Physical QScreen* overload: derives screenId and delegates.
@@ -566,8 +582,7 @@ PhosphorZones::Layout* OverlayService::resolveScreenLayout(QScreen* screen) cons
 bool OverlayService::isSnappingContextInactive(const QString& screenId) const
 {
     const int virtualDesktop = currentVirtualDesktopForScreen(screenId);
-    if (isContextDisabled(m_settings, PhosphorZones::AssignmentEntry::Snapping, screenId, virtualDesktop,
-                          m_currentActivity)) {
+    if (isSnappingContextDisabled(screenId)) {
         return true;
     }
     if (!m_layoutManager) {
@@ -637,8 +652,7 @@ void OverlayService::hideDisabledAndRefresh()
     if (m_settings) {
         const QStringList screenIds = m_screenStates.keys();
         for (const QString& screenId : screenIds) {
-            const bool disabled = isContextDisabled(m_settings, PhosphorZones::AssignmentEntry::Snapping, screenId,
-                                                    currentVirtualDesktopForScreen(screenId), m_currentActivity);
+            const bool disabled = isSnappingContextDisabled(screenId);
             if (disabled) {
                 destroyZoneSelectorWindow(screenId);
             }
@@ -651,8 +665,7 @@ void OverlayService::hideDisabledAndRefresh()
     // Update remaining zone selector (disabled-gated) and overlay (suppress-gated) windows.
     for (auto it = m_screenStates.constBegin(); it != m_screenStates.constEnd(); ++it) {
         const QString& screenId = it.key();
-        const bool disabled = isContextDisabled(m_settings, PhosphorZones::AssignmentEntry::Snapping, screenId,
-                                                currentVirtualDesktopForScreen(screenId), m_currentActivity);
+        const bool disabled = isSnappingContextDisabled(screenId);
         if (!disabled && it.value().zoneSelectorSlot()) {
             updateZoneSelectorWindow(screenId);
         }

--- a/src/daemon/overlayservice.cpp
+++ b/src/daemon/overlayservice.cpp
@@ -460,7 +460,7 @@ PhosphorLayer::Surface* OverlayService::createWarmedOsdSurface(const PhosphorLay
     QSize initialSize = screenGeom.isValid() ? screenGeom.size() : QSize(240, 70);
 
     // Virtual-screen-aware anchors / margins, same vocabulary popups use
-    // (see selector.cpp::createZoneSelectorWindow). Physical screen →
+    // (see the showOnScreen path in selector.cpp). Physical screen →
     // AnchorAll + zero margins so the compositor sizes the surface to the
     // full output. Virtual screen → Top|Left + offset margins pinning the
     // surface to the VS sub-rect's top-left within its physical screen.

--- a/src/daemon/overlayservice.cpp
+++ b/src/daemon/overlayservice.cpp
@@ -127,6 +127,12 @@ OverlayService::OverlayService(PhosphorScreens::ScreenManager* screenManager, Sh
     // wrong rather than silently falling back to library defaults.
     Q_ASSERT_X(profileRegistry, "OverlayService::OverlayService",
                "profileRegistry must not be null: composition root must own and inject the registry");
+    if (Q_UNLIKELY(!profileRegistry)) {
+        // Release-build twin of the assert above: SurfaceAnimator binds the
+        // registry by reference below, so continuing would be an immediate
+        // null deref anyway — fail with a diagnosable message instead.
+        qFatal("OverlayService: profileRegistry must not be null (composition root wiring error)");
+    }
 
     // Construct ShellHost BEFORE setupSurfaceAnimator: the latter
     // calls applyShaderProfilesToAnimator which routes per-role
@@ -564,8 +570,14 @@ bool OverlayService::isSnappingContextDisabled(const QString& screenId) const
     if (!m_contextResolver || screenId.isEmpty()) {
         return false;
     }
-    const auto handle =
+    PhosphorContext::ContextHandle handle =
         m_contextResolver->handleForPersisted(screenId, currentVirtualDesktopForScreen(screenId), m_currentActivity);
+    // Query the SNAPPING axis explicitly, as the name promises. The overlay
+    // is snapping-mode UI, and the callers this consolidated previously
+    // composed their disable checks with Mode::Snapping; letting the mode
+    // provider stamp the screen's CURRENT mode would flip the check to the
+    // autotile axis on a tiling screen.
+    handle.mode = PhosphorZones::AssignmentEntry::Snapping;
     return m_contextResolver->isDisabled(handle);
 }
 

--- a/src/daemon/overlayservice.cpp
+++ b/src/daemon/overlayservice.cpp
@@ -664,16 +664,17 @@ void OverlayService::hideDisabledAndRefresh()
     // is how a layout gets assigned, so suppress must not hide it); the snap
     // overlay is additionally gated by suppress / autotile mode via
     // isSnappingContextInactive.
-    if (m_settings) {
-        const QStringList screenIds = m_screenStates.keys();
-        for (const QString& screenId : screenIds) {
-            const bool disabled = isSnappingContextDisabled(screenId);
-            if (disabled) {
-                destroyZoneSelectorWindow(screenId);
-            }
-            if (m_visible && isSnappingContextInactive(screenId)) {
-                dismissOverlayWindow(screenId);
-            }
+    // No m_settings gate here: neither context predicate reads settings (both
+    // fail closed on their own null members), and skipping the destroy loop on
+    // a null settings pointer would leave stale selector/overlay slots up.
+    const QStringList screenIds = m_screenStates.keys();
+    for (const QString& screenId : screenIds) {
+        const bool disabled = isSnappingContextDisabled(screenId);
+        if (disabled) {
+            destroyZoneSelectorWindow(screenId);
+        }
+        if (m_visible && isSnappingContextInactive(screenId)) {
+            dismissOverlayWindow(screenId);
         }
     }
 

--- a/src/daemon/overlayservice.cpp
+++ b/src/daemon/overlayservice.cpp
@@ -308,9 +308,6 @@ OverlayService::OverlayService(PhosphorScreens::ScreenManager* screenManager, Sh
                            << "shader-timer restart on resume will not run";
     }
 
-    // Reset shader error state on construction (fresh start after reboot)
-    m_pendingShaderError.clear();
-
     m_audioProvider = std::make_unique<PhosphorAudio::CavaSpectrumProvider>();
     connect(m_audioProvider.get(), &PhosphorAudio::IAudioSpectrumProvider::spectrumUpdated, this,
             &OverlayService::onAudioSpectrumUpdated);
@@ -567,7 +564,13 @@ void OverlayService::setContextResolver(PhosphorContext::IContextResolver* resol
 
 bool OverlayService::isSnappingContextDisabled(const QString& screenId) const
 {
-    if (!m_contextResolver || screenId.isEmpty()) {
+    // Fail CLOSED on a null resolver, mirroring Daemon::isFocusedContextGated:
+    // the resolver is only null before wiring or during teardown, and showing
+    // overlay UI in either window is worse than briefly suppressing it.
+    if (!m_contextResolver) {
+        return true;
+    }
+    if (screenId.isEmpty()) {
         return false;
     }
     PhosphorContext::ContextHandle handle =
@@ -723,9 +726,9 @@ OverlayService::LayoutIncludeFlags OverlayService::resolvePerScreenLayoutInclude
     // Both buildLayoutsList (populates the popup) and visibleLayoutCount
     // (used by isNearTriggerEdge to size the keep-visible bar) go through
     // here so the trigger geometry matches the rendered popup row count.
-    // If the resolver ever skips setting one of the fields, the struct's
-    // in-class defaults (both true) supply a safe "show everything"
-    // fallback rather than UB.
+    // The brace-init seeds BOTH fields from the settings-backed member
+    // toggles (so the struct's in-class defaults never apply here); the
+    // resolution below only narrows them per screen.
     LayoutIncludeFlags flags{m_includeManualLayouts, m_includeAutotileLayouts};
     if (!m_layoutManager) {
         return flags;
@@ -813,9 +816,9 @@ void OverlayService::onPrepareForSleep(bool goingToSleep)
 
 void OverlayService::onShaderError(const QString& errorLog)
 {
+    // Log-only by design: no error latch — shaders retry on the next show
+    // (fix bugs, don't mask them).
     qCWarning(lcOverlay) << "Shader error during overlay:" << errorLog;
-    m_pendingShaderError = errorLog;
-    // Don't set m_shaderErrorPending - retry shaders on next show (fix bugs, don't mask)
 }
 
 } // namespace PlasmaZones

--- a/src/daemon/overlayservice.h
+++ b/src/daemon/overlayservice.h
@@ -815,7 +815,6 @@ private:
     QString m_lastNavigationScreenId;
     QElapsedTimer m_lastNavigationTime;
 
-    void createZoneSelectorWindow(const QString& screenId, QScreen* physScreen, const QRect& geom);
     void destroyZoneSelectorWindow(const QString& screenId);
     void updateZoneSelectorWindow(const QString& screenId);
     void showLayoutOsdImpl(PhosphorZones::Layout* layout, const QString& screenId, bool locked);

--- a/src/daemon/overlayservice.h
+++ b/src/daemon/overlayservice.h
@@ -594,9 +594,11 @@ private:
     /// True when the snapping overlay must NOT show on @p screenId for the current
     /// desktop/activity: either the context is on a disable list, OR its default
     /// layout assignment is suppressed (the global "don't assign by default"
-    /// setting, or a per-context rule) and nothing is explicitly assigned. Folds
-    /// the two gates so every overlay / selector activation site treats a
-    /// suppressed context exactly like a disabled one.
+    /// setting, or a per-context rule) and nothing is explicitly assigned.
+    /// Consumed by the OVERLAY activation sites; the zone SELECTOR is
+    /// deliberately disabled-list-only (isSnappingContextDisabled) — a
+    /// suppressed-default context still allows an explicit drag to pick a
+    /// zone, so the selector must keep showing there.
     bool isSnappingContextInactive(const QString& screenId) const;
     bool isSnappingContextDisabled(const QString& screenId) const;
 

--- a/src/daemon/overlayservice.h
+++ b/src/daemon/overlayservice.h
@@ -1117,7 +1117,6 @@ private:
 
     // Shader state
     bool m_zoneDataDirty = true;
-    QString m_pendingShaderError;
 
     // Scope generation delegated to m_surfaceManager->nextScopeGeneration().
 

--- a/src/daemon/overlayservice.h
+++ b/src/daemon/overlayservice.h
@@ -81,6 +81,9 @@ class DmabufTextureProvider;
 namespace PhosphorScreens {
 class ScreenManager;
 }
+namespace PhosphorContext {
+class IContextResolver;
+}
 class QQuickWindow;
 class QQuickItem;
 class QScreen;
@@ -160,6 +163,9 @@ public:
 
     void setSettings(ISettings* settings);
     void setLayoutManager(PhosphorZones::IZoneLayoutRegistry* layoutManager);
+    /// Late-bound daemon context resolver. The daemon creates it after this
+    /// service and clears the borrow before resolver teardown.
+    void setContextResolver(PhosphorContext::IContextResolver* resolver);
 
     /// Inject the daemon-owned tile-algorithm registry. Required when
     /// autotile entries should appear in @ref visibleLayoutCount /
@@ -592,6 +598,7 @@ private:
     /// the two gates so every overlay / selector activation site treats a
     /// suppressed context exactly like a disabled one.
     bool isSnappingContextInactive(const QString& screenId) const;
+    bool isSnappingContextDisabled(const QString& screenId) const;
 
     // PhosphorLayer infrastructure - owns the wlr-layer-shell binding, screen
     // enumeration, and Surface factory for all overlay-style windows. Members
@@ -643,6 +650,8 @@ private:
 
     QPointer<PhosphorZones::Layout> m_layout;
     QPointer<ISettings> m_settings;
+    /// Borrowed from Daemon. stop() detaches this even when init never reached start().
+    PhosphorContext::IContextResolver* m_contextResolver = nullptr;
     PhosphorZones::IZoneLayoutRegistry* m_layoutManager =
         nullptr; ///< Borrowed; nullable (setLayoutManager(nullptr) detaches)
     PhosphorTiles::ITileAlgorithmRegistry* m_algorithmRegistry = nullptr; ///< Borrowed; outlives service

--- a/src/daemon/overlayservice/lifecycle.cpp
+++ b/src/daemon/overlayservice/lifecycle.cpp
@@ -200,8 +200,6 @@ void OverlayService::hide()
         dismissOverlayWindow(screenId);
     }
 
-    m_pendingShaderError.clear();
-
     Q_EMIT visibilityChanged(false);
 }
 

--- a/src/daemon/overlayservice/selector.cpp
+++ b/src/daemon/overlayservice/selector.cpp
@@ -115,8 +115,7 @@ void OverlayService::showZoneSelector(const QString& targetScreenId)
             if (!targetScreenId.isEmpty() && screenId != targetScreenId) {
                 continue;
             }
-            if (isContextDisabled(m_settings, PhosphorZones::AssignmentEntry::Snapping, screenId,
-                                  currentVirtualDesktopForScreen(screenId), m_currentActivity)) {
+            if (isSnappingContextDisabled(screenId)) {
                 continue;
             }
             if (m_excludedScreens.contains(screenId)) {
@@ -132,8 +131,7 @@ void OverlayService::showZoneSelector(const QString& targetScreenId)
                 continue;
             }
             QString screenId = PhosphorScreens::ScreenIdentity::identifierFor(screen);
-            if (isContextDisabled(m_settings, PhosphorZones::AssignmentEntry::Snapping, screenId,
-                                  currentVirtualDesktopForScreen(screenId), m_currentActivity)) {
+            if (isSnappingContextDisabled(screenId)) {
                 continue;
             }
             if (m_excludedScreens.contains(screenId)) {

--- a/src/daemon/overlayservice/selector.cpp
+++ b/src/daemon/overlayservice/selector.cpp
@@ -60,22 +60,32 @@ void OverlayService::showZoneSelector(const QString& targetScreenId)
         return;
     }
 
-    m_zoneSelectorVisible = true;
-
     auto* mgr = m_screenManager;
     QScreen* targetScreen = nullptr;
     if (!targetScreenId.isEmpty()) {
         targetScreen = mgr ? mgr->physicalScreenFor(targetScreenId).qscreen
                            : PhosphorScreens::ScreenIdentity::findByIdOrName(targetScreenId);
+        if (!targetScreen && (!mgr || !mgr->effectiveScreenIds().contains(targetScreenId))) {
+            // An explicit target that resolves to NOTHING must not fall
+            // through to the every-screen path — a selector popping up on all
+            // monitors because one id went stale is worse than not showing.
+            qCWarning(lcOverlay) << "showZoneSelector: target screen unresolvable:" << targetScreenId;
+            return;
+        }
     }
 
     const QStringList effectiveIds = mgr ? mgr->effectiveScreenIds() : QStringList();
 
-    auto showOnScreen = [this](const QString& screenId, QScreen* physScreen, const QRect& targetGeom) {
+    // Set the logical-visibility flag only if at least one screen actually
+    // shows; a flag flipped on with zero shells shown wedges the guard at
+    // function entry (every later show early-returns "already visible").
+    bool shownAny = false;
+    auto showOnScreen = [this, &shownAny](const QString& screenId, QScreen* physScreen, const QRect& targetGeom) {
         auto* state = ensurePassiveShellFor(screenId, physScreen);
         if (!state || !state->shell || !state->shell->shellSurface() || !state->zoneSelectorSlot()) {
             return;
         }
+        shownAny = true;
         state->zoneSelectorPhysScreen = physScreen;
         state->zoneSelectorGeometry = targetGeom;
         if (state->shell->shellWindow()) {
@@ -144,6 +154,11 @@ void OverlayService::showZoneSelector(const QString& targetScreenId)
         }
     }
 
+    if (!shownAny) {
+        qCWarning(lcOverlay) << "showZoneSelector: no screen could show the selector";
+        return;
+    }
+    m_zoneSelectorVisible = true;
     Q_EMIT zoneSelectorVisibilityChanged(true);
 }
 
@@ -437,61 +452,9 @@ void OverlayService::updateSelectorPosition(int cursorX, int cursorY)
     }
 }
 
-void OverlayService::createZoneSelectorWindow(const QString& screenId, QScreen* physScreen, const QRect& geom)
-{
-    // Post-shell-migration: the per-VS PhosphorRoles::ZoneSelector wl_surface
-    // is replaced by an Item slot inside the per-screen passive shell.
-    // This function is now a thin alias for ensurePassiveShellFor +
-    // initial property push; the showZoneSelector show-loop already
-    // routes through showOnScreen which calls ensurePassiveShellFor.
-    if (!physScreen) {
-        qCWarning(lcOverlay) << "createZoneSelectorWindow: null physScreen for screen=" << screenId;
-        return;
-    }
-    auto* state = ensurePassiveShellFor(screenId, physScreen);
-    if (!state || !state->zoneSelectorSlot()) {
-        return;
-    }
-    state->zoneSelectorPhysScreen = physScreen;
-
-    const QRect screenGeom = geom.isValid() ? geom : physScreen->geometry();
-    state->zoneSelectorGeometry = screenGeom;
-
-    auto* slot = state->zoneSelectorSlot();
-    qreal aspectRatio =
-        (screenGeom.height() > 0) ? static_cast<qreal>(screenGeom.width()) / screenGeom.height() : (16.0 / 9.0);
-    aspectRatio = qBound(0.5, aspectRatio, 4.0);
-    writeQmlProperty(slot, QStringLiteral("screenAspectRatio"), aspectRatio);
-    writeQmlProperty(slot, QStringLiteral("screenWidth"), screenGeom.width());
-    if (m_settings) {
-        // Zone padding honors per-monitor gap RULES (context-rule override →
-        // global → default) via the layout registry's current context. The
-        // selector preview passes no layout, so the per-layout tier does not
-        // apply here; border width/radius layer the context overlay rule over
-        // the global config value, matching updateZoneSelectorWindow (every show
-        // path re-runs the update, so these seed values are consistent with it).
-        const PhosphorZones::ContextOverlayOverride overlayOverride =
-            overlayOverrideForScreen(m_layoutManager, screenId);
-        writeQmlProperty(
-            slot, QStringLiteral("zonePadding"),
-            GeometryUtils::getEffectiveInnerGap(
-                nullptr, m_settings, GeometryUtils::currentContextGapOverride(m_layoutManager, m_settings, screenId)));
-        writeQmlProperty(slot, QStringLiteral("zoneBorderWidth"),
-                         overlayOverride.borderWidth.value_or(m_settings->borderWidth()));
-        writeQmlProperty(slot, QStringLiteral("zoneBorderRadius"),
-                         overlayOverride.borderRadius.value_or(m_settings->borderRadius()));
-    }
-    const ZoneSelectorConfig config =
-        m_settings ? m_settings->resolvedZoneSelectorConfig(screenId) : defaultZoneSelectorConfig();
-    writeQmlProperty(slot, QStringLiteral("selectorPosition"), config.position);
-    writeQmlProperty(slot, QStringLiteral("selectorLayoutMode"), config.layoutMode);
-    writeQmlProperty(slot, QStringLiteral("selectorGridColumns"), config.gridColumns);
-    writeQmlProperty(slot, QStringLiteral("previewWidth"), config.previewWidth);
-    writeQmlProperty(slot, QStringLiteral("previewHeight"), config.previewHeight);
-    writeQmlProperty(slot, QStringLiteral("previewLockAspect"), config.previewLockAspect);
-    // No signal wiring: the slot is input-transparent by design — hit-testing
-    // and commit both happen in C++ (updateSelectorPosition + drop.cpp).
-}
+// createZoneSelectorWindow was removed: after the shell migration it was a
+// caller-less thin alias for ensurePassiveShellFor + a property seed that
+// updateZoneSelectorWindow re-writes on every show path anyway.
 
 void OverlayService::destroyZoneSelectorWindow(const QString& screenId)
 {

--- a/src/daemon/overlayservice/selector.cpp
+++ b/src/daemon/overlayservice/selector.cpp
@@ -345,8 +345,12 @@ void OverlayService::updateSelectorPosition(int cursorX, int cursorY)
                 // rule (checked first) or a manual lock on either mode.
                 if (m_settings && m_layoutManager) {
                     int curDesktop = currentVirtualDesktopForScreen(cursorScreenId);
-                    QString curActivity = m_layoutManager->currentActivity();
-                    bool locked = isAnyModeLocked(m_settings, m_layoutManager, cursorScreenId, curDesktop, curActivity);
+                    // m_currentActivity, not m_layoutManager->currentActivity():
+                    // every other context resolve in this class reads the mirror,
+                    // and mixing sources lets the lock hit-test transiently
+                    // disagree with the cards drawn from the mirror.
+                    bool locked =
+                        isAnyModeLocked(m_settings, m_layoutManager, cursorScreenId, curDesktop, m_currentActivity);
                     if (locked) {
                         // Only allow zone selection from the active layout
                         PhosphorZones::Layout* activeLayout = m_layoutManager->resolveLayoutForScreen(cursorScreenId);

--- a/src/dbus/layoutadaptor/assignment.cpp
+++ b/src/dbus/layoutadaptor/assignment.cpp
@@ -303,9 +303,8 @@ QString LayoutAdaptor::getTilingAlgorithmForScreenDesktop(const QString& screenI
 
 QString LayoutAdaptor::getScreenStates()
 {
-    if (!m_layoutManager)
-        return QStringLiteral("[]");
-
+    // No m_layoutManager guard: both constructors qFatal on a null manager,
+    // and every other slot in this file dereferences it unguarded.
     QJsonArray result;
 
     const QString activity = m_layoutManager->currentActivity();
@@ -728,8 +727,17 @@ void LayoutAdaptor::setAssignmentEntry(const QString& screenId, int virtualDeskt
         }
     }
 
+    // Reject an out-of-range mode like every other argument on this boundary
+    // (screenId / layout uuid / algorithm are validated-and-refused): a silent
+    // clamp would mis-map a caller's typo — or a future third mode — to
+    // Autotile.
+    if (mode < 0 || mode > 1) {
+        qCWarning(lcDbusLayout) << "setAssignmentEntry: mode out of range:" << mode;
+        return;
+    }
+
     PhosphorZones::AssignmentEntry entry;
-    entry.mode = static_cast<PhosphorZones::AssignmentEntry::Mode>(qBound(0, mode, 1));
+    entry.mode = static_cast<PhosphorZones::AssignmentEntry::Mode>(mode);
     entry.snappingLayout = snappingLayout;
     entry.tilingAlgorithm = tilingAlgorithm;
 

--- a/src/dbus/windowdragadaptor/drop.cpp
+++ b/src/dbus/windowdragadaptor/drop.cpp
@@ -426,6 +426,14 @@ void WindowDragAdaptor::dragStopped(const QString& windowId, int cursorX, int cu
     // the zone (floating windows are excluded from persistence).
     if (!shouldApplyGeometry && capturedWasSnapped) {
         qCInfo(lcDbusWindow) << "Drag-out unsnap for" << windowId << "releaseScreen:" << releaseScreenId;
+        // Latch the pre-snap float-back BEFORE the float write (twin of
+        // WindowTrackingAdaptor::notifyDragOutUnsnap): setWindowFloating's
+        // capture refresh records the live dragged frame into the same
+        // per-screen map this read consumes.
+        std::optional<QRect> preSnapGeo;
+        if (m_windowTracking && m_windowTracking->shouldRestoreSizeOnUnsnap(windowId)) {
+            preSnapGeo = m_windowTracking->service()->validatedUnmanagedGeometry(windowId, releaseScreenId);
+        }
         if (m_windowTracking) {
             // unsnapForFloat on WTS: saves zone for restore, clears assignment.
             // No-op if the window wasn't snapped.
@@ -441,7 +449,7 @@ void WindowDragAdaptor::dragStopped(const QString& windowId, int cursorX, int cu
         // visibility check and not restore).
         if (m_windowTracking && m_windowTracking->shouldRestoreSizeOnUnsnap(windowId)) {
             auto* wts = m_windowTracking->service();
-            auto geo = wts->validatedUnmanagedGeometry(windowId, releaseScreenId);
+            const auto& geo = preSnapGeo;
             // Require strictly-positive dimensions: a degenerate stored
             // rect would produce a RestoreSize outcome that validates to
             // "requires non-zero size" and gets dropped effect-side, so
@@ -451,9 +459,9 @@ void WindowDragAdaptor::dragStopped(const QString& windowId, int cursorX, int cu
                 snapHeight = geo->height();
                 shouldApplyGeometry = true;
                 restoreSizeOnlyOut = true;
-                // Single float-back store: clear the record's shared free geometry
-                // after we've consumed it for this drag-out restore.
-                wts->clearFreeGeometry(windowId);
+                // Consume-once, per screen — other monitors' remembered
+                // positions stay intact.
+                wts->clearFreeGeometry(windowId, releaseScreenId);
                 qCInfo(lcDbusWindow) << "Drag-out unsnap: restoring size" << geo->width() << "x" << geo->height();
             } else {
                 qCInfo(lcDbusWindow) << "Drag-out unsnap: no valid pre-tile geometry for" << windowId;

--- a/src/dbus/windowdragadaptor/drop.cpp
+++ b/src/dbus/windowdragadaptor/drop.cpp
@@ -182,7 +182,6 @@ void WindowDragAdaptor::dragStopped(const QString& windowId, int cursorX, int cu
                 ctx.toScreenId = releaseScreenId;
                 ctx.fromEngineId = sourceEngine->engineId();
                 ctx.dropPos = QPoint(cursorX, cursorY);
-                ctx.sourceGeometry = capturedOriginalGeometry;
                 ctx.wasFloating = m_windowTracking->service()->isWindowFloating(windowId);
                 if (capturedWasSnapped && !ctx.wasFloating && !capturedZoneId.isEmpty()) {
                     // sourceZoneIds is informational for receiving engines —

--- a/src/dbus/windowdragadaptor/drop.cpp
+++ b/src/dbus/windowdragadaptor/drop.cpp
@@ -430,7 +430,10 @@ void WindowDragAdaptor::dragStopped(const QString& windowId, int cursorX, int cu
         // capture refresh records the live dragged frame into the same
         // per-screen map this read consumes.
         std::optional<QRect> preSnapGeo;
-        if (m_windowTracking && m_windowTracking->shouldRestoreSizeOnUnsnap(windowId)) {
+        // Evaluated once (it routes through the rule evaluator) and reused by
+        // the restore gate below.
+        const bool restoreSizeOnUnsnap = m_windowTracking && m_windowTracking->shouldRestoreSizeOnUnsnap(windowId);
+        if (restoreSizeOnUnsnap) {
             preSnapGeo = m_windowTracking->service()->validatedUnmanagedGeometry(windowId, releaseScreenId);
         }
         if (m_windowTracking) {
@@ -446,7 +449,7 @@ void WindowDragAdaptor::dragStopped(const QString& windowId, int cursorX, int cu
         // toggle path passes screenId to validatedUnmanagedGeometry; without it,
         // coordinates captured on another screen may fail the service's on-screen
         // visibility check and not restore).
-        if (m_windowTracking && m_windowTracking->shouldRestoreSizeOnUnsnap(windowId)) {
+        if (restoreSizeOnUnsnap) {
             auto* wts = m_windowTracking->service();
             const auto& geo = preSnapGeo;
             // Require strictly-positive dimensions: a degenerate stored

--- a/src/dbus/windowtrackingadaptor/enginewiring.cpp
+++ b/src/dbus/windowtrackingadaptor/enginewiring.cpp
@@ -215,7 +215,11 @@ void WindowTrackingAdaptor::setEngines(PhosphorEngine::PlacementEngineBase* snap
         // the window's actual state — including for daemon-restart-window-open.
         connect(snap, &PhosphorSnapEngine::SnapEngine::windowSnapStateChanged, this,
                 [this](const QString& windowId, const PhosphorProtocol::WindowStateEntry&) {
-                    captureWindowPlacement(windowId);
+                    // fromStateChange: a snap commit/uncommit is authoritative
+                    // even for a minimized window (resnap sweeps re-zone
+                    // minimized-but-assigned windows), so it must not be
+                    // silenced by the minimize capture guard.
+                    captureWindowPlacement(windowId, QString(), /*fromStateChange=*/true);
                 });
     } else if (snapEngine) {
         // Snap-mode window state signals are critical for WTS correctness.

--- a/src/dbus/windowtrackingadaptor/float.cpp
+++ b/src/dbus/windowtrackingadaptor/float.cpp
@@ -100,6 +100,12 @@ void WindowTrackingAdaptor::setWindowFloating(const QString& windowId, bool floa
     if (!validateWindowId(windowId, QStringLiteral("set float state"))) {
         return;
     }
+    // Suspension classification — see WindowTrackingService::isSuspensionFloat.
+    if (floating && m_windowRegistry && m_windowRegistry->minimizedState(windowId).value_or(false)) {
+        m_service->markSuspensionFloat(windowId);
+    } else if (!floating) {
+        m_service->clearSuspensionFloat(windowId);
+    }
     m_service->setWindowFloating(windowId, floating);
     // Gate the signal emissions on a real change in what we last BROADCAST, not
     // on a re-query of the service's float state. Under the per-engine float
@@ -208,6 +214,17 @@ void WindowTrackingAdaptor::setWindowFloatingForScreen(const QString& windowId, 
 
     qCInfo(lcDbusWindow) << "setWindowFloatingForScreen: windowId=" << windowId << "floating=" << floating
                          << "screen=" << effectiveScreenId;
+
+    // Classify BEFORE routing so any capture the write triggers synchronously
+    // already sees the suspension bit (minimize state is fresh here — the
+    // effect pushes metadata ahead of float traffic on the same edge).
+    if (m_service) {
+        if (floating && m_windowRegistry && m_windowRegistry->minimizedState(windowId).value_or(false)) {
+            m_service->markSuspensionFloat(windowId);
+        } else if (!floating) {
+            m_service->clearSuspensionFloat(windowId);
+        }
+    }
 
     // Route to the correct engine based on screen mode. Both directions go
     // through the explicit cross-engine handoff contract when the window

--- a/src/dbus/windowtrackingadaptor/float.cpp
+++ b/src/dbus/windowtrackingadaptor/float.cpp
@@ -99,7 +99,16 @@ bool WindowTrackingAdaptor::isWindowFloating(const QString& windowId)
     if (windowId.isEmpty()) {
         return false;
     }
-    // Delegate to service
+    // KNOWN ASYMMETRY with setWindowFloatingForScreen: this query answers
+    // through the WTS resolver, which routes by the window's TRACKED screen's
+    // current mode, while the setter routes by the caller-supplied (effect's
+    // authoritative live) screen. Mid-mode-flip the two can briefly disagree —
+    // the query reads the slot of the mode the tracking still points at, one
+    // beat behind the screen set the setter targets. Accepted: every caller of
+    // this query wants the mode-lens answer (rule predicates, the effect's
+    // float cache), the flip converges within the same signal cascade, and a
+    // screen-scoped query would push the mode-resolution burden onto callers
+    // that don't have an authoritative screen to supply.
     return m_service->isWindowFloating(windowId);
 }
 
@@ -158,8 +167,19 @@ void WindowTrackingAdaptor::setWindowFloating(const QString& windowId, bool floa
 
 QStringList WindowTrackingAdaptor::getFloatingWindows()
 {
-    // Delegate to service
-    return m_service->floatingWindows();
+    // USER floats only — suspension floats (minimize-as-float) are filtered
+    // out. The sole caller is the effect's daemon-bringup re-seed of its
+    // FloatingCache; seeding a minimize-float there makes the effect's
+    // restart claim sweep read it as a user float and skip adopting it into
+    // minimize-float ownership, leaving an unowned float that never re-tiles
+    // on unminimize. The effect's own claim paths (batch claim at daemon
+    // ready, claimAlreadyMinimizedAsFloated) are the owners of suspension
+    // floats and re-establish their state without this reply.
+    QStringList result = m_service->floatingWindows();
+    result.removeIf([this](const QString& windowId) {
+        return m_service->isSuspensionFloat(windowId);
+    });
+    return result;
 }
 
 bool WindowTrackingAdaptor::applyGeometryForFloat(const QString& windowId, const QString& screenId)
@@ -292,7 +312,6 @@ void WindowTrackingAdaptor::setWindowFloatingForScreen(const QString& windowId, 
             ctx.wasFloating = floating;
             if (sourceTracked) {
                 ctx.fromEngineId = source->engineId();
-                ctx.sourceGeometry = m_frameGeometry.value(shadowWindowId(windowId));
                 source->handoffRelease(windowId);
             }
             dest->handoffReceive(ctx);

--- a/src/dbus/windowtrackingadaptor/float.cpp
+++ b/src/dbus/windowtrackingadaptor/float.cpp
@@ -170,10 +170,11 @@ bool WindowTrackingAdaptor::relayWindowFloatingChanged(const QString& windowId, 
     // doc: every emission channel must keep m_broadcastFloating equal to what
     // subscribers last heard, or the gate turns from a dedup into a
     // suppressor of genuine changes. setWindowFloating delegates here too.
-    if (m_broadcastFloating.value(windowId, false) == floating) {
+    const QString shadowId = shadowWindowId(windowId);
+    if (m_broadcastFloating.value(shadowId, false) == floating) {
         return false;
     }
-    m_broadcastFloating[windowId] = floating;
+    m_broadcastFloating[shadowId] = floating;
     Q_EMIT windowFloatingChanged(windowId, floating, screenId);
     return true;
 }
@@ -234,7 +235,7 @@ void WindowTrackingAdaptor::setWindowFloatingForScreen(const QString& windowId, 
             ctx.wasFloating = floating;
             if (sourceTracked) {
                 ctx.fromEngineId = source->engineId();
-                ctx.sourceGeometry = m_frameGeometry.value(windowId);
+                ctx.sourceGeometry = m_frameGeometry.value(shadowWindowId(windowId));
                 source->handoffRelease(windowId);
             }
             dest->handoffReceive(ctx);

--- a/src/dbus/windowtrackingadaptor/float.cpp
+++ b/src/dbus/windowtrackingadaptor/float.cpp
@@ -209,6 +209,11 @@ bool WindowTrackingAdaptor::relayWindowFloatingChanged(const QString& windowId, 
     // doc: every emission channel must keep m_broadcastFloating equal to what
     // subscribers last heard, or the gate turns from a dedup into a
     // suppressor of genuine changes. setWindowFloating delegates here too.
+    // DELIBERATE divergence: the dedup keys on the CANONICAL (shadow) id so a
+    // class-mutated window dedups as one window, while the signal carries the
+    // CALLER'S raw id — subscribers resolve raw ids through their own
+    // canonicalization, and rewriting the id here would desync them from the
+    // other per-window signals on the same edge.
     const QString shadowId = shadowWindowId(windowId);
     // Absent entry NEVER counts as a match. The map is populated only by this
     // relay, so after a daemon restart it is empty while WTS has restored

--- a/src/dbus/windowtrackingadaptor/float.cpp
+++ b/src/dbus/windowtrackingadaptor/float.cpp
@@ -291,12 +291,11 @@ void WindowTrackingAdaptor::setWindowFloatingForScreen(const QString& windowId, 
     //   - Autotile dest: adopt via the handoff (release source, receive with
     //     wasFloating=false tiles the arrival and announces it on the
     //     passive sync channel); the trailing relay dedups against that.
-    //   - Snap dest: NO adoption. Snap's handoffReceive floats an arrival
-    //     with no sourceZoneIds unconditionally (ignoring wasFloating) and
-    //     emits floating=true, and the setWindowFloat(false) below fails
-    //     open when no rule/pre-float zone resolves ("keeping floating") —
-    //     together that strands the snap store floating against a false
-    //     broadcast. Instead just release the source's bit and broadcast
+    //   - Snap dest: NO adoption. A handoffReceive here would add nothing:
+    //     with no sourceZoneIds and wasFloating=false its tail lands the
+    //     window as a plain free window, and the setWindowFloat(false) below
+    //     fails open when no rule/pre-float zone resolves ("keeping
+    //     floating"). Instead just release the source's bit and broadcast
     //     the unfloat; the setWindowFloat below still gives snap its
     //     rule/pre-float re-snap chance, and a window it cannot re-snap
     //     stays a free (unmanaged) window, which is what unfloating a

--- a/src/dbus/windowtrackingadaptor/float.cpp
+++ b/src/dbus/windowtrackingadaptor/float.cpp
@@ -33,6 +33,16 @@ void WindowTrackingAdaptor::notifyDragOutUnsnap(const QString& windowId)
     QString screenId = m_service->screenForWindow(windowId, m_lastActiveScreenId);
     qCInfo(lcDbusWindow) << "Drag-out unsnap (no activation trigger) for" << windowId << "screen:" << screenId;
 
+    // Latch the pre-snap float-back BEFORE the float write: setWindowFloating
+    // synchronously runs a placement capture that records the LIVE dragged
+    // frame (zone dimensions) into the same per-screen free-geometry map this
+    // read consumes — reading afterwards would "restore" the zone size and
+    // destroy the genuine pre-snap size in the process.
+    std::optional<QRect> preSnapGeo;
+    if (shouldRestoreSizeOnUnsnap(windowId)) {
+        preSnapGeo = m_service->validatedUnmanagedGeometry(windowId, screenId);
+    }
+
     // Delegate unsnap-for-float to the service directly (the SnapAdaptor
     // method windowUnsnappedForFloat does the same thing, but this path
     // doesn't need the SnapAdaptor detour for a WTS-level operation).
@@ -42,15 +52,18 @@ void WindowTrackingAdaptor::notifyDragOutUnsnap(const QString& windowId)
     // Restore pre-snap size (not position — window stays where the user dropped it).
     // This mirrors the activated-drag path in WindowDragAdaptor::dragStopped. A
     // matched SetRestoreSizeOnUnsnap rule overrides the global setting per window.
-    if (shouldRestoreSizeOnUnsnap(windowId)) {
-        auto geo = m_service->validatedUnmanagedGeometry(windowId, screenId);
-        if (geo) {
-            Q_EMIT applyGeometryRequested(windowId, 0, 0, geo->width(), geo->height(), QString(), screenId, true);
-            // Single float-back store: clear the record's shared free geometry now
-            // that we've consumed it for this drag-out restore.
-            m_service->clearFreeGeometry(windowId);
-            qCInfo(lcDbusWindow) << "Drag-out unsnap: restoring size" << geo->width() << "x" << geo->height();
-        }
+    // Dimension guard mirrors the drop.cpp twin: a degenerate stored rect
+    // produces a RestoreSize outcome that validates to "requires non-zero
+    // size" and is dropped effect-side — don't claim success for it.
+    if (preSnapGeo && preSnapGeo->width() > 0 && preSnapGeo->height() > 0) {
+        Q_EMIT applyGeometryRequested(windowId, 0, 0, preSnapGeo->width(), preSnapGeo->height(), QString(), screenId,
+                                      true);
+        // Consume-once, per screen: only this screen's float-back was used;
+        // other monitors' remembered positions stay intact.
+        m_service->clearFreeGeometry(windowId, screenId);
+        qCInfo(lcDbusWindow) << "Drag-out unsnap: restoring size" << preSnapGeo->width() << "x" << preSnapGeo->height();
+    } else if (preSnapGeo) {
+        qCInfo(lcDbusWindow) << "Drag-out unsnap: degenerate stored size for" << windowId << "— skipping restore";
     }
 }
 

--- a/src/dbus/windowtrackingadaptor/float.cpp
+++ b/src/dbus/windowtrackingadaptor/float.cpp
@@ -171,7 +171,16 @@ bool WindowTrackingAdaptor::relayWindowFloatingChanged(const QString& windowId, 
     // subscribers last heard, or the gate turns from a dedup into a
     // suppressor of genuine changes. setWindowFloating delegates here too.
     const QString shadowId = shadowWindowId(windowId);
-    if (m_broadcastFloating.value(shadowId, false) == floating) {
+    // Absent entry NEVER counts as a match. The map is populated only by this
+    // relay, so after a daemon restart it is empty while WTS has restored
+    // floating windows and subscribers still believe "floating" — treating
+    // absent as false would swallow the first genuine unfloat entirely (no
+    // signal, and via setWindowFloating's early return no state-change
+    // emission or capture refresh either). The cost is one redundant
+    // broadcast per window on its first relay, which subscribers absorb
+    // idempotently.
+    const auto it = m_broadcastFloating.constFind(shadowId);
+    if (it != m_broadcastFloating.constEnd() && it.value() == floating) {
         return false;
     }
     m_broadcastFloating[shadowId] = floating;
@@ -184,21 +193,39 @@ void WindowTrackingAdaptor::setWindowFloatingForScreen(const QString& windowId, 
     if (!validateWindowId(windowId, QStringLiteral("set float for screen"))) {
         return;
     }
+    // Boundary validation: an empty screenId makes isActiveOnScreen("") read
+    // false and silently routes an autotiled window's float traffic to the
+    // snap engine — a dead-end on the wrong slot. Recover via the window's
+    // tracked screen when possible; otherwise refuse loudly.
+    QString effectiveScreenId = screenId;
+    if (effectiveScreenId.isEmpty() && m_service) {
+        effectiveScreenId = m_service->screenForWindow(windowId);
+    }
+    if (effectiveScreenId.isEmpty()) {
+        qCWarning(lcDbusWindow) << "setWindowFloatingForScreen: no screen for" << windowId << "— refusing";
+        return;
+    }
 
     qCInfo(lcDbusWindow) << "setWindowFloatingForScreen: windowId=" << windowId << "floating=" << floating
-                         << "screen=" << screenId;
+                         << "screen=" << effectiveScreenId;
 
     // Route to the correct engine based on screen mode. Both directions go
     // through the explicit cross-engine handoff contract when the window
     // isn't yet tracked by the destination engine.
     PhosphorEngine::PlacementEngineBase* dest = nullptr;
     PhosphorEngine::PlacementEngineBase* source = nullptr;
-    if (m_autotileEngine && m_autotileEngine->isActiveOnScreen(screenId)) {
+    if (m_autotileEngine && m_autotileEngine->isActiveOnScreen(effectiveScreenId)) {
         dest = m_autotileEngine.data();
         source = m_snapEngine.data();
     } else if (m_snapEngine) {
         dest = m_snapEngine.data();
         source = m_autotileEngine.data();
+    } else {
+        // Both engine QPointers null (late-shutdown D-Bus traffic): a silent
+        // no-op on a public entry point is undiagnosable — log like every
+        // other bail in this file.
+        qCWarning(lcDbusWindow) << "setWindowFloatingForScreen: no engine wired for" << effectiveScreenId;
+        return;
     }
 
     // Float: adopt an untracked window unconditionally (a brand-new floating
@@ -231,7 +258,7 @@ void WindowTrackingAdaptor::setWindowFloatingForScreen(const QString& windowId, 
         if (floating || (sourceTracked && destIsAutotile)) {
             PhosphorEngine::IPlacementEngine::HandoffContext ctx;
             ctx.windowId = windowId;
-            ctx.toScreenId = screenId;
+            ctx.toScreenId = effectiveScreenId;
             ctx.wasFloating = floating;
             if (sourceTracked) {
                 ctx.fromEngineId = source->engineId();
@@ -240,11 +267,20 @@ void WindowTrackingAdaptor::setWindowFloatingForScreen(const QString& windowId, 
             }
             dest->handoffReceive(ctx);
             if (!floating) {
-                relayWindowFloatingChanged(windowId, false, screenId);
+                relayWindowFloatingChanged(windowId, false, effectiveScreenId);
             }
         } else if (sourceTracked) {
             source->handoffRelease(windowId);
-            relayWindowFloatingChanged(windowId, false, screenId);
+            relayWindowFloatingChanged(windowId, false, effectiveScreenId);
+            recaptureAfterFloatWrite = true;
+        } else if (!floating) {
+            // Fourth case: unfloat with NEITHER engine tracking the window
+            // (its tracking was torn down while minimized/mode-flipped). The
+            // setWindowFloat below can fail open with no signal at all, which
+            // leaves the effect's float cache stuck at the last broadcast
+            // (typically true from a minimize-float) until a restart — so the
+            // not-floating edge must always reach subscribers.
+            relayWindowFloatingChanged(windowId, false, effectiveScreenId);
             recaptureAfterFloatWrite = true;
         }
     }
@@ -255,7 +291,7 @@ void WindowTrackingAdaptor::setWindowFloatingForScreen(const QString& windowId, 
         // (possibly stale) tracked association. Without this, unfloating a window
         // that drifted to another monitor while floating non-deterministically
         // teleports it back to its source-monitor zone (Discussion #724).
-        dest->setWindowFloat(windowId, floating, screenId);
+        dest->setWindowFloat(windowId, floating, effectiveScreenId);
     }
     if (recaptureAfterFloatWrite) {
         // Snap-dest unfloat: re-anchor the live placement record after the

--- a/src/dbus/windowtrackingadaptor/lifecycle.cpp
+++ b/src/dbus/windowtrackingadaptor/lifecycle.cpp
@@ -433,7 +433,6 @@ void WindowTrackingAdaptor::windowScreenChanged(const QString& windowId, const Q
         ctx.toScreenId = newScreenId;
         ctx.fromEngineId = source ? source->engineId() : QString();
         ctx.wasFloating = true;
-        ctx.sourceGeometry = m_frameGeometry.value(shadowWindowId(windowId));
         if (source && source != dest) {
             source->handoffRelease(windowId);
         }

--- a/src/dbus/windowtrackingadaptor/lifecycle.cpp
+++ b/src/dbus/windowtrackingadaptor/lifecycle.cpp
@@ -73,6 +73,11 @@ void WindowTrackingAdaptor::captureWindowPlacement(const QString& windowId, cons
         treatAsMinimized =
             minimized.value_or(m_windowRegistry->contains(PhosphorIdentity::WindowId::extractInstanceId(windowId)));
     }
+    // The suspension-float classification outlives the live minimize bit: on
+    // the unminimize edge isMinimized flips false immediately while the
+    // unfloat only commits after the animation grace, and a capture landing
+    // inside that window must still take the preserve path.
+    treatAsMinimized = treatAsMinimized || m_service->isSuspensionFloat(windowId);
     if (treatAsMinimized && !fromStateChange) {
         if (authoritativeScreen.isEmpty()) {
             qCDebug(lcDbusWindow) << "Skipping placement capture for minimized window" << windowId;
@@ -542,6 +547,8 @@ void WindowTrackingAdaptor::windowClosed(const QString& windowId, int windowKind
     m_frameGeometry.remove(shadowId);
     // Drop the last-broadcast floating state for this window.
     m_broadcastFloating.remove(shadowId);
+    // Session-transient suspension-float classification dies with the window.
+    m_service->clearSuspensionFloat(windowId);
 
     m_service->windowClosed(windowId, kind);
 

--- a/src/dbus/windowtrackingadaptor/lifecycle.cpp
+++ b/src/dbus/windowtrackingadaptor/lifecycle.cpp
@@ -118,7 +118,7 @@ void WindowTrackingAdaptor::captureWindowPlacement(const QString& windowId, cons
             const bool unmanagedState = (slot.state == PhosphorEngine::WindowPlacement::stateFloating())
                 && !m_service->isWindowAutotileTiled(windowId);
             if (unmanagedState) {
-                const QRect frame = m_frameGeometry.value(windowId);
+                const QRect frame = m_frameGeometry.value(shadowWindowId(windowId));
                 if (frame.isValid()) {
                     // Screen key for the shared free/float geometry. The owning engine
                     // normally reports the window's screen, but a FLOATING window whose
@@ -225,7 +225,7 @@ void WindowTrackingAdaptor::captureWindowPlacement(const QString& windowId, cons
     // Scoped to the engine-miss path so a normally-tracked close (an engine captured
     // above and returned) is never second-guessed.
     if (!authoritativeScreen.isEmpty() && m_service && !m_service->isWindowAutotileTiled(windowId)) {
-        const QRect frame = m_frameGeometry.value(windowId);
+        const QRect frame = m_frameGeometry.value(shadowWindowId(windowId));
         // Same tile-rect poison guard as the primary capture path (see the
         // helper doc): a window tiled by autotile, handed off, and closed
         // before ever being repositioned still sits on its tile rect —
@@ -251,6 +251,11 @@ void WindowTrackingAdaptor::captureWindowPlacement(const QString& windowId, cons
 bool WindowTrackingAdaptor::isFrameStillOnTileRect(const QString& windowId, const QRect& frame) const
 {
     return m_autotileEngine && m_autotileEngine->lastManagedRect(windowId) == frame;
+}
+
+QString WindowTrackingAdaptor::shadowWindowId(const QString& windowId) const
+{
+    return m_service ? m_service->canonicalizeForLookup(windowId) : windowId;
 }
 
 void WindowTrackingAdaptor::refreshOpenWindowPlacements()
@@ -349,7 +354,7 @@ void WindowTrackingAdaptor::windowScreenChanged(const QString& windowId, const Q
         ctx.toScreenId = newScreenId;
         ctx.fromEngineId = source ? source->engineId() : QString();
         ctx.wasFloating = true;
-        ctx.sourceGeometry = m_frameGeometry.value(windowId);
+        ctx.sourceGeometry = m_frameGeometry.value(shadowWindowId(windowId));
         if (source && source != dest) {
             source->handoffRelease(windowId);
         }
@@ -440,7 +445,8 @@ void WindowTrackingAdaptor::windowClosed(const QString& windowId, int windowKind
     // Clear active window tracking if the closed window was the active one.
     // Without this, navigation shortcuts after closing the active window would
     // operate on a stale ID, producing confusing OSD failure messages.
-    if (m_lastActiveWindowId == windowId) {
+    const QString instanceId = PhosphorIdentity::WindowId::extractInstanceId(windowId);
+    if (PhosphorIdentity::WindowId::extractInstanceId(m_lastActiveWindowId) == instanceId) {
         m_lastActiveWindowId.clear();
     }
 
@@ -461,9 +467,10 @@ void WindowTrackingAdaptor::windowClosed(const QString& windowId, int windowKind
     captureWindowPlacement(windowId, screenId);
 
     // Drop frame-geometry shadow entry for this window.
-    m_frameGeometry.remove(windowId);
+    const QString shadowId = shadowWindowId(windowId);
+    m_frameGeometry.remove(shadowId);
     // Drop the last-broadcast floating state for this window.
-    m_broadcastFloating.remove(windowId);
+    m_broadcastFloating.remove(shadowId);
 
     m_service->windowClosed(windowId, kind);
 
@@ -473,9 +480,7 @@ void WindowTrackingAdaptor::windowClosed(const QString& windowId, int windowKind
     // disappear signal fires synchronously from remove() and subscribers may
     // still call canonicalizeForLookup on their way out.
     if (m_windowRegistry) {
-        const QString instanceId = PhosphorIdentity::WindowId::extractInstanceId(windowId);
         m_windowRegistry->remove(instanceId);
-        m_windowRegistry->releaseCanonical(instanceId);
     }
 
     // Drive in-process sibling-adaptor cleanup (WindowDragAdaptor) without
@@ -687,7 +692,7 @@ void WindowTrackingAdaptor::setFrameGeometry(const QString& windowId, int x, int
     if (windowId.isEmpty() || width <= 0 || height <= 0) {
         return;
     }
-    m_frameGeometry[windowId] = QRect(x, y, width, height);
+    m_frameGeometry[shadowWindowId(windowId)] = QRect(x, y, width, height);
 }
 
 void WindowTrackingAdaptor::notifyWindowResized(const QString& windowId, int oldX, int oldY, int oldWidth,
@@ -706,7 +711,7 @@ void WindowTrackingAdaptor::notifyWindowResized(const QString& windowId, int old
 
     const QRect newFrame(newX, newY, newWidth, newHeight);
     // Keep the frame shadow in sync with the committed geometry.
-    m_frameGeometry[windowId] = newFrame;
+    m_frameGeometry[shadowWindowId(windowId)] = newFrame;
 
     if (!m_autotileEngine) {
         return;
@@ -729,7 +734,7 @@ void WindowTrackingAdaptor::windowActivated(const QString& windowId, const QStri
     }
 
     // Track the active window for daemon-driven navigation (move/focus/swap/etc.)
-    m_lastActiveWindowId = windowId;
+    m_lastActiveWindowId = shadowWindowId(windowId);
 
     // Track the active window's screen as fallback for shortcut screen detection.
     // The primary source is now cursorScreenChanged (from KWin effect's mouseChanged).
@@ -817,7 +822,7 @@ void WindowTrackingAdaptor::pruneStaleWindows(const QStringList& aliveWindowIds)
     // case — extend the same alive-set filter to m_frameGeometry.
     int frameGeoPruned = 0;
     for (auto it = m_frameGeometry.begin(); it != m_frameGeometry.end();) {
-        if (!alive.contains(it.key())) {
+        if (!aliveInstances.contains(PhosphorIdentity::WindowId::extractInstanceId(it.key()))) {
             it = m_frameGeometry.erase(it);
             ++frameGeoPruned;
         } else {
@@ -828,7 +833,7 @@ void WindowTrackingAdaptor::pruneStaleWindows(const QStringList& aliveWindowIds)
     // would otherwise leak if the window died without a windowClosed signal.
     // Not persisted, so it does not feed the save-scheduling decision below.
     for (auto it = m_broadcastFloating.begin(); it != m_broadcastFloating.end();) {
-        if (!alive.contains(it.key())) {
+        if (!aliveInstances.contains(PhosphorIdentity::WindowId::extractInstanceId(it.key()))) {
             it = m_broadcastFloating.erase(it);
         } else {
             ++it;

--- a/src/dbus/windowtrackingadaptor/lifecycle.cpp
+++ b/src/dbus/windowtrackingadaptor/lifecycle.cpp
@@ -47,6 +47,17 @@ void WindowTrackingAdaptor::captureWindowPlacement(const QString& windowId, cons
     if (windowId.isEmpty() || !m_service) {
         return;
     }
+    // Minimize uses floating as a live suspension mechanism so the hidden
+    // window stops occupying a snap zone or autotile slot. It is not placement
+    // intent. Preserve the record exactly as it was before minimization rather
+    // than persisting that temporary float through passive, presave, periodic,
+    // close, or mode-transition captures. A genuinely user-floated window was
+    // already captured when it floated, so preserving its prior record is also
+    // correct while it is minimized.
+    if (m_windowRegistry && m_windowRegistry->isMinimized(windowId)) {
+        qCDebug(lcDbusWindow) << "Skipping placement capture for minimized window" << windowId;
+        return;
+    }
     // Capture from the engine that CURRENTLY OWNS this window, not merely the first
     // engine that returns a placement. The engines keep INDEPENDENT state (snap:
     // snapped / floated; autotile: tiled / floated), so a window now managed by

--- a/src/dbus/windowtrackingadaptor/lifecycle.cpp
+++ b/src/dbus/windowtrackingadaptor/lifecycle.cpp
@@ -15,6 +15,7 @@
 #include "persistenceworker.h"
 #include "dbus/zonedetectionadaptor.h"
 #include <PhosphorEngine/IPlacementEngine.h>
+#include <PhosphorIdentity/WindowId.h>
 #include <PhosphorTileEngine/AutotileEngine.h>
 #include <PhosphorSnapEngine/SnapEngine.h>
 #include "config/configbackends.h"
@@ -54,8 +55,33 @@ void WindowTrackingAdaptor::captureWindowPlacement(const QString& windowId, cons
     // close, or mode-transition captures. A genuinely user-floated window was
     // already captured when it floated, so preserving its prior record is also
     // correct while it is minimized.
-    if (m_windowRegistry && m_windowRegistry->isMinimized(windowId)) {
+    if (m_windowRegistry && m_windowRegistry->isMinimized(windowId) && authoritativeScreen.isEmpty()) {
         qCDebug(lcDbusWindow) << "Skipping placement capture for minimized window" << windowId;
+        return;
+    }
+    if (m_windowRegistry && m_windowRegistry->isMinimized(windowId)) {
+        std::optional<PhosphorEngine::WindowPlacement> preserved = m_service->placementStore().peekExact(windowId);
+        if (!preserved && m_autotileEngine) {
+            preserved = m_autotileEngine->capturePlacement(windowId);
+        }
+        if (!preserved) {
+            return;
+        }
+
+        preserved->windowId = shadowWindowId(windowId);
+        preserved->appId = m_service->currentAppIdFor(windowId);
+        preserved->screenId = authoritativeScreen;
+        const QString instanceId = PhosphorIdentity::WindowId::extractInstanceId(windowId);
+        if (const auto context = m_windowRegistry->windowContext(instanceId)) {
+            preserved->virtualDesktop = context->virtualDesktop;
+            preserved->activity = context->activity;
+        }
+        const bool recorded = m_service->placementStore().record(*preserved);
+        const bool collapsed =
+            m_service->placementStore().collapsePureFloatSiblings(preserved->appId, preserved->windowId);
+        if (recorded || collapsed) {
+            m_service->markDirty(PhosphorPlacement::WindowTrackingService::DirtyWindowPlacements);
+        }
         return;
     }
     // Capture from the engine that CURRENTLY OWNS this window, not merely the first

--- a/src/dbus/windowtrackingadaptor/lifecycle.cpp
+++ b/src/dbus/windowtrackingadaptor/lifecycle.cpp
@@ -778,6 +778,15 @@ void WindowTrackingAdaptor::windowActivated(const QString& windowId, const QStri
 void WindowTrackingAdaptor::pruneStaleWindows(const QStringList& aliveWindowIds)
 {
     const QSet<QString> alive(aliveWindowIds.begin(), aliveWindowIds.end());
+    QSet<QString> aliveInstances;
+    aliveInstances.reserve(aliveWindowIds.size());
+    for (const QString& id : aliveWindowIds) {
+        aliveInstances.insert(PhosphorIdentity::WindowId::extractInstanceId(id));
+    }
+    if (!m_lastActiveWindowId.isEmpty()
+        && !aliveInstances.contains(PhosphorIdentity::WindowId::extractInstanceId(m_lastActiveWindowId))) {
+        m_lastActiveWindowId.clear();
+    }
     int persistedPruned = m_service->pruneStaleAssignments(alive);
     if (m_autotileEngine) {
         // The autotile engine keys every internal map (m_states reverse map,
@@ -831,11 +840,6 @@ void WindowTrackingAdaptor::pruneStaleWindows(const QStringList& aliveWindowIds)
     // record + canonical entry for the session. The registry keys on instance
     // ids (uuid components), so build the alive set in that form.
     if (m_windowRegistry) {
-        QSet<QString> aliveInstances;
-        aliveInstances.reserve(aliveWindowIds.size());
-        for (const QString& id : aliveWindowIds) {
-            aliveInstances.insert(PhosphorIdentity::WindowId::extractInstanceId(id));
-        }
         m_windowRegistry->pruneStaleInstances(aliveInstances);
     }
     const int totalPruned = persistedPruned + frameGeoPruned;

--- a/src/dbus/windowtrackingadaptor/lifecycle.cpp
+++ b/src/dbus/windowtrackingadaptor/lifecycle.cpp
@@ -253,9 +253,12 @@ void WindowTrackingAdaptor::captureWindowPlacement(const QString& windowId, cons
             // breaking float/free geometry restore on the next open. Skip it: any
             // existing record for this window keeps its last meaningful state (a genuine
             // float/free transition always captures a valid frame, so it is never
-            // contentless — only a frame-less capture lands here).
+            // contentless — only a frame-less capture lands here). CONTINUE, not
+            // return: a contentless capture has not "won" the first-non-null
+            // ordering, and the other engine may still hold a real slot (a
+            // tiled window whose mode-flip left the primary with residue).
             if (!p->hasRestorableContent()) {
-                return;
+                continue;
             }
             // Only mark dirty when the store actually changed. A content-identical
             // re-capture (the common case — refreshOpenWindowPlacements re-captures
@@ -619,16 +622,23 @@ void WindowTrackingAdaptor::setWindowMetadata(const QString& instanceId, const Q
     }
     meta.windowType = PhosphorProtocol::windowTypeFromInt(windowType);
 
-    // Extended window-property snapshot (the trailing a{sv}). An EMPTY map is a
-    // caption-only refresh (the effect skips the snapshot on chatty title ticks):
-    // carry forward the registry's existing extended fields so a per-frame title
-    // update does not wipe geometry/state. A non-empty map fully replaces them —
-    // each key present only when the effect could observe the value, so an absent
-    // key disengages the optional (and its derived WindowQuery field), mirroring the
-    // effect-side engage-only-when-known contract in window_query.cpp. Lenient
-    // QVariant conversions are the boundary policy here, matching the pid /
-    // windowType clamping above (a malformed caller cannot corrupt placement).
-    if (extended.isEmpty()) {
+    // Extended window-property snapshot (the trailing a{sv}). An EMPTY map — or
+    // one carrying ONLY CaptionNormal — is a caption-only refresh (the effect
+    // skips the snapshot on chatty title ticks but still sends captionNormal,
+    // which derives from the caption and would otherwise stay permanently stale
+    // on exactly that path): carry forward the registry's existing extended
+    // fields so a per-frame title update does not wipe geometry/state, then take
+    // the fresh captionNormal when present. Any other non-empty map fully
+    // replaces them — each key present only when the effect could observe the
+    // value, so an absent key disengages the optional (and its derived
+    // WindowQuery field), mirroring the effect-side engage-only-when-known
+    // contract in window_query.cpp. Lenient QVariant conversions are the
+    // boundary policy here, matching the pid / windowType clamping above (a
+    // malformed caller cannot corrupt placement).
+    namespace Key = PhosphorProtocol::Service::WindowMetadataKey;
+    const bool captionOnlyRefresh =
+        extended.isEmpty() || (extended.size() == 1 && extended.contains(QString(Key::CaptionNormal)));
+    if (captionOnlyRefresh) {
         if (const std::optional<PhosphorEngine::WindowMetadata> existing = m_windowRegistry->metadata(instanceId)) {
             meta.isMinimized = existing->isMinimized;
             meta.isFullscreen = existing->isFullscreen;
@@ -654,8 +664,11 @@ void WindowTrackingAdaptor::setWindowMetadata(const QString& instanceId, const Q
             meta.captionNormal = existing->captionNormal;
             meta.virtualDesktops = existing->virtualDesktops;
         }
+        // Fresh captionNormal from the caption tick, when the effect sent one.
+        if (const auto it = extended.constFind(QString(Key::CaptionNormal)); it != extended.constEnd()) {
+            meta.captionNormal = it.value().toString();
+        }
     } else {
-        namespace Key = PhosphorProtocol::Service::WindowMetadataKey;
         const auto optBool = [&extended](QLatin1String key) -> std::optional<bool> {
             const auto it = extended.constFind(QString(key));
             return it != extended.constEnd() ? std::optional<bool>(it.value().toBool()) : std::nullopt;

--- a/src/dbus/windowtrackingadaptor/lifecycle.cpp
+++ b/src/dbus/windowtrackingadaptor/lifecycle.cpp
@@ -922,6 +922,17 @@ void WindowTrackingAdaptor::windowActivated(const QString& windowId, const QStri
 
 void WindowTrackingAdaptor::pruneStaleWindows(const QStringList& aliveWindowIds)
 {
+    // Fail CLOSED on an empty alive set, agreeing with both callees
+    // (pruneStaleAssignments and pruneStaleInstances refuse it with a
+    // warning): the effect's one-shot alive report at daemon-ready can fire
+    // before session-restored apps have mapped, and wiping the shadow stores
+    // (m_frameGeometry, m_broadcastFloating) on that empty report would
+    // silence refreshOpenWindowPlacements and drop the close-path capture
+    // fallback until the effect re-pushes.
+    if (aliveWindowIds.isEmpty()) {
+        qCWarning(lcDbusWindow) << "pruneStaleWindows: refusing empty alive set — nothing pruned";
+        return;
+    }
     const QSet<QString> alive(aliveWindowIds.begin(), aliveWindowIds.end());
     QSet<QString> aliveInstances;
     aliveInstances.reserve(aliveWindowIds.size());

--- a/src/dbus/windowtrackingadaptor/lifecycle.cpp
+++ b/src/dbus/windowtrackingadaptor/lifecycle.cpp
@@ -43,7 +43,8 @@
 
 namespace PlasmaZones {
 
-void WindowTrackingAdaptor::captureWindowPlacement(const QString& windowId, const QString& authoritativeScreen)
+void WindowTrackingAdaptor::captureWindowPlacement(const QString& windowId, const QString& authoritativeScreen,
+                                                   bool fromStateChange)
 {
     if (windowId.isEmpty() || !m_service) {
         return;
@@ -55,28 +56,72 @@ void WindowTrackingAdaptor::captureWindowPlacement(const QString& windowId, cons
     // close, or mode-transition captures. A genuinely user-floated window was
     // already captured when it floated, so preserving its prior record is also
     // correct while it is minimized.
-    if (m_windowRegistry && m_windowRegistry->isMinimized(windowId) && authoritativeScreen.isEmpty()) {
-        qCDebug(lcDbusWindow) << "Skipping placement capture for minimized window" << windowId;
-        return;
+    //
+    // Tri-state, not the collapsed bool: a REGISTERED window whose minimize
+    // state was never delivered cannot be proven visible, so it takes the
+    // guard too (capturing it would risk persisting the suspension float).
+    // An UNREGISTERED window (no record at all — already pruned, or a
+    // registry-less test service) keeps the plain capture path.
+    //
+    // An authoritative ENGINE STATE CHANGE bypasses the guard entirely: the
+    // engine then reports the freshly committed state (a resnap sweep can
+    // legitimately re-zone a minimized window), which is exactly what the
+    // record should hold. See the fromStateChange doc on the declaration.
+    bool treatAsMinimized = false;
+    if (m_windowRegistry) {
+        const std::optional<bool> minimized = m_windowRegistry->minimizedState(windowId);
+        treatAsMinimized =
+            minimized.value_or(m_windowRegistry->contains(PhosphorIdentity::WindowId::extractInstanceId(windowId)));
     }
-    if (m_windowRegistry && m_windowRegistry->isMinimized(windowId)) {
-        std::optional<PhosphorEngine::WindowPlacement> preserved = m_service->placementStore().peekExact(windowId);
-        if (!preserved && m_autotileEngine) {
-            preserved = m_autotileEngine->capturePlacement(windowId);
+    if (treatAsMinimized && !fromStateChange) {
+        if (authoritativeScreen.isEmpty()) {
+            qCDebug(lcDbusWindow) << "Skipping placement capture for minimized window" << windowId;
+            return;
         }
+        // NOTE: AutotileEngine::capturePlacement has its own minimize-preserve
+        // branch (facade.cpp) for engine-internal sweeps that never pass
+        // through this adaptor; the two deliberately coexist. No engine
+        // fallback here: when the store has nothing to preserve, the engines
+        // can only report the generic live capture — a bare suspension float,
+        // the very record this branch exists to keep out of the store.
+        std::optional<PhosphorEngine::WindowPlacement> preserved = m_service->placementStore().peekExact(windowId);
         if (!preserved) {
             return;
         }
 
         preserved->windowId = shadowWindowId(windowId);
         preserved->appId = m_service->currentAppIdFor(windowId);
+        // What is preserved is the PLACEMENT (engine slots + free geometry).
+        // The CONTEXT is deliberately refreshed: authoritativeScreen is where
+        // the window actually closed, and windowContext() is the window's OWN
+        // desktop/activity from its live registry metadata (kept current by
+        // the effect's desktopsChanged/activitiesChanged pushes) — a window
+        // moved to another desktop while minimized must reopen there, not on
+        // the desktop frozen into a pre-minimize record.
         preserved->screenId = authoritativeScreen;
         const QString instanceId = PhosphorIdentity::WindowId::extractInstanceId(windowId);
         if (const auto context = m_windowRegistry->windowContext(instanceId)) {
             preserved->virtualDesktop = context->virtualDesktop;
             preserved->activity = context->activity;
         }
+        // A pure-float record carries no engine slot, and record()'s merge
+        // only adopts context alongside engine slots — synthesize a floating
+        // slot (recordFloatingClose's convention) so the close screen lands.
+        if (preserved->engines.isEmpty() && !preserved->freeGeometryByScreen.isEmpty()) {
+            PhosphorEngine::EngineSlot slot;
+            slot.state = PhosphorEngine::WindowPlacement::stateFloating();
+            preserved->engines.insert(QString(PhosphorEngine::WindowPlacement::snapEngineId()), slot);
+        }
+        // Contentless residue must never enter the appId FIFO (mirrors the
+        // primary capture path's gate): it would starve and evict real
+        // placements.
+        if (!preserved->hasRestorableContent()) {
+            return;
+        }
         const bool recorded = m_service->placementStore().record(*preserved);
+        // Close-path-only prune (this branch requires a non-empty
+        // authoritativeScreen above, which only the close path supplies) —
+        // live captures must never prune siblings.
         const bool collapsed =
             m_service->placementStore().collapsePureFloatSiblings(preserved->appId, preserved->windowId);
         if (recorded || collapsed) {

--- a/src/dbus/windowtrackingadaptor/lifecycle.cpp
+++ b/src/dbus/windowtrackingadaptor/lifecycle.cpp
@@ -310,7 +310,9 @@ void WindowTrackingAdaptor::captureWindowPlacement(const QString& windowId, cons
     // record the float-back there so the next open restores to the right monitor.
     // Scoped to the engine-miss path so a normally-tracked close (an engine captured
     // above and returned) is never second-guessed.
-    if (!authoritativeScreen.isEmpty() && m_service && !m_service->isWindowAutotileTiled(windowId)) {
+    // No m_service re-check: the entry guard at the top of this function
+    // already established it.
+    if (!authoritativeScreen.isEmpty() && !m_service->isWindowAutotileTiled(windowId)) {
         const QRect frame = m_frameGeometry.value(shadowWindowId(windowId));
         // Same tile-rect poison guard as the primary capture path (see the
         // helper doc): a window tiled by autotile, handed off, and closed
@@ -790,8 +792,10 @@ void WindowTrackingAdaptor::cursorScreenChanged(const QString& screenId)
     if (!PhosphorIdentity::VirtualScreenId::isVirtual(screenId)) {
         auto* mgr = m_service->screenManager();
         if (mgr && mgr->hasVirtualScreens(screenId)) {
-            // Use focused window's tracked screen as hint
-            if (m_service && !m_lastActiveWindowId.isEmpty()) {
+            // Use focused window's tracked screen as hint. No m_service
+            // guard: the deref above already relies on it (ctor-owned,
+            // never null).
+            if (!m_lastActiveWindowId.isEmpty()) {
                 const QString trackedScreen = m_service->screenForWindow(m_lastActiveWindowId);
                 if (PhosphorIdentity::VirtualScreenId::isVirtual(trackedScreen)
                     && PhosphorIdentity::VirtualScreenId::extractPhysicalId(trackedScreen) == screenId) {
@@ -985,7 +989,8 @@ void WindowTrackingAdaptor::pruneStaleWindows(const QStringList& aliveWindowIds)
     }
     const int totalPruned = persistedPruned + frameGeoPruned;
     if (totalPruned > 0) {
-        qCInfo(lcDbusWindow) << "Pruned" << totalPruned << "stale window assignments (not in KWin)";
+        qCInfo(lcDbusWindow) << "Pruned" << persistedPruned << "stale persisted assignments and" << frameGeoPruned
+                             << "shadow entries (not in KWin)";
     }
     // Only schedule a save when something PERSISTED was pruned. Frame-
     // geometry is the compositor-layer shadow store (not on disk), so a

--- a/src/dbus/windowtrackingadaptor/lifecycle.cpp
+++ b/src/dbus/windowtrackingadaptor/lifecycle.cpp
@@ -713,7 +713,8 @@ void WindowTrackingAdaptor::setWindowMetadata(const QString& instanceId, const Q
     // window even after the effect restarts and re-derives a mutated-class
     // composite for it. Idempotent: the instance id is stable, so a later push
     // carrying a mutated appId returns the original composite rather than
-    // re-seeding (issue #628). Cleaned up by releaseCanonical on windowClosed.
+    // re-seeding (issue #628). The registry's own remove() retires the mapping
+    // when the window closes.
     m_windowRegistry->canonicalizeWindowId(PhosphorIdentity::WindowId::buildCompositeId(appId, instanceId));
 
     m_windowRegistry->upsert(instanceId, meta);

--- a/src/dbus/windowtrackingadaptor/lifecycle.cpp
+++ b/src/dbus/windowtrackingadaptor/lifecycle.cpp
@@ -69,9 +69,12 @@ void WindowTrackingAdaptor::captureWindowPlacement(const QString& windowId, cons
     // record should hold. See the fromStateChange doc on the declaration.
     bool treatAsMinimized = false;
     if (m_windowRegistry) {
+        // Per-capture hot path: only pay the contains() lookup when the
+        // optional is actually disengaged.
         const std::optional<bool> minimized = m_windowRegistry->minimizedState(windowId);
-        treatAsMinimized =
-            minimized.value_or(m_windowRegistry->contains(PhosphorIdentity::WindowId::extractInstanceId(windowId)));
+        treatAsMinimized = minimized.has_value()
+            ? *minimized
+            : m_windowRegistry->contains(PhosphorIdentity::WindowId::extractInstanceId(windowId));
     }
     // The suspension-float classification outlives the live minimize bit: on
     // the unminimize edge isMinimized flips false immediately while the
@@ -670,6 +673,13 @@ void WindowTrackingAdaptor::setWindowMetadata(const QString& instanceId, const Q
     // contract in window_query.cpp. Lenient QVariant conversions are the
     // boundary policy here, matching the pid / windowType clamping above (a
     // malformed caller cannot corrupt placement).
+    //
+    // Known sentinel ambiguity, accepted: a FULL push whose optionals are all
+    // disengaged would also arrive as an empty map and be read as a caption
+    // refresh. Unreachable from the effect today (geometry keys are always
+    // engaged for a live window), and the wire doc forbids senders using the
+    // empty shape to mean "nothing known" — an explicit refresh marker would
+    // be the upgrade path if a second bridge ever needs it.
     namespace Key = PhosphorProtocol::Service::WindowMetadataKey;
     const bool captionOnlyRefresh =
         extended.isEmpty() || (extended.size() == 1 && extended.contains(QString(Key::CaptionNormal)));

--- a/src/dbus/windowtrackingadaptor/lifecycle.cpp
+++ b/src/dbus/windowtrackingadaptor/lifecycle.cpp
@@ -96,6 +96,13 @@ void WindowTrackingAdaptor::captureWindowPlacement(const QString& windowId, cons
 
         preserved->windowId = shadowWindowId(windowId);
         preserved->appId = m_service->currentAppIdFor(windowId);
+        if (preserved->appId.isEmpty()) {
+            // record() rejects an appId-less record, so the preserve would be
+            // a silent no-op — say so instead of vanishing.
+            qCDebug(lcDbusWindow) << "captureWindowPlacement: empty appId for minimized preserve of" << windowId
+                                  << "— skipping";
+            return;
+        }
         // What is preserved is the PLACEMENT (engine slots + free geometry).
         // The CONTEXT is deliberately refreshed: authoritativeScreen is where
         // the window actually closed, and windowContext() is the window's OWN
@@ -352,9 +359,13 @@ void WindowTrackingAdaptor::refreshOpenWindowPlacements()
     if (!m_service) {
         return;
     }
-    for (auto it = m_frameGeometry.constBegin(); it != m_frameGeometry.constEnd(); ++it) {
-        if (it.value().isValid()) {
-            captureWindowPlacement(it.key());
+    // Snapshot the keys before iterating: captureWindowPlacement fans out into
+    // engine code and signal handlers that can reach the m_frameGeometry
+    // writers, and mutating a QHash mid-iteration is undefined.
+    const QList<QString> windowIds = m_frameGeometry.keys();
+    for (const QString& windowId : windowIds) {
+        if (m_frameGeometry.value(windowId).isValid()) {
+            captureWindowPlacement(windowId);
         }
     }
 }
@@ -437,6 +448,11 @@ void WindowTrackingAdaptor::windowScreenChanged(const QString& windowId, const Q
             source->handoffRelease(windowId);
         }
         dest->handoffReceive(ctx);
+        // No windowStateChanged "screen_changed" entry here, unlike the
+        // snapped branch below: the receive path's windowFloatingChanged
+        // relay already carries the DESTINATION screen to subscribers, so a
+        // second push would be redundant; anything else about a floating
+        // window's screen is pull-resolved (screenForWindow) on demand.
         qCInfo(lcDbusWindow) << "windowScreenChanged: floating window" << windowId << "moved from" << trackedScreen
                              << "to" << newScreenId << "- handoff complete";
         return;
@@ -542,17 +558,35 @@ void WindowTrackingAdaptor::windowClosed(const QString& windowId, int windowKind
     // orphaned the window from both engines' tracking by close time, both engine
     // capturePlacement calls miss/decline and the real screen would be lost —
     // captureWindowPlacement falls back to this screen to record the float-back.
-    captureWindowPlacement(windowId, screenId);
+    // Validate the effect-supplied close screen before it becomes the
+    // persisted record's managed context: a stale id (output unplugged
+    // mid-close) would poison the reopen screen. Fall back to resolving from
+    // the live frame's centre; an empty result makes the capture keep the
+    // record's prior screen, which is strictly better than adopting a dead
+    // one.
+    QString closeScreen = screenId;
+    if (!closeScreen.isEmpty() && m_service->screenManager()
+        && !m_service->screenManager()->physicalScreenFor(closeScreen).isValid()) {
+        const QRect closeFrame = m_frameGeometry.value(shadowWindowId(windowId));
+        closeScreen = closeFrame.isValid() ? Utils::effectiveScreenIdAt(m_service->screenManager(), closeFrame.center())
+                                           : QString();
+        qCDebug(lcDbusWindow) << "windowClosed: unknown close screen" << screenId << "for" << windowId
+                              << "— resolved to" << closeScreen;
+    }
+    captureWindowPlacement(windowId, closeScreen);
 
-    // Drop frame-geometry shadow entry for this window.
-    const QString shadowId = shadowWindowId(windowId);
-    m_frameGeometry.remove(shadowId);
-    // Drop the last-broadcast floating state for this window.
-    m_broadcastFloating.remove(shadowId);
     // Session-transient suspension-float classification dies with the window.
     m_service->clearSuspensionFloat(windowId);
 
     m_service->windowClosed(windowId, kind);
+
+    // Drop the shadow maps AFTER the service teardown: windowClosed's cascade
+    // can synchronously re-enter the float relay, and a relay landing between
+    // an earlier removal and the teardown would re-insert a zombie
+    // last-broadcast entry that outlives the window.
+    const QString shadowId = shadowWindowId(windowId);
+    m_frameGeometry.remove(shadowId);
+    m_broadcastFloating.remove(shadowId);
 
     // Drop registry state last: consumers subscribed to windowDisappeared may
     // rely on other WTS state still being present during their cleanup. The
@@ -639,79 +673,90 @@ void WindowTrackingAdaptor::setWindowMetadata(const QString& instanceId, const Q
         extended.isEmpty() || (extended.size() == 1 && extended.contains(QString(Key::CaptionNormal)));
     if (captionOnlyRefresh) {
         if (const std::optional<PhosphorEngine::WindowMetadata> existing = m_windowRegistry->metadata(instanceId)) {
-            meta.isMinimized = existing->isMinimized;
-            meta.isFullscreen = existing->isFullscreen;
-            meta.isSticky = existing->isSticky;
-            meta.isMaximized = existing->isMaximized;
-            meta.isFocused = existing->isFocused;
-            meta.isTransient = existing->isTransient;
-            meta.isNotification = existing->isNotification;
-            meta.keepAbove = existing->keepAbove;
-            meta.keepBelow = existing->keepBelow;
-            meta.skipTaskbar = existing->skipTaskbar;
-            meta.skipPager = existing->skipPager;
-            meta.skipSwitcher = existing->skipSwitcher;
-            meta.isModal = existing->isModal;
-            meta.hasDecoration = existing->hasDecoration;
-            meta.isResizable = existing->isResizable;
-            meta.isMovable = existing->isMovable;
-            meta.isMaximizable = existing->isMaximizable;
-            meta.width = existing->width;
-            meta.height = existing->height;
-            meta.positionX = existing->positionX;
-            meta.positionY = existing->positionY;
-            meta.captionNormal = existing->captionNormal;
-            meta.virtualDesktops = existing->virtualDesktops;
+            // Carry the WHOLE existing record forward, then re-apply the
+            // handful of fields THIS push is authoritative for (the plain
+            // D-Bus arguments parsed above). A hand-copied per-field
+            // carry-forward silently dropped every extended field later added
+            // to WindowMetadata.
+            const PhosphorEngine::WindowMetadata fresh = meta;
+            meta = *existing;
+            meta.appId = fresh.appId;
+            meta.desktopFile = fresh.desktopFile;
+            meta.title = fresh.title;
+            meta.windowRole = fresh.windowRole;
+            meta.pid = fresh.pid;
+            meta.virtualDesktop = fresh.virtualDesktop;
+            meta.activity = fresh.activity;
+            meta.windowType = fresh.windowType;
         }
         // Fresh captionNormal from the caption tick, when the effect sent one.
         if (const auto it = extended.constFind(QString(Key::CaptionNormal)); it != extended.constEnd()) {
             meta.captionNormal = it.value().toString();
         }
     } else {
-        const auto optBool = [&extended](QLatin1String key) -> std::optional<bool> {
-            const auto it = extended.constFind(QString(key));
-            return it != extended.constEnd() ? std::optional<bool>(it.value().toBool()) : std::nullopt;
-        };
-        const auto optInt = [&extended](QLatin1String key) -> std::optional<int> {
-            const auto it = extended.constFind(QString(key));
-            return it != extended.constEnd() ? std::optional<int>(it.value().toInt()) : std::nullopt;
-        };
-        const auto optString = [&extended](QLatin1String key) -> std::optional<QString> {
-            const auto it = extended.constFind(QString(key));
-            return it != extended.constEnd() ? std::optional<QString>(it.value().toString()) : std::nullopt;
-        };
-        meta.isMinimized = optBool(Key::IsMinimized);
-        meta.isFullscreen = optBool(Key::IsFullscreen);
-        meta.isSticky = optBool(Key::IsSticky);
-        meta.isMaximized = optBool(Key::IsMaximized);
-        meta.isFocused = optBool(Key::IsFocused);
-        meta.isTransient = optBool(Key::IsTransient);
-        meta.isNotification = optBool(Key::IsNotification);
-        meta.keepAbove = optBool(Key::KeepAbove);
-        meta.keepBelow = optBool(Key::KeepBelow);
-        meta.skipTaskbar = optBool(Key::SkipTaskbar);
-        meta.skipPager = optBool(Key::SkipPager);
-        meta.skipSwitcher = optBool(Key::SkipSwitcher);
-        meta.isModal = optBool(Key::IsModal);
-        meta.hasDecoration = optBool(Key::HasDecoration);
-        meta.isResizable = optBool(Key::IsResizable);
-        meta.isMovable = optBool(Key::IsMovable);
-        meta.isMaximizable = optBool(Key::IsMaximizable);
-        meta.width = optInt(Key::Width);
-        meta.height = optInt(Key::Height);
-        meta.positionX = optInt(Key::PositionX);
-        meta.positionY = optInt(Key::PositionY);
-        meta.captionNormal = optString(Key::CaptionNormal);
-        // Multi-desktop span list (absent for single-desktop / sticky windows,
-        // so an absent key correctly clears a previous span). Same lenient
-        // QVariant conversion policy as the fields above.
-        if (const auto it = extended.constFind(QString(Key::VirtualDesktops)); it != extended.constEnd()) {
-            const QVariantList list = it.value().toList();
-            meta.virtualDesktops.reserve(list.size());
-            for (const QVariant& v : list) {
-                const int d = v.toInt();
-                if (d > 0) {
-                    meta.virtualDesktops.append(d);
+        // Single pass over the map with allocation-free QString==QLatin1String
+        // comparisons. The previous per-key constFind lambdas converted every
+        // QLatin1String key to a temporary QString (~23 allocations per full
+        // push, and full pushes now also ride every minimize edge). Absent
+        // keys leave the optionals disengaged, same as before.
+        for (auto it = extended.constBegin(); it != extended.constEnd(); ++it) {
+            const QString& k = it.key();
+            const QVariant& v = it.value();
+            if (k == Key::IsMinimized) {
+                meta.isMinimized = v.toBool();
+            } else if (k == Key::IsFullscreen) {
+                meta.isFullscreen = v.toBool();
+            } else if (k == Key::IsSticky) {
+                meta.isSticky = v.toBool();
+            } else if (k == Key::IsMaximized) {
+                meta.isMaximized = v.toBool();
+            } else if (k == Key::IsFocused) {
+                meta.isFocused = v.toBool();
+            } else if (k == Key::IsTransient) {
+                meta.isTransient = v.toBool();
+            } else if (k == Key::IsNotification) {
+                meta.isNotification = v.toBool();
+            } else if (k == Key::KeepAbove) {
+                meta.keepAbove = v.toBool();
+            } else if (k == Key::KeepBelow) {
+                meta.keepBelow = v.toBool();
+            } else if (k == Key::SkipTaskbar) {
+                meta.skipTaskbar = v.toBool();
+            } else if (k == Key::SkipPager) {
+                meta.skipPager = v.toBool();
+            } else if (k == Key::SkipSwitcher) {
+                meta.skipSwitcher = v.toBool();
+            } else if (k == Key::IsModal) {
+                meta.isModal = v.toBool();
+            } else if (k == Key::HasDecoration) {
+                meta.hasDecoration = v.toBool();
+            } else if (k == Key::IsResizable) {
+                meta.isResizable = v.toBool();
+            } else if (k == Key::IsMovable) {
+                meta.isMovable = v.toBool();
+            } else if (k == Key::IsMaximizable) {
+                meta.isMaximizable = v.toBool();
+            } else if (k == Key::Width) {
+                meta.width = v.toInt();
+            } else if (k == Key::Height) {
+                meta.height = v.toInt();
+            } else if (k == Key::PositionX) {
+                meta.positionX = v.toInt();
+            } else if (k == Key::PositionY) {
+                meta.positionY = v.toInt();
+            } else if (k == Key::CaptionNormal) {
+                meta.captionNormal = v.toString();
+            } else if (k == Key::VirtualDesktops) {
+                // Multi-desktop span list (absent for single-desktop / sticky
+                // windows, so an absent key correctly clears a previous span).
+                // Same lenient QVariant conversion policy as the fields above.
+                const QVariantList list = v.toList();
+                meta.virtualDesktops.reserve(list.size());
+                for (const QVariant& d : list) {
+                    const int desktop = d.toInt();
+                    if (desktop > 0) {
+                        meta.virtualDesktops.append(desktop);
+                    }
                 }
             }
         }

--- a/src/dbus/windowtrackingadaptor/queries.cpp
+++ b/src/dbus/windowtrackingadaptor/queries.cpp
@@ -30,8 +30,6 @@
 #include <PhosphorScreens/VirtualScreen.h>
 #include "core/types/types.h"
 #include <PhosphorEngine/WindowRegistry.h>
-// Complete type required where ~WindowTrackingAdaptor destroys the
-// unique_ptr<RuleEvaluator> member (m_ruleEvaluator).
 #include <PhosphorRules/RuleEvaluator.h>
 #include <PhosphorProtocol/ServiceConstants.h>
 #include <QJsonArray>

--- a/src/dbus/windowtrackingadaptor/queries.cpp
+++ b/src/dbus/windowtrackingadaptor/queries.cpp
@@ -44,7 +44,7 @@ namespace PlasmaZones {
 
 QRect WindowTrackingAdaptor::frameGeometry(const QString& windowId) const
 {
-    return m_frameGeometry.value(windowId);
+    return m_frameGeometry.value(shadowWindowId(windowId));
 }
 
 QString WindowTrackingAdaptor::lastActiveScreenName() const

--- a/src/dbus/windowtrackingadaptor/windowtrackingadaptor.h
+++ b/src/dbus/windowtrackingadaptor/windowtrackingadaptor.h
@@ -1128,6 +1128,9 @@ private:
     /// tiled close on the autotile screen itself. In each, the live frame
     /// has not yet moved off the tile rect.
     bool isFrameStillOnTileRect(const QString& windowId, const QRect& frame) const;
+    /// Canonical key for daemon-local per-window shadow maps. The compositor
+    /// may resend a changed appId prefix for the same stable instance.
+    QString shadowWindowId(const QString& windowId) const;
 
     // ═══════════════════════════════════════════════════════════════════════════════
     // Screen tracking (from KWin effect's D-Bus calls)
@@ -1139,7 +1142,8 @@ private:
     // Frame-geometry shadow: populated via setFrameGeometry D-Bus pushes from
     // the compositor plugin. Entries are removed on windowClosed. Used by
     // daemon-local shortcut handlers (float toggle, etc.) so they can read
-    // fresh geometry without round-tripping through the effect.
+    // fresh geometry without round-tripping through the effect. Keys are
+    // canonical window IDs so app-class mutation cannot create aliases.
     QHash<QString, QRect> m_frameGeometry;
 
     // Last floating value broadcast via windowFloatingChanged, per window. The

--- a/src/dbus/windowtrackingadaptor/windowtrackingadaptor.h
+++ b/src/dbus/windowtrackingadaptor/windowtrackingadaptor.h
@@ -851,7 +851,12 @@ Q_SIGNALS:
      * @param windowId Window whose state changed
      * @param state PhosphorProtocol::WindowStateEntry with windowId, zoneId, screenId,
      *        isFloating, changeType, zoneIds (multi-zone spans), isSticky;
-     *        changeType: "snapped", "unsnapped", "floated", "unfloated", "screen_changed"
+     *        changeType: "snapped", "unsnapped", "floated", "unfloated", "screen_changed".
+     *        BEST-EFFORT fields: the float-toggle and screen-changed emitters
+     *        deliberately send empty zoneIds and isSticky=false rather than
+     *        re-querying — subscribers needing those must pull them
+     *        (getMultiZoneForWindow / sticky query) instead of trusting this
+     *        stream's snapshot.
      */
     void windowStateChanged(const QString& windowId, const PhosphorProtocol::WindowStateEntry& state);
 

--- a/src/dbus/windowtrackingadaptor/windowtrackingadaptor.h
+++ b/src/dbus/windowtrackingadaptor/windowtrackingadaptor.h
@@ -1,6 +1,12 @@
 // SPDX-FileCopyrightText: 2026 fuddlesworth
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+// FILE-SIZE EXCEPTION (sanctioned): this header exceeds the 1150-line ceiling
+// because it declares BOTH the D-Bus wire surface (slots whose signatures are
+// pinned by the interface XML) and the in-process orchestration API the daemon
+// wires. Splitting would sever the wire methods from the state they document
+// against; the cost of the split outweighs the ceiling here.
+
 #pragma once
 
 #include "plasmazones_export.h"
@@ -453,8 +459,13 @@ public Q_SLOTS:
     QStringList getWindowsInZone(const QString& zoneId);
     QStringList getSnappedWindows();
 
-    /// Remove zone/screen/desktop assignments for windows not in the alive set.
-    /// Called by the KWin effect after daemon ready to clean up stale KConfig entries
+    /// Remove per-window state for windows not in the alive set: zone/screen/
+    /// desktop assignments, the sticky map and legacy float set, both engines'
+    /// tracking (via their pruneStaleWindows overrides — TilingState/SnapState
+    /// membership, pending orders, min-size and last-rect caches), the
+    /// registry's metadata + canonical entries, and the adaptor's own
+    /// frame-geometry/broadcast shadow maps.
+    /// Called by the KWin effect after daemon ready to clean up stale entries
     /// from windows that no longer exist (closed between save and daemon restart).
     void pruneStaleWindows(const QStringList& aliveWindowIds);
 
@@ -669,10 +680,12 @@ public:
     void captureWindowPlacement(const QString& windowId, const QString& authoritativeScreen = QString(),
                                 bool fromStateChange = false);
 
-    /// Re-capture every open floating window's live geometry into the unified
-    /// store at save time (no per-move hook fires for drags). Called before the
-    /// dirty snapshot in saveState so a dragged floated window persists its
-    /// current position across a daemon restart.
+    /// Re-capture EVERY open window's live placement into the unified store
+    /// at save time — engine-agnostic, not floating-only: floated windows
+    /// contribute their live geometry (no per-move hook fires for drags),
+    /// snapped/tiled windows their current slot state. Called before the
+    /// dirty snapshot in saveState so open-window state survives a daemon
+    /// restart.
     void refreshOpenWindowPlacements();
 
     /**
@@ -948,8 +961,16 @@ Q_SIGNALS:
 public Q_SLOTS:
     /**
      * @brief Set a window's floating state explicitly (directional, not toggle).
-     * Routes to autotile engine for autotile screens, handles snap mode locally.
-     * Used by minimize/unminimize, drag-to-float, and monocle unmaximize handlers.
+     *
+     * Routes by the (validated/recovered) screen's mode to a DEST engine, with
+     * the other engine as SOURCE. A window the destination does not yet track
+     * goes through the cross-engine handoff contract first: floats adopt
+     * unconditionally (releasing a tracked source); an unfloat whose float bit
+     * lives in the source is adopted by an autotile destination (tiling the
+     * arrival) or, for a snap destination, released from the source with a
+     * not-floating broadcast. The suspension-float classification is stamped
+     * before routing. Used by minimize/unminimize, drag-to-float, and monocle
+     * unmaximize handlers.
      */
     void setWindowFloatingForScreen(const QString& windowId, const QString& screenId, bool floating);
 

--- a/src/dbus/windowtrackingadaptor/windowtrackingadaptor.h
+++ b/src/dbus/windowtrackingadaptor/windowtrackingadaptor.h
@@ -641,14 +641,25 @@ public:
     /// Shadow-written in P1; the single funnel every state-change + close hook
     /// calls so the persisted record always reflects the window's live state.
     ///
-    /// @p authoritativeScreen, when non-empty (the close path passes KWin's
-    /// getWindowScreenId), is the window's true current screen. It is used ONLY
-    /// as a fallback when NEITHER engine produces a placement — the case where a
-    /// cross-screen move has removed the window from the source engine's tracking
-    /// and the destination engine has not adopted it, so both capturePlacement
-    /// calls return nullopt and the live screen would otherwise be lost. In that
-    /// case the float-back is recorded on @p authoritativeScreen via
-    /// WindowTrackingService::recordFloatingClose.
+    /// MINIMIZED windows (registry tri-state engaged-true, unknown-while-
+    /// tracked, or a classified suspension float) are a special case unless
+    /// @p fromStateChange: their live frame and engine view describe the
+    /// suspension, not intent, so the capture never overwrites the record. On
+    /// a live capture that is a plain no-op; on the CLOSE path the existing
+    /// record is preserved with only its context refreshed (close screen from
+    /// @p authoritativeScreen, desktop/activity from the window's live
+    /// registry metadata) so a reopen restores the pre-minimize placement in
+    /// the right place.
+    ///
+    /// @p authoritativeScreen (the close path passes KWin's getWindowScreenId)
+    /// therefore plays TWO roles when non-empty: it marks the capture as a
+    /// close (enabling the minimize preserve branch above and the pure-float
+    /// sibling collapse), and it is the fallback screen when NEITHER engine
+    /// produces a placement — the case where a cross-screen move removed the
+    /// window from the source engine's tracking and the destination never
+    /// adopted it, so both capturePlacement calls return nullopt and the live
+    /// screen would otherwise be lost. In that case the float-back is recorded
+    /// on @p authoritativeScreen via WindowTrackingService::recordFloatingClose.
     /// @param fromStateChange Pass true when the capture is triggered by an
     ///        authoritative engine state change (snap commit/uncommit relay):
     ///        such a capture must run even for a minimized window, because the
@@ -963,8 +974,12 @@ public:
      */
     bool relayWindowFloatingChanged(const QString& windowId, bool floating, const QString& screenId);
     /**
-     * @brief Apply pre-snap/pre-autotile geometry for a floated window (call from daemon when autotile engine floats).
-     * Gets validated geometry, emits applyGeometryRequested if found, clears stored geometry.
+     * @brief Apply the remembered float-back geometry for a floated window
+     * (call from daemon when the autotile engine floats it).
+     * Resolves via WindowTrackingService::validatedUnmanagedGeometry and emits
+     * applyGeometryRequested when a rect is found. The stored geometry is NOT
+     * consumed — the record stays put for the next float/restore (per-screen
+     * clears happen only on the consume-once drag-out paths).
      * @return true if geometry was applied, false if none stored
      */
     bool applyGeometryForFloat(const QString& windowId, const QString& screenId);

--- a/src/dbus/windowtrackingadaptor/windowtrackingadaptor.h
+++ b/src/dbus/windowtrackingadaptor/windowtrackingadaptor.h
@@ -649,7 +649,14 @@ public:
     /// calls return nullopt and the live screen would otherwise be lost. In that
     /// case the float-back is recorded on @p authoritativeScreen via
     /// WindowTrackingService::recordFloatingClose.
-    void captureWindowPlacement(const QString& windowId, const QString& authoritativeScreen = QString());
+    /// @param fromStateChange Pass true when the capture is triggered by an
+    ///        authoritative engine state change (snap commit/uncommit relay):
+    ///        such a capture must run even for a minimized window, because the
+    ///        engine now reports the NEW committed state, not the transient
+    ///        minimize-suspension float the minimize guard exists to keep out
+    ///        of the store.
+    void captureWindowPlacement(const QString& windowId, const QString& authoritativeScreen = QString(),
+                                bool fromStateChange = false);
 
     /// Re-capture every open floating window's live geometry into the unified
     /// store at save time (no per-move hook fires for drags). Called before the

--- a/src/editor/services/DBusLayoutService.cpp
+++ b/src/editor/services/DBusLayoutService.cpp
@@ -5,6 +5,7 @@
 #include "core/platform/logging.h"
 #include "phosphor_i18n.h"
 
+#include <PhosphorLayoutApi/LayoutId.h>
 #include <PhosphorProtocol/ClientHelpers.h>
 #include <PhosphorProtocol/ServiceConstants.h>
 
@@ -129,7 +130,15 @@ QString DBusLayoutService::getLayoutIdForScreen(const QString& screenName)
         qCWarning(lcDbus) << "getAssignedLayoutForScreen: failed, screen=" << screenName << errorMessage(reply);
         return QString();
     }
-    return reply.arguments().constFirst().toString();
+    const QString assignedId = reply.arguments().constFirst().toString();
+    // An autotile-assigned screen returns "autotile:<algorithmId>", which is
+    // not a loadable layout uuid — loadLayout would fail the parse and surface
+    // "That layout is no longer available." to the user. Treat it like an
+    // unassigned screen so the caller falls through to createNewLayout().
+    if (PhosphorLayout::LayoutId::isAutotile(assignedId)) {
+        return QString();
+    }
+    return assignedId;
 }
 
 void DBusLayoutService::assignLayoutToScreen(const QString& screenName, const QString& layoutId)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -462,6 +462,18 @@ target_link_libraries(test_snap_assist_thumbnail_provider
     PRIVATE Qt6::Test Qt6::Core Qt6::Gui Qt6::Quick PhosphorProtocol::PhosphorProtocol)
 add_test(NAME test_snap_assist_thumbnail_provider COMMAND test_snap_assist_thumbnail_provider)
 
+# Autotile seed-order filter (Daemon::seedAutotileOrderForScreen's admission
+# predicate): minimized placeholders kept, live/durable floats dropped.
+# Compiles the daemon source directly because the filter lives in the
+# plasmazonesd executable, not plasmazones_core.
+add_executable(test_autotile_seed_filter
+    daemon/test_autotile_seed_filter.cpp
+    ${CMAKE_SOURCE_DIR}/src/daemon/daemon/seedorderfilter.cpp
+)
+target_include_directories(test_autotile_seed_filter PRIVATE ${CMAKE_SOURCE_DIR}/src)
+target_link_libraries(test_autotile_seed_filter PRIVATE Qt6::Test Qt6::Core Qt6::DBus plasmazones_core)
+add_test(NAME test_autotile_seed_filter COMMAND test_autotile_seed_filter)
+
 # Cheatsheet family compression: compiles the daemon source directly because
 # ShortcutManager lives in the plasmazonesd executable, not plasmazones_core.
 # The test drives only the static compressCheatsheetFamilies helper, so no

--- a/tests/unit/autotile/engine/test_autotile_engine_core.cpp
+++ b/tests/unit/autotile/engine/test_autotile_engine_core.cpp
@@ -681,7 +681,7 @@ private Q_SLOTS:
     // Pending-order seed float restore: EXACT record only. Pending orders are
     // built from live-session ids, so a same-app SIBLING's floating record
     // must never float a record-less seeded window (relogin restores go
-    // through insertWindow's take(), not this path). The window's own exact
+    // through insertWindow's take(), not this path). The window's own instance-exact
     // floating record still restores its float.
     // =========================================================================
 
@@ -707,7 +707,7 @@ private Q_SLOTS:
         sib.engines.insert(engine.engineId(), floatSlot);
         QVERIFY(wts.placementStore().record(sib));
 
-        // The second seeded window's OWN exact floating record.
+        // The second seeded window's OWN instance-exact floating record.
         WindowPlacement own;
         own.windowId = QStringLiteral("app|own");
         own.appId = QStringLiteral("app");
@@ -723,7 +723,7 @@ private Q_SLOTS:
         QVERIFY2(!state->isFloating(QStringLiteral("app|fresh")),
                  "a same-app sibling's floating record must not float a record-less seeded window");
         QVERIFY2(state->isFloating(QStringLiteral("app|own")),
-                 "the window's own exact floating record still restores its float");
+                 "the window's own instance-exact floating record still restores its float");
     }
 
     void testMinimizedFloatDoesNotReplaceTiledPlacementOnTeardown()

--- a/tests/unit/autotile/engine/test_autotile_engine_core.cpp
+++ b/tests/unit/autotile/engine/test_autotile_engine_core.cpp
@@ -527,8 +527,13 @@ private Q_SLOTS:
         AutotileEngine engine(nullptr, nullptr, nullptr, PlasmaZones::TestHelpers::testRegistry());
         QVERIFY(!engine.isEnabled());
 
+        // The no-op claim needs an observable: no placement change may be
+        // published from retiles of a disabled engine.
+        QSignalSpy placementChanged(&engine, &PhosphorEngine::PlacementEngineBase::placementChanged);
         engine.retile();
         engine.retile(QStringLiteral("SomeScreen"));
+        QCoreApplication::processEvents();
+        QCOMPARE(placementChanged.size(), 0);
     }
 
     // =========================================================================

--- a/tests/unit/autotile/engine/test_autotile_engine_core.cpp
+++ b/tests/unit/autotile/engine/test_autotile_engine_core.cpp
@@ -398,10 +398,9 @@ private Q_SLOTS:
         PhosphorTiles::TilingState* state = engine.tilingStateForScreen(QStringLiteral("TestScreen"));
 
         QCOMPARE(state->splitRatio(), 0.7);
-
-        state->addWindow(QStringLiteral("win1"));
-        state->addWindow(QStringLiteral("win2"));
-        state->setMasterCount(2);
+        // Inherited by the state factory from the engine config — no local
+        // setMasterCount here (the previous version wrote 2 and then asserted
+        // 2, which could never fail and proved nothing about inheritance).
         QCOMPARE(state->masterCount(), 2);
     }
 

--- a/tests/unit/autotile/engine/test_autotile_engine_core.cpp
+++ b/tests/unit/autotile/engine/test_autotile_engine_core.cpp
@@ -20,7 +20,6 @@
 #include <PhosphorTiles/TilingState.h>
 #include <PhosphorTiles/TilingAlgorithm.h>
 #include <PhosphorTiles/AlgorithmRegistry.h>
-#include "core/types/constants.h"
 
 #include "helpers/ScriptedAlgoTestSetup.h"
 

--- a/tests/unit/autotile/engine/test_autotile_engine_core.cpp
+++ b/tests/unit/autotile/engine/test_autotile_engine_core.cpp
@@ -756,6 +756,7 @@ private Q_SLOTS:
         PhosphorEngine::WindowPlacement baseline = *tiledPlacement;
         baseline.virtualDesktop = 3;
         baseline.activity = QStringLiteral("activity-a");
+        baseline.engines[engine.engineId()].order = 7;
         baseline.freeGeometryByScreen.insert(screenId, QRect(120, 90, 900, 700));
         PhosphorEngine::EngineSlot snapSlot;
         snapSlot.state = QString(PhosphorEngine::WindowPlacement::stateSnapped());
@@ -769,15 +770,33 @@ private Q_SLOTS:
         registry.upsert(instanceId, metadata);
         engine.setWindowFloat(windowId, true, screenId);
         QVERIFY(engine.isWindowFloatingInAutotile(windowId));
+        const auto minimizedCapture = engine.capturePlacement(windowId);
+        QVERIFY(minimizedCapture);
+        QCOMPARE(minimizedCapture->slotFor(engine.engineId()).state,
+                 QString(PhosphorEngine::WindowPlacement::stateTiled()));
+        QCOMPARE(minimizedCapture->slotFor(engine.engineId()).order, 0);
+        QCOMPARE(minimizedCapture->screenId, tiledPlacement->screenId);
+        QCOMPARE(minimizedCapture->virtualDesktop, tiledPlacement->virtualDesktop);
+        QCOMPARE(minimizedCapture->activity, tiledPlacement->activity);
+        QVERIFY(wts.placementStore().record(*minimizedCapture));
+        const auto normalizedBeforeTeardown = wts.placementStore().peekExact(windowId);
+        QVERIFY(normalizedBeforeTeardown);
 
         // Screen teardown captures directly through AutotileEngine, bypassing
         // WindowTrackingAdaptor. The minimized guard must still preserve the
         // pre-minimize tiled slot rather than persisting the temporary float.
+        // placementChanged describes the live occupancy release even when the
+        // durable record is already content-identical.
+        QSignalSpy placementChanged(&engine, &PhosphorEngine::PlacementEngineBase::placementChanged);
         engine.setAutotileScreens({});
+        QVERIFY(placementChanged.size() > 0);
         const auto stored = wts.placementStore().peekExact(windowId);
         QVERIFY(stored);
-        QVERIFY(stored->sameContentAs(*before));
-        QCOMPARE(stored->sequence, before->sequence);
+        QVERIFY(stored->sameContentAs(*normalizedBeforeTeardown));
+        QCOMPARE(stored->sequence, normalizedBeforeTeardown->sequence);
+        QCOMPARE(stored->slotFor(PhosphorEngine::WindowPlacement::snapEngineId()),
+                 before->slotFor(PhosphorEngine::WindowPlacement::snapEngineId()));
+        QCOMPARE(stored->freeGeometryFor(screenId), before->freeGeometryFor(screenId));
     }
 
     void testMinimizedFirstCapturePersistsTiledPlacementOnTeardown()
@@ -807,7 +826,10 @@ private Q_SLOTS:
         metadata.isMinimized = true;
         registry.upsert(instanceId, metadata);
         engine.setWindowFloat(windowId, true, screenId);
+        QVERIFY(engine.isWindowFloatingInAutotile(windowId));
+        QSignalSpy placementChanged(&engine, &PhosphorEngine::PlacementEngineBase::placementChanged);
         engine.setAutotileScreens({});
+        QVERIFY(placementChanged.size() > 0);
 
         const auto stored = wts.placementStore().peekExact(windowId);
         QVERIFY(stored);

--- a/tests/unit/autotile/engine/test_autotile_engine_core.cpp
+++ b/tests/unit/autotile/engine/test_autotile_engine_core.cpp
@@ -8,6 +8,7 @@
 #include <memory>
 
 #include <PhosphorEngine/WindowPlacement.h>
+#include <PhosphorEngine/WindowRegistry.h>
 #include <PhosphorPlacement/WindowTrackingService.h>
 #include <PhosphorTileEngine/AutotileEngine.h>
 #include <PhosphorZones/LayoutRegistry.h>
@@ -722,6 +723,49 @@ private Q_SLOTS:
                  "a same-app sibling's floating record must not float a record-less seeded window");
         QVERIFY2(state->isFloating(QStringLiteral("app|own")),
                  "the window's own exact floating record still restores its float");
+    }
+
+    void testMinimizedFloatDoesNotReplaceTiledPlacementOnTeardown()
+    {
+        PlasmaZones::TestHelpers::IsolatedConfigGuard guard;
+        std::unique_ptr<PhosphorZones::LayoutRegistry> layoutManager(
+            PlasmaZones::TestHelpers::makeLayoutRegistry(QStringLiteral("plasmazones/layouts")));
+        PlasmaZones::StubZoneDetector zoneDetector;
+        PhosphorPlacement::WindowTrackingService wts(layoutManager.get(), &zoneDetector, nullptr, nullptr);
+        PhosphorEngine::WindowRegistry registry;
+        AutotileEngine engine(nullptr, &wts, nullptr, PlasmaZones::TestHelpers::testRegistry());
+        engine.setWindowRegistry(&registry);
+
+        const QString screenId = QStringLiteral("DP-1");
+        const QString instanceId = QStringLiteral("minimized-instance");
+        const QString windowId = QStringLiteral("app|minimized-instance");
+        PhosphorEngine::WindowMetadata metadata;
+        metadata.appId = QStringLiteral("app");
+        metadata.isMinimized = false;
+        registry.upsert(instanceId, metadata);
+
+        engine.setAutotileScreens({screenId});
+        engine.windowOpened(windowId, screenId);
+        QCoreApplication::processEvents();
+
+        const auto tiledPlacement = engine.capturePlacement(windowId);
+        QVERIFY(tiledPlacement);
+        QCOMPARE(tiledPlacement->slotFor(engine.engineId()).state,
+                 QString(PhosphorEngine::WindowPlacement::stateTiled()));
+        QVERIFY(wts.placementStore().record(*tiledPlacement));
+
+        metadata.isMinimized = true;
+        registry.upsert(instanceId, metadata);
+        engine.setWindowFloat(windowId, true, screenId);
+        QVERIFY(engine.isWindowFloatingInAutotile(windowId));
+
+        // Screen teardown captures directly through AutotileEngine, bypassing
+        // WindowTrackingAdaptor. The minimized guard must still preserve the
+        // pre-minimize tiled slot rather than persisting the temporary float.
+        engine.setAutotileScreens({});
+        const auto stored = wts.placementStore().peekExact(windowId);
+        QVERIFY(stored);
+        QCOMPARE(stored->slotFor(engine.engineId()).state, QString(PhosphorEngine::WindowPlacement::stateTiled()));
     }
 };
 

--- a/tests/unit/autotile/engine/test_autotile_engine_core.cpp
+++ b/tests/unit/autotile/engine/test_autotile_engine_core.cpp
@@ -27,6 +27,7 @@
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QUuid>
 
 using namespace PlasmaZones;
 using namespace PhosphorTileEngine;
@@ -752,7 +753,17 @@ private Q_SLOTS:
         QVERIFY(tiledPlacement);
         QCOMPARE(tiledPlacement->slotFor(engine.engineId()).state,
                  QString(PhosphorEngine::WindowPlacement::stateTiled()));
-        QVERIFY(wts.placementStore().record(*tiledPlacement));
+        PhosphorEngine::WindowPlacement baseline = *tiledPlacement;
+        baseline.virtualDesktop = 3;
+        baseline.activity = QStringLiteral("activity-a");
+        baseline.freeGeometryByScreen.insert(screenId, QRect(120, 90, 900, 700));
+        PhosphorEngine::EngineSlot snapSlot;
+        snapSlot.state = QString(PhosphorEngine::WindowPlacement::stateSnapped());
+        snapSlot.zoneIds = {QUuid::createUuid().toString()};
+        baseline.engines.insert(PhosphorEngine::WindowPlacement::snapEngineId(), snapSlot);
+        QVERIFY(wts.placementStore().record(baseline));
+        const auto before = wts.placementStore().peekExact(windowId);
+        QVERIFY(before);
 
         metadata.isMinimized = true;
         registry.upsert(instanceId, metadata);
@@ -765,7 +776,44 @@ private Q_SLOTS:
         engine.setAutotileScreens({});
         const auto stored = wts.placementStore().peekExact(windowId);
         QVERIFY(stored);
-        QCOMPARE(stored->slotFor(engine.engineId()).state, QString(PhosphorEngine::WindowPlacement::stateTiled()));
+        QVERIFY(stored->sameContentAs(*before));
+        QCOMPARE(stored->sequence, before->sequence);
+    }
+
+    void testMinimizedFirstCapturePersistsTiledPlacementOnTeardown()
+    {
+        PlasmaZones::TestHelpers::IsolatedConfigGuard guard;
+        std::unique_ptr<PhosphorZones::LayoutRegistry> layoutManager(
+            PlasmaZones::TestHelpers::makeLayoutRegistry(QStringLiteral("plasmazones/layouts")));
+        PlasmaZones::StubZoneDetector zoneDetector;
+        PhosphorPlacement::WindowTrackingService wts(layoutManager.get(), &zoneDetector, nullptr, nullptr);
+        PhosphorEngine::WindowRegistry registry;
+        AutotileEngine engine(nullptr, &wts, nullptr, PlasmaZones::TestHelpers::testRegistry());
+        engine.setWindowRegistry(&registry);
+
+        const QString screenId = QStringLiteral("DP-1");
+        const QString instanceId = QStringLiteral("first-capture-instance");
+        const QString windowId = QStringLiteral("app|first-capture-instance");
+        PhosphorEngine::WindowMetadata metadata;
+        metadata.appId = QStringLiteral("app");
+        metadata.isMinimized = false;
+        registry.upsert(instanceId, metadata);
+
+        engine.setAutotileScreens({screenId});
+        engine.windowOpened(windowId, screenId);
+        QCoreApplication::processEvents();
+        QVERIFY(!wts.placementStore().peekExact(windowId));
+
+        metadata.isMinimized = true;
+        registry.upsert(instanceId, metadata);
+        engine.setWindowFloat(windowId, true, screenId);
+        engine.setAutotileScreens({});
+
+        const auto stored = wts.placementStore().peekExact(windowId);
+        QVERIFY(stored);
+        const PhosphorEngine::EngineSlot slot = stored->slotFor(engine.engineId());
+        QCOMPARE(slot.state, QString(PhosphorEngine::WindowPlacement::stateTiled()));
+        QCOMPARE(slot.order, 0);
     }
 };
 

--- a/tests/unit/autotile/engine/test_autotile_engine_core.cpp
+++ b/tests/unit/autotile/engine/test_autotile_engine_core.cpp
@@ -24,8 +24,6 @@
 
 #include "helpers/ScriptedAlgoTestSetup.h"
 
-#include <QJsonArray>
-#include <QJsonDocument>
 #include <QJsonObject>
 #include <QUuid>
 

--- a/tests/unit/autotile/engine/test_autotile_engine_core.cpp
+++ b/tests/unit/autotile/engine/test_autotile_engine_core.cpp
@@ -774,7 +774,14 @@ private Q_SLOTS:
         QVERIFY(minimizedCapture);
         QCOMPARE(minimizedCapture->slotFor(engine.engineId()).state,
                  QString(PhosphorEngine::WindowPlacement::stateTiled()));
-        QCOMPARE(minimizedCapture->slotFor(engine.engineId()).order, 0);
+        // The DURABLE order survives: the live windowOrder position of a
+        // minimize-floated window is the suspension artifact (handoff insert
+        // index), so the preserve branch must keep the stored slot's order
+        // (7, from the recorded baseline) rather than refreshing from it.
+        QCOMPARE(minimizedCapture->slotFor(engine.engineId()).order, before->slotFor(engine.engineId()).order);
+        // Context comes from the live TilingStateKey by design (the engine's
+        // current screen/desktop/activity for the window), matching what the
+        // visible capture reported.
         QCOMPARE(minimizedCapture->screenId, tiledPlacement->screenId);
         QCOMPARE(minimizedCapture->virtualDesktop, tiledPlacement->virtualDesktop);
         QCOMPARE(minimizedCapture->activity, tiledPlacement->activity);

--- a/tests/unit/autotile/engine/test_autotile_engine_master.cpp
+++ b/tests/unit/autotile/engine/test_autotile_engine_master.cpp
@@ -455,8 +455,11 @@ private Q_SLOTS:
         overrides[QStringLiteral("SplitRatio")] = 0.5;
         engine.applyPerScreenConfig(screen1, overrides);
 
+        // The per-screen override push is the load-bearing setup — no manual
+        // setSplitRatio duplicate beside it (the old double write hid which
+        // of the two the assertions depended on); assert the push landed.
         PhosphorTiles::TilingState* state = engine.tilingStateForScreen(screen1);
-        state->setSplitRatio(0.5);
+        QCOMPARE(state->splitRatio(), 0.5);
         const qreal globalBefore = engine.config()->splitRatio;
 
         engine.windowFocused(QStringLiteral("win1"), screen1);
@@ -486,8 +489,11 @@ private Q_SLOTS:
         overrides[QStringLiteral("SplitRatio")] = 0.5;
         engine.applyPerScreenConfig(screen1, overrides);
 
+        // The per-screen override push is the load-bearing setup — no manual
+        // setSplitRatio duplicate beside it (the old double write hid which
+        // of the two the assertions depended on); assert the push landed.
         PhosphorTiles::TilingState* state = engine.tilingStateForScreen(screen1);
-        state->setSplitRatio(0.5);
+        QCOMPARE(state->splitRatio(), 0.5);
         const qreal globalBefore = engine.config()->splitRatio;
 
         engine.windowFocused(QStringLiteral("win1"), screen1);

--- a/tests/unit/autotile/engine/test_autotile_engine_master.cpp
+++ b/tests/unit/autotile/engine/test_autotile_engine_master.cpp
@@ -98,6 +98,7 @@ private Q_SLOTS:
 
         const qreal initial1 = state1->splitRatio();
         const qreal initial2 = state2->splitRatio();
+        const qreal globalBefore = engine.config()->splitRatio;
 
         // Use windowFocused to properly set m_activeScreen on the engine
         engine.windowFocused(QStringLiteral("win1"), screen1);
@@ -107,6 +108,9 @@ private Q_SLOTS:
         // Only the focused screen's ratio should change
         QVERIFY(qFuzzyCompare(state1->splitRatio(), initial1 - 0.1));
         QVERIFY(qFuzzyCompare(state2->splitRatio(), initial2));
+        // Same no-bleed contract as the increase twin: the per-desktop tweak
+        // must not land in the global config.
+        QVERIFY(qFuzzyCompare(engine.config()->splitRatio, globalBefore));
     }
 
     // =========================================================================
@@ -161,12 +165,15 @@ private Q_SLOTS:
         PhosphorTiles::TilingState* state2 = engine.tilingStateForScreen(screen2);
         state1->setMasterCount(2);
         state2->setMasterCount(2);
+        const int globalBefore = engine.config()->masterCount;
 
         engine.windowFocused(QStringLiteral("win1"), screen1);
         engine.decreaseMasterCount();
 
         QCOMPARE(state1->masterCount(), 1);
         QCOMPARE(state2->masterCount(), 2);
+        // Same no-bleed contract as the increase twin.
+        QCOMPARE(engine.config()->masterCount, globalBefore);
     }
 
     void testDecreaseMasterCount_doesNotGoBelowOne()

--- a/tests/unit/autotile/engine/test_autotile_engine_master.cpp
+++ b/tests/unit/autotile/engine/test_autotile_engine_master.cpp
@@ -204,12 +204,19 @@ private Q_SLOTS:
         engine.windowFocused(QStringLiteral("win1"), screen1);
         engine.increaseMasterRatio(0.1); // tunes the current desktop's state
 
+        const qreal tunedRatio = engine.tilingStateForScreen(screen1)->splitRatio();
+        QVERIFY(!qFuzzyCompare(1.0 + tunedRatio, 1.0 + engine.config()->splitRatio)); // genuinely tuned
         engine.pruneStatesForDesktop(engine.currentDesktop());
 
-        // A fresh state on the same screen is created cleanly after the prune.
+        // A fresh state on the same screen is created cleanly after the prune
+        // (tilingStateForScreen creates lazily, so the non-null check alone
+        // could never fail — the discriminating assertion is that the tuned
+        // per-desktop ratio did NOT survive the prune into the fresh state).
         engine.windowOpened(QStringLiteral("win3"), screen1, 0, 0);
         QCoreApplication::processEvents();
-        QVERIFY(engine.tilingStateForScreen(screen1) != nullptr);
+        PhosphorTiles::TilingState* fresh = engine.tilingStateForScreen(screen1);
+        QVERIFY(fresh != nullptr);
+        QVERIFY(!qFuzzyCompare(1.0 + fresh->splitRatio(), 1.0 + tunedRatio));
     }
 
     // =========================================================================
@@ -585,6 +592,9 @@ private Q_SLOTS:
         QJsonDocument doc = QJsonDocument::fromJson(json.toUtf8());
         QVERIFY(doc.isArray());
         const QJsonArray arr = doc.array();
+        // Non-empty first: an empty array would make the omits-flag loop
+        // vacuously pass without exercising the serializer at all.
+        QCOMPARE(arr.size(), 2);
         for (const QJsonValue& val : arr) {
             QVERIFY(!val.toObject().contains(QLatin1String("monocle")));
         }
@@ -772,15 +782,19 @@ private Q_SLOTS:
         QVERIFY(state->tiledWindows().isEmpty());
         QCOMPARE(state->windowCount(), 1);
 
-        QStringList preSeeded = {QStringLiteral("win-A")};
+        // The seed must be IGNORED (the state already holds a window, floating
+        // included). Use a REORDERING seed so the outcome is distinguishable:
+        // with the seed ignored, arrival order wins (win-B first); had the
+        // guard failed and the strict seed applied, win-A would have been
+        // forced ahead of win-B and the compare below would fail.
+        QStringList preSeeded = {QStringLiteral("win-A"), QStringLiteral("win-B")};
         engine.setInitialWindowOrder(screenName, preSeeded);
 
+        engine.windowOpened(QStringLiteral("win-B"), screenName);
         engine.windowOpened(QStringLiteral("win-A"), screenName);
         QCoreApplication::processEvents();
 
-        QStringList tiledWindows = state->tiledWindows();
-        QCOMPARE(tiledWindows.size(), 1);
-        QCOMPARE(tiledWindows.at(0), QStringLiteral("win-A"));
+        QCOMPARE(state->tiledWindows(), (QStringList{QStringLiteral("win-B"), QStringLiteral("win-A")}));
     }
 };
 

--- a/tests/unit/autotile/engine/test_autotile_engine_master.cpp
+++ b/tests/unit/autotile/engine/test_autotile_engine_master.cpp
@@ -5,6 +5,7 @@
 #include <QCoreApplication>
 #include <QSignalSpy>
 
+#include <PhosphorEngine/WindowRegistry.h>
 #include <PhosphorTileEngine/AutotileEngine.h>
 #include "helpers/AutotileFakes.h"
 #include "helpers/AutotileTestHelpers.h"
@@ -712,6 +713,40 @@ private Q_SLOTS:
         QCOMPARE(tiledWindows.size(), 2);
         QCOMPARE(tiledWindows.at(0), QStringLiteral("win-A"));
         QCOMPARE(tiledWindows.at(1), QStringLiteral("win-C"));
+    }
+
+    void testRemoveWindow_cleansNeverInsertedMinimizedPlaceholder()
+    {
+        const QString screenName = QStringLiteral("DP-1");
+        const QString first = QStringLiteral("app|first");
+        const QString hidden = QStringLiteral("app|hidden");
+        const QString third = QStringLiteral("app|third");
+        PhosphorEngine::WindowRegistry registry;
+        PhosphorEngine::WindowMetadata metadata;
+        metadata.appId = QStringLiteral("app");
+        metadata.isMinimized = true;
+        registry.upsert(QStringLiteral("hidden"), metadata);
+
+        AutotileEngine engine(nullptr, nullptr, nullptr, PlasmaZones::TestHelpers::testRegistry());
+        engine.setWindowRegistry(&registry);
+        engine.config()->insertPosition = AutotileConfig::InsertPosition::End;
+        engine.setInitialWindowOrder(screenName, {first, hidden, third});
+        engine.setAutotileScreens({screenName});
+
+        PhosphorTiles::TilingState* state = engine.tilingStateForScreen(screenName);
+        QVERIFY(state);
+        QCOMPARE(state->tiledWindows(), (QStringList{first, third}));
+        QVERIFY(!state->containsWindow(hidden));
+
+        // The placeholder has no engine key because it was deliberately not
+        // inserted. Closing it must still remove it from the pending order.
+        engine.windowClosed(hidden);
+        metadata.isMinimized = false;
+        registry.upsert(QStringLiteral("hidden"), metadata);
+        engine.windowOpened(hidden, screenName);
+        QCoreApplication::processEvents();
+
+        QCOMPARE(state->tiledWindows(), (QStringList{first, third, hidden}));
     }
 
     void testSetInitialWindowOrder_guardChecksAllWindows()

--- a/tests/unit/autotile/engine/test_autotile_engine_master.cpp
+++ b/tests/unit/autotile/engine/test_autotile_engine_master.cpp
@@ -12,7 +12,6 @@
 #include <PhosphorTileEngine/AutotileConfig.h>
 #include <PhosphorTiles/TilingState.h>
 #include <PhosphorTiles/AlgorithmRegistry.h>
-#include "core/types/constants.h"
 
 #include "helpers/ScriptedAlgoTestSetup.h"
 

--- a/tests/unit/autotile/engine/test_autotile_engine_master.cpp
+++ b/tests/unit/autotile/engine/test_autotile_engine_master.cpp
@@ -724,6 +724,13 @@ private Q_SLOTS:
         PhosphorEngine::WindowRegistry registry;
         PhosphorEngine::WindowMetadata metadata;
         metadata.appId = QStringLiteral("app");
+        // Every live window carries a registry record in production (metadata
+        // is pushed at window-open); the strict seed defers windows the
+        // registry cannot vouch for, so the visible windows need engaged
+        // not-minimized records here or they would be deferred too.
+        metadata.isMinimized = false;
+        registry.upsert(QStringLiteral("first"), metadata);
+        registry.upsert(QStringLiteral("third"), metadata);
         metadata.isMinimized = true;
         registry.upsert(QStringLiteral("hidden"), metadata);
 

--- a/tests/unit/core/layout/test_layout_zones.cpp
+++ b/tests/unit/core/layout/test_layout_zones.cpp
@@ -21,17 +21,6 @@ class TestLayoutZones : public QObject
     Q_OBJECT
 
 private:
-    PhosphorZones::Layout* createLayoutWithZones(int zoneCount, QObject* parent = nullptr)
-    {
-        auto* layout = new PhosphorZones::Layout(QStringLiteral("test"), parent);
-        for (int i = 0; i < zoneCount; ++i) {
-            auto* zone = new PhosphorZones::Zone();
-            zone->setRelativeGeometry(QRectF(qreal(i) / zoneCount, 0.0, 1.0 / zoneCount, 1.0));
-            layout->addZone(zone);
-        }
-        return layout;
-    }
-
     PhosphorZones::Zone* createZoneWithGeometry(const QRectF& geometry, QObject* parent = nullptr)
     {
         auto* zone = new PhosphorZones::Zone(parent);
@@ -310,7 +299,9 @@ private Q_SLOTS:
         layout.addZone(zone);
 
         PhosphorZones::LayoutComputeService service;
-        QSignalSpy computed(&service, &PhosphorZones::LayoutComputeService::geometriesComputed);
+        // geometriesComputedForGeneration is the single result signal (the
+        // old generation-less geometriesComputed had no production
+        // subscribers and was removed).
         QSignalSpy computedForGeneration(&service,
                                          &PhosphorZones::LayoutComputeService::geometriesComputedForGeneration);
         const QString screenId = QStringLiteral("DP-1");
@@ -318,12 +309,10 @@ private Q_SLOTS:
         const QRectF secondGeometry(0, 0, 2560, 1440);
 
         QVERIFY(service.requestRecalculate(&layout, screenId, firstGeometry));
-        QTRY_COMPARE(computed.size(), 1);
         QTRY_COMPARE(computedForGeneration.size(), 1);
         const qulonglong firstGeneration = computedForGeneration.first().at(3).toULongLong();
         QCOMPARE(qulonglong(service.currentGeneration(screenId)), firstGeneration);
         QCOMPARE(layout.lastRecalcGeometry(), firstGeometry);
-        computed.clear();
         computedForGeneration.clear();
 
         // The cached completion is queued. A newer request made before that
@@ -336,18 +325,8 @@ private Q_SLOTS:
         // emission carries the layout at exactly the current generation.
         QVERIFY(service.requestRecalculate(&layout, screenId, firstGeometry));
         QVERIFY(service.requestRecalculate(&layout, screenId, secondGeometry));
-        QTRY_VERIFY(computed.size() >= 2);
         QTRY_VERIFY(computedForGeneration.size() >= 2);
 
-        bool sawSuperseded = false;
-        bool sawCurrent = false;
-        for (const QList<QVariant>& args : computed) {
-            auto* reported = qvariant_cast<PhosphorZones::Layout*>(args.at(2));
-            sawSuperseded |= reported == nullptr;
-            sawCurrent |= reported == &layout;
-        }
-        QVERIFY(sawSuperseded);
-        QVERIFY(sawCurrent);
         const qulonglong finalGeneration = qulonglong(service.currentGeneration(screenId));
         QVERIFY(finalGeneration > firstGeneration);
         bool sawSupersededGeneration = false;

--- a/tests/unit/core/layout/test_layout_zones.cpp
+++ b/tests/unit/core/layout/test_layout_zones.cpp
@@ -362,6 +362,58 @@ private Q_SLOTS:
         QVERIFY(sawCurrentGeneration);
         QCOMPARE(layout.lastRecalcGeometry(), secondGeometry);
     }
+
+    // applyResult's destroyed-layout path: a result whose layout died while
+    // the worker computed must still publish (null layout, the REQUEST's
+    // generation) so screen-scoped barriers can complete instead of waiting
+    // forever. The delete happens before the event loop spins, so the queued
+    // worker result always lands after it — deterministic, not a race.
+    void testLayout_asyncResultForDestroyedLayoutPublishesNull()
+    {
+        auto* layout = new PhosphorZones::Layout(QStringLiteral("Doomed"));
+        auto* zone = new PhosphorZones::Zone();
+        zone->setRelativeGeometry(QRectF(0, 0, 1, 1));
+        layout->addZone(zone);
+
+        PhosphorZones::LayoutComputeService service;
+        QSignalSpy computedForGeneration(&service,
+                                         &PhosphorZones::LayoutComputeService::geometriesComputedForGeneration);
+        const QString screenId = QStringLiteral("DP-1");
+        QVERIFY(service.requestRecalculate(layout, screenId, QRectF(0, 0, 1920, 1080)));
+        const qulonglong gen = qulonglong(service.currentGeneration(screenId));
+        delete layout;
+
+        QTRY_COMPARE(computedForGeneration.size(), 1);
+        const QList<QVariant> args = computedForGeneration.first();
+        QCOMPARE(qvariant_cast<PhosphorZones::Layout*>(args.at(2)), static_cast<PhosphorZones::Layout*>(nullptr));
+        QCOMPARE(args.at(3).toULongLong(), gen);
+    }
+
+    // applyResult's sync-already-applied path: when a sync recalc stamped the
+    // same rect before the worker result lands, the result publishes the LIVE
+    // layout at the request's (still current) generation — a null or dropped
+    // emission here would stall the same barriers the destroyed path serves.
+    void testLayout_asyncResultAfterSyncApplyPublishesCurrentGeneration()
+    {
+        PhosphorZones::Layout layout(QStringLiteral("SyncFirst"));
+        auto* zone = new PhosphorZones::Zone();
+        zone->setRelativeGeometry(QRectF(0, 0, 1, 1));
+        layout.addZone(zone);
+
+        PhosphorZones::LayoutComputeService service;
+        QSignalSpy computedForGeneration(&service,
+                                         &PhosphorZones::LayoutComputeService::geometriesComputedForGeneration);
+        const QString screenId = QStringLiteral("DP-1");
+        const QRectF geom(0, 0, 1920, 1080);
+        QVERIFY(service.requestRecalculate(&layout, screenId, geom));
+        // Sync path wins the race before the worker's queued result lands.
+        PhosphorZones::LayoutComputeService::recalculateSync(&layout, geom);
+
+        QTRY_COMPARE(computedForGeneration.size(), 1);
+        const QList<QVariant> args = computedForGeneration.first();
+        QCOMPARE(qvariant_cast<PhosphorZones::Layout*>(args.at(2)), &layout);
+        QCOMPARE(args.at(3).toULongLong(), qulonglong(service.currentGeneration(screenId)));
+    }
 };
 
 QTEST_MAIN(TestLayoutZones)

--- a/tests/unit/core/layout/test_layout_zones.cpp
+++ b/tests/unit/core/layout/test_layout_zones.cpp
@@ -9,8 +9,6 @@
 #include <QTest>
 #include <QSignalSpy>
 #include <QJsonObject>
-#include <QJsonArray>
-#include <QJsonDocument>
 
 #include <PhosphorZones/Layout.h>
 #include <PhosphorZones/LayoutComputeService.h>

--- a/tests/unit/core/layout/test_layout_zones.cpp
+++ b/tests/unit/core/layout/test_layout_zones.cpp
@@ -301,6 +301,43 @@ private Q_SLOTS:
         QCOMPARE(layout.lastRecalcGeometry(), newScreenGeom);
         QCOMPARE(zone->geometry(), QRectF(0, 0, 2560, 1440));
     }
+
+    void testLayout_asyncCachedResultReportsSupersession()
+    {
+        PhosphorZones::Layout layout(QStringLiteral("Async cache"));
+        auto* zone = new PhosphorZones::Zone();
+        zone->setRelativeGeometry(QRectF(0, 0, 1, 1));
+        layout.addZone(zone);
+
+        PhosphorZones::LayoutComputeService service;
+        QSignalSpy computed(&service, &PhosphorZones::LayoutComputeService::geometriesComputed);
+        const QString screenId = QStringLiteral("DP-1");
+        const QRectF firstGeometry(0, 0, 1920, 1080);
+        const QRectF secondGeometry(0, 0, 2560, 1440);
+
+        QVERIFY(service.requestRecalculate(&layout, screenId, firstGeometry));
+        QTRY_COMPARE(computed.size(), 1);
+        QCOMPARE(layout.lastRecalcGeometry(), firstGeometry);
+        computed.clear();
+
+        // The cached completion is queued. A newer request made before that
+        // callback runs must turn the cached result into a superseded null
+        // notification, followed by the current applied result.
+        QVERIFY(service.requestRecalculate(&layout, screenId, firstGeometry));
+        QVERIFY(service.requestRecalculate(&layout, screenId, secondGeometry));
+        QTRY_VERIFY(computed.size() >= 2);
+
+        bool sawSuperseded = false;
+        bool sawCurrent = false;
+        for (const QList<QVariant>& args : computed) {
+            auto* reported = qvariant_cast<PhosphorZones::Layout*>(args.at(2));
+            sawSuperseded |= reported == nullptr;
+            sawCurrent |= reported == &layout;
+        }
+        QVERIFY(sawSuperseded);
+        QVERIFY(sawCurrent);
+        QCOMPARE(layout.lastRecalcGeometry(), secondGeometry);
+    }
 };
 
 QTEST_MAIN(TestLayoutZones)

--- a/tests/unit/core/layout/test_layout_zones.cpp
+++ b/tests/unit/core/layout/test_layout_zones.cpp
@@ -311,14 +311,20 @@ private Q_SLOTS:
 
         PhosphorZones::LayoutComputeService service;
         QSignalSpy computed(&service, &PhosphorZones::LayoutComputeService::geometriesComputed);
+        QSignalSpy computedForGeneration(&service,
+                                         &PhosphorZones::LayoutComputeService::geometriesComputedForGeneration);
         const QString screenId = QStringLiteral("DP-1");
         const QRectF firstGeometry(0, 0, 1920, 1080);
         const QRectF secondGeometry(0, 0, 2560, 1440);
 
         QVERIFY(service.requestRecalculate(&layout, screenId, firstGeometry));
         QTRY_COMPARE(computed.size(), 1);
+        QTRY_COMPARE(computedForGeneration.size(), 1);
+        QCOMPARE(computedForGeneration.first().at(3).toULongLong(), qulonglong(1));
+        QCOMPARE(service.currentGeneration(screenId), uint64_t(1));
         QCOMPARE(layout.lastRecalcGeometry(), firstGeometry);
         computed.clear();
+        computedForGeneration.clear();
 
         // The cached completion is queued. A newer request made before that
         // callback runs must turn the cached result into a superseded null
@@ -326,6 +332,7 @@ private Q_SLOTS:
         QVERIFY(service.requestRecalculate(&layout, screenId, firstGeometry));
         QVERIFY(service.requestRecalculate(&layout, screenId, secondGeometry));
         QTRY_VERIFY(computed.size() >= 2);
+        QTRY_VERIFY(computedForGeneration.size() >= 2);
 
         bool sawSuperseded = false;
         bool sawCurrent = false;
@@ -336,6 +343,17 @@ private Q_SLOTS:
         }
         QVERIFY(sawSuperseded);
         QVERIFY(sawCurrent);
+        bool sawSupersededGeneration = false;
+        bool sawCurrentGeneration = false;
+        for (const QList<QVariant>& args : computedForGeneration) {
+            auto* reported = qvariant_cast<PhosphorZones::Layout*>(args.at(2));
+            const qulonglong generation = args.at(3).toULongLong();
+            sawSupersededGeneration |= reported == nullptr && generation == 2;
+            sawCurrentGeneration |= reported == &layout && generation == 3;
+        }
+        QVERIFY(sawSupersededGeneration);
+        QVERIFY(sawCurrentGeneration);
+        QCOMPARE(service.currentGeneration(screenId), uint64_t(3));
         QCOMPARE(layout.lastRecalcGeometry(), secondGeometry);
     }
 };

--- a/tests/unit/core/layout/test_layout_zones.cpp
+++ b/tests/unit/core/layout/test_layout_zones.cpp
@@ -320,15 +320,20 @@ private Q_SLOTS:
         QVERIFY(service.requestRecalculate(&layout, screenId, firstGeometry));
         QTRY_COMPARE(computed.size(), 1);
         QTRY_COMPARE(computedForGeneration.size(), 1);
-        QCOMPARE(computedForGeneration.first().at(3).toULongLong(), qulonglong(1));
-        QCOMPARE(service.currentGeneration(screenId), uint64_t(1));
+        const qulonglong firstGeneration = computedForGeneration.first().at(3).toULongLong();
+        QCOMPARE(qulonglong(service.currentGeneration(screenId)), firstGeneration);
         QCOMPARE(layout.lastRecalcGeometry(), firstGeometry);
         computed.clear();
         computedForGeneration.clear();
 
         // The cached completion is queued. A newer request made before that
         // callback runs must turn the cached result into a superseded null
-        // notification, followed by the current applied result.
+        // notification, followed by the current applied result. The cached
+        // no-op deliberately does NOT consume a generation — bumping would
+        // supersede the in-flight real compute — so the observable contract
+        // is RELATIVE: the superseded emission carries a null layout and a
+        // generation strictly below the current one, and the applied
+        // emission carries the layout at exactly the current generation.
         QVERIFY(service.requestRecalculate(&layout, screenId, firstGeometry));
         QVERIFY(service.requestRecalculate(&layout, screenId, secondGeometry));
         QTRY_VERIFY(computed.size() >= 2);
@@ -343,17 +348,18 @@ private Q_SLOTS:
         }
         QVERIFY(sawSuperseded);
         QVERIFY(sawCurrent);
+        const qulonglong finalGeneration = qulonglong(service.currentGeneration(screenId));
+        QVERIFY(finalGeneration > firstGeneration);
         bool sawSupersededGeneration = false;
         bool sawCurrentGeneration = false;
         for (const QList<QVariant>& args : computedForGeneration) {
             auto* reported = qvariant_cast<PhosphorZones::Layout*>(args.at(2));
             const qulonglong generation = args.at(3).toULongLong();
-            sawSupersededGeneration |= reported == nullptr && generation == 2;
-            sawCurrentGeneration |= reported == &layout && generation == 3;
+            sawSupersededGeneration |= reported == nullptr && generation < finalGeneration;
+            sawCurrentGeneration |= reported == &layout && generation == finalGeneration;
         }
         QVERIFY(sawSupersededGeneration);
         QVERIFY(sawCurrentGeneration);
-        QCOMPARE(service.currentGeneration(screenId), uint64_t(3));
         QCOMPARE(layout.lastRecalcGeometry(), secondGeometry);
     }
 };

--- a/tests/unit/core/layout/test_layoutmanager_assignment.cpp
+++ b/tests/unit/core/layout/test_layoutmanager_assignment.cpp
@@ -8,25 +8,12 @@
 
 #include <QTest>
 #include <QDir>
-#include <QFile>
-#include <QJsonArray>
-#include <QJsonDocument>
-#include <QJsonObject>
 #include <QScopedPointer>
 #include <QUuid>
-#include "config/configbackends.h"
-#include "config/configdefaults.h"
-#include <memory>
-#include <vector>
 
 #include <PhosphorZones/LayoutRegistry.h>
 #include <PhosphorZones/Layout.h>
 #include <PhosphorZones/Zone.h>
-#include <PhosphorRules/ContextRuleBridge.h>
-#include <PhosphorRules/RuleAction.h>
-#include <PhosphorRules/Rule.h>
-#include <PhosphorRules/RuleStore.h>
-#include "core/types/constants.h"
 #include "helpers/StubSettings.h"
 #include "LayoutManagerAssignmentFixture.h"
 

--- a/tests/unit/core/snap/test_snap_assist_virtual.cpp
+++ b/tests/unit/core/snap/test_snap_assist_virtual.cpp
@@ -18,24 +18,16 @@
 #include <QTest>
 #include <QString>
 #include <QStringList>
-#include <QHash>
 #include <QSet>
 #include <QUuid>
-#include <QJsonArray>
-#include <QJsonDocument>
-#include <QJsonObject>
 #include <memory>
 
 #include <PhosphorPlacement/WindowTrackingService.h>
 #include <PhosphorZones/LayoutRegistry.h>
 #include <PhosphorSnapEngine/SnapState.h>
-#include "config/configbackends.h"
-#include "core/interfaces/interfaces.h"
 #include <PhosphorZones/Layout.h>
 #include <PhosphorZones/Zone.h>
-#include <PhosphorWorkspaces/VirtualDesktopManager.h>
 #include <PhosphorScreens/VirtualScreen.h>
-#include "core/utils/utils.h"
 #include "helpers/IsolatedConfigGuard.h"
 #include <PhosphorScreens/ScreenIdentity.h>
 

--- a/tests/unit/core/snap/test_snap_assist_virtual.cpp
+++ b/tests/unit/core/snap/test_snap_assist_virtual.cpp
@@ -421,7 +421,7 @@ private Q_SLOTS:
         QVERIFY(!m_service->isWindowSnapped(win3));
     }
 
-    void testPruneStaleAssignments_emptyAliveSet()
+    void testPruneStaleAssignments_emptyAliveSetRefused()
     {
         QString vsId = QStringLiteral("Dell:U2722D:115107/vs:0");
         QString win1 = QStringLiteral("app1|aaa");
@@ -430,14 +430,17 @@ private Q_SLOTS:
         m_service->assignWindowToZone(win1, m_zoneIds[0], vsId, 1);
         m_service->assignWindowToZone(win2, m_zoneIds[1], vsId, 1);
 
-        // Empty alive set — all windows should be pruned. Two store items:
-        // one zone assignment per window, nothing floating.
+        // An EMPTY alive set is refused (fail closed): the effect's one-shot
+        // alive report at daemon-ready can legitimately be empty before
+        // session-restored apps map their windows, and it must not wipe
+        // every persisted assignment. Per-window prune on windowClosed
+        // covers the genuine all-closed case.
         QSet<QString> alive;
         int pruned = m_service->pruneStaleAssignments(alive);
 
-        QCOMPARE(pruned, 2);
-        QVERIFY(!m_service->isWindowSnapped(win1));
-        QVERIFY(!m_service->isWindowSnapped(win2));
+        QCOMPARE(pruned, 0);
+        QVERIFY(m_service->isWindowSnapped(win1));
+        QVERIFY(m_service->isWindowSnapped(win2));
     }
 
     void testPruneStaleAssignments_cleansFloatingState()

--- a/tests/unit/core/snap/test_snap_engine.cpp
+++ b/tests/unit/core/snap/test_snap_engine.cpp
@@ -112,7 +112,10 @@ private Q_SLOTS:
         QCOMPARE(feedbackSpy.at(0).at(2).toString(), QStringLiteral("floated"));
     }
 
-    void testToggleWindowFloat_notSnappedNotFloating_noSignal()
+    // An untracked window must not flip float state, but the shortcut press
+    // is still REPORTED (not_managed) rather than silently absorbed — every
+    // navigation shortcut produces feedback, and a silent one reads as broken.
+    void testToggleWindowFloat_notSnappedNotFloating_reportsNotManaged()
     {
         SnapEngine engine(nullptr, m_wts, nullptr, nullptr, nullptr);
         m_wts->setSnapState(engine.snapState());
@@ -125,7 +128,9 @@ private Q_SLOTS:
         engine.toggleWindowFloat(windowId, screenName);
 
         QCOMPARE(floatSpy.count(), 0);
-        QCOMPARE(feedbackSpy.count(), 0);
+        QCOMPARE(feedbackSpy.count(), 1);
+        QCOMPARE(feedbackSpy.at(0).at(0).toBool(), false);
+        QCOMPARE(feedbackSpy.at(0).at(2).toString(), QStringLiteral("not_managed"));
     }
 
     void testSetWindowFloat_true_emitsFloatingChanged()

--- a/tests/unit/core/windowtracking/test_window_placement_store.cpp
+++ b/tests/unit/core/windowtracking/test_window_placement_store.cpp
@@ -810,9 +810,12 @@ private Q_SLOTS:
         QCOMPARE(kept->freeGeometryFor(QStringLiteral("S1")), keepS1);
         QCOMPARE(kept->freeGeometryFor(QStringLiteral("S2")), bridgeS2);
 
-        // The other FIFO order — leaf recorded BEFORE the bridge — must collapse
-        // the same connected set (this is the order the fixpoint claim is about:
-        // the leaf is only reachable through a screen absorbed later).
+        // The other FIFO order — leaf recorded BEFORE the bridge. NOTE: with
+        // this ordering the backward prune scan reaches the bridge FIRST, so
+        // this is the EASY case; the ORIGINAL ordering above (leaf after
+        // bridge) is the one that exercises the fixpoint re-scan. The row is
+        // still not redundant — bucket positions and sequences differ — it
+        // just is not the discriminating permutation.
         WindowPlacementStore reversed;
         reversed.record(makePlacement(QStringLiteral("dolphin|leaf"), QStringLiteral("dolphin"),
                                       WindowPlacement::stateFloating(), WindowPlacement::snapEngineId(),

--- a/tests/unit/core/windowtracking/test_window_placement_store.cpp
+++ b/tests/unit/core/windowtracking/test_window_placement_store.cpp
@@ -7,37 +7,12 @@
 
 #include <PhosphorEngine/WindowPlacement.h>
 #include <PhosphorEngine/WindowPlacementStore.h>
+#include "helpers/WindowPlacementBuilders.h"
 
 using PhosphorEngine::EngineSlot;
 using PhosphorEngine::WindowPlacement;
 using PhosphorEngine::WindowPlacementStore;
-
-namespace {
-// Build a single-engine partial record: the calling engine's slot plus, for the
-// un-managed states (free/floating), the shared per-screen free geometry the
-// capture orchestrator would supply. record() merges these into the one record
-// per window.
-WindowPlacement make(const QString& windowId, const QString& appId, const QString& state, const QString& engine,
-                     const QString& screen = QStringLiteral("DP-1"), const QRect& rect = QRect(10, 20, 300, 400))
-{
-    WindowPlacement p;
-    p.windowId = windowId;
-    p.appId = appId;
-    p.screenId = screen;
-    EngineSlot slot;
-    slot.state = state;
-    if (state == WindowPlacement::stateSnapped()) {
-        slot.zoneIds = QStringList{QStringLiteral("z1")};
-    } else if (state == WindowPlacement::stateTiled()) {
-        slot.order = 0;
-    }
-    p.engines.insert(engine, slot);
-    if (state == WindowPlacement::stateFree() || state == WindowPlacement::stateFloating()) {
-        p.freeGeometryByScreen.insert(screen, rect);
-    }
-    return p;
-}
-} // namespace
+using PlasmaZones::TestHelpers::makePlacement;
 
 class TestWindowPlacementStore : public QObject
 {
@@ -47,8 +22,8 @@ private Q_SLOTS:
     void testRecordAndTake_exact()
     {
         WindowPlacementStore store;
-        store.record(make(QStringLiteral("firefox|a"), QStringLiteral("firefox"), WindowPlacement::stateSnapped(),
-                          WindowPlacement::snapEngineId()));
+        store.record(makePlacement(QStringLiteral("firefox|a"), QStringLiteral("firefox"),
+                                   WindowPlacement::stateSnapped(), WindowPlacement::snapEngineId()));
         QCOMPARE(store.size(), 1);
 
         auto p = store.take(QStringLiteral("firefox|a"), QStringLiteral("firefox"));
@@ -64,10 +39,10 @@ private Q_SLOTS:
         // slot (the "snapped window floats on login" bug).
         WindowPlacementStore store;
         const QString id = QStringLiteral("settings|x");
-        store.record(
-            make(id, QStringLiteral("settings"), WindowPlacement::stateFloating(), WindowPlacement::snapEngineId()));
-        store.record(
-            make(id, QStringLiteral("settings"), WindowPlacement::stateSnapped(), WindowPlacement::snapEngineId()));
+        store.record(makePlacement(id, QStringLiteral("settings"), WindowPlacement::stateFloating(),
+                                   WindowPlacement::snapEngineId()));
+        store.record(makePlacement(id, QStringLiteral("settings"), WindowPlacement::stateSnapped(),
+                                   WindowPlacement::snapEngineId()));
 
         QCOMPARE(store.size(), 1); // one record per window
         auto p = store.take(id, QStringLiteral("settings"));
@@ -83,10 +58,10 @@ private Q_SLOTS:
         // engine slots — recording the autotile slot does NOT clobber the snap slot.
         WindowPlacementStore store;
         const QString id = QStringLiteral("settings|x");
-        store.record(
-            make(id, QStringLiteral("settings"), WindowPlacement::stateSnapped(), WindowPlacement::snapEngineId()));
-        store.record(make(id, QStringLiteral("settings"), WindowPlacement::stateFloating(),
-                          WindowPlacement::autotileEngineId()));
+        store.record(makePlacement(id, QStringLiteral("settings"), WindowPlacement::stateSnapped(),
+                                   WindowPlacement::snapEngineId()));
+        store.record(makePlacement(id, QStringLiteral("settings"), WindowPlacement::stateFloating(),
+                                   WindowPlacement::autotileEngineId()));
 
         QCOMPARE(store.size(), 1); // merged into a single per-window record
 
@@ -104,11 +79,11 @@ private Q_SLOTS:
         WindowPlacementStore store;
         const QString id = QStringLiteral("zed|1");
         // Autotile floats it on DP-1 (captures a free geometry on DP-1).
-        store.record(make(id, QStringLiteral("zed"), WindowPlacement::stateFloating(),
-                          WindowPlacement::autotileEngineId(), QStringLiteral("DP-1")));
+        store.record(makePlacement(id, QStringLiteral("zed"), WindowPlacement::stateFloating(),
+                                   WindowPlacement::autotileEngineId(), QStringLiteral("DP-1")));
         // Snap snaps it (a managed slot — no geometry of its own).
-        store.record(make(id, QStringLiteral("zed"), WindowPlacement::stateSnapped(), WindowPlacement::snapEngineId(),
-                          QStringLiteral("DP-1")));
+        store.record(makePlacement(id, QStringLiteral("zed"), WindowPlacement::stateSnapped(),
+                                   WindowPlacement::snapEngineId(), QStringLiteral("DP-1")));
 
         auto p = store.peek(id, QStringLiteral("zed"));
         QVERIFY(p.has_value());
@@ -123,24 +98,24 @@ private Q_SLOTS:
         // settle: a content-identical re-capture (sequence aside) returns false.
         WindowPlacementStore store;
         const QString id = QStringLiteral("term|1");
-        QVERIFY(store.record(
-            make(id, QStringLiteral("term"), WindowPlacement::stateSnapped(), WindowPlacement::snapEngineId())));
+        QVERIFY(store.record(makePlacement(id, QStringLiteral("term"), WindowPlacement::stateSnapped(),
+                                           WindowPlacement::snapEngineId())));
         // Identical content → no change.
-        QVERIFY(!store.record(
-            make(id, QStringLiteral("term"), WindowPlacement::stateSnapped(), WindowPlacement::snapEngineId())));
+        QVERIFY(!store.record(makePlacement(id, QStringLiteral("term"), WindowPlacement::stateSnapped(),
+                                            WindowPlacement::snapEngineId())));
         // Different state → changed.
-        QVERIFY(store.record(
-            make(id, QStringLiteral("term"), WindowPlacement::stateFloating(), WindowPlacement::snapEngineId())));
+        QVERIFY(store.record(makePlacement(id, QStringLiteral("term"), WindowPlacement::stateFloating(),
+                                           WindowPlacement::snapEngineId())));
     }
 
     void testUuidExactBeforeAppIdFifo()
     {
         WindowPlacementStore store;
         // Two instances of the same app, different uuids/states.
-        store.record(make(QStringLiteral("term|1"), QStringLiteral("term"), WindowPlacement::stateSnapped(),
-                          WindowPlacement::snapEngineId()));
-        store.record(make(QStringLiteral("term|2"), QStringLiteral("term"), WindowPlacement::stateFloating(),
-                          WindowPlacement::snapEngineId()));
+        store.record(makePlacement(QStringLiteral("term|1"), QStringLiteral("term"), WindowPlacement::stateSnapped(),
+                                   WindowPlacement::snapEngineId()));
+        store.record(makePlacement(QStringLiteral("term|2"), QStringLiteral("term"), WindowPlacement::stateFloating(),
+                                   WindowPlacement::snapEngineId()));
 
         // Exact uuid match takes its own record, not the FIFO head.
         auto p2 = store.take(QStringLiteral("term|2"), QStringLiteral("term"));
@@ -158,8 +133,8 @@ private Q_SLOTS:
     void testAcceptPredicate_rejectsWrongScreen()
     {
         WindowPlacementStore store;
-        store.record(make(QStringLiteral("app|1"), QStringLiteral("app"), WindowPlacement::stateSnapped(),
-                          WindowPlacement::snapEngineId(), QStringLiteral("DP-2")));
+        store.record(makePlacement(QStringLiteral("app|1"), QStringLiteral("app"), WindowPlacement::stateSnapped(),
+                                   WindowPlacement::snapEngineId(), QStringLiteral("DP-2")));
         // Reopen on DP-1: a screen-matching predicate rejects the DP-2 record.
         auto none = store.take(QStringLiteral("app|new"), QStringLiteral("app"), [](const WindowPlacement& p) {
             return p.screenId == QStringLiteral("DP-1");
@@ -171,10 +146,10 @@ private Q_SLOTS:
     void testClearAndRemoveIf()
     {
         WindowPlacementStore store;
-        store.record(make(QStringLiteral("a|a-instance"), QStringLiteral("a"), WindowPlacement::stateSnapped(),
-                          WindowPlacement::snapEngineId(), QStringLiteral("DP-1")));
-        store.record(make(QStringLiteral("b|b-instance"), QStringLiteral("b"), WindowPlacement::stateSnapped(),
-                          WindowPlacement::snapEngineId(), QStringLiteral("DP-2")));
+        store.record(makePlacement(QStringLiteral("a|a-instance"), QStringLiteral("a"), WindowPlacement::stateSnapped(),
+                                   WindowPlacement::snapEngineId(), QStringLiteral("DP-1")));
+        store.record(makePlacement(QStringLiteral("b|b-instance"), QStringLiteral("b"), WindowPlacement::stateSnapped(),
+                                   WindowPlacement::snapEngineId(), QStringLiteral("DP-2")));
         store.clear(QStringLiteral("a|a-instance"));
         QVERIFY(!store.contains(QStringLiteral("a|a-instance"), QStringLiteral("a")));
         QCOMPARE(store.size(), 1);
@@ -189,8 +164,8 @@ private Q_SLOTS:
     void testSerializeRoundTrip()
     {
         WindowPlacementStore store;
-        WindowPlacement p = make(QStringLiteral("firefox|u"), QStringLiteral("firefox"),
-                                 WindowPlacement::stateSnapped(), WindowPlacement::snapEngineId());
+        WindowPlacement p = makePlacement(QStringLiteral("firefox|u"), QStringLiteral("firefox"),
+                                          WindowPlacement::stateSnapped(), WindowPlacement::snapEngineId());
         p.virtualDesktop = 3;
         p.activity = QStringLiteral("act-1");
         p.kind = PhosphorEngine::WindowKind::Normal;
@@ -217,10 +192,10 @@ private Q_SLOTS:
     void testSerializeHonorsKeepPredicate()
     {
         WindowPlacementStore store;
-        store.record(make(QStringLiteral("a|a-instance"), QStringLiteral("a"), WindowPlacement::stateSnapped(),
-                          WindowPlacement::snapEngineId(), QStringLiteral("DP-1")));
-        store.record(make(QStringLiteral("b|b-instance"), QStringLiteral("b"), WindowPlacement::stateSnapped(),
-                          WindowPlacement::snapEngineId(), QStringLiteral("DP-2")));
+        store.record(makePlacement(QStringLiteral("a|a-instance"), QStringLiteral("a"), WindowPlacement::stateSnapped(),
+                                   WindowPlacement::snapEngineId(), QStringLiteral("DP-1")));
+        store.record(makePlacement(QStringLiteral("b|b-instance"), QStringLiteral("b"), WindowPlacement::stateSnapped(),
+                                   WindowPlacement::snapEngineId(), QStringLiteral("DP-2")));
         // keep only DP-1 (mirrors the disabled-context gate).
         const QJsonObject json = store.serialize([](const WindowPlacement& p) {
             return p.screenId == QStringLiteral("DP-1");
@@ -234,10 +209,10 @@ private Q_SLOTS:
         // peek() with a non-matching uuid falls back to the appId bucket and must
         // return the NEWEST (highest sequence) record, not an arbitrary one.
         WindowPlacementStore store;
-        store.record(make(QStringLiteral("term|old"), QStringLiteral("term"), WindowPlacement::stateTiled(),
-                          WindowPlacement::autotileEngineId()));
-        store.record(make(QStringLiteral("term|new"), QStringLiteral("term"), WindowPlacement::stateFloating(),
-                          WindowPlacement::autotileEngineId()));
+        store.record(makePlacement(QStringLiteral("term|old"), QStringLiteral("term"), WindowPlacement::stateTiled(),
+                                   WindowPlacement::autotileEngineId()));
+        store.record(makePlacement(QStringLiteral("term|new"), QStringLiteral("term"), WindowPlacement::stateFloating(),
+                                   WindowPlacement::autotileEngineId()));
 
         auto p = store.peek(QStringLiteral("term|unknown"), QStringLiteral("term"));
         QVERIFY(p.has_value());
@@ -252,8 +227,8 @@ private Q_SLOTS:
         // record must not answer for a record-less window (the sibling zone /
         // float-state bleed the live-state readers were exposed to).
         WindowPlacementStore store;
-        store.record(make(QStringLiteral("term|sibling"), QStringLiteral("term"), WindowPlacement::stateSnapped(),
-                          WindowPlacement::snapEngineId()));
+        store.record(makePlacement(QStringLiteral("term|sibling"), QStringLiteral("term"),
+                                   WindowPlacement::stateSnapped(), WindowPlacement::snapEngineId()));
 
         QVERIFY(store.peek(QStringLiteral("term|other"), QStringLiteral("term")).has_value()); // fallback would bleed
         QVERIFY(!store.peekExact(QStringLiteral("term|other")).has_value()); // exact-only refuses
@@ -268,8 +243,8 @@ private Q_SLOTS:
         // The accepting (not just rejecting) path: an appId-FIFO candidate that
         // satisfies the predicate is selected and consumed.
         WindowPlacementStore store;
-        store.record(make(QStringLiteral("app|1"), QStringLiteral("app"), WindowPlacement::stateSnapped(),
-                          WindowPlacement::snapEngineId(), QStringLiteral("DP-2")));
+        store.record(makePlacement(QStringLiteral("app|1"), QStringLiteral("app"), WindowPlacement::stateSnapped(),
+                                   WindowPlacement::snapEngineId(), QStringLiteral("DP-2")));
         auto p = store.take(QStringLiteral("app|new"), QStringLiteral("app"), [](const WindowPlacement& r) {
             return r.screenId == QStringLiteral("DP-2");
         });
@@ -288,11 +263,12 @@ private Q_SLOTS:
         // first and the window never returns to its zone. With it, the snapped
         // record wins even though it is newer AND on a different screen.
         WindowPlacementStore store;
-        store.record(make(QStringLiteral("ghastty|old"), QStringLiteral("ghastty"), WindowPlacement::stateFree(),
-                          WindowPlacement::snapEngineId(), QString())); // empty screen, older
-        store.record(make(QStringLiteral("ghastty|snapped"), QStringLiteral("ghastty"), WindowPlacement::stateSnapped(),
-                          WindowPlacement::snapEngineId(),
-                          QStringLiteral("DP-1"))); // newer, snapped on DP-1
+        store.record(makePlacement(QStringLiteral("ghastty|old"), QStringLiteral("ghastty"),
+                                   WindowPlacement::stateFree(), WindowPlacement::snapEngineId(),
+                                   QString())); // empty screen, older
+        store.record(makePlacement(QStringLiteral("ghastty|snapped"), QStringLiteral("ghastty"),
+                                   WindowPlacement::stateSnapped(), WindowPlacement::snapEngineId(),
+                                   QStringLiteral("DP-1"))); // newer, snapped on DP-1
 
         const auto accept = [](const WindowPlacement& p) {
             if (p.slotFor(WindowPlacement::snapEngineId()).state == WindowPlacement::stateSnapped()) {
@@ -319,8 +295,8 @@ private Q_SLOTS:
         // When no record satisfies `preferred`, the oldest merely-accepted record is
         // still consumed — `preferred` only re-ranks, it never filters.
         WindowPlacementStore store;
-        store.record(make(QStringLiteral("app|1"), QStringLiteral("app"), WindowPlacement::stateFree(),
-                          WindowPlacement::snapEngineId(), QStringLiteral("DP-2")));
+        store.record(makePlacement(QStringLiteral("app|1"), QStringLiteral("app"), WindowPlacement::stateFree(),
+                                   WindowPlacement::snapEngineId(), QStringLiteral("DP-2")));
         const auto accept = [](const WindowPlacement& p) {
             return p.screenId.isEmpty() || p.screenId == QStringLiteral("DP-2");
         };
@@ -336,18 +312,18 @@ private Q_SLOTS:
     void testHasRestorableContent()
     {
         // Valid free/float geometry → content.
-        QVERIFY(make(QStringLiteral("a|1"), QStringLiteral("a"), WindowPlacement::stateFree(),
-                     WindowPlacement::snapEngineId())
+        QVERIFY(makePlacement(QStringLiteral("a|1"), QStringLiteral("a"), WindowPlacement::stateFree(),
+                              WindowPlacement::snapEngineId())
                     .hasRestorableContent());
-        QVERIFY(make(QStringLiteral("a|1"), QStringLiteral("a"), WindowPlacement::stateFloating(),
-                     WindowPlacement::snapEngineId())
+        QVERIFY(makePlacement(QStringLiteral("a|1"), QStringLiteral("a"), WindowPlacement::stateFloating(),
+                              WindowPlacement::snapEngineId())
                     .hasRestorableContent());
         // A managed slot (snapped / tiled) → content even with no geometry.
-        QVERIFY(make(QStringLiteral("a|1"), QStringLiteral("a"), WindowPlacement::stateSnapped(),
-                     WindowPlacement::snapEngineId())
+        QVERIFY(makePlacement(QStringLiteral("a|1"), QStringLiteral("a"), WindowPlacement::stateSnapped(),
+                              WindowPlacement::snapEngineId())
                     .hasRestorableContent());
-        QVERIFY(make(QStringLiteral("a|1"), QStringLiteral("a"), WindowPlacement::stateTiled(),
-                     WindowPlacement::autotileEngineId())
+        QVERIFY(makePlacement(QStringLiteral("a|1"), QStringLiteral("a"), WindowPlacement::stateTiled(),
+                              WindowPlacement::autotileEngineId())
                     .hasRestorableContent());
 
         // A bare {free, no geometry, no zones} record — the residue a window leaves
@@ -411,8 +387,9 @@ private Q_SLOTS:
         residue.engines.insert(WindowPlacement::snapEngineId(), freeSlot);
         store.record(residue);
         // Newer floating record carrying the resized geometry.
-        store.record(make(QStringLiteral("kate|floated"), QStringLiteral("kate"), WindowPlacement::stateFloating(),
-                          WindowPlacement::snapEngineId(), QStringLiteral("DP-1")));
+        store.record(makePlacement(QStringLiteral("kate|floated"), QStringLiteral("kate"),
+                                   WindowPlacement::stateFloating(), WindowPlacement::snapEngineId(),
+                                   QStringLiteral("DP-1")));
 
         // Mirror the engine's predicates: snapped records are eligible cross-screen;
         // contentless residue is rejected; other content is accepted (restore-unsnapped
@@ -442,10 +419,12 @@ private Q_SLOTS:
         // to "any free geometry" let the older floating record win by age — and, in
         // the cross-mode case, let a snap-screen open consume a record it could not use.
         WindowPlacementStore store;
-        store.record(make(QStringLiteral("kate|floated"), QStringLiteral("kate"), WindowPlacement::stateFloating(),
-                          WindowPlacement::snapEngineId(), QStringLiteral("DP-1"))); // older, content (geometry)
-        store.record(make(QStringLiteral("kate|snapped"), QStringLiteral("kate"), WindowPlacement::stateSnapped(),
-                          WindowPlacement::snapEngineId(), QStringLiteral("DP-1"))); // newer, snapped
+        store.record(makePlacement(QStringLiteral("kate|floated"), QStringLiteral("kate"),
+                                   WindowPlacement::stateFloating(), WindowPlacement::snapEngineId(),
+                                   QStringLiteral("DP-1"))); // older, content (geometry)
+        store.record(makePlacement(QStringLiteral("kate|snapped"), QStringLiteral("kate"),
+                                   WindowPlacement::stateSnapped(), WindowPlacement::snapEngineId(),
+                                   QStringLiteral("DP-1"))); // newer, snapped
 
         const auto accept = [](const WindowPlacement& p) {
             if (p.slotFor(WindowPlacement::snapEngineId()).state == WindowPlacement::stateSnapped()) {
@@ -469,8 +448,9 @@ private Q_SLOTS:
         // something to restore and drop bare {free, no geometry} residue, so it never
         // reaches disk to crowd the next session's FIFO.
         WindowPlacementStore store;
-        store.record(make(QStringLiteral("good|good-instance"), QStringLiteral("good"),
-                          WindowPlacement::stateFloating(), WindowPlacement::snapEngineId(), QStringLiteral("DP-1")));
+        store.record(makePlacement(QStringLiteral("good|good-instance"), QStringLiteral("good"),
+                                   WindowPlacement::stateFloating(), WindowPlacement::snapEngineId(),
+                                   QStringLiteral("DP-1")));
         WindowPlacement residue;
         residue.windowId = QStringLiteral("noise|noise-instance");
         residue.appId = QStringLiteral("noise");
@@ -492,8 +472,8 @@ private Q_SLOTS:
         // app → the first (term|0) is evicted; term|1..16 survive.
         WindowPlacementStore store;
         for (int i = 0; i < 17; ++i) {
-            store.record(make(QStringLiteral("term|%1").arg(i), QStringLiteral("term"), WindowPlacement::stateSnapped(),
-                              WindowPlacement::snapEngineId()));
+            store.record(makePlacement(QStringLiteral("term|%1").arg(i), QStringLiteral("term"),
+                                       WindowPlacement::stateSnapped(), WindowPlacement::snapEngineId()));
         }
         QCOMPARE(store.size(), 16); // capped at MaxPerApp
         QVERIFY(!store.contains(QStringLiteral("term|0"))); // oldest evicted
@@ -506,14 +486,15 @@ private Q_SLOTS:
         // prefix drops the stale entry from the old bucket and moves it to the
         // new one (mid-session class rename).
         WindowPlacementStore store;
-        store.record(make(QStringLiteral("oldapp|1"), QStringLiteral("oldapp"), WindowPlacement::stateSnapped(),
-                          WindowPlacement::snapEngineId()));
-        store.record(make(QStringLiteral("newapp|1"), QStringLiteral("newapp"), WindowPlacement::stateFloating(),
-                          WindowPlacement::snapEngineId()));
+        store.record(makePlacement(QStringLiteral("oldapp|1"), QStringLiteral("oldapp"),
+                                   WindowPlacement::stateSnapped(), WindowPlacement::snapEngineId()));
+        store.record(makePlacement(QStringLiteral("newapp|1"), QStringLiteral("newapp"),
+                                   WindowPlacement::stateFloating(), WindowPlacement::snapEngineId()));
 
         QCOMPARE(store.size(), 1); // not duplicated across buckets
         QCOMPARE(store.records().size(), 1); // exactly one record total (old bucket erased)
-        // The old appId bucket is gone (empty appId arg = bucket-only check).
+        // The old appId bucket is gone (empty windowId arg + appId = "does the
+        // bucket hold ANY record" check).
         QVERIFY(!store.contains(QString(), QStringLiteral("oldapp")));
         auto p = store.take(QStringLiteral("newapp|1"), QStringLiteral("newapp"));
         QVERIFY(p.has_value());
@@ -523,11 +504,14 @@ private Q_SLOTS:
 
     void testTake_prefixMutationUsesOwnInstanceBeforeSiblingFifo()
     {
+        // A reopened window whose appId prefix mutated (oldclass → newclass) must
+        // still take ITS OWN prior record via the instance suffix, not fall back
+        // to FIFO and steal a sibling's record from the new-prefix bucket.
         WindowPlacementStore store;
-        store.record(make(QStringLiteral("oldclass|own-instance"), QStringLiteral("oldclass"),
-                          WindowPlacement::stateSnapped(), WindowPlacement::snapEngineId()));
-        store.record(make(QStringLiteral("newclass|sibling"), QStringLiteral("newclass"),
-                          WindowPlacement::stateFloating(), WindowPlacement::snapEngineId()));
+        store.record(makePlacement(QStringLiteral("oldclass|own-instance"), QStringLiteral("oldclass"),
+                                   WindowPlacement::stateSnapped(), WindowPlacement::snapEngineId()));
+        store.record(makePlacement(QStringLiteral("newclass|sibling"), QStringLiteral("newclass"),
+                                   WindowPlacement::stateFloating(), WindowPlacement::snapEngineId()));
 
         const auto own = store.take(QStringLiteral("newclass|own-instance"), QStringLiteral("newclass"));
         QVERIFY(own.has_value());
@@ -547,22 +531,24 @@ private Q_SLOTS:
         // the emptied bucket is not necessarily the last in hash order.
         WindowPlacementStore store;
         for (int i = 0; i < 5; ++i) {
-            store.record(make(QStringLiteral("keep%1|keep-instance-%1").arg(i), QStringLiteral("keep%1").arg(i),
-                              WindowPlacement::stateSnapped(), WindowPlacement::snapEngineId()));
+            store.record(makePlacement(QStringLiteral("keep%1|keep-instance-%1").arg(i),
+                                       QStringLiteral("keep%1").arg(i), WindowPlacement::stateSnapped(),
+                                       WindowPlacement::snapEngineId()));
         }
-        store.record(make(QStringLiteral("w|1"), QStringLiteral("renamefrom"), WindowPlacement::stateTiled(),
-                          WindowPlacement::autotileEngineId()));
+        store.record(makePlacement(QStringLiteral("renamefrom|1"), QStringLiteral("renamefrom"),
+                                   WindowPlacement::stateTiled(), WindowPlacement::autotileEngineId()));
         QCOMPARE(store.size(), 6);
 
-        store.record(make(QStringLiteral("w|1"), QStringLiteral("renameto"), WindowPlacement::stateFloating(),
-                          WindowPlacement::autotileEngineId()));
+        store.record(makePlacement(QStringLiteral("renameto|1"), QStringLiteral("renameto"),
+                                   WindowPlacement::stateFloating(), WindowPlacement::autotileEngineId()));
 
         QCOMPARE(store.size(), 6); // 5 keepers + the moved record (no duplication)
-        QVERIFY(!store.contains(QString(), QStringLiteral("renamefrom"))); // old bucket erased
+        // Empty windowId arg = bucket-level emptiness check: old bucket erased.
+        QVERIFY(!store.contains(QString(), QStringLiteral("renamefrom")));
         // peekExact + appId compare, not the two-arg contains (which passes
         // on ANY record in the bucket and so cannot pin the central claim:
         // that THIS record moved into the renamed bucket).
-        const auto moved = store.peekExact(QStringLiteral("w|1"));
+        const auto moved = store.peekExact(QStringLiteral("renameto|1"));
         QVERIFY(moved.has_value());
         QCOMPARE(moved->appId, QStringLiteral("renameto"));
         for (int i = 0; i < 5; ++i) {
@@ -576,12 +562,12 @@ private Q_SLOTS:
         // has no `appId|uuid` separator (structureless/forged) must both be dropped.
         // A windowId whose embedded class differs from the bucket appId is NOT dropped
         // (legitimate registry appId drift, e.g. Electron re-broadcasting WM_CLASS).
-        WindowPlacement good = make(QStringLiteral("vesktop|u"), QStringLiteral("vesktop"),
-                                    WindowPlacement::stateSnapped(), WindowPlacement::snapEngineId());
-        WindowPlacement drifted = make(QStringLiteral("oldclass|u2"), QStringLiteral("vesktop"),
-                                       WindowPlacement::stateSnapped(), WindowPlacement::snapEngineId());
-        WindowPlacement structureless = make(QStringLiteral("nosep"), QStringLiteral("vesktop"),
+        WindowPlacement good = makePlacement(QStringLiteral("vesktop|u"), QStringLiteral("vesktop"),
                                              WindowPlacement::stateSnapped(), WindowPlacement::snapEngineId());
+        WindowPlacement drifted = makePlacement(QStringLiteral("oldclass|u2"), QStringLiteral("vesktop"),
+                                                WindowPlacement::stateSnapped(), WindowPlacement::snapEngineId());
+        WindowPlacement structureless = makePlacement(QStringLiteral("nosep"), QStringLiteral("vesktop"),
+                                                      WindowPlacement::stateSnapped(), WindowPlacement::snapEngineId());
         QJsonObject root;
         root[QStringLiteral("vesktop")] = QJsonArray{good.toJson(), drifted.toJson(), structureless.toJson()};
         root[QStringLiteral("corrupt|key")] = QJsonArray{good.toJson()};
@@ -596,12 +582,21 @@ private Q_SLOTS:
 
     void testDeserialize_mergesDuplicateInstanceAcrossPrefixes()
     {
-        WindowPlacement older = make(QStringLiteral("oldclass|same-instance"), QStringLiteral("oldclass"),
-                                     WindowPlacement::stateSnapped(), WindowPlacement::snapEngineId());
+        // Two persisted records for the SAME live instance under different appId
+        // prefixes must merge into one on reload, with the higher-sequence record
+        // winning identity AND any conflicting engine slot (replay is oldest to
+        // newest, so the newer record's slots land last).
+        WindowPlacement older = makePlacement(QStringLiteral("oldclass|same-instance"), QStringLiteral("oldclass"),
+                                              WindowPlacement::stateSnapped(), WindowPlacement::snapEngineId());
         older.sequence = 4;
-        WindowPlacement newer = make(QStringLiteral("newclass|same-instance"), QStringLiteral("newclass"),
-                                     WindowPlacement::stateTiled(), WindowPlacement::autotileEngineId());
+        WindowPlacement newer = makePlacement(QStringLiteral("newclass|same-instance"), QStringLiteral("newclass"),
+                                              WindowPlacement::stateTiled(), WindowPlacement::autotileEngineId());
         newer.sequence = 9;
+        // Conflicting snap slot on the newer record: sequence precedence must be
+        // observable as an overwrite, not just a union of disjoint engines.
+        EngineSlot newerSnap;
+        newerSnap.state = WindowPlacement::stateFloating();
+        newer.engines.insert(WindowPlacement::snapEngineId(), newerSnap);
 
         QJsonObject root;
         root[QStringLiteral("oldclass")] = QJsonArray{older.toJson()};
@@ -611,12 +606,15 @@ private Q_SLOTS:
         store.deserialize(root);
 
         QCOMPARE(store.size(), 1);
+        // Empty windowId arg = bucket-level emptiness check.
         QVERIFY(!store.contains(QString(), QStringLiteral("oldclass")));
         const auto merged = store.peekExact(QStringLiteral("newclass|same-instance"));
         QVERIFY(merged.has_value());
         QCOMPARE(merged->windowId, QStringLiteral("newclass|same-instance"));
         QCOMPARE(merged->appId, QStringLiteral("newclass"));
-        QCOMPARE(merged->slotFor(WindowPlacement::snapEngineId()).state, QString(WindowPlacement::stateSnapped()));
+        // Sequence 9 wins the contested snap slot (Floating over the older
+        // record's Snapped); the uncontested autotile slot is unioned in.
+        QCOMPARE(merged->slotFor(WindowPlacement::snapEngineId()).state, QString(WindowPlacement::stateFloating()));
         QCOMPARE(merged->slotFor(WindowPlacement::autotileEngineId()).state, QString(WindowPlacement::stateTiled()));
     }
 
@@ -625,8 +623,8 @@ private Q_SLOTS:
         // The engine-agnostic claim: an autotile slot (its own state + order) round-
         // trips through serialize/deserialize unchanged.
         WindowPlacementStore store;
-        WindowPlacement p = make(QStringLiteral("ghostty|u"), QStringLiteral("ghostty"), WindowPlacement::stateTiled(),
-                                 WindowPlacement::autotileEngineId());
+        WindowPlacement p = makePlacement(QStringLiteral("ghostty|u"), QStringLiteral("ghostty"),
+                                          WindowPlacement::stateTiled(), WindowPlacement::autotileEngineId());
         EngineSlot slot = p.slotFor(WindowPlacement::autotileEngineId());
         slot.order = 3;
         p.engines.insert(WindowPlacement::autotileEngineId(), slot);
@@ -649,10 +647,12 @@ private Q_SLOTS:
         // state that makes a reopen "open in a different spot each time" under the
         // oldest-first take(). Collapsing keeps the named (closing) record only.
         WindowPlacementStore store;
-        store.record(make(QStringLiteral("dolphin|old"), QStringLiteral("dolphin"), WindowPlacement::stateFloating(),
-                          WindowPlacement::snapEngineId(), QStringLiteral("S1")));
-        store.record(make(QStringLiteral("dolphin|new"), QStringLiteral("dolphin"), WindowPlacement::stateFloating(),
-                          WindowPlacement::snapEngineId(), QStringLiteral("S1")));
+        store.record(makePlacement(QStringLiteral("dolphin|old"), QStringLiteral("dolphin"),
+                                   WindowPlacement::stateFloating(), WindowPlacement::snapEngineId(),
+                                   QStringLiteral("S1")));
+        store.record(makePlacement(QStringLiteral("dolphin|new"), QStringLiteral("dolphin"),
+                                   WindowPlacement::stateFloating(), WindowPlacement::snapEngineId(),
+                                   QStringLiteral("S1")));
 
         QVERIFY(store.collapsePureFloatSiblings(QStringLiteral("dolphin"), QStringLiteral("dolphin|new")));
 
@@ -666,16 +666,20 @@ private Q_SLOTS:
     {
         WindowPlacementStore store;
         // Snapped (managed) sibling — never pruned.
-        store.record(make(QStringLiteral("dolphin|snapped"), QStringLiteral("dolphin"), WindowPlacement::stateSnapped(),
-                          WindowPlacement::snapEngineId(), QStringLiteral("S1")));
+        store.record(makePlacement(QStringLiteral("dolphin|snapped"), QStringLiteral("dolphin"),
+                                   WindowPlacement::stateSnapped(), WindowPlacement::snapEngineId(),
+                                   QStringLiteral("S1")));
         // Pure-float on a DIFFERENT screen — distinct memory, kept.
-        store.record(make(QStringLiteral("dolphin|other"), QStringLiteral("dolphin"), WindowPlacement::stateFloating(),
-                          WindowPlacement::snapEngineId(), QStringLiteral("S2")));
+        store.record(makePlacement(QStringLiteral("dolphin|other"), QStringLiteral("dolphin"),
+                                   WindowPlacement::stateFloating(), WindowPlacement::snapEngineId(),
+                                   QStringLiteral("S2")));
         // Pure-float on the SAME screen as the kept record — pruned.
-        store.record(make(QStringLiteral("dolphin|dup"), QStringLiteral("dolphin"), WindowPlacement::stateFloating(),
-                          WindowPlacement::snapEngineId(), QStringLiteral("S1")));
-        store.record(make(QStringLiteral("dolphin|keep"), QStringLiteral("dolphin"), WindowPlacement::stateFloating(),
-                          WindowPlacement::snapEngineId(), QStringLiteral("S1")));
+        store.record(makePlacement(QStringLiteral("dolphin|dup"), QStringLiteral("dolphin"),
+                                   WindowPlacement::stateFloating(), WindowPlacement::snapEngineId(),
+                                   QStringLiteral("S1")));
+        store.record(makePlacement(QStringLiteral("dolphin|keep"), QStringLiteral("dolphin"),
+                                   WindowPlacement::stateFloating(), WindowPlacement::snapEngineId(),
+                                   QStringLiteral("S1")));
 
         QVERIFY(store.collapsePureFloatSiblings(QStringLiteral("dolphin"), QStringLiteral("dolphin|keep")));
 
@@ -689,10 +693,12 @@ private Q_SLOTS:
     {
         // A managed (snapped) close must not prune float siblings.
         WindowPlacementStore store;
-        store.record(make(QStringLiteral("dolphin|float"), QStringLiteral("dolphin"), WindowPlacement::stateFloating(),
-                          WindowPlacement::snapEngineId(), QStringLiteral("S1")));
-        store.record(make(QStringLiteral("dolphin|snapped"), QStringLiteral("dolphin"), WindowPlacement::stateSnapped(),
-                          WindowPlacement::snapEngineId(), QStringLiteral("S1")));
+        store.record(makePlacement(QStringLiteral("dolphin|float"), QStringLiteral("dolphin"),
+                                   WindowPlacement::stateFloating(), WindowPlacement::snapEngineId(),
+                                   QStringLiteral("S1")));
+        store.record(makePlacement(QStringLiteral("dolphin|snapped"), QStringLiteral("dolphin"),
+                                   WindowPlacement::stateSnapped(), WindowPlacement::snapEngineId(),
+                                   QStringLiteral("S1")));
 
         // A managed keep is a no-op: nothing pruned, so the store is unchanged.
         QVERIFY(!store.collapsePureFloatSiblings(QStringLiteral("dolphin"), QStringLiteral("dolphin|snapped")));
@@ -713,8 +719,9 @@ private Q_SLOTS:
         // — e.g. a shares-screen scan that started counting the record's bare
         // screenId as coverage would prune the sibling and fail here.
         WindowPlacementStore store;
-        store.record(make(QStringLiteral("dolphin|sib"), QStringLiteral("dolphin"), WindowPlacement::stateFloating(),
-                          WindowPlacement::snapEngineId(), QStringLiteral("S1")));
+        store.record(makePlacement(QStringLiteral("dolphin|sib"), QStringLiteral("dolphin"),
+                                   WindowPlacement::stateFloating(), WindowPlacement::snapEngineId(),
+                                   QStringLiteral("S1")));
         WindowPlacement bareKeep;
         bareKeep.windowId = QStringLiteral("dolphin|bare");
         bareKeep.appId = QStringLiteral("dolphin");
@@ -744,13 +751,16 @@ private Q_SLOTS:
         const QRect sibS2(1970, 80, 640, 480);
         const QRect keepS1(110, 120, 800, 600);
         // Sibling floated on S1 then S2 — its single record accumulates both.
-        store.record(make(QStringLiteral("dolphin|sib"), QStringLiteral("dolphin"), WindowPlacement::stateFloating(),
-                          WindowPlacement::snapEngineId(), QStringLiteral("S1"), sibS1));
-        store.record(make(QStringLiteral("dolphin|sib"), QStringLiteral("dolphin"), WindowPlacement::stateFloating(),
-                          WindowPlacement::snapEngineId(), QStringLiteral("S2"), sibS2));
+        store.record(makePlacement(QStringLiteral("dolphin|sib"), QStringLiteral("dolphin"),
+                                   WindowPlacement::stateFloating(), WindowPlacement::snapEngineId(),
+                                   QStringLiteral("S1"), sibS1));
+        store.record(makePlacement(QStringLiteral("dolphin|sib"), QStringLiteral("dolphin"),
+                                   WindowPlacement::stateFloating(), WindowPlacement::snapEngineId(),
+                                   QStringLiteral("S2"), sibS2));
         // Kept record floated only on S1.
-        store.record(make(QStringLiteral("dolphin|keep"), QStringLiteral("dolphin"), WindowPlacement::stateFloating(),
-                          WindowPlacement::snapEngineId(), QStringLiteral("S1"), keepS1));
+        store.record(makePlacement(QStringLiteral("dolphin|keep"), QStringLiteral("dolphin"),
+                                   WindowPlacement::stateFloating(), WindowPlacement::snapEngineId(),
+                                   QStringLiteral("S1"), keepS1));
 
         QVERIFY(store.collapsePureFloatSiblings(QStringLiteral("dolphin"), QStringLiteral("dolphin|keep")));
 
@@ -777,14 +787,18 @@ private Q_SLOTS:
         const QRect bridgeS2(2000, 50, 600, 450);
         const QRect leafS2(2200, 90, 640, 480);
         const QRect keepS1(130, 140, 820, 620);
-        store.record(make(QStringLiteral("dolphin|bridge"), QStringLiteral("dolphin"), WindowPlacement::stateFloating(),
-                          WindowPlacement::snapEngineId(), QStringLiteral("S1"), bridgeS1));
-        store.record(make(QStringLiteral("dolphin|bridge"), QStringLiteral("dolphin"), WindowPlacement::stateFloating(),
-                          WindowPlacement::snapEngineId(), QStringLiteral("S2"), bridgeS2)); // bridge now S1+S2
-        store.record(make(QStringLiteral("dolphin|leaf"), QStringLiteral("dolphin"), WindowPlacement::stateFloating(),
-                          WindowPlacement::snapEngineId(), QStringLiteral("S2"), leafS2)); // newer than bridge
-        store.record(make(QStringLiteral("dolphin|keep"), QStringLiteral("dolphin"), WindowPlacement::stateFloating(),
-                          WindowPlacement::snapEngineId(), QStringLiteral("S1"), keepS1)); // newest
+        store.record(makePlacement(QStringLiteral("dolphin|bridge"), QStringLiteral("dolphin"),
+                                   WindowPlacement::stateFloating(), WindowPlacement::snapEngineId(),
+                                   QStringLiteral("S1"), bridgeS1));
+        store.record(makePlacement(QStringLiteral("dolphin|bridge"), QStringLiteral("dolphin"),
+                                   WindowPlacement::stateFloating(), WindowPlacement::snapEngineId(),
+                                   QStringLiteral("S2"), bridgeS2)); // bridge now S1+S2
+        store.record(makePlacement(QStringLiteral("dolphin|leaf"), QStringLiteral("dolphin"),
+                                   WindowPlacement::stateFloating(), WindowPlacement::snapEngineId(),
+                                   QStringLiteral("S2"), leafS2)); // newer than bridge
+        store.record(makePlacement(QStringLiteral("dolphin|keep"), QStringLiteral("dolphin"),
+                                   WindowPlacement::stateFloating(), WindowPlacement::snapEngineId(),
+                                   QStringLiteral("S1"), keepS1)); // newest
 
         QVERIFY(store.collapsePureFloatSiblings(QStringLiteral("dolphin"), QStringLiteral("dolphin|keep")));
 
@@ -795,6 +809,32 @@ private Q_SLOTS:
         QVERIFY(kept.has_value());
         QCOMPARE(kept->freeGeometryFor(QStringLiteral("S1")), keepS1);
         QCOMPARE(kept->freeGeometryFor(QStringLiteral("S2")), bridgeS2);
+
+        // The other FIFO order — leaf recorded BEFORE the bridge — must collapse
+        // the same connected set (this is the order the fixpoint claim is about:
+        // the leaf is only reachable through a screen absorbed later).
+        WindowPlacementStore reversed;
+        reversed.record(makePlacement(QStringLiteral("dolphin|leaf"), QStringLiteral("dolphin"),
+                                      WindowPlacement::stateFloating(), WindowPlacement::snapEngineId(),
+                                      QStringLiteral("S2"), leafS2));
+        reversed.record(makePlacement(QStringLiteral("dolphin|bridge"), QStringLiteral("dolphin"),
+                                      WindowPlacement::stateFloating(), WindowPlacement::snapEngineId(),
+                                      QStringLiteral("S1"), bridgeS1));
+        reversed.record(makePlacement(QStringLiteral("dolphin|bridge"), QStringLiteral("dolphin"),
+                                      WindowPlacement::stateFloating(), WindowPlacement::snapEngineId(),
+                                      QStringLiteral("S2"), bridgeS2));
+        reversed.record(makePlacement(QStringLiteral("dolphin|keep"), QStringLiteral("dolphin"),
+                                      WindowPlacement::stateFloating(), WindowPlacement::snapEngineId(),
+                                      QStringLiteral("S1"), keepS1));
+
+        QVERIFY(reversed.collapsePureFloatSiblings(QStringLiteral("dolphin"), QStringLiteral("dolphin|keep")));
+        QVERIFY(reversed.contains(QStringLiteral("dolphin|keep")));
+        QVERIFY(!reversed.contains(QStringLiteral("dolphin|bridge")));
+        QVERIFY(!reversed.contains(QStringLiteral("dolphin|leaf")));
+        const auto keptRev = reversed.peek(QStringLiteral("dolphin|keep"), QStringLiteral("dolphin"));
+        QVERIFY(keptRev.has_value());
+        QCOMPARE(keptRev->freeGeometryFor(QStringLiteral("S1")), keepS1);
+        QCOMPARE(keptRev->freeGeometryFor(QStringLiteral("S2")), bridgeS2);
     }
 
     void testCollapse_prefixMutationStillFindsKeptRecord()
@@ -805,10 +845,12 @@ private Q_SLOTS:
         // stored record and prune the same-screen duplicate — an exact-id
         // compare would silently no-op for exactly this renamed-window case.
         WindowPlacementStore store;
-        store.record(make(QStringLiteral("dolphin|old-uuid"), QStringLiteral("dolphin"),
-                          WindowPlacement::stateFloating(), WindowPlacement::snapEngineId(), QStringLiteral("S1")));
-        store.record(make(QStringLiteral("dolphin|kept-uuid"), QStringLiteral("dolphin"),
-                          WindowPlacement::stateFloating(), WindowPlacement::snapEngineId(), QStringLiteral("S1")));
+        store.record(makePlacement(QStringLiteral("dolphin|old-uuid"), QStringLiteral("dolphin"),
+                                   WindowPlacement::stateFloating(), WindowPlacement::snapEngineId(),
+                                   QStringLiteral("S1")));
+        store.record(makePlacement(QStringLiteral("dolphin|kept-uuid"), QStringLiteral("dolphin"),
+                                   WindowPlacement::stateFloating(), WindowPlacement::snapEngineId(),
+                                   QStringLiteral("S1")));
 
         QVERIFY(
             store.collapsePureFloatSiblings(QStringLiteral("dolphin"), QStringLiteral("org.kde.dolphin|kept-uuid")));
@@ -824,8 +866,8 @@ private Q_SLOTS:
         // a cap lowered between versions) must still come back capped.
         WindowPlacementStore store;
         for (int i = 0; i < WindowPlacementStore::MaxPerApp; ++i) {
-            store.record(make(QStringLiteral("dolphin|u%1").arg(i), QStringLiteral("dolphin"),
-                              WindowPlacement::stateFloating(), WindowPlacement::snapEngineId()));
+            store.record(makePlacement(QStringLiteral("dolphin|u%1").arg(i), QStringLiteral("dolphin"),
+                                       WindowPlacement::stateFloating(), WindowPlacement::snapEngineId()));
         }
         QJsonObject serialized = store.serialize();
         // Splice extra entries into the persisted bucket beyond the cap.
@@ -848,15 +890,15 @@ private Q_SLOTS:
         // and the moved record lands NEWEST in the FIFO.
         WindowPlacementStore store;
         for (int i = 0; i < WindowPlacementStore::MaxPerApp; ++i) {
-            store.record(make(QStringLiteral("newapp|f%1").arg(i), QStringLiteral("newapp"),
-                              WindowPlacement::stateFloating(), WindowPlacement::snapEngineId()));
+            store.record(makePlacement(QStringLiteral("newapp|f%1").arg(i), QStringLiteral("newapp"),
+                                       WindowPlacement::stateFloating(), WindowPlacement::snapEngineId()));
         }
-        store.record(make(QStringLiteral("oldapp|renamer"), QStringLiteral("oldapp"), WindowPlacement::stateFloating(),
-                          WindowPlacement::snapEngineId()));
+        store.record(makePlacement(QStringLiteral("oldapp|renamer"), QStringLiteral("oldapp"),
+                                   WindowPlacement::stateFloating(), WindowPlacement::snapEngineId()));
 
         // Rename: same instance re-recorded under the full bucket's appId.
-        QVERIFY(store.record(make(QStringLiteral("newapp|renamer"), QStringLiteral("newapp"),
-                                  WindowPlacement::stateFloating(), WindowPlacement::snapEngineId())));
+        QVERIFY(store.record(makePlacement(QStringLiteral("newapp|renamer"), QStringLiteral("newapp"),
+                                           WindowPlacement::stateFloating(), WindowPlacement::snapEngineId())));
 
         QCOMPARE(store.size(), WindowPlacementStore::MaxPerApp);
         QVERIFY(!store.contains(QStringLiteral("newapp|f0"))); // oldest evicted
@@ -879,12 +921,15 @@ private Q_SLOTS:
         const QRect r1(10, 10, 300, 200);
         const QRect r2(20, 20, 310, 210);
         const QRect r3(30, 30, 320, 220);
-        store.record(make(QStringLiteral("dolphin|u1"), QStringLiteral("dolphin"), WindowPlacement::stateFloating(),
-                          WindowPlacement::snapEngineId(), QStringLiteral("S1"), r1));
-        store.record(make(QStringLiteral("dolphin|u2"), QStringLiteral("dolphin"), WindowPlacement::stateFloating(),
-                          WindowPlacement::snapEngineId(), QStringLiteral("S2"), r2));
-        store.record(make(QStringLiteral("dolphin|u3"), QStringLiteral("dolphin"), WindowPlacement::stateFloating(),
-                          WindowPlacement::snapEngineId(), QStringLiteral("S1"), r3));
+        store.record(makePlacement(QStringLiteral("dolphin|u1"), QStringLiteral("dolphin"),
+                                   WindowPlacement::stateFloating(), WindowPlacement::snapEngineId(),
+                                   QStringLiteral("S1"), r1));
+        store.record(makePlacement(QStringLiteral("dolphin|u2"), QStringLiteral("dolphin"),
+                                   WindowPlacement::stateFloating(), WindowPlacement::snapEngineId(),
+                                   QStringLiteral("S2"), r2));
+        store.record(makePlacement(QStringLiteral("dolphin|u3"), QStringLiteral("dolphin"),
+                                   WindowPlacement::stateFloating(), WindowPlacement::snapEngineId(),
+                                   QStringLiteral("S1"), r3));
 
         WindowPlacementStore reloaded;
         reloaded.deserialize(store.serialize());

--- a/tests/unit/core/windowtracking/test_window_placement_store.cpp
+++ b/tests/unit/core/windowtracking/test_window_placement_store.cpp
@@ -171,12 +171,12 @@ private Q_SLOTS:
     void testClearAndRemoveIf()
     {
         WindowPlacementStore store;
-        store.record(make(QStringLiteral("a|1"), QStringLiteral("a"), WindowPlacement::stateSnapped(),
+        store.record(make(QStringLiteral("a|a-instance"), QStringLiteral("a"), WindowPlacement::stateSnapped(),
                           WindowPlacement::snapEngineId(), QStringLiteral("DP-1")));
-        store.record(make(QStringLiteral("b|1"), QStringLiteral("b"), WindowPlacement::stateSnapped(),
+        store.record(make(QStringLiteral("b|b-instance"), QStringLiteral("b"), WindowPlacement::stateSnapped(),
                           WindowPlacement::snapEngineId(), QStringLiteral("DP-2")));
-        store.clear(QStringLiteral("a|1"));
-        QVERIFY(!store.contains(QStringLiteral("a|1"), QStringLiteral("a")));
+        store.clear(QStringLiteral("a|a-instance"));
+        QVERIFY(!store.contains(QStringLiteral("a|a-instance"), QStringLiteral("a")));
         QCOMPARE(store.size(), 1);
 
         const int removed = store.removeIf([](const WindowPlacement& p) {
@@ -217,9 +217,9 @@ private Q_SLOTS:
     void testSerializeHonorsKeepPredicate()
     {
         WindowPlacementStore store;
-        store.record(make(QStringLiteral("a|1"), QStringLiteral("a"), WindowPlacement::stateSnapped(),
+        store.record(make(QStringLiteral("a|a-instance"), QStringLiteral("a"), WindowPlacement::stateSnapped(),
                           WindowPlacement::snapEngineId(), QStringLiteral("DP-1")));
-        store.record(make(QStringLiteral("b|1"), QStringLiteral("b"), WindowPlacement::stateSnapped(),
+        store.record(make(QStringLiteral("b|b-instance"), QStringLiteral("b"), WindowPlacement::stateSnapped(),
                           WindowPlacement::snapEngineId(), QStringLiteral("DP-2")));
         // keep only DP-1 (mirrors the disabled-context gate).
         const QJsonObject json = store.serialize([](const WindowPlacement& p) {
@@ -469,10 +469,10 @@ private Q_SLOTS:
         // something to restore and drop bare {free, no geometry} residue, so it never
         // reaches disk to crowd the next session's FIFO.
         WindowPlacementStore store;
-        store.record(make(QStringLiteral("good|1"), QStringLiteral("good"), WindowPlacement::stateFloating(),
-                          WindowPlacement::snapEngineId(), QStringLiteral("DP-1")));
+        store.record(make(QStringLiteral("good|good-instance"), QStringLiteral("good"),
+                          WindowPlacement::stateFloating(), WindowPlacement::snapEngineId(), QStringLiteral("DP-1")));
         WindowPlacement residue;
-        residue.windowId = QStringLiteral("noise|1");
+        residue.windowId = QStringLiteral("noise|noise-instance");
         residue.appId = QStringLiteral("noise");
         EngineSlot freeSlot;
         freeSlot.state = WindowPlacement::stateFree();
@@ -502,21 +502,41 @@ private Q_SLOTS:
 
     void testRecord_appIdRenameMovesRecord()
     {
-        // Re-recording the SAME windowId under a NEW appId drops the stale entry from
-        // the old bucket and appends to the new one (mid-session class rename).
+        // Re-recording the SAME live instance under a NEW appId and composite
+        // prefix drops the stale entry from the old bucket and moves it to the
+        // new one (mid-session class rename).
         WindowPlacementStore store;
-        store.record(make(QStringLiteral("x|1"), QStringLiteral("oldapp"), WindowPlacement::stateSnapped(),
+        store.record(make(QStringLiteral("oldapp|1"), QStringLiteral("oldapp"), WindowPlacement::stateSnapped(),
                           WindowPlacement::snapEngineId()));
-        store.record(make(QStringLiteral("x|1"), QStringLiteral("newapp"), WindowPlacement::stateFloating(),
+        store.record(make(QStringLiteral("newapp|1"), QStringLiteral("newapp"), WindowPlacement::stateFloating(),
                           WindowPlacement::snapEngineId()));
 
         QCOMPARE(store.size(), 1); // not duplicated across buckets
         QCOMPARE(store.records().size(), 1); // exactly one record total (old bucket erased)
         // The old appId bucket is gone (empty appId arg = bucket-only check).
         QVERIFY(!store.contains(QString(), QStringLiteral("oldapp")));
-        auto p = store.take(QStringLiteral("x|1"), QStringLiteral("newapp"));
+        auto p = store.take(QStringLiteral("newapp|1"), QStringLiteral("newapp"));
         QVERIFY(p.has_value());
+        QCOMPARE(p->windowId, QStringLiteral("newapp|1"));
         QCOMPARE(p->slotFor(WindowPlacement::snapEngineId()).state, QString(WindowPlacement::stateFloating()));
+    }
+
+    void testTake_prefixMutationUsesOwnInstanceBeforeSiblingFifo()
+    {
+        WindowPlacementStore store;
+        store.record(make(QStringLiteral("oldclass|own-instance"), QStringLiteral("oldclass"),
+                          WindowPlacement::stateSnapped(), WindowPlacement::snapEngineId()));
+        store.record(make(QStringLiteral("newclass|sibling"), QStringLiteral("newclass"),
+                          WindowPlacement::stateFloating(), WindowPlacement::snapEngineId()));
+
+        const auto own = store.take(QStringLiteral("newclass|own-instance"), QStringLiteral("newclass"));
+        QVERIFY(own.has_value());
+        QCOMPARE(own->windowId, QStringLiteral("oldclass|own-instance"));
+        QCOMPARE(own->slotFor(WindowPlacement::snapEngineId()).state, QString(WindowPlacement::stateSnapped()));
+
+        const auto sibling = store.take(QStringLiteral("newclass|new-instance"), QStringLiteral("newclass"));
+        QVERIFY(sibling.has_value());
+        QCOMPARE(sibling->windowId, QStringLiteral("newclass|sibling"));
     }
 
     void testRecord_appIdRenameWithOtherBucketsIntact()
@@ -527,7 +547,7 @@ private Q_SLOTS:
         // the emptied bucket is not necessarily the last in hash order.
         WindowPlacementStore store;
         for (int i = 0; i < 5; ++i) {
-            store.record(make(QStringLiteral("keep%1|u").arg(i), QStringLiteral("keep%1").arg(i),
+            store.record(make(QStringLiteral("keep%1|keep-instance-%1").arg(i), QStringLiteral("keep%1").arg(i),
                               WindowPlacement::stateSnapped(), WindowPlacement::snapEngineId()));
         }
         store.record(make(QStringLiteral("w|1"), QStringLiteral("renamefrom"), WindowPlacement::stateTiled(),
@@ -541,7 +561,7 @@ private Q_SLOTS:
         QVERIFY(!store.contains(QString(), QStringLiteral("renamefrom"))); // old bucket erased
         QVERIFY(store.contains(QStringLiteral("w|1"), QStringLiteral("renameto")));
         for (int i = 0; i < 5; ++i) {
-            QVERIFY(store.contains(QStringLiteral("keep%1|u").arg(i))); // unrelated records intact
+            QVERIFY(store.contains(QStringLiteral("keep%1|keep-instance-%1").arg(i))); // unrelated records intact
         }
     }
 
@@ -567,6 +587,32 @@ private Q_SLOTS:
         QVERIFY(store.contains(QStringLiteral("vesktop|u")));
         QVERIFY(store.contains(QStringLiteral("oldclass|u2"))); // drift preserved
         QVERIFY(!store.contains(QStringLiteral("nosep")));
+    }
+
+    void testDeserialize_mergesDuplicateInstanceAcrossPrefixes()
+    {
+        WindowPlacement older = make(QStringLiteral("oldclass|same-instance"), QStringLiteral("oldclass"),
+                                     WindowPlacement::stateSnapped(), WindowPlacement::snapEngineId());
+        older.sequence = 4;
+        WindowPlacement newer = make(QStringLiteral("newclass|same-instance"), QStringLiteral("newclass"),
+                                     WindowPlacement::stateTiled(), WindowPlacement::autotileEngineId());
+        newer.sequence = 9;
+
+        QJsonObject root;
+        root[QStringLiteral("oldclass")] = QJsonArray{older.toJson()};
+        root[QStringLiteral("newclass")] = QJsonArray{newer.toJson()};
+
+        WindowPlacementStore store;
+        store.deserialize(root);
+
+        QCOMPARE(store.size(), 1);
+        QVERIFY(!store.contains(QString(), QStringLiteral("oldclass")));
+        const auto merged = store.peekExact(QStringLiteral("newclass|same-instance"));
+        QVERIFY(merged.has_value());
+        QCOMPARE(merged->windowId, QStringLiteral("newclass|same-instance"));
+        QCOMPARE(merged->appId, QStringLiteral("newclass"));
+        QCOMPARE(merged->slotFor(WindowPlacement::snapEngineId()).state, QString(WindowPlacement::stateSnapped()));
+        QCOMPARE(merged->slotFor(WindowPlacement::autotileEngineId()).state, QString(WindowPlacement::stateTiled()));
     }
 
     void testTiledRecord_roundTripPreservesOrder()

--- a/tests/unit/core/windowtracking/test_window_placement_store.cpp
+++ b/tests/unit/core/windowtracking/test_window_placement_store.cpp
@@ -812,6 +812,57 @@ private Q_SLOTS:
         QVERIFY(!store.contains(QStringLiteral("dolphin|old-uuid")));
     }
 
+    void testDeserialize_overCapBucketIsCappedByReplay()
+    {
+        // The per-app cap moved out of deserialize into record()'s replay
+        // path; a persisted bucket exceeding MaxPerApp (hand-edited file, or
+        // a cap lowered between versions) must still come back capped.
+        WindowPlacementStore store;
+        for (int i = 0; i < WindowPlacementStore::MaxPerApp; ++i) {
+            store.record(make(QStringLiteral("dolphin|u%1").arg(i), QStringLiteral("dolphin"),
+                              WindowPlacement::stateFloating(), WindowPlacement::snapEngineId()));
+        }
+        QJsonObject serialized = store.serialize();
+        // Splice extra entries into the persisted bucket beyond the cap.
+        QJsonArray bucket = serialized.value(QStringLiteral("dolphin")).toArray();
+        const QJsonObject younger = bucket.last().toObject();
+        for (int i = 0; i < 4; ++i) {
+            bucket.append(younger);
+        }
+        serialized.insert(QStringLiteral("dolphin"), bucket);
+
+        WindowPlacementStore reloaded;
+        reloaded.deserialize(serialized);
+        QCOMPARE(reloaded.size(), WindowPlacementStore::MaxPerApp);
+    }
+
+    void testRecord_renameIntoFullBucket_evictsAndAppendsNewest()
+    {
+        // A mid-session appId rename moves the record into the new bucket;
+        // when that bucket is already at capacity the OLDEST entry is evicted
+        // and the moved record lands NEWEST in the FIFO.
+        WindowPlacementStore store;
+        for (int i = 0; i < WindowPlacementStore::MaxPerApp; ++i) {
+            store.record(make(QStringLiteral("newapp|f%1").arg(i), QStringLiteral("newapp"),
+                              WindowPlacement::stateFloating(), WindowPlacement::snapEngineId()));
+        }
+        store.record(make(QStringLiteral("oldapp|renamer"), QStringLiteral("oldapp"), WindowPlacement::stateFloating(),
+                          WindowPlacement::snapEngineId()));
+
+        // Rename: same instance re-recorded under the full bucket's appId.
+        QVERIFY(store.record(make(QStringLiteral("newapp|renamer"), QStringLiteral("newapp"),
+                                  WindowPlacement::stateFloating(), WindowPlacement::snapEngineId())));
+
+        QCOMPARE(store.size(), WindowPlacementStore::MaxPerApp);
+        QVERIFY(!store.contains(QStringLiteral("newapp|f0"))); // oldest evicted
+        QVERIFY(store.contains(QStringLiteral("newapp|renamer")));
+        // FIFO position: the moved record is NEWEST, so the appId-FIFO
+        // fallback hands out a surviving older sibling first.
+        const auto oldest = store.take(QStringLiteral("newapp|fresh-uuid"), QStringLiteral("newapp"));
+        QVERIFY(oldest.has_value());
+        QCOMPARE(oldest->windowId, QStringLiteral("newapp|f1"));
+    }
+
     void testDeserialize_preservesAppIdFifoOrder()
     {
         // The per-app bucket is a FIFO: take() consumes oldest-first so

--- a/tests/unit/core/windowtracking/test_window_placement_store.cpp
+++ b/tests/unit/core/windowtracking/test_window_placement_store.cpp
@@ -559,7 +559,12 @@ private Q_SLOTS:
 
         QCOMPARE(store.size(), 6); // 5 keepers + the moved record (no duplication)
         QVERIFY(!store.contains(QString(), QStringLiteral("renamefrom"))); // old bucket erased
-        QVERIFY(store.contains(QStringLiteral("w|1"), QStringLiteral("renameto")));
+        // peekExact + appId compare, not the two-arg contains (which passes
+        // on ANY record in the bucket and so cannot pin the central claim:
+        // that THIS record moved into the renamed bucket).
+        const auto moved = store.peekExact(QStringLiteral("w|1"));
+        QVERIFY(moved.has_value());
+        QCOMPARE(moved->appId, QStringLiteral("renameto"));
         for (int i = 0; i < 5; ++i) {
             QVERIFY(store.contains(QStringLiteral("keep%1|keep-instance-%1").arg(i))); // unrelated records intact
         }

--- a/tests/unit/core/windowtracking/test_window_placement_store.cpp
+++ b/tests/unit/core/windowtracking/test_window_placement_store.cpp
@@ -18,7 +18,7 @@ namespace {
 // capture orchestrator would supply. record() merges these into the one record
 // per window.
 WindowPlacement make(const QString& windowId, const QString& appId, const QString& state, const QString& engine,
-                     const QString& screen = QStringLiteral("DP-1"))
+                     const QString& screen = QStringLiteral("DP-1"), const QRect& rect = QRect(10, 20, 300, 400))
 {
     WindowPlacement p;
     p.windowId = windowId;
@@ -33,7 +33,7 @@ WindowPlacement make(const QString& windowId, const QString& appId, const QStrin
     }
     p.engines.insert(engine, slot);
     if (state == WindowPlacement::stateFree() || state == WindowPlacement::stateFloating()) {
-        p.freeGeometryByScreen.insert(screen, QRect(10, 20, 300, 400));
+        p.freeGeometryByScreen.insert(screen, rect);
     }
     return p;
 }
@@ -732,22 +732,28 @@ private Q_SLOTS:
         // DIFFERENT monitor the kept record lacks. That position must not be lost
         // — the kept record absorbs it before the duplicate is removed.
         WindowPlacementStore store;
+        // DISTINCT rects per (record, screen) so fill-missing is
+        // distinguishable from overwrite-all: the kept record's own S1 spot
+        // must survive, and only the missing S2 spot is absorbed.
+        const QRect sibS1(50, 60, 700, 500);
+        const QRect sibS2(1970, 80, 640, 480);
+        const QRect keepS1(110, 120, 800, 600);
         // Sibling floated on S1 then S2 — its single record accumulates both.
         store.record(make(QStringLiteral("dolphin|sib"), QStringLiteral("dolphin"), WindowPlacement::stateFloating(),
-                          WindowPlacement::snapEngineId(), QStringLiteral("S1")));
+                          WindowPlacement::snapEngineId(), QStringLiteral("S1"), sibS1));
         store.record(make(QStringLiteral("dolphin|sib"), QStringLiteral("dolphin"), WindowPlacement::stateFloating(),
-                          WindowPlacement::snapEngineId(), QStringLiteral("S2")));
+                          WindowPlacement::snapEngineId(), QStringLiteral("S2"), sibS2));
         // Kept record floated only on S1.
         store.record(make(QStringLiteral("dolphin|keep"), QStringLiteral("dolphin"), WindowPlacement::stateFloating(),
-                          WindowPlacement::snapEngineId(), QStringLiteral("S1")));
+                          WindowPlacement::snapEngineId(), QStringLiteral("S1"), keepS1));
 
         QVERIFY(store.collapsePureFloatSiblings(QStringLiteral("dolphin"), QStringLiteral("dolphin|keep")));
 
         QVERIFY(!store.contains(QStringLiteral("dolphin|sib"))); // S1-sharing duplicate pruned
         const auto kept = store.peek(QStringLiteral("dolphin|keep"), QStringLiteral("dolphin"));
         QVERIFY(kept.has_value());
-        QVERIFY(kept->freeGeometryFor(QStringLiteral("S1")).isValid());
-        QVERIFY(kept->freeGeometryFor(QStringLiteral("S2")).isValid()); // absorbed from the pruned sibling
+        QCOMPARE(kept->freeGeometryFor(QStringLiteral("S1")), keepS1); // own spot kept, NOT overwritten
+        QCOMPARE(kept->freeGeometryFor(QStringLiteral("S2")), sibS2); // missing spot absorbed
     }
 
     void testCollapse_transitiveCollapseIsOrderIndependent()
@@ -759,14 +765,21 @@ private Q_SLOTS:
         // absorbing the bridge's S2 and prunes the leaf too. Whole connected set
         // collapses into keep regardless of FIFO order.
         WindowPlacementStore store;
+        // Distinct rects so absorb provenance is assertable (see the
+        // absorb test above): keep's own S1 survives, and S2 comes from the
+        // BRIDGE (absorbed first); the leaf's S2 is never absorbed over it.
+        const QRect bridgeS1(30, 40, 500, 400);
+        const QRect bridgeS2(2000, 50, 600, 450);
+        const QRect leafS2(2200, 90, 640, 480);
+        const QRect keepS1(130, 140, 820, 620);
         store.record(make(QStringLiteral("dolphin|bridge"), QStringLiteral("dolphin"), WindowPlacement::stateFloating(),
-                          WindowPlacement::snapEngineId(), QStringLiteral("S1")));
+                          WindowPlacement::snapEngineId(), QStringLiteral("S1"), bridgeS1));
         store.record(make(QStringLiteral("dolphin|bridge"), QStringLiteral("dolphin"), WindowPlacement::stateFloating(),
-                          WindowPlacement::snapEngineId(), QStringLiteral("S2"))); // bridge now S1+S2
+                          WindowPlacement::snapEngineId(), QStringLiteral("S2"), bridgeS2)); // bridge now S1+S2
         store.record(make(QStringLiteral("dolphin|leaf"), QStringLiteral("dolphin"), WindowPlacement::stateFloating(),
-                          WindowPlacement::snapEngineId(), QStringLiteral("S2"))); // newer than bridge
+                          WindowPlacement::snapEngineId(), QStringLiteral("S2"), leafS2)); // newer than bridge
         store.record(make(QStringLiteral("dolphin|keep"), QStringLiteral("dolphin"), WindowPlacement::stateFloating(),
-                          WindowPlacement::snapEngineId(), QStringLiteral("S1"))); // newest
+                          WindowPlacement::snapEngineId(), QStringLiteral("S1"), keepS1)); // newest
 
         QVERIFY(store.collapsePureFloatSiblings(QStringLiteral("dolphin"), QStringLiteral("dolphin|keep")));
 
@@ -775,8 +788,62 @@ private Q_SLOTS:
         QVERIFY(!store.contains(QStringLiteral("dolphin|leaf"))); // connected via absorbed S2 → pruned
         const auto kept = store.peek(QStringLiteral("dolphin|keep"), QStringLiteral("dolphin"));
         QVERIFY(kept.has_value());
-        QVERIFY(kept->freeGeometryFor(QStringLiteral("S1")).isValid());
-        QVERIFY(kept->freeGeometryFor(QStringLiteral("S2")).isValid());
+        QCOMPARE(kept->freeGeometryFor(QStringLiteral("S1")), keepS1);
+        QCOMPARE(kept->freeGeometryFor(QStringLiteral("S2")), bridgeS2);
+    }
+
+    void testCollapse_prefixMutationStillFindsKeptRecord()
+    {
+        // The kept record is addressed with a MUTATED appId prefix (a window
+        // that renamed its class mid-session closes under the new composite).
+        // findKeep matches by instance, so the collapse must still resolve the
+        // stored record and prune the same-screen duplicate — an exact-id
+        // compare would silently no-op for exactly this renamed-window case.
+        WindowPlacementStore store;
+        store.record(make(QStringLiteral("dolphin|old-uuid"), QStringLiteral("dolphin"),
+                          WindowPlacement::stateFloating(), WindowPlacement::snapEngineId(), QStringLiteral("S1")));
+        store.record(make(QStringLiteral("dolphin|kept-uuid"), QStringLiteral("dolphin"),
+                          WindowPlacement::stateFloating(), WindowPlacement::snapEngineId(), QStringLiteral("S1")));
+
+        QVERIFY(
+            store.collapsePureFloatSiblings(QStringLiteral("dolphin"), QStringLiteral("org.kde.dolphin|kept-uuid")));
+
+        QVERIFY(store.contains(QStringLiteral("dolphin|kept-uuid")));
+        QVERIFY(!store.contains(QStringLiteral("dolphin|old-uuid")));
+    }
+
+    void testDeserialize_preservesAppIdFifoOrder()
+    {
+        // The per-app bucket is a FIFO: take() consumes oldest-first so
+        // multi-instance apps distribute records deterministically. That
+        // ordering must survive a serialize → deserialize round trip — a
+        // bucket rebuilt in a different order silently rotates which reopened
+        // instance receives which placement.
+        WindowPlacementStore store;
+        const QRect r1(10, 10, 300, 200);
+        const QRect r2(20, 20, 310, 210);
+        const QRect r3(30, 30, 320, 220);
+        store.record(make(QStringLiteral("dolphin|u1"), QStringLiteral("dolphin"), WindowPlacement::stateFloating(),
+                          WindowPlacement::snapEngineId(), QStringLiteral("S1"), r1));
+        store.record(make(QStringLiteral("dolphin|u2"), QStringLiteral("dolphin"), WindowPlacement::stateFloating(),
+                          WindowPlacement::snapEngineId(), QStringLiteral("S2"), r2));
+        store.record(make(QStringLiteral("dolphin|u3"), QStringLiteral("dolphin"), WindowPlacement::stateFloating(),
+                          WindowPlacement::snapEngineId(), QStringLiteral("S1"), r3));
+
+        WindowPlacementStore reloaded;
+        reloaded.deserialize(store.serialize());
+
+        // Consume via the appId FIFO with fresh (unmatched) uuids so only the
+        // bucket order decides: oldest first, in the original record order.
+        const auto first = reloaded.take(QStringLiteral("dolphin|new1"), QStringLiteral("dolphin"));
+        QVERIFY(first.has_value());
+        QCOMPARE(first->windowId, QStringLiteral("dolphin|u1"));
+        const auto second = reloaded.take(QStringLiteral("dolphin|new2"), QStringLiteral("dolphin"));
+        QVERIFY(second.has_value());
+        QCOMPARE(second->windowId, QStringLiteral("dolphin|u2"));
+        const auto third = reloaded.take(QStringLiteral("dolphin|new3"), QStringLiteral("dolphin"));
+        QVERIFY(third.has_value());
+        QCOMPARE(third->windowId, QStringLiteral("dolphin|u3"));
     }
 };
 

--- a/tests/unit/core/windowtracking/test_window_placement_store.cpp
+++ b/tests/unit/core/windowtracking/test_window_placement_store.cpp
@@ -870,11 +870,16 @@ private Q_SLOTS:
                                        WindowPlacement::stateFloating(), WindowPlacement::snapEngineId()));
         }
         QJsonObject serialized = store.serialize();
-        // Splice extra entries into the persisted bucket beyond the cap.
+        // Splice extra entries into the persisted bucket beyond the cap, each
+        // with a DISTINCT windowId: same-id copies would take record()'s
+        // sameWindowInstance merge branch on replay and never append, so the
+        // cap (evictForCapacity on the replay path) would pass vacuously.
         QJsonArray bucket = serialized.value(QStringLiteral("dolphin")).toArray();
         const QJsonObject younger = bucket.last().toObject();
         for (int i = 0; i < 4; ++i) {
-            bucket.append(younger);
+            QJsonObject extra = younger;
+            extra.insert(QStringLiteral("windowId"), QStringLiteral("dolphin|extra%1").arg(i));
+            bucket.append(extra);
         }
         serialized.insert(QStringLiteral("dolphin"), bucket);
 

--- a/tests/unit/core/windowtracking/test_window_registry.cpp
+++ b/tests/unit/core/windowtracking/test_window_registry.cpp
@@ -26,6 +26,8 @@
 using PhosphorEngine::WindowMetadata;
 using PhosphorEngine::WindowRegistry;
 
+Q_DECLARE_METATYPE(PhosphorEngine::WindowMetadata)
+
 namespace {
 WindowMetadata make(const QString& appId, const QString& desktopFile = {}, const QString& title = {})
 {
@@ -42,6 +44,11 @@ class TestWindowRegistry : public QObject
     Q_OBJECT
 
 private Q_SLOTS:
+    void initTestCase()
+    {
+        qRegisterMetaType<PhosphorEngine::WindowMetadata>();
+    }
+
     // ────────────────────────────────────────────────────────────────────
     // upsert / lifecycle
     // ────────────────────────────────────────────────────────────────────
@@ -288,11 +295,27 @@ private Q_SLOTS:
     {
         WindowRegistry reg;
         WindowMetadata metadata = make(QStringLiteral("firefox"));
+        reg.upsert(QStringLiteral("uuid-1"), metadata);
+
+        QVERIFY(!reg.isMinimized(QStringLiteral("uuid-1")));
+        QVERIFY(!reg.isMinimized(QStringLiteral("firefox|uuid-1")));
+
+        QSignalSpy changed(&reg, &WindowRegistry::metadataChanged);
         metadata.isMinimized = true;
         reg.upsert(QStringLiteral("uuid-1"), metadata);
 
         QVERIFY(reg.isMinimized(QStringLiteral("uuid-1")));
         QVERIFY(reg.isMinimized(QStringLiteral("firefox|uuid-1")));
+        QCOMPARE(changed.size(), 1);
+
+        metadata.isMinimized = false;
+        reg.upsert(QStringLiteral("uuid-1"), metadata);
+        QVERIFY(!reg.isMinimized(QStringLiteral("uuid-1")));
+        QVERIFY(!reg.isMinimized(QStringLiteral("firefox|uuid-1")));
+        QCOMPARE(changed.size(), 2);
+
+        reg.upsert(QStringLiteral("uuid-1"), metadata);
+        QCOMPARE(changed.size(), 2);
         QVERIFY(!reg.isMinimized(QStringLiteral("firefox|unknown")));
     }
 
@@ -351,24 +374,16 @@ private Q_SLOTS:
         // removed). The sweep must still drop the orphan canonical entry.
         WindowRegistry reg;
         reg.canonicalizeWindowId(QStringLiteral("ghost|orphan-1"));
+        QSignalSpy disappeared(&reg, &WindowRegistry::windowDisappeared);
 
         const int pruned = reg.pruneStaleInstances({QStringLiteral("alive-1")});
 
         QCOMPARE(pruned, 1);
+        QCOMPARE(disappeared.size(), 1);
+        QCOMPARE(disappeared.first().at(0).toString(), QStringLiteral("orphan-1"));
         QCOMPARE(reg.canonicalizeForLookup(QStringLiteral("ghost-2|orphan-1")), QStringLiteral("ghost-2|orphan-1"));
     }
 };
 
-// metadataChanged carries WindowMetadata by value in its signal payload;
-// QSignalSpy stores QVariants so the type must be registered to round-trip.
-Q_DECLARE_METATYPE(PhosphorEngine::WindowMetadata)
-
-int main(int argc, char** argv)
-{
-    qRegisterMetaType<PhosphorEngine::WindowMetadata>("PhosphorEngine::WindowMetadata");
-    QCoreApplication app(argc, argv);
-    TestWindowRegistry tc;
-    return QTest::qExec(&tc, argc, argv);
-}
-
+QTEST_MAIN(TestWindowRegistry)
 #include "test_window_registry.moc"

--- a/tests/unit/core/windowtracking/test_window_registry.cpp
+++ b/tests/unit/core/windowtracking/test_window_registry.cpp
@@ -341,9 +341,13 @@ private Q_SLOTS:
         const QString canonical = QStringLiteral("app|reentrant-instance");
         reg.upsert(instanceId, make(QStringLiteral("app")));
         reg.canonicalizeWindowId(canonical);
+        // No QCOMPARE inside the lambda: a failing compare there returns from
+        // the LAMBDA, not the test — capture and assert after.
+        QString observedRemovedId;
+        QString observedCanonical;
         connect(&reg, &WindowRegistry::windowDisappeared, &reg, [&](const QString& removedId) {
-            QCOMPARE(removedId, instanceId);
-            QCOMPARE(reg.canonicalizeForLookup(QStringLiteral("renamed|reentrant-instance")), canonical);
+            observedRemovedId = removedId;
+            observedCanonical = reg.canonicalizeForLookup(QStringLiteral("renamed|reentrant-instance"));
             reg.remove(instanceId);
             reg.clear();
         });
@@ -352,6 +356,8 @@ private Q_SLOTS:
         reg.remove(instanceId);
 
         QCOMPARE(disappeared.size(), 1);
+        QCOMPARE(observedRemovedId, instanceId);
+        QCOMPARE(observedCanonical, canonical);
         QVERIFY(!reg.contains(instanceId));
         QCOMPARE(reg.canonicalizeForLookup(QStringLiteral("renamed|reentrant-instance")),
                  QStringLiteral("renamed|reentrant-instance"));
@@ -363,22 +369,28 @@ private Q_SLOTS:
         const QString instanceId = QStringLiteral("reinserted-instance");
         reg.upsert(instanceId, make(QStringLiteral("old-app")));
         bool reinserted = false;
+        // Event ACCUMULATOR (id-carrying), not a bare count: two
+        // disappearances of the wrong ids would satisfy a count-only pin.
+        QStringList events;
         connect(&reg, &WindowRegistry::windowDisappeared, &reg, [&](const QString& removedId) {
+            events.append(QStringLiteral("disappeared:") + removedId);
             if (!reinserted) {
                 reinserted = true;
                 reg.upsert(removedId, make(QStringLiteral("new-app")));
             }
         });
         connect(&reg, &WindowRegistry::windowAppeared, &reg, [&](const QString& appearedId) {
+            events.append(QStringLiteral("appeared:") + appearedId);
             if (reinserted) {
                 reg.remove(appearedId);
             }
         });
-        QSignalSpy disappeared(&reg, &WindowRegistry::windowDisappeared);
 
         reg.remove(instanceId);
 
-        QCOMPARE(disappeared.size(), 2);
+        QCOMPARE(events,
+                 (QStringList{QStringLiteral("disappeared:") + instanceId, QStringLiteral("appeared:") + instanceId,
+                              QStringLiteral("disappeared:") + instanceId}));
         QVERIFY(!reg.contains(instanceId));
         QVERIFY(reg.instancesWithAppId(QStringLiteral("new-app")).isEmpty());
     }
@@ -473,19 +485,37 @@ private Q_SLOTS:
             [](WindowMetadata& m) {
                 m.windowType = PhosphorProtocol::WindowType::Dialog;
             },
+            // Extended-field representatives, one per shape: the span list,
+            // an optional<int>, and an optional<bool> — pins that the widened
+            // operator== covers the extended block, not just the wide scalars.
+            [](WindowMetadata& m) {
+                m.virtualDesktops = QList<int>{1, 2};
+            },
+            [](WindowMetadata& m) {
+                m.width = 1280;
+            },
+            [](WindowMetadata& m) {
+                m.isMinimized = true;
+            },
         };
 
-        for (const auto& mutate : mutators) {
+        // Accumulate failures instead of QCOMPARE-ing inside the loop: an
+        // in-loop abort hides which LATER mutators also regressed.
+        QStringList failures;
+        for (int i = 0; i < mutators.size(); ++i) {
             WindowRegistry reg;
             reg.upsert(QStringLiteral("u1"), base);
             QSignalSpy changed(&reg, &WindowRegistry::metadataChanged);
 
             WindowMetadata next = base;
-            mutate(next);
+            mutators.at(i)(next);
             reg.upsert(QStringLiteral("u1"), next);
 
-            QCOMPARE(changed.size(), 1);
+            if (changed.size() != 1) {
+                failures.append(QStringLiteral("mutator %1 emitted %2 (expected 1)").arg(i).arg(changed.size()));
+            }
         }
+        QVERIFY2(failures.isEmpty(), qPrintable(failures.join(QStringLiteral("; "))));
     }
 
     // ────────────────────────────────────────────────────────────────────

--- a/tests/unit/core/windowtracking/test_window_registry.cpp
+++ b/tests/unit/core/windowtracking/test_window_registry.cpp
@@ -102,13 +102,29 @@ private Q_SLOTS:
     void appIdMutation_updatesRecord_emitsMetadataChangedOnly()
     {
         WindowRegistry reg;
-        reg.upsert(QStringLiteral("cef1ba31"), make(QStringLiteral("emby-beta")));
+        WindowMetadata oldValue =
+            make(QStringLiteral("emby-beta"), QStringLiteral("emby.desktop"), QStringLiteral("Library"));
+        oldValue.windowRole = QStringLiteral("browser");
+        oldValue.pid = 1001;
+        oldValue.virtualDesktop = 2;
+        oldValue.virtualDesktops = {2, 3};
+        oldValue.activity = QStringLiteral("activity-a");
+        oldValue.windowType = PhosphorProtocol::WindowType::Normal;
+        oldValue.isMinimized = false;
+        oldValue.width = 1280;
+        oldValue.height = 720;
+        reg.upsert(QStringLiteral("cef1ba31"), oldValue);
 
         QSignalSpy appeared(&reg, &WindowRegistry::windowAppeared);
         QSignalSpy disappeared(&reg, &WindowRegistry::windowDisappeared);
         QSignalSpy changed(&reg, &WindowRegistry::metadataChanged);
 
-        reg.upsert(QStringLiteral("cef1ba31"), make(QStringLiteral("media.emby.client.beta")));
+        WindowMetadata newValue = oldValue;
+        newValue.appId = QStringLiteral("media.emby.client.beta");
+        newValue.title = QStringLiteral("Now Playing");
+        newValue.isMinimized = true;
+        newValue.width = 1920;
+        reg.upsert(QStringLiteral("cef1ba31"), newValue);
 
         QCOMPARE(appeared.size(), 0); // Same window — no appearance event
         QCOMPARE(disappeared.size(), 0); // Same window — no disappearance event
@@ -119,8 +135,8 @@ private Q_SLOTS:
         QCOMPARE(args.at(0).toString(), QStringLiteral("cef1ba31"));
         const auto oldMeta = args.at(1).value<WindowMetadata>();
         const auto newMeta = args.at(2).value<WindowMetadata>();
-        QCOMPARE(oldMeta.appId, QStringLiteral("emby-beta"));
-        QCOMPARE(newMeta.appId, QStringLiteral("media.emby.client.beta"));
+        QVERIFY(oldMeta == oldValue);
+        QVERIFY(newMeta == newValue);
 
         // Latest lookup reflects the new class.
         QCOMPARE(reg.appIdFor(QStringLiteral("cef1ba31")), QStringLiteral("media.emby.client.beta"));
@@ -204,13 +220,87 @@ private Q_SLOTS:
         WindowRegistry reg;
         reg.upsert(QStringLiteral("u1"), make(QStringLiteral("firefox")));
         reg.upsert(QStringLiteral("u2"), make(QStringLiteral("kate")));
+        reg.canonicalizeWindowId(QStringLiteral("ghost|canonical-only"));
         QSignalSpy disappeared(&reg, &WindowRegistry::windowDisappeared);
 
         reg.clear();
 
-        QCOMPARE(disappeared.size(), 2);
+        QStringList ids;
+        for (const QList<QVariant>& args : disappeared) {
+            ids.append(args.at(0).toString());
+        }
+        ids.sort();
+        QCOMPARE(ids, (QStringList{QStringLiteral("canonical-only"), QStringLiteral("u1"), QStringLiteral("u2")}));
         QCOMPARE(reg.size(), 0);
         QVERIFY(reg.instancesWithAppId(QStringLiteral("firefox")).isEmpty());
+    }
+
+    void remove_canonicalOnly_emitsBeforeReleasingCanonical()
+    {
+        WindowRegistry reg;
+        const QString canonical = QStringLiteral("ghost|canonical-only");
+        reg.canonicalizeWindowId(canonical);
+        QString resolvedDuringSignal;
+        connect(&reg, &WindowRegistry::windowDisappeared, &reg, [&](const QString&) {
+            resolvedDuringSignal = reg.canonicalizeForLookup(QStringLiteral("renamed|canonical-only"));
+        });
+        QSignalSpy disappeared(&reg, &WindowRegistry::windowDisappeared);
+
+        reg.remove(QStringLiteral("canonical-only"));
+
+        QCOMPARE(disappeared.size(), 1);
+        QCOMPARE(resolvedDuringSignal, canonical);
+        QCOMPARE(reg.canonicalizeForLookup(QStringLiteral("renamed|canonical-only")),
+                 QStringLiteral("renamed|canonical-only"));
+    }
+
+    void remove_reentrantRemoval_emitsOnce()
+    {
+        WindowRegistry reg;
+        const QString instanceId = QStringLiteral("reentrant-instance");
+        const QString canonical = QStringLiteral("app|reentrant-instance");
+        reg.upsert(instanceId, make(QStringLiteral("app")));
+        reg.canonicalizeWindowId(canonical);
+        connect(&reg, &WindowRegistry::windowDisappeared, &reg, [&](const QString& removedId) {
+            QCOMPARE(removedId, instanceId);
+            QCOMPARE(reg.canonicalizeForLookup(QStringLiteral("renamed|reentrant-instance")), canonical);
+            reg.remove(instanceId);
+            reg.clear();
+        });
+        QSignalSpy disappeared(&reg, &WindowRegistry::windowDisappeared);
+
+        reg.remove(instanceId);
+
+        QCOMPARE(disappeared.size(), 1);
+        QVERIFY(!reg.contains(instanceId));
+        QCOMPARE(reg.canonicalizeForLookup(QStringLiteral("renamed|reentrant-instance")),
+                 QStringLiteral("renamed|reentrant-instance"));
+    }
+
+    void remove_reinsertedInstance_honorsNestedRemoval()
+    {
+        WindowRegistry reg;
+        const QString instanceId = QStringLiteral("reinserted-instance");
+        reg.upsert(instanceId, make(QStringLiteral("old-app")));
+        bool reinserted = false;
+        connect(&reg, &WindowRegistry::windowDisappeared, &reg, [&](const QString& removedId) {
+            if (!reinserted) {
+                reinserted = true;
+                reg.upsert(removedId, make(QStringLiteral("new-app")));
+            }
+        });
+        connect(&reg, &WindowRegistry::windowAppeared, &reg, [&](const QString& appearedId) {
+            if (reinserted) {
+                reg.remove(appearedId);
+            }
+        });
+        QSignalSpy disappeared(&reg, &WindowRegistry::windowDisappeared);
+
+        reg.remove(instanceId);
+
+        QCOMPARE(disappeared.size(), 2);
+        QVERIFY(!reg.contains(instanceId));
+        QVERIFY(reg.instancesWithAppId(QStringLiteral("new-app")).isEmpty());
     }
 
     // ────────────────────────────────────────────────────────────────────
@@ -344,7 +434,12 @@ private Q_SLOTS:
         QVERIFY(!reg.contains(QStringLiteral("dead-2")));
         // windowDisappeared fired for each dead record so subscribers (e.g.
         // saved-autotile-order cleanup) drop their ghost state.
-        QCOMPARE(disappeared.size(), 2);
+        QStringList disappearedIds;
+        for (const QList<QVariant>& args : disappeared) {
+            disappearedIds.append(args.at(0).toString());
+        }
+        disappearedIds.sort();
+        QCOMPARE(disappearedIds, (QStringList{QStringLiteral("dead-1"), QStringLiteral("dead-2")}));
         // The dead window's canonical translation is gone — a re-observation
         // under a mutated appId no longer resolves to the stale canonical.
         QCOMPARE(reg.canonicalizeForLookup(QStringLiteral("konsole-renamed|dead-1")),

--- a/tests/unit/core/windowtracking/test_window_registry.cpp
+++ b/tests/unit/core/windowtracking/test_window_registry.cpp
@@ -284,6 +284,18 @@ private Q_SLOTS:
         QCOMPARE(reg.appIdFor(QStringLiteral("unknown")), QString());
     }
 
+    void isMinimized_resolvesCompositeWindowId()
+    {
+        WindowRegistry reg;
+        WindowMetadata metadata = make(QStringLiteral("firefox"));
+        metadata.isMinimized = true;
+        reg.upsert(QStringLiteral("uuid-1"), metadata);
+
+        QVERIFY(reg.isMinimized(QStringLiteral("uuid-1")));
+        QVERIFY(reg.isMinimized(QStringLiteral("firefox|uuid-1")));
+        QVERIFY(!reg.isMinimized(QStringLiteral("firefox|unknown")));
+    }
+
     // ────────────────────────────────────────────────────────────────────
     // pruneStaleInstances — defensive batch cleanup for signal-less deaths
     // ────────────────────────────────────────────────────────────────────

--- a/tests/unit/core/windowtracking/test_window_registry.cpp
+++ b/tests/unit/core/windowtracking/test_window_registry.cpp
@@ -523,11 +523,15 @@ private Q_SLOTS:
         QPointer<WindowRegistry> reg = new WindowRegistry;
         reg->upsert(QStringLiteral("dead-1"), make(QStringLiteral("konsole")));
         reg->upsert(QStringLiteral("dead-2"), make(QStringLiteral("dolphin")));
+        reg->upsert(QStringLiteral("alive-1"), make(QStringLiteral("kate")));
         connect(reg.data(), &WindowRegistry::windowDisappeared, this, [&reg](const QString&) {
             delete reg.data();
         });
 
-        reg->pruneStaleInstances({});
+        // Non-empty alive set: the empty set is a fail-closed no-op (a
+        // premature alive report must not wipe the registry), so the
+        // receiver-deletes-registry sweep needs a survivor.
+        reg->pruneStaleInstances({QStringLiteral("alive-1")});
 
         QVERIFY(reg.isNull());
     }

--- a/tests/unit/core/windowtracking/test_window_registry.cpp
+++ b/tests/unit/core/windowtracking/test_window_registry.cpp
@@ -18,6 +18,7 @@
  */
 
 #include <PhosphorEngine/WindowRegistry.h>
+#include <QPointer>
 #include <QSignalSpy>
 #include <QTest>
 
@@ -242,6 +243,7 @@ private Q_SLOTS:
         reg.canonicalizeWindowId(canonical);
         QString resolvedDuringSignal;
         connect(&reg, &WindowRegistry::windowDisappeared, &reg, [&](const QString&) {
+            reg.releaseCanonical(QStringLiteral("renamed|canonical-only"));
             resolvedDuringSignal = reg.canonicalizeForLookup(QStringLiteral("renamed|canonical-only"));
         });
         QSignalSpy disappeared(&reg, &WindowRegistry::windowDisappeared);
@@ -301,6 +303,43 @@ private Q_SLOTS:
         QCOMPARE(disappeared.size(), 2);
         QVERIFY(!reg.contains(instanceId));
         QVERIFY(reg.instancesWithAppId(QStringLiteral("new-app")).isEmpty());
+    }
+
+    void remove_reentrantUpsertRunsAfterDisappearance()
+    {
+        WindowRegistry reg;
+        const QString instanceId = QStringLiteral("reappearing-instance");
+        reg.upsert(instanceId, make(QStringLiteral("old-app")));
+        QStringList events;
+        connect(&reg, &WindowRegistry::windowDisappeared, &reg, [&](const QString& removedId) {
+            events.append(QStringLiteral("disappeared"));
+            reg.upsert(removedId, make(QStringLiteral("new-app")));
+        });
+        connect(&reg, &WindowRegistry::windowAppeared, &reg, [&](const QString&) {
+            events.append(QStringLiteral("appeared"));
+        });
+
+        reg.remove(instanceId);
+
+        QCOMPARE(events, (QStringList{QStringLiteral("disappeared"), QStringLiteral("appeared")}));
+        QVERIFY(reg.contains(instanceId));
+        QCOMPARE(reg.appIdFor(instanceId), QStringLiteral("new-app"));
+        QVERIFY(reg.instancesWithAppId(QStringLiteral("old-app")).isEmpty());
+        QCOMPARE(reg.instancesWithAppId(QStringLiteral("new-app")), QStringList{instanceId});
+    }
+
+    void clear_receiverMayDeleteRegistry()
+    {
+        QPointer<WindowRegistry> reg = new WindowRegistry;
+        reg->upsert(QStringLiteral("u1"), make(QStringLiteral("firefox")));
+        reg->upsert(QStringLiteral("u2"), make(QStringLiteral("kate")));
+        connect(reg.data(), &WindowRegistry::windowDisappeared, this, [&reg](const QString&) {
+            delete reg.data();
+        });
+
+        reg->clear();
+
+        QVERIFY(reg.isNull());
     }
 
     // ────────────────────────────────────────────────────────────────────
@@ -477,6 +516,20 @@ private Q_SLOTS:
         QCOMPARE(disappeared.size(), 1);
         QCOMPARE(disappeared.first().at(0).toString(), QStringLiteral("orphan-1"));
         QCOMPARE(reg.canonicalizeForLookup(QStringLiteral("ghost-2|orphan-1")), QStringLiteral("ghost-2|orphan-1"));
+    }
+
+    void pruneStaleInstances_receiverMayDeleteRegistry()
+    {
+        QPointer<WindowRegistry> reg = new WindowRegistry;
+        reg->upsert(QStringLiteral("dead-1"), make(QStringLiteral("konsole")));
+        reg->upsert(QStringLiteral("dead-2"), make(QStringLiteral("dolphin")));
+        connect(reg.data(), &WindowRegistry::windowDisappeared, this, [&reg](const QString&) {
+            delete reg.data();
+        });
+
+        reg->pruneStaleInstances({});
+
+        QVERIFY(reg.isNull());
     }
 };
 

--- a/tests/unit/core/windowtracking/test_window_registry.cpp
+++ b/tests/unit/core/windowtracking/test_window_registry.cpp
@@ -15,6 +15,12 @@
  *  - instancesWithAppId reverse index stays in sync across mutations and removes
  *  - remove emits windowDisappeared
  *  - clear emits windowDisappeared for every tracked id
+ *  - canonical retirement: remove/clear emit before retiring the canonical
+ *    record, and a subscriber-reseeded canonical survives the removal
+ *  - re-entrancy: nested clear/remove/upsert from signal receivers (including
+ *    receiver-deletes-registry) leave the registry consistent and emit once
+ *  - isMinimized resolves composite windowIds to the instance record
+ *  - pruneStaleInstances sweeps absent records and orphaned canonicals
  */
 
 #include <PhosphorEngine/WindowRegistry.h>
@@ -27,6 +33,8 @@
 using PhosphorEngine::WindowMetadata;
 using PhosphorEngine::WindowRegistry;
 
+// QSignalSpy stores signal arguments as QVariants, so the record type carried
+// by metadataChanged must be metatype-registered for the spies below.
 Q_DECLARE_METATYPE(PhosphorEngine::WindowMetadata)
 
 namespace {

--- a/tests/unit/core/windowtracking/test_window_registry.cpp
+++ b/tests/unit/core/windowtracking/test_window_registry.cpp
@@ -28,6 +28,7 @@
 #include <QSignalSpy>
 #include <QTest>
 
+#include <algorithm>
 #include <functional>
 
 using PhosphorEngine::WindowMetadata;

--- a/tests/unit/core/windowtracking/test_window_registry.cpp
+++ b/tests/unit/core/windowtracking/test_window_registry.cpp
@@ -281,6 +281,33 @@ private Q_SLOTS:
         QCOMPARE(reg.canonicalizeForLookup(QStringLiteral("later|reseed-instance")), freshCanonical);
     }
 
+    void clear_nestedClearAndReentrantUpsert_leavesRegistryEmpty()
+    {
+        WindowRegistry reg;
+        reg.upsert(QStringLiteral("n1"), make(QStringLiteral("appA")));
+        reg.upsert(QStringLiteral("n2"), make(QStringLiteral("appB")));
+        reg.upsert(QStringLiteral("n3"), make(QStringLiteral("appC")));
+        bool nested = false;
+        connect(&reg, &WindowRegistry::windowDisappeared, &reg, [&](const QString& removedId) {
+            // First disappearance: a subscriber both re-upserts the dying
+            // instance AND triggers a nested bulk clear while two records
+            // remain. Neither may leave residue — the clear supersedes the
+            // re-entrant upsert (it is dropped, not replayed).
+            if (!nested) {
+                nested = true;
+                reg.upsert(removedId, make(QStringLiteral("resurrected")));
+                reg.clear();
+            }
+        });
+
+        reg.clear();
+
+        QCOMPARE(reg.size(), 0);
+        QVERIFY(!reg.contains(QStringLiteral("n1")));
+        QVERIFY(!reg.contains(QStringLiteral("n2")));
+        QVERIFY(!reg.contains(QStringLiteral("n3")));
+    }
+
     void remove_reentrantCrossRemoval_removesBoth()
     {
         WindowRegistry reg;

--- a/tests/unit/core/windowtracking/test_window_registry.cpp
+++ b/tests/unit/core/windowtracking/test_window_registry.cpp
@@ -236,14 +236,14 @@ private Q_SLOTS:
         QVERIFY(reg.instancesWithAppId(QStringLiteral("firefox")).isEmpty());
     }
 
-    void remove_canonicalOnly_emitsBeforeReleasingCanonical()
+    void remove_canonicalOnly_emitsBeforeRetiringCanonical()
     {
         WindowRegistry reg;
         const QString canonical = QStringLiteral("ghost|canonical-only");
         reg.canonicalizeWindowId(canonical);
         QString resolvedDuringSignal;
         connect(&reg, &WindowRegistry::windowDisappeared, &reg, [&](const QString&) {
-            reg.releaseCanonical(QStringLiteral("renamed|canonical-only"));
+            // The mapping must still resolve for synchronous subscribers.
             resolvedDuringSignal = reg.canonicalizeForLookup(QStringLiteral("renamed|canonical-only"));
         });
         QSignalSpy disappeared(&reg, &WindowRegistry::windowDisappeared);
@@ -252,8 +252,59 @@ private Q_SLOTS:
 
         QCOMPARE(disappeared.size(), 1);
         QCOMPARE(resolvedDuringSignal, canonical);
+        // Retired after the emit completes.
         QCOMPARE(reg.canonicalizeForLookup(QStringLiteral("renamed|canonical-only")),
                  QStringLiteral("renamed|canonical-only"));
+    }
+
+    void remove_subscriberReseededCanonical_survivesRemoval()
+    {
+        WindowRegistry reg;
+        const QString instanceId = QStringLiteral("reseed-instance");
+        const QString freshCanonical = QStringLiteral("fresh|reseed-instance");
+        // A record WITHOUT a canonical mapping: the effect's metadata push
+        // seeds the canonical, but a record can arrive through other
+        // notifications first.
+        reg.upsert(instanceId, make(QStringLiteral("old")));
+        connect(&reg, &WindowRegistry::windowDisappeared, &reg, [&](const QString&) {
+            // A re-announce racing the close seeds a fresh canonical for the
+            // same instance while the removal is in flight.
+            reg.canonicalizeWindowId(freshCanonical);
+        });
+        QSignalSpy disappeared(&reg, &WindowRegistry::windowDisappeared);
+
+        reg.remove(instanceId);
+
+        QCOMPARE(disappeared.size(), 1);
+        // The subscriber's fresh mapping must not be clobbered by the
+        // post-emit retirement of the pre-emit one.
+        QCOMPARE(reg.canonicalizeForLookup(QStringLiteral("later|reseed-instance")), freshCanonical);
+    }
+
+    void remove_reentrantCrossRemoval_removesBoth()
+    {
+        WindowRegistry reg;
+        const QString first = QStringLiteral("cross-a");
+        const QString second = QStringLiteral("cross-b");
+        reg.upsert(first, make(QStringLiteral("app")));
+        reg.upsert(second, make(QStringLiteral("app")));
+        connect(&reg, &WindowRegistry::windowDisappeared, &reg, [&](const QString& removedId) {
+            if (removedId == first) {
+                // A subscriber tearing down a DIFFERENT window re-entrantly
+                // (grouped-close handlers do this) must not corrupt the
+                // outer removal's bookkeeping.
+                reg.remove(second);
+            }
+        });
+        QSignalSpy disappeared(&reg, &WindowRegistry::windowDisappeared);
+
+        reg.remove(first);
+
+        QCOMPARE(disappeared.size(), 2);
+        QVERIFY(!reg.contains(first));
+        QVERIFY(!reg.contains(second));
+        QCOMPARE(reg.size(), 0);
+        QVERIFY(reg.instancesWithAppId(QStringLiteral("app")).isEmpty());
     }
 
     void remove_reentrantRemoval_emitsOnce()

--- a/tests/unit/core/windowtracking/test_wts_dirty_mask.cpp
+++ b/tests/unit/core/windowtracking/test_wts_dirty_mask.cpp
@@ -34,13 +34,11 @@
 #include <PhosphorZones/Layout.h>
 #include <PhosphorZones/LayoutRegistry.h>
 #include <PhosphorSnapEngine/SnapState.h>
-#include "config/configbackends.h"
 #include <PhosphorWorkspaces/VirtualDesktopManager.h>
 #include <PhosphorPlacement/WindowTrackingService.h>
 #include <PhosphorZones/Zone.h>
 #include "helpers/IsolatedConfigGuard.h"
 #include "helpers/LayoutRegistryTestHelpers.h"
-#include "helpers/StubSettings.h"
 #include "helpers/StubZoneDetector.h"
 
 using namespace PlasmaZones;
@@ -58,7 +56,6 @@ private Q_SLOTS:
         m_parent = new QObject(nullptr);
         m_layoutManager = PlasmaZones::TestHelpers::makeLayoutRegistry(QStringLiteral("plasmazones/layouts"), m_parent);
         m_virtualDesktopManager = new PhosphorWorkspaces::VirtualDesktopManager(m_parent);
-        m_settings = new StubSettings(m_parent);
         m_zoneDetector = new StubZoneDetector(m_parent);
 
         m_layout = new PhosphorZones::Layout(QStringLiteral("TestLayout"));
@@ -93,7 +90,6 @@ private Q_SLOTS:
         m_parent = nullptr;
         m_layoutManager = nullptr;
         m_virtualDesktopManager = nullptr;
-        m_settings = nullptr;
         m_zoneDetector = nullptr;
         m_layout = nullptr;
         m_service = nullptr;
@@ -333,7 +329,6 @@ private:
     QObject* m_parent = nullptr;
     PhosphorZones::LayoutRegistry* m_layoutManager = nullptr;
     PhosphorWorkspaces::VirtualDesktopManager* m_virtualDesktopManager = nullptr;
-    StubSettings* m_settings = nullptr;
     StubZoneDetector* m_zoneDetector = nullptr;
     PhosphorSnapEngine::SnapState* m_snapState = nullptr;
     PhosphorZones::Layout* m_layout = nullptr;

--- a/tests/unit/core/windowtracking/test_wts_dirty_mask.cpp
+++ b/tests/unit/core/windowtracking/test_wts_dirty_mask.cpp
@@ -253,7 +253,10 @@ private Q_SLOTS:
         m_service->assignWindowToZone(QStringLiteral("app|abc"), m_zone1Id, QStringLiteral("DP-1"), 1);
         m_service->clearDirty();
 
-        const int pruned = m_service->pruneStaleAssignments(QSet<QString>{});
+        // Non-empty alive set (an unrelated survivor): the empty set is a
+        // fail-closed no-op so a premature alive report cannot wipe every
+        // persisted assignment.
+        const int pruned = m_service->pruneStaleAssignments(QSet<QString>{QStringLiteral("other|zzz")});
         QVERIFY(pruned >= 1);
 
         const auto mask = m_service->peekDirty();

--- a/tests/unit/core/windowtracking/test_wts_lifecycle.cpp
+++ b/tests/unit/core/windowtracking/test_wts_lifecycle.cpp
@@ -31,8 +31,6 @@
 #include <PhosphorPlacement/WindowTrackingService.h>
 #include <PhosphorSnapEngine/SnapEngine.h>
 #include <PhosphorZones/LayoutRegistry.h>
-#include <PhosphorSnapEngine/SnapState.h>
-#include "core/interfaces/interfaces.h"
 #include <PhosphorZones/Layout.h>
 #include <PhosphorZones/Zone.h>
 #include "helpers/IsolatedConfigGuard.h"

--- a/tests/unit/core/windowtracking/test_wts_lifecycle.cpp
+++ b/tests/unit/core/windowtracking/test_wts_lifecycle.cpp
@@ -692,9 +692,14 @@ private Q_SLOTS:
 
     void testOnLayoutChanged_floatingWindowsExcludedFromResnap()
     {
-        QString windowId = QStringLiteral("app|12345");
-        m_service->assignWindowToZone(windowId, m_zoneIds[0], QString(), 0);
-        m_service->setWindowFloating(windowId, true);
+        const QString floatedId = QStringLiteral("app|12345");
+        // Non-floating CONTROL window: proves the resnap actually produced
+        // entries, so the exclusion loop below cannot pass vacuously on an
+        // empty list.
+        const QString snappedId = QStringLiteral("app|control");
+        m_service->assignWindowToZone(floatedId, m_zoneIds[0], QString(), 0);
+        m_service->assignWindowToZone(snappedId, m_zoneIds[1], QString(), 0);
+        m_service->setWindowFloating(floatedId, true);
 
         PhosphorZones::Layout* newLayout = createTestLayout(3, m_layoutManager);
         m_layoutManager->addLayout(newLayout);
@@ -702,9 +707,8 @@ private Q_SLOTS:
         m_service->onLayoutChanged();
 
         QVector<ZoneAssignmentEntry> resnap = m_engine->calculateResnapFromPreviousLayout();
-        for (const ZoneAssignmentEntry& entry : resnap) {
-            QVERIFY(entry.windowId != windowId);
-        }
+        QCOMPARE(resnap.size(), 1);
+        QCOMPARE(resnap.first().windowId, snappedId);
     }
 
 private:

--- a/tests/unit/core/windowtracking/test_wts_lifecycle.cpp
+++ b/tests/unit/core/windowtracking/test_wts_lifecycle.cpp
@@ -23,24 +23,18 @@
 #include <QTest>
 #include <QString>
 #include <QStringList>
-#include <QHash>
 #include <QRect>
-#include <QSet>
-#include <QUuid>
 #include <QSignalSpy>
-#include <QRectF>
 #include <memory>
 
+#include <PhosphorIdentity/WindowId.h>
 #include <PhosphorPlacement/WindowTrackingService.h>
 #include <PhosphorSnapEngine/SnapEngine.h>
 #include <PhosphorZones/LayoutRegistry.h>
 #include <PhosphorSnapEngine/SnapState.h>
-#include "config/configbackends.h"
 #include "core/interfaces/interfaces.h"
 #include <PhosphorZones/Layout.h>
 #include <PhosphorZones/Zone.h>
-#include <PhosphorWorkspaces/VirtualDesktopManager.h>
-#include "core/utils/utils.h"
 #include "helpers/IsolatedConfigGuard.h"
 #include "helpers/LayoutRegistryTestHelpers.h"
 
@@ -495,6 +489,10 @@ private Q_SLOTS:
 
     void testRecordFreeGeometry_prefixMutationStillHonorsFirstCapture()
     {
+        // An appId-prefix mutation must not defeat first-capture-wins: the
+        // renamed window still owns its earlier record via the instance suffix,
+        // so a non-overwrite capture keeps the FIRST geometry (and an explicit
+        // overwrite still replaces it under the new id).
         const QString oldId = QStringLiteral("oldclass|renamed-instance");
         const QString newId = QStringLiteral("newclass|renamed-instance");
         const QString screen = QStringLiteral("DP-1");
@@ -549,6 +547,9 @@ private Q_SLOTS:
 
     void testRecordFloatingClose_prefixMutationKeepsOwnEngineSlots()
     {
+        // Closing floating after an appId-prefix mutation must merge into the
+        // window's OWN prior record (matched by instance suffix), preserving its
+        // other engine slots rather than synthesizing a fresh floating-only record.
         const QString oldId = QStringLiteral("oldclass|closing-instance");
         const QString newId = QStringLiteral("newclass|closing-instance");
         PhosphorEngine::WindowPlacement existing;

--- a/tests/unit/core/windowtracking/test_wts_lifecycle.cpp
+++ b/tests/unit/core/windowtracking/test_wts_lifecycle.cpp
@@ -118,7 +118,12 @@ private Q_SLOTS:
 
         QVERIFY(!m_service->isWindowSnapped(windowId));
         QVERIFY(m_service->pendingRestoreQueues().contains(appId));
-        QCOMPARE(m_service->pendingRestoreQueues().value(appId).first().zoneIds.first(), m_zoneIds[0]);
+        // Guard both derefs: a bare .first() on an empty queue/list is UB, not
+        // a test failure.
+        const auto queue = m_service->pendingRestoreQueues().value(appId);
+        QVERIFY(!queue.isEmpty());
+        QVERIFY(!queue.first().zoneIds.isEmpty());
+        QCOMPARE(queue.first().zoneIds.first(), m_zoneIds[0]);
     }
 
     void testWindowClosed_floatingWindowNotPersisted()
@@ -154,9 +159,11 @@ private Q_SLOTS:
 
         m_service->windowClosed(windowId);
 
-        // Float state and pre-float zones should be fully cleared on close
+        // Float state and pre-float zones should be fully cleared on close —
+        // BOTH keys: the windowId-keyed runtime entry and the appId alias.
         QVERIFY(!m_service->isWindowFloating(windowId));
         QVERIFY(!m_service->isWindowFloating(appId));
+        QVERIFY(m_service->preFloatZone(windowId).isEmpty());
         QVERIFY(m_service->preFloatZone(appId).isEmpty());
     }
 

--- a/tests/unit/core/windowtracking/test_wts_lifecycle.cpp
+++ b/tests/unit/core/windowtracking/test_wts_lifecycle.cpp
@@ -486,6 +486,30 @@ private Q_SLOTS:
         QCOMPARE(rec->freeGeometryFor(screen), QRect(50, 60, 700, 500));
     }
 
+    void testRecordFreeGeometry_prefixMutationStillHonorsFirstCapture()
+    {
+        const QString oldId = QStringLiteral("oldclass|renamed-instance");
+        const QString newId = QStringLiteral("newclass|renamed-instance");
+        const QString screen = QStringLiteral("DP-1");
+        const QRect firstGeometry(10, 20, 500, 400);
+
+        m_service->recordFreeGeometry(oldId, screen, firstGeometry, /*overwrite=*/false);
+        m_service->recordFreeGeometry(newId, screen, QRect(90, 80, 900, 700), /*overwrite=*/false);
+
+        auto rec = m_service->placementStore().peekExact(newId);
+        QVERIFY(rec.has_value());
+        QCOMPARE(rec->freeGeometryFor(screen), firstGeometry);
+        QCOMPARE(m_service->placementStore().size(), 1);
+
+        const QRect replacement(30, 40, 600, 450);
+        m_service->recordFreeGeometry(newId, screen, replacement, /*overwrite=*/true);
+        rec = m_service->placementStore().peekExact(newId);
+        QVERIFY(rec.has_value());
+        QCOMPARE(rec->windowId, newId);
+        QCOMPARE(rec->appId, QStringLiteral("newclass"));
+        QCOMPARE(rec->freeGeometryFor(screen), replacement);
+    }
+
     void testRecordFloatingClose_neverInheritsSiblingEngineSlots()
     {
         // A record-less window closing floating must take recordFloatingClose's
@@ -514,6 +538,34 @@ private Q_SLOTS:
         QVERIFY(sibRec.has_value());
         QCOMPARE(sibRec->slotFor(PhosphorEngine::WindowPlacement::snapEngineId()).state,
                  QString(PhosphorEngine::WindowPlacement::stateSnapped()));
+    }
+
+    void testRecordFloatingClose_prefixMutationKeepsOwnEngineSlots()
+    {
+        const QString oldId = QStringLiteral("oldclass|closing-instance");
+        const QString newId = QStringLiteral("newclass|closing-instance");
+        PhosphorEngine::WindowPlacement existing;
+        existing.windowId = oldId;
+        existing.appId = QStringLiteral("oldclass");
+        existing.screenId = QStringLiteral("DP-1");
+        PhosphorEngine::EngineSlot snap;
+        snap.state = QString(PhosphorEngine::WindowPlacement::stateSnapped());
+        snap.zoneIds = QStringList{m_zoneIds[0]};
+        existing.engines.insert(PhosphorEngine::WindowPlacement::snapEngineId(), snap);
+        QVERIFY(m_service->placementStore().record(existing));
+
+        const QRect closeGeometry(70, 80, 700, 500);
+        m_service->recordFloatingClose(newId, QStringLiteral("DP-1"), closeGeometry);
+
+        QCOMPARE(m_service->placementStore().size(), 1);
+        const auto rec = m_service->placementStore().peekExact(newId);
+        QVERIFY(rec.has_value());
+        QCOMPARE(rec->windowId, newId);
+        QCOMPARE(rec->appId, QStringLiteral("newclass"));
+        QCOMPARE(rec->slotFor(PhosphorEngine::WindowPlacement::snapEngineId()).state,
+                 QString(PhosphorEngine::WindowPlacement::stateSnapped()));
+        QCOMPARE(rec->slotFor(PhosphorEngine::WindowPlacement::snapEngineId()).zoneIds, QStringList{m_zoneIds[0]});
+        QCOMPARE(rec->freeGeometryFor(QStringLiteral("DP-1")), closeGeometry);
     }
 
     void testRecordedSnapZones_appIdFallbackAfterRelogin()

--- a/tests/unit/daemon/test_autotile_seed_filter.cpp
+++ b/tests/unit/daemon/test_autotile_seed_filter.cpp
@@ -1,0 +1,156 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Pins the autotile seed-order filter (Daemon::seedAutotileOrderForScreen's
+// admission predicate, extracted as filterAutotileSeedOrder): minimized
+// windows stay as positional placeholders, live user floats and durable
+// snap-slot floats are dropped, plain tiled windows pass through.
+
+#include <QObject>
+#include <QTest>
+
+#include "daemon/daemon/seedorderfilter.h"
+#include "helpers/IsolatedConfigGuard.h"
+#include "helpers/LayoutRegistryTestHelpers.h"
+#include "helpers/StubZoneDetector.h"
+#include <PhosphorEngine/WindowPlacement.h>
+#include <PhosphorEngine/WindowRegistry.h>
+#include <PhosphorPlacement/WindowTrackingService.h>
+#include <PhosphorWorkspaces/VirtualDesktopManager.h>
+
+using namespace PlasmaZones;
+using PlasmaZones::TestHelpers::IsolatedConfigGuard;
+
+namespace {
+PhosphorEngine::WindowMetadata makeMeta(const QString& appId, bool minimized)
+{
+    PhosphorEngine::WindowMetadata meta;
+    meta.appId = appId;
+    meta.isMinimized = minimized;
+    return meta;
+}
+} // namespace
+
+class TestAutotileSeedFilter : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void init()
+    {
+        m_guard = std::make_unique<IsolatedConfigGuard>();
+        m_parent = new QObject(nullptr);
+        auto* layoutManager =
+            PlasmaZones::TestHelpers::makeLayoutRegistry(QStringLiteral("plasmazones/layouts"), m_parent);
+        auto* virtualDesktopManager = new PhosphorWorkspaces::VirtualDesktopManager(m_parent);
+        auto* zoneDetector = new StubZoneDetector(m_parent);
+        m_service =
+            new PhosphorPlacement::WindowTrackingService(layoutManager, zoneDetector, nullptr, virtualDesktopManager,
+                                                         nullptr, PhosphorPlacement::PlacementConfig{}, m_parent);
+        m_registry = new PhosphorEngine::WindowRegistry(m_parent);
+    }
+
+    void cleanup()
+    {
+        delete m_parent;
+        m_parent = nullptr;
+        m_guard.reset();
+    }
+
+    void tiledWindows_pass()
+    {
+        m_registry->upsert(QStringLiteral("u1"), makeMeta(QStringLiteral("kate"), false));
+        QStringList order{QStringLiteral("kate|u1")};
+        filterAutotileSeedOrder(order, m_service, m_registry);
+        QCOMPARE(order, QStringList{QStringLiteral("kate|u1")});
+    }
+
+    void liveFloat_dropped()
+    {
+        m_registry->upsert(QStringLiteral("u1"), makeMeta(QStringLiteral("kate"), false));
+        m_service->setWindowFloating(QStringLiteral("kate|u1"), true);
+        QStringList order{QStringLiteral("kate|u1")};
+        filterAutotileSeedOrder(order, m_service, m_registry);
+        QVERIFY(order.isEmpty());
+    }
+
+    void minimizedFloat_keptAsPlaceholder()
+    {
+        // A minimize-floated window (suspension float) keeps its position in
+        // the order; the engine's strict seed defers tiling it until its
+        // windowOpened arrives.
+        m_registry->upsert(QStringLiteral("u1"), makeMeta(QStringLiteral("kate"), true));
+        m_service->setWindowFloating(QStringLiteral("kate|u1"), true);
+        QStringList order{QStringLiteral("kate|u1")};
+        filterAutotileSeedOrder(order, m_service, m_registry);
+        QCOMPARE(order, QStringList{QStringLiteral("kate|u1")});
+    }
+
+    void durableSnapFloatSlot_dropped()
+    {
+        // The mode flips before the second seed, so the live floating resolver
+        // reads the empty autotile slot; the instance-exact record's floating
+        // snap slot is what preserves the source-mode user float.
+        m_registry->upsert(QStringLiteral("u1"), makeMeta(QStringLiteral("kate"), false));
+        PhosphorEngine::WindowPlacement p;
+        p.windowId = QStringLiteral("kate|u1");
+        p.appId = QStringLiteral("kate");
+        p.screenId = QStringLiteral("DP-1");
+        PhosphorEngine::EngineSlot slot;
+        slot.state = PhosphorEngine::WindowPlacement::stateFloating();
+        p.engines.insert(QString(PhosphorEngine::WindowPlacement::snapEngineId()), slot);
+        p.freeGeometryByScreen.insert(QStringLiteral("DP-1"), QRect(10, 10, 400, 300));
+        QVERIFY(m_service->placementStore().record(p));
+
+        QStringList order{QStringLiteral("kate|u1")};
+        filterAutotileSeedOrder(order, m_service, m_registry);
+        QVERIFY(order.isEmpty());
+    }
+
+    void durableSnapFloatSlot_droppedEvenWhenMinimized()
+    {
+        // A user-floated-then-minimized window must not become a tile
+        // placeholder: on unminimize it stays floating.
+        m_registry->upsert(QStringLiteral("u1"), makeMeta(QStringLiteral("kate"), true));
+        PhosphorEngine::WindowPlacement p;
+        p.windowId = QStringLiteral("kate|u1");
+        p.appId = QStringLiteral("kate");
+        p.screenId = QStringLiteral("DP-1");
+        PhosphorEngine::EngineSlot slot;
+        slot.state = PhosphorEngine::WindowPlacement::stateFloating();
+        p.engines.insert(QString(PhosphorEngine::WindowPlacement::snapEngineId()), slot);
+        p.freeGeometryByScreen.insert(QStringLiteral("DP-1"), QRect(10, 10, 400, 300));
+        QVERIFY(m_service->placementStore().record(p));
+
+        QStringList order{QStringLiteral("kate|u1")};
+        filterAutotileSeedOrder(order, m_service, m_registry);
+        QVERIFY(order.isEmpty());
+    }
+
+    void unknownWindow_noRegistryRecord_passes()
+    {
+        // No registry record and no float state: nothing disqualifies the
+        // entry; the engine-side strict seed applies its own conservative
+        // deferral for unknown windows.
+        QStringList order{QStringLiteral("kate|ghost")};
+        filterAutotileSeedOrder(order, m_service, m_registry);
+        QCOMPARE(order, QStringList{QStringLiteral("kate|ghost")});
+    }
+
+    void nullRegistry_floatFilterStillApplies()
+    {
+        m_service->setWindowFloating(QStringLiteral("kate|u1"), true);
+        QStringList order{QStringLiteral("kate|u1")};
+        filterAutotileSeedOrder(order, m_service, nullptr);
+        QVERIFY(order.isEmpty());
+    }
+
+private:
+    std::unique_ptr<IsolatedConfigGuard> m_guard;
+    QObject* m_parent = nullptr;
+    PhosphorPlacement::WindowTrackingService* m_service = nullptr;
+    PhosphorEngine::WindowRegistry* m_registry = nullptr;
+};
+
+QTEST_MAIN(TestAutotileSeedFilter)
+#include "test_autotile_seed_filter.moc"

--- a/tests/unit/daemon/test_overlay_scope_prefixes.cpp
+++ b/tests/unit/daemon/test_overlay_scope_prefixes.cpp
@@ -35,6 +35,8 @@
 
 #include <QTest>
 
+#include <memory>
+
 #include <PhosphorAnimation/SurfaceAnimator.h>
 #include <PhosphorAnimation/PhosphorProfileRegistry.h>
 #include <PhosphorLayer/Role.h>
@@ -312,10 +314,10 @@ private Q_SLOTS:
     }
 
     /// Regression: the bare base role (no per-instance suffix) must
-    /// also resolve. The OSD creation path uses `withScopePrefix` to
-    /// derive a per-instance role, but a future refactor that registers
-    /// a base role directly (or a test that constructs one inline)
-    /// should still work.
+    /// also resolve. The OSD creation path derives a per-instance role
+    /// via `PhosphorRoles::makePerInstanceRole`, but a future refactor
+    /// that registers a base role directly (or a test that constructs
+    /// one inline) should still work.
     void exact_base_scope_resolves()
     {
         PhosphorAnimation::PhosphorProfileRegistry registry;

--- a/tests/unit/daemon/test_overlay_scope_prefixes.cpp
+++ b/tests/unit/daemon/test_overlay_scope_prefixes.cpp
@@ -19,7 +19,7 @@
  * OutCubic fallback instead of the configured `osd.show` /
  * `popup.zoneSelector.show` / etc.
  *
- * The previous safety net was a single Q_ASSERT_X in
+ * The previous safety net was a single Q_ASSERT_X in the (since removed)
  * createZoneSelectorWindow: debug-only, and only covered ZoneSelector.
  * Production now constructs every per-instance role via
  * `PhosphorRoles::makePerInstanceRole(base, id, gen)` so the prefix-match is
@@ -219,8 +219,9 @@ private Q_SLOTS:
         QCOMPARE(cfg.showScaleProfile, QStringLiteral("osd.show"));
     }
 
-    /// Regression: ZoneSelector. The Q_ASSERT_X in createZoneSelectorWindow
-    /// only catches divergence in debug builds; this test catches it in
+    /// Regression: ZoneSelector. The old Q_ASSERT_X (in the since-removed
+    /// createZoneSelectorWindow) only caught divergence in debug builds;
+    /// this test catches it in
     /// release too. Pre-fix the daemon used "plasmazones-selector-..."
     /// which did NOT prefix-match "plasmazones-zone-selector".
     ///

--- a/tests/unit/dbus/test_wta_capture_guards.cpp
+++ b/tests/unit/dbus/test_wta_capture_guards.cpp
@@ -383,6 +383,9 @@ private Q_SLOTS:
 
     void testMinimizedCloseRebindsChangedAppPrefixWithoutLosingPlacement()
     {
+        // A minimized window closing under a MUTATED appId prefix must re-key its
+        // durable record to the current windowId instead of stranding it under
+        // the old prefix (where a reopen under the new class could never find it).
         PhosphorScreens::FakeScreenProvider fake;
         fake.addScreen(QStringLiteral("DP-1"), QRect(0, 0, 3072, 1728), QStringLiteral("DP-1"));
         PhosphorScreens::ScreenManager screenMgr(

--- a/tests/unit/dbus/test_wta_capture_guards.cpp
+++ b/tests/unit/dbus/test_wta_capture_guards.cpp
@@ -25,6 +25,7 @@
 #include <PhosphorEngine/IPlacementState.h>
 #include <PhosphorEngine/PlacementEngineBase.h>
 #include <PhosphorEngine/WindowPlacement.h>
+#include <PhosphorEngine/WindowRegistry.h>
 #include <PhosphorPlacement/WindowTrackingService.h>
 #include <PhosphorScreens/Manager.h>
 #include <PhosphorSnapEngine/SnapEngine.h>
@@ -291,6 +292,75 @@ private Q_SLOTS:
         wta->service()->setSnapState(nullptr);
         wta->service()->setSnapEngine(nullptr);
         delete snap;
+    }
+
+    // Minimize-float is a live occupancy suspension, not a placement change.
+    // Every capture source must preserve the pre-minimize snap slot while the
+    // compositor reports the window hidden.
+    void testMinimizedCapturePreservesPreMinimizePlacement()
+    {
+        PhosphorScreens::FakeScreenProvider fake;
+        fake.addScreen(QStringLiteral("DP-1"), QRect(0, 0, 3072, 1728), QStringLiteral("DP-1"));
+        PhosphorScreens::ScreenManager screenMgr(
+            PhosphorScreens::ScreenManagerConfig{.screenProvider = &fake, .useGeometrySensors = false});
+        screenMgr.start();
+
+        PhosphorEngine::WindowRegistry registry;
+        QObject parent;
+        auto* wta = new WindowTrackingAdaptor(m_layoutManager, m_zoneDetector, &screenMgr, m_settings, nullptr, nullptr,
+                                              &parent);
+        wta->setWindowRegistry(&registry);
+        auto* snap = new SnapEngine(m_layoutManager, wta->service(), m_zoneDetector, nullptr, nullptr);
+        wta->service()->setSnapState(snap->snapState());
+        wta->service()->setSnapEngine(snap);
+        wta->setEngines(snap, nullptr);
+
+        const QString instanceId = QStringLiteral("minimized-instance");
+        const QString windowId = QStringLiteral("app|minimized-instance");
+        const QString screenId = QStringLiteral("DP-1");
+        const QString zoneId = QUuid::createUuid().toString();
+
+        PhosphorEngine::WindowMetadata metadata;
+        metadata.appId = QStringLiteral("app");
+        metadata.isMinimized = true;
+        registry.upsert(instanceId, metadata);
+
+        PhosphorEngine::WindowPlacement placement;
+        placement.windowId = windowId;
+        placement.appId = metadata.appId;
+        placement.screenId = screenId;
+        PhosphorEngine::EngineSlot slot;
+        slot.state = QString(PhosphorEngine::WindowPlacement::stateSnapped());
+        slot.zoneIds = QStringList{zoneId};
+        placement.engines.insert(snap->engineId(), slot);
+        QVERIFY(wta->service()->placementStore().record(placement));
+
+        // Runtime post-minimize state is floating and carries a valid frame.
+        // Without the minimized guard, capture overwrites the frozen snapped
+        // slot with this temporary float.
+        snap->snapState()->setFloatingOnScreen(windowId, screenId, 1);
+        wta->setFrameGeometry(windowId, 620, 410, 1100, 760);
+        wta->captureWindowPlacement(windowId);
+
+        auto stored = wta->service()->placementStore().peekExact(windowId);
+        QVERIFY(stored);
+        QCOMPARE(stored->slotFor(snap->engineId()).state, QString(PhosphorEngine::WindowPlacement::stateSnapped()));
+        QCOMPARE(stored->slotFor(snap->engineId()).zoneIds, QStringList{zoneId});
+
+        // Once visible, the same capture is allowed and proves the test's
+        // floating setup would have changed the record without the guard.
+        metadata.isMinimized = false;
+        registry.upsert(instanceId, metadata);
+        wta->captureWindowPlacement(windowId);
+        stored = wta->service()->placementStore().peekExact(windowId);
+        QVERIFY(stored);
+        QCOMPARE(stored->slotFor(snap->engineId()).state, QString(PhosphorEngine::WindowPlacement::stateFloating()));
+
+        wta->setEngines(snap, nullptr);
+        wta->service()->setSnapState(nullptr);
+        wta->service()->setSnapEngine(nullptr);
+        delete snap;
+        wta->setWindowRegistry(nullptr);
     }
 
     // The engine-miss CLOSE fallback carries the same tile-rect poison guard

--- a/tests/unit/dbus/test_wta_capture_guards.cpp
+++ b/tests/unit/dbus/test_wta_capture_guards.cpp
@@ -372,6 +372,59 @@ private Q_SLOTS:
         wta->setWindowRegistry(nullptr);
     }
 
+    void testMinimizedCloseRebindsChangedAppPrefixWithoutLosingPlacement()
+    {
+        PhosphorScreens::FakeScreenProvider fake;
+        fake.addScreen(QStringLiteral("DP-1"), QRect(0, 0, 3072, 1728), QStringLiteral("DP-1"));
+        PhosphorScreens::ScreenManager screenMgr(
+            PhosphorScreens::ScreenManagerConfig{.screenProvider = &fake, .useGeometrySensors = false});
+        screenMgr.start();
+
+        PhosphorEngine::WindowRegistry registry;
+        QObject parent;
+        auto* wta = new WindowTrackingAdaptor(m_layoutManager, m_zoneDetector, &screenMgr, m_settings, nullptr, nullptr,
+                                              &parent);
+        wta->setWindowRegistry(&registry);
+
+        const QString instanceId = QStringLiteral("renamed-minimized-instance");
+        const QString oldWindowId = QStringLiteral("oldclass|renamed-minimized-instance");
+        const QString currentWindowId = QStringLiteral("newclass|renamed-minimized-instance");
+        const QString screenId = QStringLiteral("DP-1");
+        PhosphorEngine::WindowMetadata metadata;
+        metadata.appId = QStringLiteral("newclass");
+        metadata.virtualDesktop = 3;
+        metadata.activity = QStringLiteral("activity-a");
+        metadata.isMinimized = true;
+        registry.upsert(instanceId, metadata);
+
+        PhosphorEngine::WindowPlacement placement;
+        placement.windowId = oldWindowId;
+        placement.appId = QStringLiteral("oldclass");
+        placement.screenId = screenId;
+        placement.virtualDesktop = 1;
+        placement.activity = QStringLiteral("old-activity");
+        placement.freeGeometryByScreen.insert(screenId, QRect(100, 120, 900, 700));
+        PhosphorEngine::EngineSlot slot;
+        slot.state = QString(PhosphorEngine::WindowPlacement::stateSnapped());
+        slot.zoneIds = QStringList{QUuid::createUuid().toString()};
+        placement.engines.insert(PhosphorEngine::WindowPlacement::snapEngineId(), slot);
+        QVERIFY(wta->service()->placementStore().record(placement));
+
+        wta->captureWindowPlacement(currentWindowId, screenId);
+
+        QCOMPARE(wta->service()->placementStore().size(), 1);
+        const auto stored = wta->service()->placementStore().peekExact(currentWindowId);
+        QVERIFY(stored.has_value());
+        QCOMPARE(stored->windowId, currentWindowId);
+        QCOMPARE(stored->appId, QStringLiteral("newclass"));
+        QCOMPARE(stored->virtualDesktop, 3);
+        QCOMPARE(stored->activity, QStringLiteral("activity-a"));
+        QCOMPARE(stored->slotFor(PhosphorEngine::WindowPlacement::snapEngineId()), slot);
+        QCOMPARE(stored->freeGeometryFor(screenId), placement.freeGeometryFor(screenId));
+
+        wta->setWindowRegistry(nullptr);
+    }
+
     // The engine-miss CLOSE fallback carries the same tile-rect poison guard
     // as the primary capture path: a window tiled by autotile, handed off
     // (the tiled bit clears; the engine's last-applied rect memory

--- a/tests/unit/dbus/test_wta_capture_guards.cpp
+++ b/tests/unit/dbus/test_wta_capture_guards.cpp
@@ -189,10 +189,10 @@ private Q_SLOTS:
         QObject parent;
         auto* wta = new WindowTrackingAdaptor(m_layoutManager, m_zoneDetector, &screenMgr, m_settings, nullptr, nullptr,
                                               &parent);
-        auto* snap = new SnapEngine(m_layoutManager, wta->service(), m_zoneDetector, nullptr, nullptr);
+        auto snap = std::make_unique<SnapEngine>(m_layoutManager, wta->service(), m_zoneDetector, nullptr, nullptr);
         wta->service()->setSnapState(snap->snapState());
-        wta->service()->setSnapEngine(snap);
-        wta->setEngines(snap, &tileEngine);
+        wta->service()->setSnapEngine(snap.get());
+        wta->setEngines(snap.get(), &tileEngine);
 
         const QString windowId = QStringLiteral("ghostty|inst-tile");
         const QString screenId = QStringLiteral("DP-1");
@@ -226,10 +226,10 @@ private Q_SLOTS:
         QVERIFY(rec);
         QCOMPARE(rec->freeGeometryFor(screenId), movedFrame);
 
-        wta->setEngines(snap, nullptr);
+        wta->setEngines(snap.get(), nullptr);
         wta->service()->setSnapState(nullptr);
         wta->service()->setSnapEngine(nullptr);
-        delete snap;
+        snap.reset();
     }
 
     // Regression (phantom snap-float after a mode round-trip): a snapped
@@ -254,10 +254,10 @@ private Q_SLOTS:
         QObject parent;
         auto* wta = new WindowTrackingAdaptor(m_layoutManager, m_zoneDetector, &screenMgr, m_settings, nullptr, nullptr,
                                               &parent);
-        auto* snap = new SnapEngine(m_layoutManager, wta->service(), m_zoneDetector, nullptr, nullptr);
+        auto snap = std::make_unique<SnapEngine>(m_layoutManager, wta->service(), m_zoneDetector, nullptr, nullptr);
         wta->service()->setSnapState(snap->snapState());
-        wta->service()->setSnapEngine(snap);
-        wta->setEngines(snap, nullptr);
+        wta->service()->setSnapEngine(snap.get());
+        wta->setEngines(snap.get(), nullptr);
 
         const QString windowId = QStringLiteral("app|handoff");
         const QString appId = wta->service()->currentAppIdFor(windowId);
@@ -291,7 +291,7 @@ private Q_SLOTS:
 
         wta->service()->setSnapState(nullptr);
         wta->service()->setSnapEngine(nullptr);
-        delete snap;
+        snap.reset();
     }
 
     // Minimize-float is a live occupancy suspension, not a placement change.
@@ -310,10 +310,10 @@ private Q_SLOTS:
         auto* wta = new WindowTrackingAdaptor(m_layoutManager, m_zoneDetector, &screenMgr, m_settings, nullptr, nullptr,
                                               &parent);
         wta->setWindowRegistry(&registry);
-        auto* snap = new SnapEngine(m_layoutManager, wta->service(), m_zoneDetector, nullptr, nullptr);
+        auto snap = std::make_unique<SnapEngine>(m_layoutManager, wta->service(), m_zoneDetector, nullptr, nullptr);
         wta->service()->setSnapState(snap->snapState());
-        wta->service()->setSnapEngine(snap);
-        wta->setEngines(snap, nullptr);
+        wta->service()->setSnapEngine(snap.get());
+        wta->setEngines(snap.get(), nullptr);
 
         const QString instanceId = QStringLiteral("minimized-instance");
         const QString windowId = QStringLiteral("app|minimized-instance");
@@ -365,10 +365,10 @@ private Q_SLOTS:
         QVERIFY(stored);
         QCOMPARE(stored->slotFor(snap->engineId()).state, QString(PhosphorEngine::WindowPlacement::stateFloating()));
 
-        wta->setEngines(snap, nullptr);
+        wta->setEngines(snap.get(), nullptr);
         wta->service()->setSnapState(nullptr);
         wta->service()->setSnapEngine(nullptr);
-        delete snap;
+        snap.reset();
         wta->setWindowRegistry(nullptr);
     }
 
@@ -392,10 +392,10 @@ private Q_SLOTS:
         QObject parent;
         auto* wta = new WindowTrackingAdaptor(m_layoutManager, m_zoneDetector, &screenMgr, m_settings, nullptr, nullptr,
                                               &parent);
-        auto* snap = new SnapEngine(m_layoutManager, wta->service(), m_zoneDetector, nullptr, nullptr);
+        auto snap = std::make_unique<SnapEngine>(m_layoutManager, wta->service(), m_zoneDetector, nullptr, nullptr);
         wta->service()->setSnapState(snap->snapState());
-        wta->service()->setSnapEngine(snap);
-        wta->setEngines(snap, &tileEngine);
+        wta->service()->setSnapEngine(snap.get());
+        wta->setEngines(snap.get(), &tileEngine);
 
         const QString windowId = QStringLiteral("app|closed-on-tile");
         const QString screenId = QStringLiteral("DP-1");
@@ -420,10 +420,10 @@ private Q_SLOTS:
         QVERIFY(rec);
         QCOMPARE(rec->freeGeometryFor(screenId), freeFrame);
 
-        wta->setEngines(snap, nullptr);
+        wta->setEngines(snap.get(), nullptr);
         wta->service()->setSnapState(nullptr);
         wta->service()->setSnapEngine(nullptr);
-        delete snap;
+        snap.reset();
     }
 };
 

--- a/tests/unit/dbus/test_wta_capture_guards.cpp
+++ b/tests/unit/dbus/test_wta_capture_guards.cpp
@@ -329,11 +329,20 @@ private Q_SLOTS:
         placement.windowId = windowId;
         placement.appId = metadata.appId;
         placement.screenId = screenId;
+        placement.virtualDesktop = 4;
+        placement.activity = QStringLiteral("activity-a");
+        placement.freeGeometryByScreen.insert(screenId, QRect(140, 100, 1000, 720));
         PhosphorEngine::EngineSlot slot;
         slot.state = QString(PhosphorEngine::WindowPlacement::stateSnapped());
         slot.zoneIds = QStringList{zoneId};
         placement.engines.insert(snap->engineId(), slot);
+        PhosphorEngine::EngineSlot autotileSlot;
+        autotileSlot.state = QString(PhosphorEngine::WindowPlacement::stateTiled());
+        autotileSlot.order = 2;
+        placement.engines.insert(PhosphorEngine::WindowPlacement::autotileEngineId(), autotileSlot);
         QVERIFY(wta->service()->placementStore().record(placement));
+        const auto before = wta->service()->placementStore().peekExact(windowId);
+        QVERIFY(before);
 
         // Runtime post-minimize state is floating and carries a valid frame.
         // Without the minimized guard, capture overwrites the frozen snapped
@@ -344,8 +353,8 @@ private Q_SLOTS:
 
         auto stored = wta->service()->placementStore().peekExact(windowId);
         QVERIFY(stored);
-        QCOMPARE(stored->slotFor(snap->engineId()).state, QString(PhosphorEngine::WindowPlacement::stateSnapped()));
-        QCOMPARE(stored->slotFor(snap->engineId()).zoneIds, QStringList{zoneId});
+        QVERIFY(stored->sameContentAs(*before));
+        QCOMPARE(stored->sequence, before->sequence);
 
         // Once visible, the same capture is allowed and proves the test's
         // floating setup would have changed the record without the guard.

--- a/tests/unit/dbus/test_wta_capture_guards.cpp
+++ b/tests/unit/dbus/test_wta_capture_guards.cpp
@@ -313,7 +313,11 @@ private Q_SLOTS:
         screenMgr.start();
 
         PhosphorEngine::WindowRegistry registry;
-        // Engine before parent — see testMinimizedCapturePreservesPreMinimizePlacement.
+        // Engine declared BEFORE parent so reverse destruction tears the
+        // parent (and the WTA/service inside it) down first — destroying the
+        // SnapEngine while the service's snap-state resolver still points into
+        // it would deref freed state. (The other tests cross-reference this
+        // rationale.)
         std::unique_ptr<SnapEngine> snap;
         QObject parent;
         auto* wta = new WindowTrackingAdaptor(m_layoutManager, m_zoneDetector, &screenMgr, m_settings, nullptr, nullptr,

--- a/tests/unit/dbus/test_wta_capture_guards.cpp
+++ b/tests/unit/dbus/test_wta_capture_guards.cpp
@@ -186,10 +186,15 @@ private Q_SLOTS:
         // engine ref is a self-nulling QPointer, outliving it makes the
         // teardown safety structural rather than incidental.
         StubTileRectEngine tileEngine;
+        // Declared BEFORE `parent` so the engine outlives the WTA/service on
+        // EVERY exit path — an early QVERIFY return skips the tail cleanup,
+        // and reverse destruction would otherwise tear the SnapEngine down
+        // first while the service's snap resolver still points into it.
+        std::unique_ptr<SnapEngine> snap;
         QObject parent;
         auto* wta = new WindowTrackingAdaptor(m_layoutManager, m_zoneDetector, &screenMgr, m_settings, nullptr, nullptr,
                                               &parent);
-        auto snap = std::make_unique<SnapEngine>(m_layoutManager, wta->service(), m_zoneDetector, nullptr, nullptr);
+        snap = std::make_unique<SnapEngine>(m_layoutManager, wta->service(), m_zoneDetector, nullptr, nullptr);
         wta->service()->setSnapState(snap->snapState());
         wta->service()->setSnapEngine(snap.get());
         wta->setEngines(snap.get(), &tileEngine);
@@ -251,10 +256,12 @@ private Q_SLOTS:
             PhosphorScreens::ScreenManagerConfig{.screenProvider = &fake, .useGeometrySensors = false});
         screenMgr.start();
 
+        // Engine before parent — see testMinimizedCapturePreservesPreMinimizePlacement.
+        std::unique_ptr<SnapEngine> snap;
         QObject parent;
         auto* wta = new WindowTrackingAdaptor(m_layoutManager, m_zoneDetector, &screenMgr, m_settings, nullptr, nullptr,
                                               &parent);
-        auto snap = std::make_unique<SnapEngine>(m_layoutManager, wta->service(), m_zoneDetector, nullptr, nullptr);
+        snap = std::make_unique<SnapEngine>(m_layoutManager, wta->service(), m_zoneDetector, nullptr, nullptr);
         wta->service()->setSnapState(snap->snapState());
         wta->service()->setSnapEngine(snap.get());
         wta->setEngines(snap.get(), nullptr);
@@ -306,11 +313,13 @@ private Q_SLOTS:
         screenMgr.start();
 
         PhosphorEngine::WindowRegistry registry;
+        // Engine before parent — see testMinimizedCapturePreservesPreMinimizePlacement.
+        std::unique_ptr<SnapEngine> snap;
         QObject parent;
         auto* wta = new WindowTrackingAdaptor(m_layoutManager, m_zoneDetector, &screenMgr, m_settings, nullptr, nullptr,
                                               &parent);
         wta->setWindowRegistry(&registry);
-        auto snap = std::make_unique<SnapEngine>(m_layoutManager, wta->service(), m_zoneDetector, nullptr, nullptr);
+        snap = std::make_unique<SnapEngine>(m_layoutManager, wta->service(), m_zoneDetector, nullptr, nullptr);
         wta->service()->setSnapState(snap->snapState());
         wta->service()->setSnapEngine(snap.get());
         wta->setEngines(snap.get(), nullptr);
@@ -425,6 +434,64 @@ private Q_SLOTS:
         wta->setWindowRegistry(nullptr);
     }
 
+    // Control for the rebind test above: the SAME capture with the registry
+    // reporting NOT-minimized must not take the minimize preserve branch.
+    // With no engine wired and no reported frame the capture has nothing to
+    // record, so the record stays untouched under its OLD id and context —
+    // proving the rebind + context refresh asserted above came specifically
+    // from the minimize branch, not from some always-on path.
+    void testNotMinimizedCloseLeavesRecordUntouched()
+    {
+        PhosphorScreens::FakeScreenProvider fake;
+        fake.addScreen(QStringLiteral("DP-1"), QRect(0, 0, 3072, 1728), QStringLiteral("DP-1"));
+        PhosphorScreens::ScreenManager screenMgr(
+            PhosphorScreens::ScreenManagerConfig{.screenProvider = &fake, .useGeometrySensors = false});
+        screenMgr.start();
+
+        PhosphorEngine::WindowRegistry registry;
+        QObject parent;
+        auto* wta = new WindowTrackingAdaptor(m_layoutManager, m_zoneDetector, &screenMgr, m_settings, nullptr, nullptr,
+                                              &parent);
+        wta->setWindowRegistry(&registry);
+
+        const QString instanceId = QStringLiteral("renamed-visible-instance");
+        const QString oldWindowId = QStringLiteral("oldclass|renamed-visible-instance");
+        const QString currentWindowId = QStringLiteral("newclass|renamed-visible-instance");
+        const QString screenId = QStringLiteral("DP-1");
+        PhosphorEngine::WindowMetadata metadata;
+        metadata.appId = QStringLiteral("newclass");
+        metadata.virtualDesktop = 3;
+        metadata.activity = QStringLiteral("activity-a");
+        metadata.isMinimized = false;
+        registry.upsert(instanceId, metadata);
+
+        PhosphorEngine::WindowPlacement placement;
+        placement.windowId = oldWindowId;
+        placement.appId = QStringLiteral("oldclass");
+        placement.screenId = screenId;
+        placement.virtualDesktop = 1;
+        placement.activity = QStringLiteral("old-activity");
+        placement.freeGeometryByScreen.insert(screenId, QRect(100, 120, 900, 700));
+        PhosphorEngine::EngineSlot slot;
+        slot.state = QString(PhosphorEngine::WindowPlacement::stateSnapped());
+        slot.zoneIds = QStringList{QUuid::createUuid().toString()};
+        placement.engines.insert(PhosphorEngine::WindowPlacement::snapEngineId(), slot);
+        QVERIFY(wta->service()->placementStore().record(placement));
+
+        wta->captureWindowPlacement(currentWindowId, screenId);
+
+        QCOMPARE(wta->service()->placementStore().size(), 1);
+        // peekExact matches by instance id, so it finds the record either way;
+        // the discriminating assertions are the UNCHANGED id and context.
+        const auto stored = wta->service()->placementStore().peekExact(currentWindowId);
+        QVERIFY(stored.has_value());
+        QCOMPARE(stored->windowId, oldWindowId);
+        QCOMPARE(stored->virtualDesktop, 1);
+        QCOMPARE(stored->activity, QStringLiteral("old-activity"));
+
+        wta->setWindowRegistry(nullptr);
+    }
+
     // The engine-miss CLOSE fallback carries the same tile-rect poison guard
     // as the primary capture path: a window tiled by autotile, handed off
     // (the tiled bit clears; the engine's last-applied rect memory
@@ -442,10 +509,12 @@ private Q_SLOTS:
 
         // Same structural stub-before-parent ordering as the primary-path test.
         StubTileRectEngine tileEngine;
+        // Engine before parent — see testMinimizedCapturePreservesPreMinimizePlacement.
+        std::unique_ptr<SnapEngine> snap;
         QObject parent;
         auto* wta = new WindowTrackingAdaptor(m_layoutManager, m_zoneDetector, &screenMgr, m_settings, nullptr, nullptr,
                                               &parent);
-        auto snap = std::make_unique<SnapEngine>(m_layoutManager, wta->service(), m_zoneDetector, nullptr, nullptr);
+        snap = std::make_unique<SnapEngine>(m_layoutManager, wta->service(), m_zoneDetector, nullptr, nullptr);
         wta->service()->setSnapState(snap->snapState());
         wta->service()->setSnapEngine(snap.get());
         wta->setEngines(snap.get(), &tileEngine);

--- a/tests/unit/helpers/WindowPlacementBuilders.h
+++ b/tests/unit/helpers/WindowPlacementBuilders.h
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <QRect>
+#include <QString>
+#include <QStringList>
+
+#include <PhosphorEngine/WindowPlacement.h>
+
+namespace PlasmaZones::TestHelpers {
+
+// Build a single-engine partial record: the calling engine's slot plus, for the
+// un-managed states (free/floating), the shared per-screen free geometry the
+// capture orchestrator would supply. WindowPlacementStore::record() merges these
+// into the one record per window. Tests needing multi-engine or multi-screen
+// fixtures set the extra fields on the returned value.
+inline PhosphorEngine::WindowPlacement makePlacement(const QString& windowId, const QString& appId,
+                                                     const QString& state, const QString& engine,
+                                                     const QString& screen = QStringLiteral("DP-1"),
+                                                     const QRect& rect = QRect(10, 20, 300, 400))
+{
+    PhosphorEngine::WindowPlacement p;
+    p.windowId = windowId;
+    p.appId = appId;
+    p.screenId = screen;
+    PhosphorEngine::EngineSlot slot;
+    slot.state = state;
+    if (state == PhosphorEngine::WindowPlacement::stateSnapped()) {
+        slot.zoneIds = QStringList{QStringLiteral("z1")};
+    } else if (state == PhosphorEngine::WindowPlacement::stateTiled()) {
+        slot.order = 0;
+    }
+    p.engines.insert(engine, slot);
+    if (state == PhosphorEngine::WindowPlacement::stateFree()
+        || state == PhosphorEngine::WindowPlacement::stateFloating()) {
+        p.freeGeometryByScreen.insert(screen, rect);
+    }
+    return p;
+}
+
+} // namespace PlasmaZones::TestHelpers


### PR DESCRIPTION
## Summary

- keep minimized windows out of autotile seeds on both sides of a mode change
- preserve independent snap and autotile placement records while minimize uses a temporary float
- transfer minimize-float ownership and deferred unminimize commits when the active mode changes

## Root cause

Minimize temporarily uses floating state to release layout occupancy. Capture and teardown paths could persist that temporary state as placement intent, while hidden unfloat echoes could discard the effect-side owner needed for the later unminimize transition. The second autotile seed also queried a registry keyed by instance UUID with a composite window ID.

## Testing

- `cmake --build build --parallel $(nproc)`
- focused snapping, autotile, and window-tracking suite: 36 passed
- `ctest --output-on-failure`: 322 passed, 1 environment-dependent test skipped
- manual minimize, mode-switch, and unminimize workflow confirmed