### PR TITLE
fix: fractional-scale blur at 1.5x, stretched content during snaps, and shadowed user packs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to PlasmaZones are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Windows are no longer blurry on a display scaled to exactly 150%**: every window PlasmaZones draws a border on stayed persistently soft at 150%, while 125% was affected only at some window positions and other fractional scales such as 148.33% were fine. The offscreen surface those windows are drawn through was positioned half a device pixel away from where the compositor rounds it to, and half a pixel is the one offset that rounding cannot absorb, so the surface was stretched by a single pixel and resampled ([#868](https://github.com/fuddlesworth/PlasmaZones/discussions/868), [#884](https://github.com/fuddlesworth/PlasmaZones/pull/884)).
+- **Window content no longer stretches while a window snaps or tiles**: the default geometry animation drew the window's content squeezed into the rectangle it was travelling through, so text and icons were distorted for the length of the animation and then snapped sharp at the end. The content is now drawn at its final size throughout and the animation reveals it as the window grows ([#868](https://github.com/fuddlesworth/PlasmaZones/discussions/868), [#884](https://github.com/fuddlesworth/PlasmaZones/pull/884)).
+- **Choosing "None" for a snap animation no longer distorts the window either**: with no animation shader selected, the fallback animation scaled the window's content the same way. It now animates only where the window sits ([#884](https://github.com/fuddlesworth/PlasmaZones/pull/884)).
+- **Your own animation and decoration packs now override the bundled ones**: a pack you installed under your home directory with the same name as one that ships with PlasmaZones was ignored for windows, while the daemon still used yours for on-screen displays and popups, so the same pack could look different in the two places ([#884](https://github.com/fuddlesworth/PlasmaZones/pull/884)).
+
 ## [3.3.4] - 2026-08-03
 
 ### Fixed

--- a/data/animations/window-morph/effect.frag
+++ b/data/animations/window-morph/effect.frag
@@ -3,13 +3,25 @@
 //
 // Window-morph fragment shader — shader-driven geometry move/resize.
 //
-// The window jumps to its destination instantly (moveResize); this shader
-// animates the visual transition by interpolating the drawn rect from the
-// OLD frame (iFromRect) to the NEW frame (iToRect) by iTime, cross-fading a
-// snapshot of the old content (uOldWindow) out as the live new content
-// (uTexture0, via surfaceColor) fades in. Both are sampled at the SAME
-// normalised rect coordinate, so each is shown at its own native aspect —
-// no non-uniform stretch like the C++ setXScale/setYScale path it replaces.
+// VERTEX-ONLY: the window's content is never resampled. The window jumps to
+// its destination instantly (moveResize), and this shader animates the visual
+// transition by interpolating the DRAWN RECT from the OLD frame (iFromRect) to
+// the NEW frame (iToRect) by iTime while the live content is drawn at its own
+// final scale, anchored to that moving rect and cropped by it. A grow reveals
+// more of the content, a shrink crops it, and the pixels themselves are
+// identical to the settled window on every frame of the leg.
+//
+// This replaced a cross-fade that sampled the live content at the INTERPOLATED
+// rect's normalised coordinate. That squeezed already-final-size content into
+// the old geometry at t = 0 and only reached 1:1 at t = 1, so every snap, tile
+// and reflow visibly stretched its content for the whole leg and then snapped
+// sharp (discussion #868). Scaling the content was the one thing this pack
+// existed to avoid, and normalising into the morphing rect reintroduced it.
+//
+// No old-content snapshot is sampled, so none is captured for this pack: the
+// capture request is gated on the compiled shader linking uOldWindow. Packs
+// that DO want the old frame (the cross-fade families) keep it by declaring
+// the uniform.
 //
 // Surface-extent shader: apply() lays an output-spanning quad, so vTexCoord
 // spans the host output and iResolution is the output size. iFromRect/iToRect
@@ -20,19 +32,10 @@
 // window's top-left offset within that output, so their difference is the
 // output's global top-left. screenPx = outputOrigin + vTexCoord * iResolution.
 //
-// The old-content snapshot (uOldWindow) is captured at the window's CURRENT
-// (post-moveResize) expanded geometry, so iAnchorRectInTexture — the new
-// frame's sub-rect within the new expanded texture — maps card-space uv into
-// it correctly, exactly as it does for the live uTexture0.
-
 // Geometry-morph endpoints (logical-screen px, x/y/w/h). Default-block
-// uniforms pushed by the kwin-effect paint pipeline. The old-content snapshot
-// (uOldWindow) comes from the shared old_content.glsl include below.
+// uniforms pushed by the kwin-effect paint pipeline.
 uniform vec4 iFromRect;
 uniform vec4 iToRect;
-
-// uOldWindow + oldColor(): the shared captured-old-frame sampler.
-#include <old_content.glsl>
 
 vec4 pTransition(vec2 uv, float t) {
     // `t` is the raw (possibly flipped) iTime the pTransition entry contract
@@ -52,10 +55,6 @@ vec4 pTransition(vec2 uv, float t) {
     //     The max() below stops the NaN but collapses the rect to a 1px axis, so the
     //     mask zeroes and the window VANISHES into a sliver before popping back.
     //     "Before the start" does not mean "negative width".
-    //   - the old→new COLOUR cross-fade, where extrapolating premultiplied colours
-    //     past their endpoints drives them out of range (over-contrast on a unorm8
-    //     target, unbounded on a float/HDR one). A cross-fade has no meaning past
-    //     its ends.
     // The POSITION carries the bounce, which is where the eye reads it: the window
     // sails past its target and springs back, at its final size.
     float tc = clamp(t, 0.0, 1.0);
@@ -75,12 +74,9 @@ vec4 pTransition(vec2 uv, float t) {
     //
     // The rect is the window FRAME, and ruv is frame-relative, so the bare
     // [0, 1] range cropped the decoration chain's halo at the frame edge for
-    // the whole morph. Widen by the chain's outer margin: oldColor() and
-    // surfaceColor() are both frame-anchored, so the same out-of-range ruv
-    // resolves into the padded canvas's margin band on either side of the
-    // cross-fade. The pad rides the rect lerp, so the halo scales with the
-    // window as it morphs rather than sitting at a fixed screen width. Zero
-    // pad reduces to the previous frame-edge mask.
+    // the whole morph. Widen by the chain's outer margin: surfaceColor() is
+    // frame-anchored, so an out-of-range coordinate resolves into the padded
+    // canvas's margin band. Zero pad reduces to the plain frame-edge mask.
     vec2 pad = surfacePadRel();
     vec2 fw = max(fwidth(ruv), vec2(1.0e-4));
     vec2 edge = min(smoothstep(vec2(0.0), fw, ruv + pad), smoothstep(vec2(0.0), fw, 1.0 + pad - ruv));
@@ -89,10 +85,27 @@ vec4 pTransition(vec2 uv, float t) {
         return vec4(0.0);
     }
 
-    vec4 oldC = oldColor(ruv);           // captured old content, native aspect
-    vec4 newC = surfaceColor(ruv);       // live new content, native aspect
+    // Content coordinate: normalised against the FINAL size, not the morphing
+    // one, and anchored at the morphing rect's origin. That is the whole
+    // vertex-only property — the divisor never changes, so the content is
+    // sampled at exactly one texel per device pixel for the entire leg, and at
+    // t = 1 (rect == iToRect) this reduces to the settled window's own mapping.
+    // Sampling at `ruv` instead, as this used to, divides by the morphing size
+    // and scales the content by iToRect.zw / rect.zw every frame.
+    vec2 cuv = (screenPx - rect.xy) / max(iToRect.zw, vec2(1.0));
 
-    // Cross-fade old -> new across the morph. Inputs are premultiplied
-    // (KWin FBO storage); a straight mix of premultiplied colours is correct.
-    return mix(oldC, newC, tc) * mask;
+    // Crop to the content's own extent as well as the rect. A SHRINK leg has a
+    // rect LARGER than the final content for most of its run (unmaximize is the
+    // everyday case), and without this the fragments past the content edge
+    // sample CLAMP_TO_EDGE and smear the window's last texel column across the
+    // remaining band. Cropped, a shrink instead reads as the final-size window
+    // travelling to its new home, which is the honest vertex-only answer: there
+    // are no pixels for that band, and inventing them by scaling is what this
+    // pack is here to avoid.
+    // Its OWN fwidth: cuv's derivative is 1 / iToRect.zw while ruv's is
+    // 1 / rect.zw, so reusing `fw` would feather this edge by the wrong number
+    // of pixels by exactly the ratio the morph is mid-way through.
+    vec2 cfw = max(fwidth(cuv), vec2(1.0e-4));
+    vec2 cedge = min(smoothstep(vec2(0.0), cfw, cuv + pad), smoothstep(vec2(0.0), cfw, 1.0 + pad - cuv));
+    return surfaceColor(cuv) * mask * cedge.x * cedge.y;
 }

--- a/data/animations/window-morph/metadata.json
+++ b/data/animations/window-morph/metadata.json
@@ -1,7 +1,7 @@
 {
     "id": "window-morph",
     "name": "Window Morph",
-    "description": "Geometry move/resize transition. The window jumps to its destination instantly, and this shader cross-fades a snapshot of the old frame into the live new content while interpolating the drawn rect from the old geometry to the new. A snap, tile, or reflow then animates through the shader instead of a C++ scale that stretches content.",
+    "description": "Geometry move and resize transition. The window jumps to its destination instantly, and this shader animates the drawn rect from the old geometry to the new one. The content is drawn at its final size the whole way, so a snap, tile or reflow slides and crops into place with the window's pixels staying exactly as sharp as they are when it settles.",
     "author": "PlasmaZones",
     "version": "1.0",
     "category": "Geometry",

--- a/kwin-effect/compositor/windowanimator.cpp
+++ b/kwin-effect/compositor/windowanimator.cpp
@@ -464,25 +464,25 @@ void WindowAnimator::applyTransform(KWin::EffectWindow* window, KWin::WindowPain
 
     const QRectF current = anim->value();
 
-    // Translate: desired visual top-left offset from the actual frameGeometry.
+    // Translate ONLY — the position is animated, the content is never resampled.
+    //
+    // This used to also setXScale/setYScale from the animated size over the live
+    // frame size whenever the animation had a size change. KWin has already
+    // committed the FINAL geometry and the client has already painted at the
+    // final size by the time this runs, so that scale took finished content and
+    // squeezed it into the in-flight rect, easing back to 1.0 only at the end —
+    // a visible stretch-then-settle on every size-changing leg (discussion
+    // #868). WindowPaintData offers no crop, so the honest fallback is to draw
+    // the window at its true size and animate only where it sits.
+    //
+    // Reachable only when NO shader owns the geometry: paintWindow calls this
+    // solely under `!shaderOwnsGeometry`, and the built-in default for the snap
+    // legs (window-morph) declares iFromRect. So this is the path a user takes
+    // by choosing "None" — and "None" must not mean "the stretching one". The
+    // vertex-only fragment path reaches the same conclusion for packs.
     const QPointF desiredPos = current.topLeft();
     const QPointF actualPos = window->frameGeometry().topLeft();
     data += (desiredPos - actualPos);
-
-    // Scale: smoothly morph from old size to target size.
-    if (anim->hasSizeChange()) {
-        const QSizeF desiredSize = current.size();
-        const QSizeF actualSize = window->frameGeometry().size();
-        constexpr qreal kMinActualDim = 1.0;
-        constexpr qreal kMinScaleFactor = 0.01;
-        constexpr qreal kMaxScaleFactor = 100.0;
-        const qreal sx =
-            qBound(kMinScaleFactor, desiredSize.width() / qMax(actualSize.width(), kMinActualDim), kMaxScaleFactor);
-        const qreal sy =
-            qBound(kMinScaleFactor, desiredSize.height() / qMax(actualSize.height(), kMinActualDim), kMaxScaleFactor);
-        data.setXScale(data.xScale() * sx);
-        data.setYScale(data.yScale() * sy);
-    }
 }
 
 // ═══════════════════════════════════════════════════════════════════════
@@ -563,8 +563,31 @@ QMarginsF WindowAnimator::expandedPadding(KWin::EffectWindow* window,
     const QRectF expanded = (window && !window->isDeleted()) ? QRectF(window->expandedGeometry()) : anim.to();
 
     const QRectF frameGeo = anim.to();
-    return QMarginsF(qMax(0.0, frameGeo.x() - expanded.x()), qMax(0.0, frameGeo.y() - expanded.y()),
-                     qMax(0.0, expanded.right() - frameGeo.right()), qMax(0.0, expanded.bottom() - frameGeo.bottom()));
+    QMarginsF margins(qMax(0.0, frameGeo.x() - expanded.x()), qMax(0.0, frameGeo.y() - expanded.y()),
+                      qMax(0.0, expanded.right() - frameGeo.right()), qMax(0.0, expanded.bottom() - frameGeo.bottom()));
+
+    // Cover what applyTransform actually DRAWS, which is no longer what
+    // anim.bounds() describes. bounds() is the union of the from/to rects, but
+    // the transform translates the window at its FINAL size to every position
+    // along that sweep, so the drawn rect can reach past the union — a snap
+    // travelling LEFT into a larger zone draws (old position + final width),
+    // which for from(1000,0 400x300) → to(0,0 1200x900) overruns the union's
+    // right edge by 800px. Undamaged, that band keeps whatever was under it and
+    // the window trails.
+    //
+    // The shortfall on an axis is at most (final extent - the SMALLEST extent
+    // the sweep passes through): bounds.right is never less than
+    // position(t) + width(t) for any sampled t, and the drawn right is
+    // position(t) + finalWidth. Bounding it that way needs no position term, so
+    // it stays correct under the overshoot samples bounds() already folds in,
+    // and it self-zeroes for a pure move (all widths equal). One-sided like the
+    // margins above: bounds only ever grow.
+    const QSizeF finalSize = (window && !window->isDeleted()) ? window->frameGeometry().size() : anim.to().size();
+    const qreal minWidth = qMin(anim.from().width(), anim.to().width());
+    const qreal minHeight = qMin(anim.from().height(), anim.to().height());
+    margins.setRight(margins.right() + qMax(0.0, finalSize.width() - minWidth));
+    margins.setBottom(margins.bottom() + qMax(0.0, finalSize.height() - minHeight));
+    return margins;
 }
 
 PhosphorAnimation::IMotionClock* WindowAnimator::clockForHandle(KWin::EffectWindow* window) const

--- a/kwin-effect/plasmazoneseffect/drag_snap.cpp
+++ b/kwin-effect/plasmazoneseffect/drag_snap.cpp
@@ -544,7 +544,17 @@ void PlasmaZonesEffect::applyWindowGeometry(KWin::EffectWindow* window, const QR
                     // at the already-committed previous target instead of the
                     // animator's departure rect.
                     mt->fromGeometry = morphAnchor;
-                    if (!mt->oldSnapshot) {
+                    // Gate on the compiled shader actually LINKING uOldWindow,
+                    // matching the two sibling request sites (the move-start
+                    // hookup and beginMaximizeShaderMorph) and the bind/unbind
+                    // pair in decoration_render.cpp, which already test this
+                    // same predicate. The bundled window-morph is vertex-only
+                    // and samples no old frame, so an ungated request paid a
+                    // full-window drawWindow re-entry plus an RGBA8 allocation
+                    // on every snap, tile and reflow to fill a texture nothing
+                    // would ever read. A cross-fade pack keeps its snapshot by
+                    // declaring the uniform.
+                    if (mt->cached->iOldWindowLoc >= 0 && !mt->oldSnapshot) {
                         mt->needsSnapshot = true;
                     }
                 }

--- a/kwin-effect/plasmazoneseffect/paint_capture.cpp
+++ b/kwin-effect/plasmazoneseffect/paint_capture.cpp
@@ -265,11 +265,20 @@ void PlasmaZonesEffect::apply(KWin::EffectWindow* window, int mask, KWin::Window
             // the fold's failure paths, which can erase the multipass entry.
             QRectF padded = textureGeo.adjusted(-pad, -pad, pad, pad);
             bool haveCanvas = false;
+            // The scale the canvas was BUILT at, carried beside it. Re-deriving it here
+            // with windowSurfaceScale would answer for the window's CURRENT outputs,
+            // which is a different question than "what scale is this texture's grid" the
+            // moment a window crosses outputs between the fold and the present.
+            qreal presentScale = 0.0;
             if (const auto psIt = m_surfaceMultipass.find(getWindowId(window)); psIt != m_surfaceMultipass.end()) {
                 if (psIt->second.canvasGeo.isValid()) {
                     padded = psIt->second.canvasGeo;
                     haveCanvas = true;
                 }
+                presentScale = psIt->second.captureScaleKey;
+            }
+            if (presentScale <= 0.0) {
+                presentScale = windowSurfaceScale(window);
             }
             // UNPADDED windows rewrite too, not just padded ones: surfaceCanvasFor
             // device-aligns the canvas, so even at pad == 0 the composite covers the
@@ -293,8 +302,41 @@ void PlasmaZonesEffect::apply(KWin::EffectWindow* window, int mask, KWin::Window
                 qLeft = qMin(qLeft, quads[i].left());
                 qTop = qMin(qTop, quads[i].top());
             }
-            const double ox = qLeft + (padded.x() - textureGeo.x());
-            const double oy = qTop + (padded.y() - textureGeo.y());
+            // Offset from the anchor the quad ACTUALLY carries, which is the expanded
+            // rect SNAPPED to the device grid — not the raw expanded rect.
+            // OffscreenEffect builds this quad from the redirect's visible rect, and the
+            // scene rounds every vertex to a whole device pixel (RenderGeometry's default
+            // VertexSnappingMode::Round), so qLeft names round(textureGeo.x * scale)
+            // device pixels, not textureGeo.x * scale. Measuring the canvas delta against
+            // the unsnapped origin therefore carried KWin's own rounding into the quad as
+            // a sub-pixel error.
+            //
+            // At scale 1.5 that error is exactly half a device pixel, and a half pixel is
+            // the one value the vertex rounding cannot absorb: the left edge sits at a
+            // negative window-relative coordinate and the right at a positive one, so
+            // round-half-AWAY-FROM-ZERO pushes them APART (-97.5 → -98, +1058.5 → +1059).
+            // The quad came out one device pixel wider than its own texture and stretched
+            // the whole composite through GL_LINEAR — every decorated window permanently
+            // soft at 1.5x, while 1.25x and 1.48333x (whose fractions are never exactly
+            // .5) stayed pixel-exact. That asymmetry is the fingerprint (discussion #868).
+            //
+            // Anchoring on the snapped origin puts both edges on whole device pixels — the
+            // canvas is device-aligned by construction (surfaceCanvasFor) and the anchor
+            // is now an integer device coordinate too — so the vertex rounding is a no-op
+            // and the texture presents 1:1.
+            //
+            // Rounding the ABSOLUTE screen coordinate models what the scene does to the
+            // window-RELATIVE one, and the two agree exactly while the window's own origin
+            // lands on a device pixel, which is the case a zone layout produces. When it
+            // does not, our edges inherit the window origin's fraction — the same fraction
+            // KWin's own quads carry — so we track its rendering rather than adding error
+            // of our own. What holds unconditionally is the WIDTH: both edges are an exact
+            // integer number of device pixels apart, and rounding is translation-invariant
+            // by integers everywhere except the .5 tie this anchor removes.
+            const double anchorX = std::round(textureGeo.x() * presentScale) / presentScale;
+            const double anchorY = std::round(textureGeo.y() * presentScale) / presentScale;
+            const double ox = qLeft + (padded.x() - anchorX);
+            const double oy = qTop + (padded.y() - anchorY);
             const double ow = padded.width();
             const double oh = padded.height();
 

--- a/kwin-effect/plasmazoneseffect/surface_compile.cpp
+++ b/kwin-effect/plasmazoneseffect/surface_compile.cpp
@@ -22,6 +22,8 @@
 #include <opengl/glshadermanager.h>
 #include <opengl/gltexture.h>
 
+#include <algorithm>
+
 #include <QByteArray>
 #include <QColor>
 #include <QDir>
@@ -129,8 +131,18 @@ void PlasmaZonesEffect::ensureSurfaceRegistryPaths()
     // packs that appear later (a fresh install). The daemon-delivered path
     // mechanism the animation registry uses (loadShaderRegistryFromDbus) is a
     // follow-up for surface packs; QStandardPaths covers the bundled pack today.
+    // ASCENDING priority (system lowest first, the user dir LAST).
+    // standardLocations hands back the writable user location first, and
+    // MetadataPackScanStrategy reverse-iterates the registered paths with
+    // first-wins on an id collision — so registering that order verbatim let
+    // /usr/share claim a bundled id before the user dir could, and a user pack
+    // overriding a bundled one ("border", "shadow") was silently shadowed in
+    // the compositor while the daemon honoured it. Every sibling that feeds a
+    // pack registry reverses for exactly this reason (shader_warmup.cpp,
+    // animationbootstrap.cpp, settingscontroller.cpp, ShaderRegistry).
     QStringList paths;
-    const QStringList bases = QStandardPaths::standardLocations(QStandardPaths::GenericDataLocation);
+    QStringList bases = QStandardPaths::standardLocations(QStandardPaths::GenericDataLocation);
+    std::reverse(bases.begin(), bases.end());
     paths.reserve(bases.size());
     for (const QString& base : bases) {
         paths.append(base + QStringLiteral("/plasmazones/surface"));

--- a/src/dbus/settingsadaptor/settingsadaptor_registry.cpp
+++ b/src/dbus/settingsadaptor/settingsadaptor_registry.cpp
@@ -585,6 +585,18 @@ void SettingsAdaptor::initializeRegistry()
             QStringList paths =
                 QStandardPaths::locateAll(QStandardPaths::GenericDataLocation, QStringLiteral("plasmazones/animations"),
                                           QStandardPaths::LocateDirectory);
+            // REVERSE into ascending priority, exactly as the daemon's own registry
+            // population does (shader_warmup.cpp). This list is registered verbatim
+            // by the effect via addSearchPaths, and MetadataPackScanStrategy
+            // reverse-iterates the registered paths and applies first-wins on an id
+            // collision — so it requires lowest-priority-FIRST, while locateAll
+            // hands back highest-priority-first. Publishing locateAll's order made
+            // the strategy examine /usr/share before the user dir, so a user pack
+            // that deliberately overrides a bundled id ("window-morph") was silently
+            // shadowed in the COMPOSITOR while the daemon (which reverses) honoured
+            // it — the same pack id resolving to different files in the two
+            // processes.
+            std::reverse(paths.begin(), paths.end());
             const QString userDir = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation)
                 + QStringLiteral("/plasmazones/animations");
             if (!paths.contains(userDir))


### PR DESCRIPTION
Follow-up to #881 for discussion #868. The reporter confirmed 3.3.4 fixed the mixed-DPI case but left two symptoms: windows still soft at exactly 150% scale, and window content visibly stretching during a resize before settling. Both are fixed here, and two further bugs turned up while verifying them.

All of this was measured in a nested `kwin_wayland --virtual` session at 3840x2160 (the reporter's panel) rather than reasoned about, because the first two attempts at diagnosing this got the mechanism wrong.

## Blur at exactly 1.5x

`apply()` measured the device-aligned canvas delta against the raw expanded rect, but the quad `OffscreenEffect` hands us is anchored on the expanded rect already snapped to the device grid, since the scene rounds every vertex to a whole device pixel.

At scale 1.5 that leaves a half-pixel error, and a half pixel is the one value vertex rounding cannot absorb: the left edge sits at a negative window-relative coordinate and the right at a positive one, so round-half-away-from-zero pushes them apart (-97.5 to -98, +1058.5 to +1059). The quad came out one device pixel wider than its own texture and stretched the whole composite through `GL_LINEAR`.

That explains the reporter's otherwise baffling table exactly: 150% always blurry, 125% occasionally, 148.33% and 100% never. Only an exact `.5` fraction triggers it.

| window interior | daemon on | daemon off |
|---|---|---|
| before | 3746 | 9814 |
| after | 9814 | 9814 |

(Laplacian variance. Before: 24.49% of interior pixels differed. After: pixel-identical, with 1.25x, 1.48333x and 1.0x still pixel-exact.)

## Content stretching during a snap

Not the redirect, and not maximize. `window-morph` is the built-in default for `snapIn`, `snapOut` and `layoutSwitch`, so it runs for users who never chose an animation at all. Its fragment sampled the live content normalised against the **interpolated** rect, which scales already-final-size content every frame and reaches 1:1 only at the end.

It now samples against the final size anchored to the moving rect, so the content is drawn at one texel per device pixel for the whole leg and the morph reveals rather than squeezes.

| mid-leg (2s duration) | window | text line period | visible lines |
|---|---|---|---|
| before | 1921x1033 | 23.61px | 41 |
| after | 1908x1020 | 16.19px | 59 |
| settled | 1909x1285 | 16.05px | 76 |

The same stretch was reachable from the C++ fallback when a user picks "None", via an X/Y scale on content KWin had already committed at its final size. That is gone too, and the damage bounds are widened to match, since the fallback now draws the final size at every position along the sweep and could otherwise trail.

## User packs were shadowed by bundled ones

Found because the first edit to `window-morph` had no effect. `MetadataPackScanStrategy` reverse-iterates search paths with first-wins on an id collision, so it needs them lowest-priority first. Two feeders published the opposite order, so `/usr/share` claimed a bundled id before the user dir could and a user's override was silently ignored **in the compositor** while the daemon honoured it. The same pack id resolved to different files in the two processes.

Every sibling that feeds a pack registry already reverses; these two were the outliers.

## Reviewer notes

- **Behaviour changes ride along with the bug fixes.** The blur and precedence fixes are unambiguous. The vertex-only morph changes how every snap looks, and "None" now pops to size rather than scaling. On a patch release to 3.3.4 users that is a visible change nobody asked for, so it may be worth splitting if that is not wanted here.
- **Shrink legs read differently.** An unmaximize now shows the final-size window travelling to its new home instead of scaling down. That is inherent to vertex-only and worth eyeballing on real hardware.
- **`hasSizeChange()` now has no callers** outside its own library and tests. Left in place as public API of an LGPL lib rather than removed.
- The animation behaviour was measured against the v3.4 build. The shader and effect files are identical between the branches, but `drag_snap.cpp` and `windowanimator.cpp` carry 3.4-only changes nearby that were not re-verified in the harness on this branch.
- Local: build clean, 323/323 ctest, shader validator OK on all 81 packs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
