### PR TITLE
fix(editor): stop screen switch from opening the default layout for editing

### DIFF
--- a/dbus/org.plasmazones.LayoutRegistry.xml
+++ b/dbus/org.plasmazones.LayoutRegistry.xml
@@ -191,6 +191,15 @@ SPDX-License-Identifier: GPL-3.0-or-later
                 <annotation name="org.gtk.GDBus.DocString" value="Layout UUID or empty string."/>
             </arg>
         </method>
+        <method name="getAssignedLayoutForScreen">
+            <annotation name="org.gtk.GDBus.DocString" value="Get the layout assigned to a screen through the assignment cascade (resolves with current virtual desktop and activity context). Unlike getLayoutForScreen, returns an empty string when the screen has no assignment of its own instead of falling back to the global default layout."/>
+            <arg name="screenId" type="s" direction="in">
+                <annotation name="org.gtk.GDBus.DocString" value="Screen name (e.g. DP-1)."/>
+            </arg>
+            <arg name="layoutId" type="s" direction="out">
+                <annotation name="org.gtk.GDBus.DocString" value="Layout UUID, autotile:&lt;algorithmId&gt;, or empty string when unassigned."/>
+            </arg>
+        </method>
         <method name="assignLayoutToScreen">
             <annotation name="org.gtk.GDBus.DocString" value="Assign a layout to a screen for all virtual desktops."/>
             <arg name="screenId" type="s" direction="in">

--- a/libs/phosphor-zones/include/PhosphorZones/LayoutRegistry.h
+++ b/libs/phosphor-zones/include/PhosphorZones/LayoutRegistry.h
@@ -532,6 +532,18 @@ public:
     Q_INVOKABLE QString assignmentIdForScreen(const QString& screenId, int virtualDesktop = 0,
                                               const QString& activity = QString()) const override;
 
+    /// Like @ref assignmentIdForScreen, but WITHOUT the level-1 global
+    /// default fallback: resolves the same per-context cascade (including
+    /// the connector-name / virtual-screen retries) and returns empty on a
+    /// cascade miss instead of synthesizing an id from the default
+    /// providers. Answers "does this context have a layout of its OWN" —
+    /// a rule-based assignment counts, the registry-wide default does not.
+    /// The editor's screen switcher uses this to offer a fresh layout for
+    /// a screen that has never been assigned one, rather than opening the
+    /// default layout for in-place editing (discussion #858).
+    Q_INVOKABLE QString storedAssignmentIdForScreen(const QString& screenId, int virtualDesktop = 0,
+                                                    const QString& activity = QString()) const;
+
     /// Full entry for a (screen, desktop, activity) context. Shares
     /// the per-context cascade with @ref layoutForScreen up through
     /// level-2 (per-screen base entry), but the two diverge at level-1

--- a/libs/phosphor-zones/include/PhosphorZones/LayoutRegistry.h
+++ b/libs/phosphor-zones/include/PhosphorZones/LayoutRegistry.h
@@ -528,7 +528,8 @@ public:
     /// @ref setDefaultAutotileAlgorithmProvider). Empty when every
     /// cascade level misses AND both providers return empty. Callers
     /// that need to distinguish "stored" from "synthesized fallback"
-    /// must pair this with @ref hasExplicitAssignment.
+    /// should use @ref storedAssignmentIdForScreen, which walks the same
+    /// cascade but reports a miss as empty instead of synthesizing.
     Q_INVOKABLE QString assignmentIdForScreen(const QString& screenId, int virtualDesktop = 0,
                                               const QString& activity = QString()) const override;
 

--- a/libs/phosphor-zones/src/layoutregistry_assignments.cpp
+++ b/libs/phosphor-zones/src/layoutregistry_assignments.cpp
@@ -51,8 +51,9 @@ namespace {
 /// every variant misses. @p tryOne must return a @c std::optional; an engaged
 /// optional holding a "settled" value (e.g. a non-null-but-empty Layout*) stops
 /// the chain, exactly as the inline retries did. Centralizes the rewrite shared
-/// by layoutForScreen / assignmentIdForScreen / assignmentEntryForScreen /
-/// hasMatchingAssignmentRule so the four cannot drift.
+/// by layoutForScreen / storedAssignmentIdForScreen (which assignmentIdForScreen
+/// delegates to) / assignmentEntryForScreen / hasMatchingAssignmentRule so the
+/// four callers cannot drift.
 template<typename TryFn>
 auto resolveWithScreenFallback(const QString& screenId, TryFn&& tryOne) -> decltype(tryOne(screenId))
 {
@@ -376,20 +377,12 @@ bool LayoutRegistry::hasExplicitAssignment(const QString& screenId, int virtualD
 QString LayoutRegistry::assignmentIdForScreen(const QString& screenId, int virtualDesktop,
                                               const QString& activity) const
 {
-    // Shared cascade with layoutForScreen, but accepts any entry whose
-    // activeLayoutId() is non-empty (incl. Autotile entries). Connector /
-    // virtual-screen fallback applies here too.
-    auto tryResolve = [this, virtualDesktop, &activity](const QString& sid) -> std::optional<QString> {
-        const auto entry = resolveAssignmentEntry(sid, virtualDesktop, activity);
-        if (!entry) {
-            return std::nullopt;
-        }
-        const QString id = entry->activeLayoutId();
-        return id.isEmpty() ? std::nullopt : std::optional<QString>(id);
-    };
-
-    if (const auto result = resolveWithScreenFallback(screenId, tryResolve)) {
-        return *result;
+    // The stored cascade walk lives in storedAssignmentIdForScreen — this
+    // method is that walk plus the level-1 default tail, and delegating keeps
+    // the two from ever resolving the cascade differently.
+    const QString stored = storedAssignmentIdForScreen(screenId, virtualDesktop, activity);
+    if (!stored.isEmpty()) {
+        return stored;
     }
 
     // No stored entry in the cascade — fall through to the level-1 global
@@ -402,10 +395,12 @@ QString LayoutRegistry::assignmentIdForScreen(const QString& screenId, int virtu
 QString LayoutRegistry::storedAssignmentIdForScreen(const QString& screenId, int virtualDesktop,
                                                     const QString& activity) const
 {
-    // Same cascade as assignmentIdForScreen, but a miss stays a miss: no
-    // level-1 default synthesis. Distinguishes "this context has its own
-    // assignment (exact or rule-based)" from "the resolver would hand out
-    // the registry-wide default".
+    // Shared cascade with layoutForScreen, accepting any entry whose
+    // activeLayoutId() is non-empty (incl. Autotile entries), but a miss
+    // stays a miss: no level-1 default synthesis. Distinguishes "this
+    // context has its own assignment (exact or rule-based)" from "the
+    // resolver would hand out the registry-wide default". Connector /
+    // virtual-screen fallback applies here too.
     auto tryResolve = [this, virtualDesktop, &activity](const QString& sid) -> std::optional<QString> {
         const auto entry = resolveAssignmentEntry(sid, virtualDesktop, activity);
         if (!entry) {

--- a/libs/phosphor-zones/src/layoutregistry_assignments.cpp
+++ b/libs/phosphor-zones/src/layoutregistry_assignments.cpp
@@ -399,6 +399,28 @@ QString LayoutRegistry::assignmentIdForScreen(const QString& screenId, int virtu
     return def.activeLayoutId();
 }
 
+QString LayoutRegistry::storedAssignmentIdForScreen(const QString& screenId, int virtualDesktop,
+                                                    const QString& activity) const
+{
+    // Same cascade as assignmentIdForScreen, but a miss stays a miss: no
+    // level-1 default synthesis. Distinguishes "this context has its own
+    // assignment (exact or rule-based)" from "the resolver would hand out
+    // the registry-wide default".
+    auto tryResolve = [this, virtualDesktop, &activity](const QString& sid) -> std::optional<QString> {
+        const auto entry = resolveAssignmentEntry(sid, virtualDesktop, activity);
+        if (!entry) {
+            return std::nullopt;
+        }
+        const QString id = entry->activeLayoutId();
+        return id.isEmpty() ? std::nullopt : std::optional<QString>(id);
+    };
+
+    if (const auto result = resolveWithScreenFallback(screenId, tryResolve)) {
+        return *result;
+    }
+    return QString();
+}
+
 AssignmentEntry LayoutRegistry::assignmentEntryForScreen(const QString& screenId, int virtualDesktop,
                                                          const QString& activity) const
 {

--- a/src/daemon/daemon/autotile_init.cpp
+++ b/src/daemon/daemon/autotile_init.cpp
@@ -15,6 +15,7 @@
 #include "daemon/overlayservice.h"
 #include "dbus/windowtrackingadaptor/windowtrackingadaptor.h"
 
+#include <PhosphorContext/ContextResolver.h>
 #include <PhosphorEngine/PlacementEngineBase.h>
 #include <PhosphorPlacement/WindowTrackingService.h>
 #include <PhosphorScreens/Manager.h>

--- a/src/dbus/layoutadaptor/assignment.cpp
+++ b/src/dbus/layoutadaptor/assignment.cpp
@@ -61,6 +61,21 @@ QString LayoutAdaptor::getLayoutForScreen(const QString& screenId)
     return layout ? layout->id().toString() : QString();
 }
 
+QString LayoutAdaptor::getAssignedLayoutForScreen(const QString& screenId)
+{
+    QString resolvedId = PhosphorScreens::ScreenIdentity::idForName(screenId);
+    // Same context resolution as getLayoutForScreen: the queried screen's own
+    // desktop plus the current activity.
+    int desktop = m_virtualDesktopManager ? m_virtualDesktopManager->currentDesktopForScreen(resolvedId) : 0;
+    QString activity = m_activityManager ? m_activityManager->currentActivity() : QString();
+
+    // Cascade only — empty means the screen has no assignment of its own and
+    // the caller must NOT be handed the registry-wide default (the editor
+    // would otherwise open the default layout for in-place editing and a
+    // save would overwrite it; discussion #858).
+    return m_layoutManager->storedAssignmentIdForScreen(resolvedId, desktop, activity);
+}
+
 void LayoutAdaptor::assignLayoutToScreen(const QString& screenId, const QString& layoutId)
 {
     if (!validateNonEmpty(screenId, QStringLiteral("screen name"), QStringLiteral("assign layout"))) {

--- a/src/dbus/layoutadaptor/layoutadaptor.h
+++ b/src/dbus/layoutadaptor/layoutadaptor.h
@@ -153,6 +153,7 @@ public Q_SLOTS:
 
     // Screen assignments
     QString getLayoutForScreen(const QString& screenId);
+    QString getAssignedLayoutForScreen(const QString& screenId);
     void assignLayoutToScreen(const QString& screenId, const QString& layoutId);
     void clearAssignment(const QString& screenId);
     void setAllScreenAssignments(const QVariantMap& assignments); // Batch set - saves once

--- a/src/editor/services/DBusLayoutService.cpp
+++ b/src/editor/services/DBusLayoutService.cpp
@@ -119,9 +119,14 @@ QString DBusLayoutService::getLayoutIdForScreen(const QString& screenName)
         return QString();
     }
 
-    const QDBusMessage reply = callLayoutRegistry(QStringLiteral("getLayoutForScreen"), {screenName});
+    // getAssignedLayoutForScreen, NOT getLayoutForScreen: the latter falls
+    // back to the registry-wide default layout for an unassigned screen, so
+    // switching the editor to that screen would open the default layout for
+    // in-place editing and a save would overwrite it (discussion #858). An
+    // empty reply here routes the caller to createNewLayout() instead.
+    const QDBusMessage reply = callLayoutRegistry(QStringLiteral("getAssignedLayoutForScreen"), {screenName});
     if (reply.type() != QDBusMessage::ReplyMessage || reply.arguments().isEmpty()) {
-        qCWarning(lcDbus) << "getLayoutForScreen: failed, screen=" << screenName << errorMessage(reply);
+        qCWarning(lcDbus) << "getAssignedLayoutForScreen: failed, screen=" << screenName << errorMessage(reply);
         return QString();
     }
     return reply.arguments().constFirst().toString();

--- a/tests/unit/core/layout/test_layoutmanager_assignment.cpp
+++ b/tests/unit/core/layout/test_layoutmanager_assignment.cpp
@@ -170,6 +170,34 @@ private Q_SLOTS:
         QCOMPARE(fallback->name(), QStringLiteral("Default"));
     }
 
+    // storedAssignmentIdForScreen: same cascade as assignmentIdForScreen but a
+    // miss must stay a miss — no default-layout synthesis. Discussion #858:
+    // the editor asked "what layout is on DP-2", got the registry-wide default
+    // (the only layout, UW1) back as if DP-2 owned it, opened it for in-place
+    // editing, and the user's save overwrote UW1.
+    void testLayoutManager_storedAssignmentIdForScreen_noDefaultSynthesis()
+    {
+        QScopedPointer<PhosphorZones::LayoutRegistry> mgr(createManager());
+
+        auto* uw1 = createTestLayout(QStringLiteral("UW1"));
+        mgr->addLayout(uw1);
+        mgr->assignLayout(QStringLiteral("DP-1"), 0, QString(), uw1);
+
+        // Assigned screen: the stored query answers like the resolvers.
+        QCOMPARE(mgr->assignmentIdForScreen(QStringLiteral("DP-1")), uw1->id().toString());
+        QCOMPARE(mgr->storedAssignmentIdForScreen(QStringLiteral("DP-1")), uw1->id().toString());
+
+        // The cascade itself still applies: a desktop-specific query on the
+        // assigned screen falls through to the base entry.
+        QCOMPARE(mgr->storedAssignmentIdForScreen(QStringLiteral("DP-1"), 3), uw1->id().toString());
+
+        // Unassigned screen: layoutForScreen keeps handing out the default
+        // (first) layout, but the stored query must report empty so callers
+        // can tell "DP-2 has no layout of its own".
+        QCOMPARE(mgr->layoutForScreen(QStringLiteral("DP-2")), uw1);
+        QVERIFY(mgr->storedAssignmentIdForScreen(QStringLiteral("DP-2")).isEmpty());
+    }
+
     // Per-activity assignments (stored at virtualDesktop=0 with a
     // non-empty activity) must be reachable through the cascade and must
     // win over the monitor-only default. Discussion #413 reported that


### PR DESCRIPTION
Fixes the data loss reported in discussion #858.

## Problem

Switching the Layout Editor to a screen with no assignment of its own asked the daemon `getLayoutForScreen`, whose registry fallback hands out the default layout (configured id, or simply the first layout). The editor opened that layout for in-place editing, so renaming it and saving overwrote the original record. In the #858 reproduction, UW1 (created for DP-1) was silently loaded when the user clicked DP-2, renamed to Vertical1, and overwritten on save. Both monitors then resolved to the same UUID.

The intended behavior already existed in `applyTargetScreen` ("No layout assigned to screen - creating new layout") but was unreachable, because `getLayoutForScreen` almost never returns empty once any layout exists.

## Fix

- **`LayoutRegistry::storedAssignmentIdForScreen`**: resolves the same assignment cascade as `assignmentIdForScreen` (rule-based assignments count, connector and virtual-screen retries apply) but returns empty on a cascade miss instead of synthesizing the default. `hasExplicitAssignment` was not usable here since it is an exact-tuple lookup that misses rule-based assignments.
- **`getAssignedLayoutForScreen`** on `org.plasmazones.LayoutRegistry`: exposes the query with the same screen-id, per-screen-desktop, and activity resolution as `getLayoutForScreen`. Covered by the XML/adaptor contract test.
- **Editor**: `DBusLayoutService::getLayoutIdForScreen` now calls the new method, honoring the contract its interface doc always promised ("empty string if no assignment"). Switching to an unassigned screen, or launching the editor on one, now takes the create-new-layout branch and gets a fresh canvas. Screens with real assignments behave as before.
- **Regression test** mirroring the #858 shape in `test_layoutmanager_assignment.cpp`.

A separate commit fixes a pre-existing no-unity build break (missing `ContextResolver` include in `autotile_init.cpp`) that only the unity build masked.

## Verification

Both trees (unity and no-unity) build clean; all 322 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)