### PR TITLE
fix(scroll-engine): make focus scroll and restart restore deterministic

### DIFF
--- a/libs/phosphor-engine/include/PhosphorEngine/IPlacementEngine.h
+++ b/libs/phosphor-engine/include/PhosphorEngine/IPlacementEngine.h
@@ -96,8 +96,9 @@ public:
     }
 
     /// Bracket a BURST of windowOpened calls delivered together (the
-    /// adaptor's windowsOpenedBatch / deferred-open flush loops — daemon
-    /// bring-up re-announce and mode flips). An engine that applies geometry
+    /// adaptor's three dispatch loops: windowsOpenedBatch, the deferred-open
+    /// flush, and the parked-open replay — daemon bring-up re-announce and
+    /// mode flips). An engine that applies geometry
     /// per arrival may defer those applies until endArrivalBurst so a
     /// restore of an unchanged session resolves one final layout instead of
     /// N visible intermediates marching across the screen. Defaults are

--- a/libs/phosphor-engine/include/PhosphorEngine/IPlacementEngine.h
+++ b/libs/phosphor-engine/include/PhosphorEngine/IPlacementEngine.h
@@ -95,6 +95,23 @@ public:
         windowOpened(windowId, screenId, 0, 0);
     }
 
+    /// Bracket a BURST of windowOpened calls delivered together (the
+    /// adaptor's windowsOpenedBatch / deferred-open flush loops — daemon
+    /// bring-up re-announce and mode flips). An engine that applies geometry
+    /// per arrival may defer those applies until endArrivalBurst so a
+    /// restore of an unchanged session resolves one final layout instead of
+    /// N visible intermediates marching across the screen. Defaults are
+    /// no-ops: an engine whose arrivals already coalesce (autotile's queued
+    /// retile) needs nothing. Brackets may nest; only the outermost end
+    /// flushes. Model state is fully updated during the burst either way —
+    /// only the compositor-facing geometry apply is deferred.
+    virtual void beginArrivalBurst()
+    {
+    }
+    virtual void endArrivalBurst()
+    {
+    }
+
     /// A window was closed.
     virtual void windowClosed(const QString& windowId) = 0;
 

--- a/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/ScrollEngine.h
+++ b/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/ScrollEngine.h
@@ -123,6 +123,8 @@ public:
 
     using IPlacementEngine::windowOpened;
     void windowOpened(const QString& windowId, const QString& screenId, int minWidth, int minHeight) override;
+    void beginArrivalBurst() override;
+    void endArrivalBurst() override;
     void windowClosed(const QString& windowId) override;
     void windowFocused(const QString& windowId, const QString& screenId) override;
     void windowMinSizeUpdated(const QString& windowId, int minWidth, int minHeight) override;
@@ -669,6 +671,32 @@ private:
     PhosphorEngine::ScreenContextTracker m_context;
     QSet<QString> m_scrollingScreens;
     QString m_activeScreen;
+    /// FIFO of window ids this engine asked the compositor to activate
+    /// (applyLayout's focusWindowAfter arm) whose windowFocused report has
+    /// not come back yet. The effect reports EVERY activation back through
+    /// notifyWindowFocused, including ones this engine initiated, and the
+    /// round trip is asynchronous: on a rapid focus scroll the strip has
+    /// already advanced past the echoed window by the time the report lands,
+    /// and treating that stale echo as user focus rewinds the active column —
+    /// the next scroll step then advances from the rewound column and skips
+    /// one. windowFocused consumes a matching entry and drops the report; a
+    /// NON-matching report clears the whole queue, which is sound because the
+    /// effect's calls share one ordered D-Bus connection — any echo sent
+    /// earlier has already arrived, so a leftover entry means the effect
+    /// dropped that activation (show desktop, window gone). The tab-click
+    /// path is unaffected: its activation goes out via the adaptor's
+    /// focusWindowRequested, never through this engine's emit, so its echo
+    /// is never queued and still drives the strip (signals.cpp documents
+    /// that contract).
+    QStringList m_pendingSelfActivations;
+    /// Arrival-burst bracket depth (IPlacementEngine::beginArrivalBurst).
+    /// While positive, windowOpened defers its per-arrival applyLayout into
+    /// m_burstPendingApplies (screen → whether any deferred arrival took
+    /// focus) and the outermost endArrivalBurst applies once per screen —
+    /// a daemon-restart re-announce then resolves the restored strip in one
+    /// geometry batch instead of N visible partial-strip intermediates.
+    int m_arrivalBurstDepth = 0;
+    QHash<QString, bool> m_burstPendingApplies;
     /// Armed by the context setters (desktop/activity switch), consumed by
     /// setActiveScreens so the identical-set re-emit only claims
     /// isDesktopSwitch=true for a REAL switch — same contract as

--- a/libs/phosphor-scroll-engine/src/scrollengine/engine_apply.cpp
+++ b/libs/phosphor-scroll-engine/src/scrollengine/engine_apply.cpp
@@ -466,6 +466,16 @@ void ScrollEngine::applyLayout(const QString& screenId, bool focusWindowAfter)
     if (focusWindowAfter) {
         const QString active = state->strip().activeWindowId();
         if (!active.isEmpty()) {
+            // Remember the request so windowFocused can tell this
+            // activation's echo apart from genuine user focus (the
+            // m_pendingSelfActivations doc). Bounded: an effect-side drop
+            // leaves an entry behind until the clear-on-mismatch reclaims it,
+            // and the cap keeps a pathological run of drops from growing the
+            // queue without limit.
+            m_pendingSelfActivations.append(active);
+            while (m_pendingSelfActivations.size() > 16) {
+                m_pendingSelfActivations.removeFirst();
+            }
             Q_EMIT activateWindowRequested(active);
         }
     }

--- a/libs/phosphor-scroll-engine/src/scrollengine/engine_core.cpp
+++ b/libs/phosphor-scroll-engine/src/scrollengine/engine_core.cpp
@@ -205,8 +205,13 @@ void ScrollEngine::releaseScreenState(ScrollState* state, QStringList& releasedW
     // Only the unfloat-slot memory dies here. The float markers and the
     // last-applied rects are inputs to the daemon's windowsReleased handler,
     // which has not run yet — see the contract on the declaration.
+    // The pending self-activation entries go too, for windowClosed's reason:
+    // a released window's echo can never be answered while the screen sits in
+    // another mode, and the stale entry would eat the first genuine focus
+    // report when the window comes back to scrolling.
     for (const QString& windowId : windows) {
         m_floatRestore.remove(windowId);
+        m_pendingSelfActivations.removeAll(windowId);
     }
     releasedWindows.append(windows);
     // Per-screen bookkeeping dies with the state: a stale seed must not

--- a/libs/phosphor-scroll-engine/src/scrollengine/engine_lifecycle.cpp
+++ b/libs/phosphor-scroll-engine/src/scrollengine/engine_lifecycle.cpp
@@ -10,6 +10,9 @@
 
 #include "scrollenginelogging.h"
 
+#include <algorithm>
+#include <utility>
+
 namespace PhosphorScrollEngine {
 
 void ScrollEngine::seedFloatRestoreForOpen(const QString& windowId, int minWidth, int minHeight)
@@ -425,10 +428,15 @@ void ScrollEngine::endArrivalBurst()
     }
     const QHash<QString, bool> pending = std::move(m_burstPendingApplies);
     m_burstPendingApplies.clear();
-    for (auto it = pending.cbegin(); it != pending.cend(); ++it) {
+    // Sorted, not hash order: with focus-taking arrivals on two screens the
+    // LAST activation request wins the compositor's focus, and hash order
+    // would make that winner vary run to run.
+    QStringList screens = pending.keys();
+    std::sort(screens.begin(), screens.end());
+    for (const QString& screenId : std::as_const(screens)) {
         // The screen may have left the scrolling set mid-burst (mode flip
         // races); applyLayout's own state/work-area guards make that a no-op.
-        applyLayout(it.key(), it.value());
+        applyLayout(screenId, pending.value(screenId));
     }
 }
 

--- a/libs/phosphor-scroll-engine/src/scrollengine/engine_lifecycle.cpp
+++ b/libs/phosphor-scroll-engine/src/scrollengine/engine_lifecycle.cpp
@@ -395,13 +395,50 @@ void ScrollEngine::windowOpened(const QString& rawWindowId, const QString& scree
     if (arrivalTookFocus) {
         m_activeScreen = screenId;
     }
-    applyLayout(screenId, arrivalTookFocus);
+    // Inside an arrival burst (daemon-restart re-announce, mode flip) the
+    // apply is deferred to the outermost endArrivalBurst: each arrival here
+    // splices into a PARTIAL strip, and applying per arrival marches every
+    // already-placed window through N intermediate layouts the user can see
+    // even when the restored strip resolves to exactly the pre-restart rects.
+    if (m_arrivalBurstDepth > 0) {
+        auto it = m_burstPendingApplies.find(screenId);
+        if (it == m_burstPendingApplies.end()) {
+            m_burstPendingApplies.insert(screenId, arrivalTookFocus);
+        } else {
+            it.value() = it.value() || arrivalTookFocus;
+        }
+    } else {
+        applyLayout(screenId, arrivalTookFocus);
+    }
     Q_EMIT placementChanged(screenId);
+}
+
+void ScrollEngine::beginArrivalBurst()
+{
+    ++m_arrivalBurstDepth;
+}
+
+void ScrollEngine::endArrivalBurst()
+{
+    if (m_arrivalBurstDepth == 0 || --m_arrivalBurstDepth > 0) {
+        return;
+    }
+    const QHash<QString, bool> pending = std::move(m_burstPendingApplies);
+    m_burstPendingApplies.clear();
+    for (auto it = pending.cbegin(); it != pending.cend(); ++it) {
+        // The screen may have left the scrolling set mid-burst (mode flip
+        // races); applyLayout's own state/work-area guards make that a no-op.
+        applyLayout(it.key(), it.value());
+    }
 }
 
 void ScrollEngine::windowClosed(const QString& rawWindowId)
 {
     const QString windowId = canonicalizeForLookup(rawWindowId);
+    // A pending self-activation for a window that closes before its echo
+    // lands can never be answered; without this a later genuine focus of a
+    // reused id would be eaten as that echo.
+    m_pendingSelfActivations.removeAll(windowId);
     PhosphorEngine::PlacementStateKey key;
     ScrollState* state = stateForWindow(windowId, &key);
     if (!state) {
@@ -443,6 +480,21 @@ void ScrollEngine::windowFocused(const QString& rawWindowId, const QString& scre
     if (!screenId.isEmpty() && m_scrollingScreens.contains(screenId)) {
         m_activeScreen = screenId;
     }
+    // Self-activation echo filter (the m_pendingSelfActivations doc): a
+    // report answering this engine's own activateWindowRequested carries no
+    // new information — the strip already reflects it, or has legitimately
+    // moved past it on a rapid focus scroll, and focusWindow below would
+    // rewind the active column to the stale echo. Entries ahead of the match
+    // go with it: their echoes were dropped by the effect and can never
+    // arrive after this one on the ordered connection.
+    if (const int selfIdx = m_pendingSelfActivations.indexOf(windowId); selfIdx >= 0) {
+        m_pendingSelfActivations.erase(m_pendingSelfActivations.begin(),
+                                       m_pendingSelfActivations.begin() + selfIdx + 1);
+        return;
+    }
+    // A genuine focus report implies every previously-sent echo already
+    // landed, so whatever is left in the queue was dropped — reclaim it.
+    m_pendingSelfActivations.clear();
     PhosphorEngine::PlacementStateKey key;
     ScrollState* state = stateForWindow(windowId, &key);
     if (!state || state->isFloating(windowId)) {

--- a/libs/phosphor-scroll-engine/tests/scrollstriptestutils.h
+++ b/libs/phosphor-scroll-engine/tests/scrollstriptestutils.h
@@ -67,6 +67,18 @@ inline PhosphorScrollEngine::ScrollEngine* makeProviderEngine(QObject* parent, c
     }
     auto* engine = new PhosphorScrollEngine::ScrollEngine(nullptr, nullptr, parent);
     engine->setScreenGeometryProviders(availableGeometry, screenGeometry);
+    // A well-behaved compositor answers every activation request with a
+    // windowFocused report (the effect relays each KWin windowActivated back
+    // through notifyWindowFocused). The engine pairs those echoes against its
+    // pending-self-activation queue, so a fixture that never echoes leaves
+    // the queue populated and the NEXT simulated user focus of that window
+    // is consumed as the missing echo. Direct connection is safe: the echo
+    // handler consumes the queue entry and returns before touching strip
+    // state, so the re-entry into the engine mid-applyLayout mutates nothing.
+    QObject::connect(engine, &PhosphorEngine::PlacementEngineBase::activateWindowRequested, engine,
+                     [engine](const QString& windowId) {
+                         engine->windowFocused(windowId, engine->screenForTrackedWindow(windowId));
+                     });
     engine->setActiveScreens(screens);
     return engine;
 }

--- a/libs/phosphor-scroll-engine/tests/test_scrollengine_persistence.cpp
+++ b/libs/phosphor-scroll-engine/tests/test_scrollengine_persistence.cpp
@@ -26,6 +26,7 @@ class TestScrollEnginePersistence : public QObject
 private Q_SLOTS:
     void modeRoundTripRestoresFocusAndAnchor();
     void serializedStripRestoreSurvivesIdDrift();
+    void arrivalBurstRestoreAppliesOnce();
     void pruneSweepsStashedTilesForClosedWindows();
     void pruneSpareStashStagedFromPersistence();
     void unclaimedStashTilesExpireAfterThreeSessions();
@@ -152,6 +153,49 @@ void TestScrollEnginePersistence::serializedStripRestoreSurvivesIdDrift()
     QCOMPARE(tabbed.tiles.at(tabbed.activeTileIdx).windowId, QStringLiteral("app|n2"));
     // The stashed focus (other|u3) followed its claimed successor.
     QCOMPARE(state->strip().activeWindowId(), QStringLiteral("other|n3"));
+}
+
+void TestScrollEnginePersistence::arrivalBurstRestoreAppliesOnce()
+{
+    // Daemon-restart re-announce: the adaptor brackets the whole open batch
+    // with begin/endArrivalBurst, and the engine must resolve the restored
+    // strip in ONE geometry batch — the per-arrival applies otherwise march
+    // every already-placed window through partial-strip intermediates the
+    // user sees as a restore-time retile even when nothing changed.
+    QObject owner;
+    ScrollEngine* engine1 = makeProviderEngine(&owner, {QStringLiteral("S1")});
+    engine1->setCurrentDesktopForScreen(QStringLiteral("S1"), 1);
+    engine1->windowOpened(QStringLiteral("app|u1"), QStringLiteral("S1"), 0, 0);
+    engine1->windowOpened(QStringLiteral("app|u2"), QStringLiteral("S1"), 0, 0);
+    engine1->windowOpened(QStringLiteral("other|u3"), QStringLiteral("S1"), 0, 0);
+    const QRect r1 = engine1->lastManagedRect(QStringLiteral("app|u1"));
+    const QRect r2 = engine1->lastManagedRect(QStringLiteral("app|u2"));
+    const QRect r3 = engine1->lastManagedRect(QStringLiteral("other|u3"));
+    QVERIFY(r1.isValid() && r2.isValid() && r3.isValid());
+    const QJsonObject blob = engine1->serializeStripState();
+    QVERIFY(!blob.isEmpty());
+
+    // Fresh engine, same window ids (same-session daemon reload — KWin kept
+    // the windows, only the daemon restarted).
+    ScrollEngine* engine2 = makeProviderEngine(&owner, {QStringLiteral("S1")});
+    engine2->setCurrentDesktopForScreen(QStringLiteral("S1"), 1);
+    engine2->restoreStripState(blob);
+    QSignalSpy tiledSpy(engine2, &ScrollEngine::windowsTiled);
+    engine2->beginArrivalBurst();
+    engine2->windowOpened(QStringLiteral("app|u1"), QStringLiteral("S1"), 0, 0);
+    engine2->windowOpened(QStringLiteral("app|u2"), QStringLiteral("S1"), 0, 0);
+    engine2->windowOpened(QStringLiteral("other|u3"), QStringLiteral("S1"), 0, 0);
+    // Model state is fully live during the burst; only geometry is deferred.
+    QCOMPARE(tiledSpy.count(), 0);
+    engine2->endArrivalBurst();
+    QCOMPARE(tiledSpy.count(), 1);
+
+    // The one batch resolves the FINAL restored layout: identical rects to
+    // the pre-restart strip, so the compositor's same-rect skip makes the
+    // whole restore invisible.
+    QCOMPARE(engine2->lastManagedRect(QStringLiteral("app|u1")), r1);
+    QCOMPARE(engine2->lastManagedRect(QStringLiteral("app|u2")), r2);
+    QCOMPARE(engine2->lastManagedRect(QStringLiteral("other|u3")), r3);
 }
 
 void TestScrollEnginePersistence::pruneSweepsStashedTilesForClosedWindows()

--- a/src/dbus/tilingadaptor/tilingadaptor.cpp
+++ b/src/dbus/tilingadaptor/tilingadaptor.cpp
@@ -172,8 +172,18 @@ void TilingAdaptor::notifyEngineScreensChanged(bool isDesktopSwitch)
             // re-parked.
             if (!m_unclaimedOpens.isEmpty()) {
                 const auto parked = std::exchange(m_unclaimedOpens, {});
+                // Burst bracket, same as windowsOpenedBatch: a flip can park a
+                // whole screen's opens, and replaying them per-arrival would
+                // march the strip through the partial intermediates the
+                // bracket exists to suppress.
+                for (PhosphorEngine::IPlacementEngine* engine : m_lifecycleEngines) {
+                    engine->beginArrivalBurst();
+                }
                 for (const auto& entry : parked) {
                     dispatchOpenToClaimingEngine(entry, /*allowPark=*/false);
+                }
+                for (PhosphorEngine::IPlacementEngine* engine : m_lifecycleEngines) {
+                    engine->endArrivalBurst();
                 }
             }
         },

--- a/src/dbus/tilingadaptor/tilingadaptor.cpp
+++ b/src/dbus/tilingadaptor/tilingadaptor.cpp
@@ -384,8 +384,16 @@ void TilingAdaptor::flushPendingWindowOpens()
     const PhosphorProtocol::WindowOpenedList toFlush = std::move(m_pendingOpens);
     m_pendingOpens.clear();
     qCInfo(lcDbusTiling) << "flushPendingWindowOpens: processing" << toFlush.size() << "deferred windows";
+    // Same burst bracket as windowsOpenedBatch — this flush IS the batch
+    // path whenever the opens were queued behind the panel-geometry gate.
+    for (PhosphorEngine::IPlacementEngine* engine : m_lifecycleEngines) {
+        engine->beginArrivalBurst();
+    }
     for (const auto& entry : toFlush) {
         dispatchWindowOpened(entry);
+    }
+    for (PhosphorEngine::IPlacementEngine* engine : m_lifecycleEngines) {
+        engine->endArrivalBurst();
     }
 }
 
@@ -438,8 +446,18 @@ void TilingAdaptor::windowsOpenedBatch(const PhosphorProtocol::WindowOpenedList&
 
     qCInfo(lcDbusTiling) << "windowsOpenedBatch: processing" << entries.size() << "windows";
 
+    // Burst bracket (IPlacementEngine::beginArrivalBurst): engines that
+    // apply geometry per arrival defer to one apply per screen, so a
+    // daemon-restart re-announce of an unchanged session does not march
+    // windows through partial intermediate layouts.
+    for (PhosphorEngine::IPlacementEngine* engine : m_lifecycleEngines) {
+        engine->beginArrivalBurst();
+    }
     for (const auto& entry : entries) {
         dispatchWindowOpened(entry);
+    }
+    for (PhosphorEngine::IPlacementEngine* engine : m_lifecycleEngines) {
+        engine->endArrivalBurst();
     }
 }
 

--- a/tests/unit/dbus/test_scrolling_adaptor.cpp
+++ b/tests/unit/dbus/test_scrolling_adaptor.cpp
@@ -75,6 +75,15 @@ private Q_SLOTS:
             return QRect(1920, 0, 1200, 800);
         };
         m_engine->setScreenGeometryProviders(available, screen);
+        // Well-behaved-compositor echo, same as ScrollTestUtils'
+        // makeProviderEngine: every activation request is answered with a
+        // windowFocused report so the engine's pending-self-activation queue
+        // drains — without it the next simulated USER focus of that window is
+        // consumed as the missing echo.
+        connect(m_engine, &PhosphorEngine::PlacementEngineBase::activateWindowRequested, m_engine,
+                [this](const QString& windowId) {
+                    m_engine->windowFocused(windowId, m_engine->screenForTrackedWindow(windowId));
+                });
         m_parent = new QObject(nullptr);
         m_adaptor = new ScrollingAdaptor(m_engine, m_parent);
         m_engine->setActiveScreens({QStringLiteral("DP-1")});


### PR DESCRIPTION
## Summary

Two window-focus defects in scrolling mode shared one root shape: asynchronous feedback re-entering the engine as if it were fresh user input.

### Focus scroll skips a column

Every focus verb requests activation, and the effect reports each KWin activation back through `notifyWindowFocused`. On a rapid focus scroll (Meta+wheel) the strip has already advanced past the echoed window when the report lands, and treating the stale echo as user focus rewound the active column. The next tick then advanced from the rewound column and a window was never focused.

**Fix:** the engine keeps a FIFO of its own pending activation requests (`m_pendingSelfActivations`) and consumes matching `windowFocused` reports instead of refocusing. A non-matching (genuine) report clears leftovers, which is sound because the effect's reports arrive in order on one D-Bus connection. The tab-click path is unaffected: its activation goes out via the adaptor's `focusWindowRequested`, never through the engine's emit, so its echo still drives the strip as documented in `signals.cpp`.

### Visible retile on daemon restart

The strip is rebuilt one window at a time as the bring-up re-announce arrives, and `windowOpened` applied layout after every splice — a restore of N windows emitted up to N geometry batches over partial strips, visibly marching windows through intermediate positions even though the restored strip resolves to exactly the pre-restart rects.

**Fix:** new `beginArrivalBurst()`/`endArrivalBurst()` bracket on `IPlacementEngine` (default no-ops), wrapped around `TilingAdaptor`'s batch and deferred-flush dispatch loops. The scroll engine defers per-arrival applies to one `applyLayout` per touched screen at the outermost end, so the restore resolves in a single batch the effect's same-rect skip makes invisible. Model state stays fully live during the burst; single-window opens are untouched. Autotile inherits the no-op defaults — its arrivals already coalesce through the queued retile.

### Tests

- Test fixtures (`makeProviderEngine`, scrolling-adaptor fixture) now echo every activation request back into `windowFocused`, modelling a well-behaved compositor — the missing echo was exactly the gap that let the rewind bug exist.
- New `arrivalBurstRestoreAppliesOnce` pins the restore contract: one `windowsTiled` emission, rects identical to the pre-restart strip.
- Full suite: 339/339 pass.

### Not covered

The restart retile reported on **autotile** screens is not addressed here: autotile's arrivals were already coalesced, so its visible movement implies the final computed layout genuinely differs (seed-order fallback via `buildZoneOrderedWindowList`, and split ratios not being persisted are the suspects). Needs a log capture of `Setting window geometry from ... to ...` during a restart to pin down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)