### PR TITLE
fix(kwin-effect): clip backdrop capture to the frame's painted region

### DIFF
--- a/kwin-effect/plasmazoneseffect/paint_pipeline.cpp
+++ b/kwin-effect/plasmazoneseffect/paint_pipeline.cpp
@@ -946,7 +946,7 @@ void PlasmaZonesEffect::paintWindow(const KWin::RenderTarget& renderTarget, cons
                 // the animator's current rect is what the draw transforms by.
                 animatedFrame = m_windowAnimator->currentValue(w, QRectF());
             }
-            captureWindowBackdrop(renderTarget, viewport, w, *backIt, animatedFrame);
+            captureWindowBackdrop(renderTarget, viewport, w, *backIt, deviceRegion, animatedFrame);
         }
     }
 

--- a/kwin-effect/plasmazoneseffect/paint_pipeline.cpp
+++ b/kwin-effect/plasmazoneseffect/paint_pipeline.cpp
@@ -805,7 +805,9 @@ void PlasmaZonesEffect::paintWindow(const KWin::RenderTarget& renderTarget, cons
     // Backdrop capture for needsBackdrop decoration chains (frost / glass):
     // snapshot the scene UNDER this window's padded canvas from the live
     // render target BEFORE any fold below runs — at this point in the scene
-    // walk the target holds exactly the content painted below this window.
+    // walk the target holds the content painted below this window WITHIN the
+    // frame's damage region (outside it the buffer still holds the previous
+    // presented frame, which is why the capture clips to deviceRegion).
     // Live windows only: a closing window's decoration reuses its frozen
     // composite (renderSurfaceChain) and must never re-capture. Covers both
     // fold sites (the rest-path composite further down AND the transition

--- a/kwin-effect/plasmazoneseffect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect/plasmazoneseffect.h
@@ -1260,6 +1260,13 @@ private:
     /// so packs sample composite and backdrop with one uv. Called from
     /// paintWindow for needsBackdrop chains, live windows only (the close
     /// path reuses the frozen composite and must never re-capture).
+    /// paintedDeviceRegion: the paint region paintWindow received (device
+    /// px). The blit is CLIPPED to it: outside this frame's damage the
+    /// render target still holds the PREVIOUS presented frame — the full
+    /// composite, including windows painted ABOVE @p w — and blitting it
+    /// feeds the finished scene back into the backdrop (visible as a
+    /// neighbour's padded-canvas edge re-blurred inside this window's
+    /// frost).
     /// animatedFrame: where the animation is DRAWING the window this frame
     /// (WindowAnimator's current rect, or a morph transition's interpolated
     /// rect), in logical frame-rect terms. When valid, the blit SOURCE
@@ -1268,7 +1275,7 @@ private:
     /// resting rect. Invalid = capture at the live geometry.
     void captureWindowBackdrop(const KWin::RenderTarget& renderTarget, const KWin::RenderViewport& viewport,
                                KWin::EffectWindow* w, const WindowDecoration& wb,
-                               const QRectF& animatedFrame = QRectF());
+                               const KWin::Region& paintedDeviceRegion, const QRectF& animatedFrame = QRectF());
 
     /// Fold @p w's decoration chain into a per-window ping-pong composite, and return the
     /// texture holding the result (null on no decoration / allocation failure). drawWindow

--- a/kwin-effect/plasmazoneseffect/surface_backdrop.cpp
+++ b/kwin-effect/plasmazoneseffect/surface_backdrop.cpp
@@ -101,6 +101,9 @@ void PlasmaZonesEffect::captureWindowBackdrop(const KWin::RenderTarget& renderTa
         state.backdropTex->setWrapMode(GL_CLAMP_TO_EDGE);
         state.backdropSize = textureSize;
         state.backdropRect = QVector4D();
+        // Nothing has been written over the fresh clear yet — the coverage
+        // region that keeps backdropRect off cleared texels restarts empty.
+        state.backdropWritten = KWin::Region();
         // Fresh texture means no output has contributed to any accumulation generation yet, so
         // reset the generation tracker alongside the rect. Harmless today (backdropUsable gates
         // the union on the just-zeroed rect), but leaving stale output rects here would resurface
@@ -174,9 +177,12 @@ void PlasmaZonesEffect::captureWindowBackdrop(const KWin::RenderTarget& renderTa
     // before asking: the aligned (rounded-out) canvas edge can poke a
     // fraction of a pixel past a device-aligned damage rect that covers it
     // for every purpose that matters, and a false negative here starves the
-    // generation restart below. (A canvas ≤2 device px across degenerates to
-    // an empty probe and answers false — it also has nothing to restart.)
-    const bool fullSlice = paintedDevice.contains(deviceVisible.adjusted(1, 1, -1, -1));
+    // generation restart below. The explicit isEmpty guard is load-bearing:
+    // Region::contains on an empty rect is undocumented, and a canvas ≤2
+    // device px across (whose shrunk probe degenerates) must answer false —
+    // it has nothing to restart.
+    const KWin::Rect fullProbe = deviceVisible.adjusted(1, 1, -1, -1);
+    const bool fullSlice = !fullProbe.isEmpty() && paintedDevice.contains(fullProbe);
     // ── Generation restart ──────────────────────────────────────────────
     // The valid rect must eventually CONTRACT (a window dragged half off its
     // output must not keep claiming canvas it no longer captures — the
@@ -212,6 +218,7 @@ void PlasmaZonesEffect::captureWindowBackdrop(const KWin::RenderTarget& renderTa
     // through the gaps between them. Contained (inward-rounding) mapping so
     // a slice never claims a device pixel this pass did not repaint.
     QRectF destUnion;
+    QRectF largestSlice;
     for (const KWin::Rect& deviceSlice : paintedDevice.rects()) {
         const KWin::Rect logicalSlice = viewport.mapFromDeviceCoordinatesContained(deviceSlice);
         const QRectF sliceF =
@@ -233,7 +240,15 @@ void PlasmaZonesEffect::captureWindowBackdrop(const KWin::RenderTarget& renderTa
         if (!fbo.blitFromRenderTarget(renderTarget, viewport, source, destination)) {
             continue;
         }
+        // Record what this blit actually covered, grown by 1 px: the inward
+        // source rounding at fractional scale can open sub-pixel seams between
+        // adjacent slices, and without the growth those seams would read as
+        // coverage gaps below and needlessly shrink the published rect.
+        state.backdropWritten += destination.grownBy(QMargins(1, 1, 1, 1));
         destUnion = destUnion.isEmpty() ? destF : destUnion.united(destF);
+        if (destF.width() * destF.height() > largestSlice.width() * largestSlice.height()) {
+            largestSlice = destF;
+        }
     }
     if (destUnion.isEmpty()) {
         // No slice landed. Leave backdropRect alone, exactly as the empty-source path
@@ -244,22 +259,36 @@ void PlasmaZonesEffect::captureWindowBackdrop(const KWin::RenderTarget& renderTa
         // failed blit means THIS slice is missing, not that the others are invalid.
         return;
     }
-    // Valid sub-rect in TOP-DOWN normalized coords — matches backdropTexel's
-    // clamp space. Non-restart captures UNION with the slices already
-    // accumulated (sibling outputs tiling the canvas, earlier damage slices
-    // from this one). The bounding box can span texels no slice covered, but
-    // those hold the previous capture of the same scene spot, not garbage —
-    // the texture is only ever cleared at allocation.
-    QVector4D destNorm(static_cast<float>(destUnion.x() / texW), static_cast<float>(destUnion.y() / texH),
-                       static_cast<float>(destUnion.width() / texW), static_cast<float>(destUnion.height() / texH));
+    // Valid sub-rect in TEXTURE PIXELS first, normalized at the end — matches
+    // backdropTexel's clamp space. Non-restart captures UNION with the slices
+    // already accumulated (sibling outputs tiling the canvas, earlier damage
+    // slices from this one). A bounding-box union can span texels no slice
+    // ever covered, and on a freshly-cleared texture those still hold the
+    // transparent allocation clear — which a pack clamping into the rect WOULD
+    // sample, as black patches in the frost. So the published rect must pass
+    // the written-coverage check: fall back from the union to this frame's
+    // union, then to the largest single blitted slice (fully written by
+    // construction). After the first full-canvas capture the coverage region
+    // spans the texture and the checks are trivially true, so the union
+    // behaves exactly as it always has; gap texels then hold the PREVIOUS
+    // capture of the same scene spot, which is fine.
+    QRectF validPx = destUnion;
     if (!restartGeneration && backdropUsable(state)) {
-        const float x0 = qMin(state.backdropRect.x(), destNorm.x());
-        const float y0 = qMin(state.backdropRect.y(), destNorm.y());
-        const float x1 = qMax(state.backdropRect.x() + state.backdropRect.z(), destNorm.x() + destNorm.z());
-        const float y1 = qMax(state.backdropRect.y() + state.backdropRect.w(), destNorm.y() + destNorm.w());
-        destNorm = QVector4D(x0, y0, x1 - x0, y1 - y0);
+        validPx = validPx.united(QRectF(state.backdropRect.x() * texW, state.backdropRect.y() * texH,
+                                        state.backdropRect.z() * texW, state.backdropRect.w() * texH));
     }
-    state.backdropRect = destNorm;
+    const auto fullyWritten = [&state](const QRectF& r) {
+        // Shrink the probe by 1 px, mirroring the 1 px growth the inserts get:
+        // the boundary texel band is tolerated, a hole in the middle is not.
+        const QRect probe = r.toAlignedRect().adjusted(1, 1, -1, -1);
+        return probe.isEmpty() || state.backdropWritten.contains(KWin::Rect(probe));
+    };
+    if (!fullyWritten(validPx)) {
+        validPx = fullyWritten(destUnion) ? destUnion : largestSlice;
+    }
+    state.backdropRect =
+        QVector4D(static_cast<float>(validPx.x() / texW), static_cast<float>(validPx.y() / texH),
+                  static_cast<float>(validPx.width() / texW), static_cast<float>(validPx.height() / texH));
     // Commit the generation-set write now that a blit succeeded: a restart
     // clears first and re-adds this output; a first full slice from a new
     // output adds itself; a partial slice leaves the set untouched (see the

--- a/kwin-effect/plasmazoneseffect/surface_backdrop.cpp
+++ b/kwin-effect/plasmazoneseffect/surface_backdrop.cpp
@@ -8,6 +8,7 @@
 #include "types.h"
 #include "window_query.h"
 
+#include <core/region.h>
 #include <core/rendertarget.h>
 #include <core/renderviewport.h>
 #include <effect/effectwindow.h>
@@ -30,7 +31,8 @@ namespace PlasmaZones {
 // the content painted below this window.
 void PlasmaZonesEffect::captureWindowBackdrop(const KWin::RenderTarget& renderTarget,
                                               const KWin::RenderViewport& viewport, KWin::EffectWindow* w,
-                                              const WindowDecoration& wb, const QRectF& animatedFrame)
+                                              const WindowDecoration& wb, const KWin::Region& paintedDeviceRegion,
+                                              const QRectF& animatedFrame)
 {
     // Mirror renderSurfaceChainComposite's canvas math EXACTLY (padded
     // logical rect, capped capture scale, derived texture size) so uBackdrop
@@ -145,29 +147,57 @@ void PlasmaZonesEffect::captureWindowBackdrop(const KWin::RenderTarget& renderTa
     // a window half-dragged off, an animation passing the edge): blit only
     // the part the render target covers and record the valid sub-rect so
     // packs clamp samples into it rather than reading the cleared margin.
-    const QRectF sourceLogicalF = sourceRect & viewport.renderRect();
-    if (sourceLogicalF.isEmpty()) {
+    const QRectF visibleCanvasF = sourceRect & viewport.renderRect();
+    if (visibleCanvasF.isEmpty()) {
         return; // keep whatever another output captured
     }
-    // A new generation starts when THIS OUTPUT blits again; a sibling output blitting into
-    // the same canvas joins the current one. The generation cannot be decided by a clock:
-    // outputs have independent frame clocks, which is why the wall-clock window this used to
-    // use never expired at all (16ms at 60Hz, well under the 50ms window), so backdropRect
-    // only ever grew to the union and never contracted. A window dragged half off its output
-    // then kept a valid rect covering canvas it no longer captures, the clamp stopped biting,
-    // and the overhanging band sampled a frozen reflection of where the window used to be.
+    // ── Damage clip ─────────────────────────────────────────────────────
+    // "The target holds exactly the content painted below this window" (the
+    // header's contract) is only true INSIDE this frame's damage region.
+    // KWin repaints partially (buffer age): outside the damage, the target
+    // still holds the PREVIOUS presented frame — the finished composite,
+    // including windows painted ABOVE this one. Blitting the whole canvas
+    // fed that back into the backdrop, and the seam between fresh scene and
+    // stale full frame landed exactly at the damage edge — user-visible as
+    // a focused neighbour's padded-canvas boundary re-blurred inside this
+    // window's frost. So clip the capture to what this pass actually
+    // painted, and let the slices accumulate across frames exactly like the
+    // multi-output slices always have: a region only enters the texture on
+    // a frame it was genuinely repainted below this window, and anything
+    // that changes behind the window necessarily produces damage there.
+    const KWin::Rect deviceVisible = viewport.mapToDeviceCoordinatesAligned(KWin::RectF(visibleCanvasF));
+    const KWin::Region paintedDevice = paintedDeviceRegion.intersected(deviceVisible);
+    if (paintedDevice.isEmpty()) {
+        return; // nothing repainted below us this pass — keep the prior capture
+    }
+    // Did the damage cover the WHOLE visible canvas? Shrink by one device px
+    // before asking: the aligned (rounded-out) canvas edge can poke a
+    // fraction of a pixel past a device-aligned damage rect that covers it
+    // for every purpose that matters, and a false negative here starves the
+    // generation restart below. (A canvas ≤2 device px across degenerates to
+    // an empty probe and answers false — it also has nothing to restart.)
+    const bool fullSlice = paintedDevice.contains(deviceVisible.adjusted(1, 1, -1, -1));
+    // ── Generation restart ──────────────────────────────────────────────
+    // The valid rect must eventually CONTRACT (a window dragged half off its
+    // output must not keep claiming canvas it no longer captures — the
+    // overhang would sample a frozen reflection), and no clock can decide
+    // when: outputs have independent frame clocks, which is why the
+    // wall-clock window this used to use never expired at all. So the rect
+    // restarts when an output that already contributed a FULL slice blits a
+    // full slice again — its next frame. Partial (damage-clipped) slices
+    // always union and never touch the generation set: a sliver of damage is
+    // neither a new frame's worth of canvas nor a full contribution, and
+    // restarting on one would collapse the valid rect to the sliver. Full
+    // slices are not rare — the ~30fps backdrop driver damages the whole
+    // canvas (addRepaintFull + damagePaddedBand), and animations force full
+    // repaints — so contraction still lands within a frame or two of the
+    // window moving.
     const QRectF outputRect = viewport.renderRect();
-    // Has THIS output already contributed to the current generation? If so this is its next
-    // frame, and the rect restarts at this slice. If not, it is a sibling output tiling the
-    // same canvas in the same generation, and the rect unions.
-    const bool sameGeneration = !state.backdropGenerationOutputs.contains(outputRect);
-    // The generation-set mutation (clear-then-append) is deferred to AFTER a successful
-    // blit, below. Doing the clear here would leave the set emptied-but-not-re-appended on
-    // the failed-blit early return, so the NEXT frame would see this output as
-    // sameGeneration and UNION its slice with the still-stale backdropRect — reproducing,
-    // for one frame, the over-large stale-reflection band the generation set replaced. The
-    // captured `sameGeneration` bool above is what the union check uses, so deferring the
-    // set write changes nothing this frame.
+    const bool restartGeneration = fullSlice && state.backdropGenerationOutputs.contains(outputRect);
+    // The generation-set mutation is deferred to AFTER a successful blit,
+    // below: clearing it here would leave the set emptied on the no-blit
+    // early return, and the next frame would union with a stale rect it
+    // should have restarted from.
     if (!state.backdropFbo) {
         state.backdropTex.reset();
         state.backdropSize = QSize();
@@ -175,36 +205,54 @@ void PlasmaZonesEffect::captureWindowBackdrop(const KWin::RenderTarget& renderTa
     }
     KWin::GLFramebuffer& fbo = *state.backdropFbo;
     // No clear here — see the accumulation note above.
-    const KWin::Rect source(qRound(sourceLogicalF.x()), qRound(sourceLogicalF.y()), qRound(sourceLogicalF.width()),
-                            qRound(sourceLogicalF.height()));
-    // Destination: the source's PROPORTIONAL position within sourceRect,
-    // mapped onto the texture — reduces to the plain scaled copy at rest
-    // (sourceRect == logicalGeometry) and scales a moving/resizing source
-    // into the rest-sized canvas during animations.
     const qreal texW = textureSize.width();
     const qreal texH = textureSize.height();
-    const QRectF destF((source.x() - sourceRect.x()) / sourceRect.width() * texW,
-                       (source.y() - sourceRect.y()) / sourceRect.height() * texH,
-                       source.width() / sourceRect.width() * texW, source.height() / sourceRect.height() * texH);
-    const KWin::Rect destination(qRound(destF.x()), qRound(destF.y()), qRound(destF.width()), qRound(destF.height()));
-    if (!fbo.blitFromRenderTarget(renderTarget, viewport, source, destination)) {
-        // Leave backdropRect alone, exactly as the empty-source path above does. This
-        // runs once per OUTPUT, and a canvas straddling two of them accumulates their
-        // slices into one texture — so zeroing the rect here would throw away a sibling
-        // output's perfectly good capture from the same frame, drop uHasBackdrop to 0,
-        // and collapse the frost to nothing for that frame. A failed blit means THIS
-        // slice is missing, not that the others are invalid.
+    // One blit per damage rect. The region's rects are what was actually
+    // repainted; a single bounding-box blit would re-import the stale frame
+    // through the gaps between them. Contained (inward-rounding) mapping so
+    // a slice never claims a device pixel this pass did not repaint.
+    QRectF destUnion;
+    for (const KWin::Rect& deviceSlice : paintedDevice.rects()) {
+        const KWin::Rect logicalSlice = viewport.mapFromDeviceCoordinatesContained(deviceSlice);
+        const QRectF sliceF =
+            QRectF(logicalSlice.x(), logicalSlice.y(), logicalSlice.width(), logicalSlice.height()) & visibleCanvasF;
+        if (sliceF.isEmpty()) {
+            continue;
+        }
+        const KWin::Rect source(qRound(sliceF.x()), qRound(sliceF.y()), qRound(sliceF.width()),
+                                qRound(sliceF.height()));
+        // Destination: the source's PROPORTIONAL position within sourceRect,
+        // mapped onto the texture — reduces to the plain scaled copy at rest
+        // (sourceRect == logicalGeometry) and scales a moving/resizing source
+        // into the rest-sized canvas during animations.
+        const QRectF destF((source.x() - sourceRect.x()) / sourceRect.width() * texW,
+                           (source.y() - sourceRect.y()) / sourceRect.height() * texH,
+                           source.width() / sourceRect.width() * texW, source.height() / sourceRect.height() * texH);
+        const KWin::Rect destination(qRound(destF.x()), qRound(destF.y()), qRound(destF.width()),
+                                     qRound(destF.height()));
+        if (!fbo.blitFromRenderTarget(renderTarget, viewport, source, destination)) {
+            continue;
+        }
+        destUnion = destUnion.isEmpty() ? destF : destUnion.united(destF);
+    }
+    if (destUnion.isEmpty()) {
+        // No slice landed. Leave backdropRect alone, exactly as the empty-source path
+        // above does. This runs once per OUTPUT, and a canvas straddling two of them
+        // accumulates their slices into one texture — so zeroing the rect here would
+        // throw away a sibling output's perfectly good capture from the same frame,
+        // drop uHasBackdrop to 0, and collapse the frost to nothing for that frame. A
+        // failed blit means THIS slice is missing, not that the others are invalid.
         return;
     }
     // Valid sub-rect in TOP-DOWN normalized coords — matches backdropTexel's
-    // clamp space. Same-frame captures UNION with the slices other outputs
-    // already blitted (adjacent outputs tile the canvas, so the bounding box
-    // is exact for the straddling case).
-    QVector4D destNorm(static_cast<float>(destF.x() / textureSize.width()),
-                       static_cast<float>(destF.y() / textureSize.height()),
-                       static_cast<float>(destF.width() / textureSize.width()),
-                       static_cast<float>(destF.height() / textureSize.height()));
-    if (sameGeneration && backdropUsable(state)) {
+    // clamp space. Non-restart captures UNION with the slices already
+    // accumulated (sibling outputs tiling the canvas, earlier damage slices
+    // from this one). The bounding box can span texels no slice covered, but
+    // those hold the previous capture of the same scene spot, not garbage —
+    // the texture is only ever cleared at allocation.
+    QVector4D destNorm(static_cast<float>(destUnion.x() / texW), static_cast<float>(destUnion.y() / texH),
+                       static_cast<float>(destUnion.width() / texW), static_cast<float>(destUnion.height() / texH));
+    if (!restartGeneration && backdropUsable(state)) {
         const float x0 = qMin(state.backdropRect.x(), destNorm.x());
         const float y0 = qMin(state.backdropRect.y(), destNorm.y());
         const float x1 = qMax(state.backdropRect.x() + state.backdropRect.z(), destNorm.x() + destNorm.z());
@@ -212,13 +260,16 @@ void PlasmaZonesEffect::captureWindowBackdrop(const KWin::RenderTarget& renderTa
         destNorm = QVector4D(x0, y0, x1 - x0, y1 - y0);
     }
     state.backdropRect = destNorm;
-    // Commit the generation-set write now that the blit succeeded: a fresh generation
-    // (this output starting over) clears first, a sibling in the same generation just adds
-    // itself. The failed-blit path above skipped this, leaving the set as it was.
-    if (!sameGeneration) {
+    // Commit the generation-set write now that a blit succeeded: a restart
+    // clears first and re-adds this output; a first full slice from a new
+    // output adds itself; a partial slice leaves the set untouched (see the
+    // generation note above). The no-blit path skipped all of this.
+    if (restartGeneration) {
         state.backdropGenerationOutputs.clear();
     }
-    state.backdropGenerationOutputs.append(outputRect);
+    if (fullSlice && !state.backdropGenerationOutputs.contains(outputRect)) {
+        state.backdropGenerationOutputs.append(outputRect);
+    }
 }
 
 } // namespace PlasmaZones

--- a/kwin-effect/plasmazoneseffect/surface_types.h
+++ b/kwin-effect/plasmazoneseffect/surface_types.h
@@ -456,14 +456,21 @@ struct SurfaceMultipassState
     /// means "no capture this frame" and pushes uHasBackdrop = 0.
     QVector4D backdropRect;
 
-    /// Every output that has blitted into the CURRENT accumulation generation.
+    /// Every output that has blitted a FULL canvas slice into the CURRENT
+    /// accumulation generation.
     ///
     /// This, and NOT a clock, is what separates one generation from the next. A canvas
     /// straddling several outputs is blitted once per output, and those slices must UNION
-    /// into one valid rect — but a blit from an output ALREADY in this generation is the next
-    /// frame for that output and must RESTART the rect, or a window that has moved keeps
-    /// claiming canvas it no longer captures. Outputs have independent frame clocks, so no
-    /// clock can tell those two cases apart.
+    /// into one valid rect — but a FULL slice from an output ALREADY in this generation is
+    /// the next frame for that output and must RESTART the rect, or a window that has moved
+    /// keeps claiming canvas it no longer captures. Outputs have independent frame clocks,
+    /// so no clock can tell those two cases apart.
+    ///
+    /// Only FULL slices (damage covering the whole visible canvas) participate: the capture
+    /// is clipped to the frame's damage region, and a partial slice unions without touching
+    /// this set — restarting on one would collapse the valid rect to a damage sliver.
+    /// Contraction still happens promptly, because full slices are routine (the ~30fps
+    /// backdrop driver damages the whole canvas; animations force full repaints).
     ///
     /// A SET, not "the last output that blitted". With two outputs both covering the canvas
     /// the blits alternate A, B, A, B — so "different from the last one" is true every single

--- a/kwin-effect/plasmazoneseffect/surface_types.h
+++ b/kwin-effect/plasmazoneseffect/surface_types.h
@@ -15,6 +15,7 @@
 
 #include <PhosphorSurface/SurfaceShaderContract.h>
 
+#include <core/region.h>
 #include <opengl/glframebuffer.h>
 #include <opengl/glshader.h>
 #include <opengl/gltexture.h>
@@ -452,9 +453,26 @@ struct SurfaceMultipassState
     std::unique_ptr<KWin::GLFramebuffer> backdropFbo;
     QSize backdropSize;
     /// Valid sub-rect of backdropTex in TOP-DOWN normalized coords (xy=min,
-    /// zw=size) — the part actually blitted (canvas ∩ output). Zero-size
-    /// means "no capture this frame" and pushes uHasBackdrop = 0.
+    /// zw=size) — the part actually blitted (canvas ∩ output ∩ damage). Zero-size
+    /// means "no capture this frame" and pushes uHasBackdrop = 0. INVARIANT:
+    /// always fully inside backdropWritten, so a pack clamping into it can
+    /// never sample a texel still holding the allocation clear.
     QVector4D backdropRect;
+
+    /// Texture-pixel region of backdropTex written since its allocation clear.
+    ///
+    /// backdropRect is one rect, but the captures feeding it are damage-clipped
+    /// slices that can be DISJOINT — and a bounding-box union of disjoint slices
+    /// on a freshly-cleared texture spans gap texels that still hold the
+    /// transparent clear, which packs would then sample as black patches in the
+    /// frost. So every successful blit records its destination here (grown by
+    /// 1 px to absorb the inward source rounding at fractional scale), and the
+    /// published backdropRect is only ever a rect this region fully contains —
+    /// the capture falls back to a smaller covered rect otherwise. Reset with
+    /// the texture's allocation clear; after the first full-canvas capture it
+    /// collapses to one rect covering the texture and the containment checks
+    /// are trivially true.
+    KWin::Region backdropWritten;
 
     /// Every output that has blitted a FULL canvas slice into the CURRENT
     /// accumulation generation.


### PR DESCRIPTION
## Problem

With two windows side by side and a blur/frost decoration active, a visible line appeared in one window at the boundary of the neighbour's extended FBO (padded decoration canvas). Only our `needsBackdrop` packs showed it.

## Root cause

`captureWindowBackdrop` blitted the window's whole padded canvas from the live render target, assuming it held exactly the content painted below the window. That only holds inside the frame's damage region. KWin repaints partially (buffer age), so outside the damage the backbuffer still holds the previous presented frame, which is the finished composite including windows painted above this one. The blur then re-blurred that stale full frame, and the seam between fresh scene-below and stale composite landed exactly at the damage edge, which is the focused neighbour's padded-canvas boundary. This was masked before PR #872: the ungated `PAINT_SCREEN_WITH_TRANSFORMED_WINDOWS` and blanket `setTranslucent` forced effectively full repaints, so the capture was always clean.

## Fix

- Pass the paint region `paintWindow` receives (device px) through to `captureWindowBackdrop` and clip the capture to it. If nothing below the window was repainted this pass, the prior capture is kept.
- Blit per damage rect (not the bounding box) with inward-rounding device-to-logical mapping, so a slice never claims a pixel this pass did not repaint and stale content cannot enter through gaps between damage rects. Slices union into the existing multi-output valid-rect accumulation.
- The generation restart (valid-rect contraction for moved windows) now keys on full-canvas slices only, so a damage sliver cannot collapse the valid rect. Full slices stay routine: the ~30fps backdrop driver damages the whole canvas and animations force full repaints, so contraction still lands within a frame or two.

## Testing

- Clean build, no warnings; all 339 ctest tests pass.
- Verified live: the extended-FBO edge line in adjacent windows is gone with blur packs active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)