### PR TITLE
fix(settings): sync combo display with stored value after model load

### DIFF
--- a/src/settings/qml/GeneralPage.qml
+++ b/src/settings/qml/GeneralPage.qml
@@ -58,14 +58,9 @@ SettingsFlickable {
                     description: i18n("Graphics API used for overlay rendering")
                     searchAnchor: "renderingBackend"
 
-                    ComboBox {
+                    WideComboBox {
                         id: renderingBackendCombo
 
-                        // currentIndex is a binding and stays one. appSettings
-                        // .renderingBackend has a NOTIFY, so the binding already
-                        // re-evaluates on every change; a Connections handler
-                        // assigning currentIndex would sever it on its first run
-                        // and then be the only thing keeping the combo in sync.
                         enabled: !settingsController.daemonRunning
                         Accessible.name: i18n("Rendering backend")
                         // One list of {text, value} pairs rather than two
@@ -73,7 +68,7 @@ SettingsFlickable {
                         textRole: "text"
                         valueRole: "value"
                         model: settingsController.valueOptions("Rendering", "Backend")
-                        currentIndex: Math.max(0, indexOfValue(appSettings.renderingBackend))
+                        storedValue: appSettings.renderingBackend
                         onActivated: appSettings.renderingBackend = currentValue
                     }
                 }
@@ -360,9 +355,7 @@ SettingsFlickable {
                         textRole: "text"
                         valueRole: "value"
                         model: settingsController.valueOptions("Shaders.Audio", "ChannelMode")
-                        // A binding, not a JS assignment: see
-                        // renderingBackendCombo above.
-                        currentIndex: Math.max(0, indexOfValue(appSettings.audioChannelMode))
+                        storedValue: appSettings.audioChannelMode
                         onActivated: appSettings.audioChannelMode = currentValue
                     }
                 }
@@ -423,9 +416,7 @@ SettingsFlickable {
                         textRole: "text"
                         valueRole: "value"
                         model: settingsController.valueOptions("Shaders.Audio", "InputMethod")
-                        // A binding, not a JS assignment: see
-                        // renderingBackendCombo above.
-                        currentIndex: Math.max(0, indexOfValue(appSettings.audioInputMethod))
+                        storedValue: appSettings.audioInputMethod
                         onActivated: appSettings.audioInputMethod = currentValue
                     }
                 }

--- a/src/settings/qml/components/WideComboBox.qml
+++ b/src/settings/qml/components/WideComboBox.qml
@@ -57,7 +57,13 @@ ComboBox {
         Qt.callLater(_recalcLongestWidth);
         _syncStoredValue();
     }
-    onModelChanged: Qt.callLater(_recalcLongestWidth)
+    // Sync here as well as on countChanged: a model replaced by another of the
+    // SAME length never fires countChanged, and the old index would then map
+    // through the previous model's ordering.
+    onModelChanged: {
+        Qt.callLater(_recalcLongestWidth);
+        _syncStoredValue();
+    }
     Component.onCompleted: {
         _recalcLongestWidth();
         _syncStoredValue();

--- a/src/settings/qml/components/WideComboBox.qml
+++ b/src/settings/qml/components/WideComboBox.qml
@@ -19,6 +19,24 @@ import org.kde.kirigami as Kirigami
 ComboBox {
     id: root
 
+    // Value-keyed current selection. Sites bind the backend value here instead
+    // of binding `currentIndex: Math.max(0, indexOfValue(value))` themselves:
+    // that binding evaluates during creation, before the model is applied, so
+    // indexOfValue returns -1, Math.max clamps it to 0, and — indexOfValue not
+    // being a tracked dependency — the binding never re-runs when the model
+    // lands. The combo then displays its first option regardless of the stored
+    // value (discussion #860). Left undefined, the site manages currentIndex
+    // itself.
+    property var storedValue: undefined
+
+    function _syncStoredValue() {
+        if (storedValue === undefined)
+            return;
+        // Unknown/stale stored value falls back to the first option, matching
+        // the Math.max(0, ...) clamp the per-site bindings used.
+        currentIndex = Math.max(0, indexOfValue(storedValue));
+    }
+
     // Cached widest-item width — recalculated only when model or count changes.
     // Using a separate TextMetrics avoids the binding loop caused by the
     // _longestItemWidth → metrics.text → advanceWidth → _longestItemWidth cycle.
@@ -34,9 +52,16 @@ ComboBox {
     }
 
     implicitContentWidthPolicy: ComboBox.WidestTextWhenCompleted
-    onCountChanged: Qt.callLater(_recalcLongestWidth)
+    onStoredValueChanged: _syncStoredValue()
+    onCountChanged: {
+        Qt.callLater(_recalcLongestWidth);
+        _syncStoredValue();
+    }
     onModelChanged: Qt.callLater(_recalcLongestWidth)
-    Component.onCompleted: _recalcLongestWidth()
+    Component.onCompleted: {
+        _recalcLongestWidth();
+        _syncStoredValue();
+    }
 
     TextMetrics {
         id: metrics

--- a/src/settings/qml/pages/decoration/OsdCard.qml
+++ b/src/settings/qml/pages/decoration/OsdCard.qml
@@ -92,7 +92,7 @@ Item {
                     valueRole: "value"
                     // Value-keyed rather than index-keyed: the stored enum no
                     // longer has to match this list's ordering.
-                    currentIndex: Math.max(0, indexOfValue(osdRoot.appSettings.osdStyle))
+                    storedValue: osdRoot.appSettings.osdStyle
                     model: settingsController.valueOptions("Snapping.Effects", "OsdStyle")
                     onActivated: osdRoot.appSettings.osdStyle = currentValue
                 }
@@ -108,7 +108,7 @@ Item {
                     Accessible.name: i18n("Overlay style")
                     textRole: "text"
                     valueRole: "value"
-                    currentIndex: Math.max(0, indexOfValue(osdRoot.appSettings.overlayDisplayMode))
+                    storedValue: osdRoot.appSettings.overlayDisplayMode
                     model: settingsController.valueOptions("Snapping.Effects", "OverlayDisplayMode")
                     onActivated: osdRoot.appSettings.overlayDisplayMode = currentValue
                 }

--- a/src/settings/qml/pages/screens/ZoneSelectorSection.qml
+++ b/src/settings/qml/pages/screens/ZoneSelectorSection.qml
@@ -243,7 +243,7 @@ ColumnLayout {
                         textRole: "text"
                         valueRole: "value"
                         model: settingsController.valueOptions("Snapping.ZoneSelector", "LayoutMode")
-                        currentIndex: Math.max(0, indexOfValue(root.effectiveLayoutMode))
+                        storedValue: root.effectiveLayoutMode
                         onActivated: root.writeSetting("LayoutMode", currentValue, function (v) {
                             appSettings.zoneSelectorLayoutMode = v;
                         })

--- a/src/settings/qml/pages/snapping/SnappingWindowHandlingCard.qml
+++ b/src/settings/qml/pages/snapping/SnappingWindowHandlingCard.qml
@@ -141,7 +141,7 @@ SettingsCard {
                 textRole: "text"
                 valueRole: "value"
                 model: settingsController.valueOptions("Snapping.Behavior.WindowHandling", "StickyWindowHandling")
-                currentIndex: Math.max(0, indexOfValue(appSettings.snappingStickyWindowHandling))
+                storedValue: appSettings.snappingStickyWindowHandling
                 onActivated: appSettings.snappingStickyWindowHandling = currentValue
             }
         }

--- a/src/settings/qml/pages/tiling/TilingWindowHandlingCard.qml
+++ b/src/settings/qml/pages/tiling/TilingWindowHandlingCard.qml
@@ -29,7 +29,7 @@ SettingsCard {
                 textRole: "text"
                 valueRole: "value"
                 model: settingsController.valueOptions("Tiling.Behavior", "InsertPosition")
-                currentIndex: Math.max(0, indexOfValue(appSettings.autotileInsertPosition))
+                storedValue: appSettings.autotileInsertPosition
                 onActivated: appSettings.autotileInsertPosition = currentValue
             }
         }
@@ -97,7 +97,7 @@ SettingsCard {
                 textRole: "text"
                 valueRole: "value"
                 model: settingsController.valueOptions("Tiling.Behavior", "StickyWindowHandling")
-                currentIndex: Math.max(0, indexOfValue(appSettings.autotileStickyWindowHandling))
+                storedValue: appSettings.autotileStickyWindowHandling
                 onActivated: appSettings.autotileStickyWindowHandling = currentValue
             }
         }
@@ -115,7 +115,7 @@ SettingsCard {
                 textRole: "text"
                 valueRole: "value"
                 model: settingsController.valueOptions("Tiling.Behavior", "DragBehavior")
-                currentIndex: Math.max(0, indexOfValue(appSettings.autotileDragBehavior))
+                storedValue: appSettings.autotileDragBehavior
                 onActivated: appSettings.autotileDragBehavior = currentValue
             }
         }
@@ -133,7 +133,7 @@ SettingsCard {
                 textRole: "text"
                 valueRole: "value"
                 model: settingsController.valueOptions("Tiling.Behavior", "OverflowBehavior")
-                currentIndex: Math.max(0, indexOfValue(appSettings.autotileOverflowBehavior))
+                storedValue: appSettings.autotileOverflowBehavior
                 onActivated: appSettings.autotileOverflowBehavior = currentValue
             }
         }


### PR DESCRIPTION
## Summary

Fixes issue #3 from discussion #860 (and the display half of issue #1).

Settings combos bound `currentIndex: Math.max(0, indexOfValue(value))`. That binding evaluates during object creation, before the ComboBox model is applied, so `indexOfValue` returns -1, `Math.max` clamps it to 0, and the binding never re-runs when the model lands (`indexOfValue` is a function call, not a tracked dependency). Every such combo displayed its **first option** regardless of the saved value. Re-selecting the already-saved value is then a no-op write, so no unsaved-changes prompt appears. This is why the reporter saw "Drag behavior" stuck on "Float on drag" while their config held Reorder, and why "Sticky windows" showed "Treat as normal" while their config held "Restore only" (which is what actually disabled autotile on their pinned side-monitor windows).

## Fix

- `WideComboBox` gains a `storedValue` property and re-syncs `currentIndex` on `Component.onCompleted`, `countChanged`, and `storedValue` changes. The `storedValue` binding keeps the backend-change reactivity the old pattern had (page reset/discard, external edits).
- All 11 affected combos converted to `storedValue`: TilingWindowHandlingCard (insert position, sticky windows, drag behavior, overflow behavior), SnappingWindowHandlingCard (sticky windows), GeneralPage (rendering backend, audio channels, audio backend), OsdCard (OSD style, overlay style), ZoneSelectorSection (arrangement).
- `renderingBackendCombo` switched from plain `ComboBox` to `WideComboBox` to pick up the fix; its now-incorrect "the binding already re-evaluates" comment removed.
- The two remaining `indexOfValue` uses (profiles pages) are imperative calls inside handlers and were already correct.

## Verification

- Reproduced the bug and verified the fix with an offscreen `qml6` probe replicating the component logic: before, `displayText=Float on drag` with stored value 1; after, `displayText=Reorder on drag` at load and correct re-sync when the backend value changes afterward.
- Full build clean, 323/323 tests pass, qmlformat clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)