### PR TITLE
fix(effect): key the decoration canvas scale on the frame rect, not the shadow band

### DIFF
--- a/kwin-effect/plasmazoneseffect/surface_fold.h
+++ b/kwin-effect/plasmazoneseffect/surface_fold.h
@@ -65,22 +65,36 @@ inline bool backdropUsable(const SurfaceMultipassState& state)
 /// the fold's most expensive step — a full effects->drawWindow() re-entry — twice per frame,
 /// forever. Every cache the window had was dead for exactly the mixed-DPI multi-monitor case.
 ///
-/// Pin to the HIGHEST scale among the outputs the window's expanded rect intersects: one
+/// Pin to the HIGHEST scale among the outputs the window's FRAME rect intersects: one
 /// canvas, one capture, one fold, and the lower-scale output's paint samples the cache.
 /// Highest rather than the current output's, so the hi-DPI half of a straddle is rendered at
 /// full resolution instead of upscaled from a low-resolution canvas. It cannot change with
 /// which output is painting, so the two per-frame calls now agree and the caches hold.
 ///
-/// Falls back to the window's own screen (then 1.0) when the intersection finds nothing — a
-/// window mid-move can briefly report a rect touching no output at all.
+/// The FRAME rect, deliberately not the expanded rect the canvas itself covers. The expanded
+/// rect is inflated by the shadow band, and on a mixed-DPI layout every window that merely
+/// ABUTS the shared monitor edge overhangs the neighbour with shadow alone. Keying the scale
+/// on that overhang pinned such a window's canvas to the neighbour's HIGHER scale while its
+/// visible content sits entirely on the lower-scale output — so the present downsampled the
+/// whole composite (content, text, border) through GL_LINEAR, permanently, for precisely the
+/// windows a zone layout produces (discussion #868, the residual blur after the device-align
+/// fix). A window whose VISIBLE frame truly straddles still pins to the max scale, and the
+/// lower-DPI side of it resamples exactly like KWin natively resamples a straddling window's
+/// single hi-DPI buffer. Shadows and glow padding grazing a hi-DPI output render at the
+/// window's own scale instead; both are feathered soft bands, where a density mismatch is
+/// invisible. QRectF::intersects is false for a shared edge with no area, so an exactly
+/// abutting window keeps its own screen's scale.
+///
+/// Falls back to the expanded rect when the frame is empty, then the window's own screen,
+/// then 1.0 — a window mid-move can briefly report a rect touching no output at all.
 inline qreal windowSurfaceScale(const KWin::EffectWindow* w)
 {
     if (!w || !KWin::effects) {
         return 1.0;
     }
-    QRectF rect = w->expandedGeometry();
+    QRectF rect = w->frameGeometry();
     if (rect.isEmpty()) {
-        rect = w->frameGeometry();
+        rect = w->expandedGeometry();
     }
     qreal best = 0.0;
     const auto outputs = KWin::effects->screens();


### PR DESCRIPTION
## Summary

Fixes the residual mixed-DPI blur from discussion #868 (comment 17884182): after the v3.3.3 device-alignment fix, decorated (bordered/snapped) windows on a lower-scale monitor still rendered measurably soft while the daemon was running.

`windowSurfaceScale` pinned a decorated window's composite canvas to the highest scale among the outputs its **expanded** rect intersects. The expanded rect includes the shadow band, so on a mixed-DPI layout (the reporter runs 4K @ 1.5 beside 1080p @ 1.0) every window that merely abuts the shared monitor edge overhangs the neighbouring output with shadow alone. Its canvas was composited at the neighbour's higher scale and bilinearly downsampled at present time, permanently softening content, text, and borders for exactly the windows a zone layout produces (snapped windows touch screen edges by construction).

The fix keys the scale on the **frame** rect instead (fallback: expanded rect, then the window's screen, then 1.0). The canvas itself still covers the expanded rect. A window whose visible frame genuinely straddles two outputs still pins to the max scale, which resamples on the lower-DPI side exactly like KWin natively resamples a straddling window's single hi-DPI buffer.

## Verification

Reproduced and validated in a nested `kwin_wayland --virtual` harness (isolated D-Bus and XDG tree, effect loaded from the build tree, two outputs at 1.5/1.0, daemon-on vs daemon-off screenshots compared by pixel identity and Laplacian sharpness):

- Same-scale fractional (1.5) redirect present: pixel-identical before and after this change, confirming the v3.3.3 alignment fix holds and this was the only remaining resample.
- Shadow-grazing case (frame clear of the scaled output, shadow crossing the edge): before, `sc=1.5` on a `screenScale=1` window with Laplacian variance 508 vs the 1660 undecorated baseline; after, `sc=1` and pixel-identical.
- Frame-diffing the reporter's video shows the same signature: sharpness roughly doubles on both snapped windows the moment the daemon stops.

Effect target builds clean against main with no warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)