### PR TITLE
fix(effect): keep decorated windows device-aligned at fractional scale

### DIFF
--- a/kwin-effect/plasmazoneseffect/decoration_render.cpp
+++ b/kwin-effect/plasmazoneseffect/decoration_render.cpp
@@ -279,8 +279,7 @@ float PlasmaZonesEffect::advanceFocusFade(const QString& windowId, bool focused)
 
 void PlasmaZonesEffect::pushBorderUniforms(KWin::EffectWindow* w, const WindowDecoration& wb, const QString& packId,
                                            const CompiledSurfacePack& pack, qreal scale, float timeSec,
-                                           const QPointF& foldCursor, qreal texturePaddingLogical,
-                                           const QString& windowId)
+                                           const QPointF& foldCursor, const QRectF& canvasRect, const QString& windowId)
 {
     // The caller (renderSurfaceChainComposite's per-pack fold) has already
     // resolved @p pack and @p wb, confirmed the border is applied, and bound
@@ -305,17 +304,18 @@ void PlasmaZonesEffect::pushBorderUniforms(KWin::EffectWindow* w, const WindowDe
     // scale is the frame's offset inside that texture (top-down device px), and
     // frameSize = frameGeometry.size * scale its extent.
     const QRectF frame = w->frameGeometry();
-    QRectF expanded = w->expandedGeometry();
-    if (expanded.isEmpty()) {
-        expanded = frame;
-    }
-    // Padded composite path: the target texture's canvas is the expanded rect
-    // inflated by the chain's outer margin (renderSurfaceChainComposite uses
-    // the same construction), so the geometry uniforms must describe that
-    // padded space. @p texturePaddingLogical is 0 when the chain declares no
-    // padding pack.
-    if (texturePaddingLogical > 0.0) {
-        expanded.adjust(-texturePaddingLogical, -texturePaddingLogical, texturePaddingLogical, texturePaddingLogical);
+    // The canvas the fold is drawing into — surfaceCanvasFor's device-aligned
+    // rect, padding included. NOT re-derived from expandedGeometry + padding:
+    // the alignment shifts the canvas off the raw expanded rect by a
+    // sub-pixel band, and these uniforms position the frame INSIDE the
+    // texture in device px, so they must describe the actual canvas to the
+    // texel. The expanded/frame fallback covers callers with no canvas.
+    QRectF expanded = canvasRect;
+    if (!expanded.isValid() || expanded.isEmpty()) {
+        expanded = w->expandedGeometry();
+        if (expanded.isEmpty()) {
+            expanded = frame;
+        }
     }
     const QVector2D windowExpandedSize(static_cast<float>(expanded.width() * scale),
                                        static_cast<float>(expanded.height() * scale));

--- a/kwin-effect/plasmazoneseffect/lifecycle_wiring.cpp
+++ b/kwin-effect/plasmazoneseffect/lifecycle_wiring.cpp
@@ -51,13 +51,18 @@ Q_DECLARE_LOGGING_CATEGORY(lcEffect)
 // clocks block documents is preserved within initRenderingAndRegistries().
 void PlasmaZonesEffect::initRenderingAndRegistries()
 {
-    // Sub-pixel vertex precision. KWin's default snapping rounds quad
-    // vertex positions to integer pixels before rasterising, which is
-    // fine for static / pixel-aligned windows but quantises smooth
-    // animations into 1px steps — visible judder at low translate
-    // velocities (the end of a bounce as it eases to rest, slow drag
-    // snaps). MagicLamp uses the same setting for its quad deformation.
-    setVertexSnappingMode(KWin::RenderGeometry::VertexSnappingMode::None);
+    // Vertex snapping stays at KWin's default (Round) here and is toggled
+    // per frame by prePaintScreen: None only while an animation or shader
+    // transition is in flight, Round the rest of the time. None exists for
+    // sub-pixel animation smoothness (KWin's Round quantises smooth
+    // translates into 1px steps — visible judder at low velocities; MagicLamp
+    // uses None for its quad deformation for the same reason). But the mode
+    // is effect-global and every decorated window is PERMANENTLY redirected
+    // (reconcileDecorationShader), so a blanket None resampled every static
+    // decorated window on a half-pixel grid at fractional output scales —
+    // steady-state blur on every 1.25x/1.5x desktop (discussion #868). The
+    // per-frame toggle keeps both properties: crisp at rest, smooth in
+    // motion.
 
     // Single-worker pool for off-loading user-texture loads. See the
     // header docstring for `m_shaderManager.m_textureLoaderPool` for the rationale —

--- a/kwin-effect/plasmazoneseffect/paint_capture.cpp
+++ b/kwin-effect/plasmazoneseffect/paint_capture.cpp
@@ -247,7 +247,7 @@ void PlasmaZonesEffect::apply(KWin::EffectWindow* window, int mask, KWin::Window
     // false) and its own quad handling wins.
     if (!st && !quads.isEmpty() && !m_windowDecorations.isEmpty()) {
         const auto bit = m_windowDecorations.find(getWindowId(window));
-        if (bit != m_windowDecorations.end() && bit->shaderApplied && bit->outerPadding > 0) {
+        if (bit != m_windowDecorations.end() && bit->shaderApplied) {
             QRectF textureGeo = window->expandedGeometry();
             if (textureGeo.isEmpty()) {
                 textureGeo = window->frameGeometry();
@@ -264,10 +264,24 @@ void PlasmaZonesEffect::apply(KWin::EffectWindow* window, int mask, KWin::Window
             // the texture does not match. The live derivation stays as the fallback for
             // the fold's failure paths, which can erase the multipass entry.
             QRectF padded = textureGeo.adjusted(-pad, -pad, pad, pad);
+            bool haveCanvas = false;
             if (const auto psIt = m_surfaceMultipass.find(getWindowId(window)); psIt != m_surfaceMultipass.end()) {
                 if (psIt->second.canvasGeo.isValid()) {
                     padded = psIt->second.canvasGeo;
+                    haveCanvas = true;
                 }
+            }
+            // UNPADDED windows rewrite too, not just padded ones: surfaceCanvasFor
+            // device-aligns the canvas, so even at pad == 0 the composite covers the
+            // ALIGNED rect, which can exceed the expanded rect by a sub-pixel band on
+            // each side at fractional scale. Presenting that texture on KWin's natural
+            // expanded-rect quad (uv 0..1) would squeeze the canvas into the smaller
+            // rect — a whole-window sub-pixel resample, the exact blur the alignment
+            // exists to remove (discussion #868). Only the no-canvas pad == 0 fallback
+            // keeps the natural quad: there the composite was never built, so there is
+            // nothing of ours to map.
+            if (pad <= 0 && !haveCanvas) {
+                return;
             }
 
             // quad-space <-> screen-space is a pure translation at 1:1

--- a/kwin-effect/plasmazoneseffect/paint_pipeline.cpp
+++ b/kwin-effect/plasmazoneseffect/paint_pipeline.cpp
@@ -86,7 +86,21 @@ void PlasmaZonesEffect::prePaintScreen(KWin::ScreenPrePaintData& data)
     // single-digit counts.
     m_windowAnimator->advanceAnimations();
 
-    if (m_windowAnimator->hasActiveAnimations() || !m_shaderManager.empty()) {
+    // Vertex snapping tracks the animation state (see the initRenderingAndRegistries
+    // note): None while anything animates so smooth translates keep sub-pixel
+    // precision, Round (KWin's default) at rest so permanently-redirected
+    // decorated windows stay device-pixel-aligned at fractional output scales
+    // instead of being bilinearly resampled every frame (discussion #868).
+    // `!m_shaderManager.empty()` over-includes installed-but-expired transitions;
+    // that only extends None by a frame or two, which is harmless.
+    const bool animationsInFlight = m_windowAnimator->hasActiveAnimations() || !m_shaderManager.empty();
+    if (animationsInFlight != m_vertexSnappingDisabled) {
+        setVertexSnappingMode(animationsInFlight ? KWin::RenderGeometry::VertexSnappingMode::None
+                                                 : KWin::RenderGeometry::VertexSnappingMode::Round);
+        m_vertexSnappingDisabled = animationsInFlight;
+    }
+
+    if (animationsInFlight) {
         // Windows have translation transforms that move them outside their
         // frame geometry bounds — force full compositing mode. Shader
         // transitions also need this: without

--- a/kwin-effect/plasmazoneseffect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect/plasmazoneseffect.h
@@ -1140,9 +1140,14 @@ private:
     /// per-pack fold) owns the KWin::ShaderBinder, has already resolved @p pack
     /// and the border entry, and has ruled out a transition owning the slot, so
     /// this neither binds/unbinds nor re-validates the window.
-    /// @p texturePaddingLogical: outer margin (logical px) baked into the
-    /// TARGET texture's canvas — non-zero only on the padded composite path,
-    /// where the geometry uniforms must describe the inflated space.
+    /// @p canvasRect: the TARGET texture's canvas in logical coordinates —
+    /// the device-aligned rect surfaceCanvasFor produced (the fold's
+    /// logicalGeometry / SurfaceMultipassState::canvasGeo), which already
+    /// carries any outer padding. Threaded in rather than re-derived from
+    /// expandedGeometry + padding: the alignment shifts the canvas off the
+    /// raw expanded rect by a sub-pixel band, and the geometry uniforms must
+    /// describe the texture that is actually being drawn into, to the texel.
+    /// Falls back to the window's expanded/frame rect when invalid.
     /// @p timeSec: the clock the FOLD decided on, in seconds. Threaded in rather than
     /// sampled here because a chain that Decorations.Performance has paused is handed a
     /// frozen clock — see SurfaceMultipassState::pausedAtMs / timeOffsetMs. Sampling live
@@ -1154,7 +1159,7 @@ private:
     /// exact value and the shader must be given the same one.
     void pushBorderUniforms(KWin::EffectWindow* w, const WindowDecoration& wb, const QString& packId,
                             const CompiledSurfacePack& pack, qreal scale, float timeSec, const QPointF& foldCursor,
-                            qreal texturePaddingLogical = 0.0, const QString& windowId = {});
+                            const QRectF& canvasRect = {}, const QString& windowId = {});
 
     /// Advance the per-window smoothed focus value (m_focusFade) toward the
     /// hard 0/1 target and return it, so focus changes cross-fade instead of
@@ -1871,6 +1876,13 @@ private:
     // the chain, so paint/apply hooks behave plainly during the raw capture
     // pass (no morph quad deform / re-capture).
     bool m_capturingSnapshot = false;
+
+    /// True while prePaintScreen has switched vertex snapping to None for an
+    /// in-flight animation. Mirrors the mode we last set so the per-frame
+    /// toggle only calls setVertexSnappingMode on the edges. Starts false:
+    /// KWin's default is Round and the ctor leaves it there (see
+    /// initRenderingAndRegistries).
+    bool m_vertexSnappingDisabled = false;
 
     /// True while DesktopTransitionManager::compositeWindowsInto drives
     /// paintWindow DIRECTLY (outside KWin's chain walk). That is the shared tail

--- a/kwin-effect/plasmazoneseffect/surface_fold.h
+++ b/kwin-effect/plasmazoneseffect/surface_fold.h
@@ -177,11 +177,37 @@ inline SurfaceCanvas surfaceCanvasFor(const QRectF& expandedOrFrame, qreal outer
     canvas.logicalGeometry = expandedOrFrame;
     canvas.logicalGeometry.adjust(-outerPadding, -outerPadding, outerPadding, outerPadding);
     canvas.captureScale = outputScale;
+    // Cap against kMaxSurfaceDim - 1 so the outward device alignment below,
+    // which can add at most one pixel per axis, still lands inside the cap.
+    // Capping against the bare limit would let a window sized exactly at it
+    // round up to kMaxSurfaceDim + 1 and blow the guard this exists to be.
+    constexpr qreal kMaxAlignedDim = kMaxSurfaceDim - 1.0;
     const qreal longestPx = qMax(canvas.logicalGeometry.width(), canvas.logicalGeometry.height()) * canvas.captureScale;
-    if (longestPx > kMaxSurfaceDim) {
-        canvas.captureScale *= kMaxSurfaceDim / longestPx;
+    if (longestPx > kMaxAlignedDim) {
+        canvas.captureScale *= kMaxAlignedDim / longestPx;
     }
-    canvas.textureSize = (canvas.logicalGeometry.size() * canvas.captureScale).toSize();
+    // DEVICE-ALIGN the canvas: snap the padded rect outward to the device
+    // pixel grid at captureScale, and size the texture from that aligned
+    // device rect. The old `(logicalSize * scale).toSize()` truncated, and the
+    // origin was never aligned at all — on a fractional scale (1.5x: any odd
+    // logical coordinate) the composite's texel grid sat a sub-pixel off the
+    // device grid AND at a slightly wrong density, so every decorated window
+    // was bilinearly resampled at present time, permanently (discussion
+    // #868). Alignment makes the capture viewport's texels 1:1 with device
+    // pixels; apply() presents the composite on this same canvasGeo, and with
+    // vertex snapping Round at rest the quad corners land exactly on the
+    // aligned device coordinates. Same lesson desktoptransitioncapture.cpp
+    // learned with deviceSize(): round the way KWin rounds, once, and carry
+    // the rounded rect everywhere — canvasGeo is the SSOT that carries it.
+    const QRect alignedDevice =
+        QRectF(canvas.logicalGeometry.x() * canvas.captureScale, canvas.logicalGeometry.y() * canvas.captureScale,
+               canvas.logicalGeometry.width() * canvas.captureScale,
+               canvas.logicalGeometry.height() * canvas.captureScale)
+            .toAlignedRect();
+    canvas.logicalGeometry =
+        QRectF(alignedDevice.x() / canvas.captureScale, alignedDevice.y() / canvas.captureScale,
+               alignedDevice.width() / canvas.captureScale, alignedDevice.height() / canvas.captureScale);
+    canvas.textureSize = alignedDevice.size();
     return canvas;
 }
 

--- a/kwin-effect/plasmazoneseffect/surfacelayers.cpp
+++ b/kwin-effect/plasmazoneseffect/surfacelayers.cpp
@@ -728,7 +728,8 @@ KWin::GLTexture* PlasmaZonesEffect::renderSurfaceChainComposite(KWin::EffectWind
             }
             // Contract uniforms + pack params. windowId threaded in so the
             // focus-fade ramp doesn't recompute getWindowId(w) per pack.
-            pushBorderUniforms(w, *bit, chain.at(k), *pk, captureScale, foldTime, plan.foldCursor, pad, windowId);
+            pushBorderUniforms(w, *bit, chain.at(k), *pk, captureScale, foldTime, plan.foldCursor, logicalGeometry,
+                               windowId);
             drawFullscreenQuad();
         }
         for (int i = 0; i < mainChannelsBound; ++i) {


### PR DESCRIPTION
Fixes the steady-state blur reported in discussion #868, and removes one plausible contributor to the maximize flicker reported alongside it.

## The report

A user on a 4K output at **1.5x fractional scale** (plus a 1080p at 1.0x) reported two things, neither present in 0.3.1.3:

1. Image and font quality visibly degraded on **select applications** while the daemon runs, restored by turning it off.
2. Maximizing/restoring a zone-snapped window through `Super+PgUp` flickers and shows stretched frames before settling.

## Root cause

Both defects live on the permanent offscreen redirect that arrived in 3.2.0 (`8a4d01677`, "one composite path for every decorated window"). Before that, borders were drawn through KWin's scene items with no offscreen pass at all — which is why 3.1.3 was clean. Two things on that path were never made fractional-scale-safe.

**Vertex snapping was pinned to `None` for the entire effect** in the constructor. That setting exists for animation smoothness (KWin's default `Round` quantises slow translates into 1px steps) and was harmless when redirects were animation-scoped. Applied permanently to every decorated window, it resampled *static* windows onto a half-pixel grid at any fractional scale, every frame, forever.

**The composite canvas was never device-aligned.** `surfaceCanvasFor` sized the texture with a truncating `(logicalSize * scale).toSize()` and never aligned the canvas *origin* at all, so the composite sat a sub-pixel off the device grid **and** at a slightly wrong density.

The reporter's config confirms the path is active for them: `ShaderProfileTree` and `DecorationProfileTree` are both empty (no packs), but `Windows/ShowBorder=True` with `BorderScope=tiled` puts every snapped window on the `["border"]` chain — permanently redirected. That is exactly why the degradation appeared on "select applications" rather than all of them.

## The fix

- **Toggle vertex snapping per frame** from `prePaintScreen`: `None` while an animation or shader transition is in flight, KWin's `Round` at rest. Crisp when still, smooth in motion.
- **Device-align the canvas** in `surfaceCanvasFor` via `toAlignedRect`, size the texture from the aligned device rect, and carry that rect back out as `canvasGeo` so every consumer maps 1:1. Same rounding discipline `desktoptransitioncapture.cpp` already applies through `deviceSize()`. The dimension cap drops to one pixel below the limit so the outward rounding cannot cross it.
- **`pushBorderUniforms` takes the canvas rect** instead of a padding scalar, so `uSurfaceSize` matches the texture exactly — it could previously be a pixel off, shifting the border SDF.
- **`apply()` rewrites the present quad for unpadded decorated windows too.** The aligned canvas can exceed the expanded rect by a sub-pixel band, and presenting it on KWin's natural quad would squeeze the whole window — reintroducing the exact resample the alignment removes.

## Status of each symptom

**Blur: fixed.** Two concrete mechanisms identified and removed.

**Maximize flicker: only indirectly addressed, and not verified.** Alignment makes our composite presentation pixel-identical to KWin's native one, so a decoration flip mid-maximize stops reading as a pop — but the flicker's actual mechanism was never proven, and it can't be reproduced without fractional-scale multi-monitor hardware. If it survives this, the two leads are the composite realloc clearing `captureValid`/`compositeValid` mid-resize (`surface_capture.cpp:69-133`) and `BorderScope=tiled` undecorating then re-decorating across the maximize edge.

## Considered and rejected

Widening the stock-`maximize` suppression gate to fire whenever animations are enabled, paired with a C++ `WindowAnimator` fallback. Two reasons it's wrong: the support report captures **no KWin effect configuration**, so there is no evidence the reporter even has the stock effect loaded; and it would hand an animation to anyone who deliberately set "Window maximize: None". Suppression stays pack-gated.

Separately worth doing: the support report should capture the loaded KWin effect list. That gap forced a guess twice during this investigation.

## Testing

Clean build, 323/323 ctest passing (the one skip is the GPU-gated `test_surface_decoration_orientation`, by design). The rendering change itself needs eyes on real fractional-scale hardware — no automated coverage reaches the effect's composite path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)