### PR TITLE
refactor(scrolling): resolve the drop indicator's theme fallback in Settings

### DIFF
--- a/src/config/configdefaults_scrolling.h
+++ b/src/config/configdefaults_scrolling.h
@@ -485,11 +485,12 @@ public:
     {
         return true;
     }
-    /// Fill and border colours. EMPTY MEANS "follow the theme" — the overlay
-    /// falls back to Kirigami.Theme's highlight colour, same resolution tier
-    /// as the tab colours above. Two colours rather than one so the highlight
-    /// can be a tinted fill with a contrasting edge, which is how the snapping
-    /// zone overlay spells the same idea (Highlight + Border).
+    /// Fill and border colours. EMPTY MEANS "follow the theme", resolved the
+    /// way the zone quartet resolves it: Settings::resolvedSystemColor reads
+    /// the live palette and the getters hand the overlay a concrete colour, so
+    /// the sentinel never leaves the config layer. Two colours rather than one
+    /// so the highlight can be a tinted fill with a contrasting edge, which is
+    /// how the snapping zone overlay spells the same idea (Highlight + Border).
     static QString scrollingDropIndicatorColor()
     {
         return QString();
@@ -497,6 +498,21 @@ public:
     static QString scrollingDropIndicatorBorderColor()
     {
         return QString();
+    }
+    /// The resolution fallback for both colours when there is no GUI
+    /// application to take a palette from (headless config tools), the peer of
+    /// the zone quartet's *FallbackColor accessors. NOT the stored default,
+    /// which is the empty sentinel above.
+    ///
+    /// OPAQUE, unlike ZoneDefaults::HighlightColor's own half alpha: the fill's
+    /// alpha comes from the opacity slider, which replaces whatever the colour
+    /// carries, and the border has no slider at all, so an alpha here would
+    /// only ever show up as an unset border quietly drawing half transparent.
+    static QColor scrollingDropIndicatorFallbackColor()
+    {
+        QColor color = ::PhosphorZones::ZoneDefaults::HighlightColor;
+        color.setAlpha(255);
+        return color;
     }
     /// Fill opacity. Replaces the fill colour's own alpha, matching the
     /// snapping zone overlay's fill, so the fill can be faint enough to read

--- a/src/config/settings.h
+++ b/src/config/settings.h
@@ -1947,13 +1947,14 @@ Q_SIGNALS:
     // here — see src/core/interfaces/isettings.h.
 
 protected:
-    /// Re-announces the zone colours whose stored value is the empty
-    /// theme-fallback sentinel when the application palette changes at
-    /// runtime (theme switch). Resolution happens in the getters, so nothing
-    /// is written and no dirty tracking is involved; without the re-announce,
-    /// every long-running process (daemon, settings app) would keep serving
-    /// the palette SNAPSHOT its bindings read last and show stale zone colors
-    /// until something else re-read them.
+    /// Re-announces the palette-following colours whose stored value is the
+    /// empty theme-fallback sentinel when the application palette changes at
+    /// runtime (theme switch). That is the zone quartet plus the scrolling
+    /// drop indicator's fill and border. Resolution happens in the getters, so
+    /// nothing is written and no dirty tracking is involved; without the
+    /// re-announce, every long-running process (daemon, settings app) would
+    /// keep serving the palette SNAPSHOT its bindings read last and show stale
+    /// colors until something else re-read them.
     ///
     /// Protected, matching QObject's own access: nothing calls this directly —
     /// Qt dispatches it through the filter installed by
@@ -2022,7 +2023,7 @@ private:
     // NOTIFY-able Q_PROPERTY value (index-aligned to the metaobject) BEFORE the
     // mutation; emitChangedNotifyProperties() fires the NOTIFY of each property
     // whose value changed and returns whether any fired. One added
-    // precondition since the theme-fallback colours: the four resolved
+    // precondition since the theme-fallback colours: the six resolved
     // QColor properties are palette-derived, so the snapshot/compare span
     // must stay synchronous — an event-loop spin between the two calls could
     // let a palette change masquerade as (or mask) a store mutation.
@@ -2052,7 +2053,7 @@ private:
     };
     static QColor resolvedSystemColor(SystemColorRole role);
 
-    // Shared body of the four resolved QColor getters: the stored raw string
+    // Shared body of the six resolved QColor getters: the stored raw string
     // when it names a colour Qt can parse, otherwise the palette-derived role.
     // Unparseable counts as the empty "follow the palette" sentinel — see the
     // definition in settings/storescalars.cpp for why.

--- a/src/config/settings.h
+++ b/src/config/settings.h
@@ -424,10 +424,18 @@ public:
     // Scrolling.DropIndicator
     Q_PROPERTY(bool scrollingDropIndicatorEnabled READ scrollingDropIndicatorEnabled WRITE
                    setScrollingDropIndicatorEnabled NOTIFY scrollingDropIndicatorEnabledChanged)
-    Q_PROPERTY(QString scrollingDropIndicatorColor READ scrollingDropIndicatorColor WRITE setScrollingDropIndicatorColor
+    // The two indicator colours are theme-fallback keys with the same resolved
+    // + Raw pair as the zone quartet above, and for the same reason: the
+    // overlay paints a concrete colour while the settings UI edits the stored
+    // sentinel.
+    Q_PROPERTY(QColor scrollingDropIndicatorColor READ scrollingDropIndicatorColor WRITE setScrollingDropIndicatorColor
                    NOTIFY scrollingDropIndicatorColorChanged)
-    Q_PROPERTY(QString scrollingDropIndicatorBorderColor READ scrollingDropIndicatorBorderColor WRITE
+    Q_PROPERTY(QColor scrollingDropIndicatorBorderColor READ scrollingDropIndicatorBorderColor WRITE
                    setScrollingDropIndicatorBorderColor NOTIFY scrollingDropIndicatorBorderColorChanged)
+    Q_PROPERTY(QString scrollingDropIndicatorColorRaw READ scrollingDropIndicatorColorRaw WRITE
+                   setScrollingDropIndicatorColorRaw NOTIFY scrollingDropIndicatorColorRawChanged)
+    Q_PROPERTY(QString scrollingDropIndicatorBorderColorRaw READ scrollingDropIndicatorBorderColorRaw WRITE
+                   setScrollingDropIndicatorBorderColorRaw NOTIFY scrollingDropIndicatorBorderColorRawChanged)
     Q_PROPERTY(double scrollingDropIndicatorOpacity READ scrollingDropIndicatorOpacity WRITE
                    setScrollingDropIndicatorOpacity NOTIFY scrollingDropIndicatorOpacityChanged)
     Q_PROPERTY(int scrollingDropIndicatorBorderWidth READ scrollingDropIndicatorBorderWidth WRITE
@@ -1263,10 +1271,18 @@ public:
     // math the drop uses).
     bool scrollingDropIndicatorEnabled() const override;
     void setScrollingDropIndicatorEnabled(bool enabled) override;
-    QString scrollingDropIndicatorColor() const override;
-    void setScrollingDropIndicatorColor(const QString& color) override;
-    QString scrollingDropIndicatorBorderColor() const override;
-    void setScrollingDropIndicatorBorderColor(const QString& color) override;
+    // Theme-fallback pair, same split as the zone quartet: the QColor getters
+    // resolve (palette-derived while the stored string is empty) and the QColor
+    // setters store the concrete #AARRGGBB form, while the Raw accessors
+    // read/write the stored string itself, including the empty sentinel.
+    QColor scrollingDropIndicatorColor() const override;
+    void setScrollingDropIndicatorColor(const QColor& color) override;
+    QColor scrollingDropIndicatorBorderColor() const override;
+    void setScrollingDropIndicatorBorderColor(const QColor& color) override;
+    QString scrollingDropIndicatorColorRaw() const;
+    void setScrollingDropIndicatorColorRaw(const QString& color);
+    QString scrollingDropIndicatorBorderColorRaw() const;
+    void setScrollingDropIndicatorBorderColorRaw(const QString& color);
     double scrollingDropIndicatorOpacity() const override;
     void setScrollingDropIndicatorOpacity(double opacity) override;
     int scrollingDropIndicatorBorderWidth() const override;
@@ -1908,6 +1924,10 @@ Q_SIGNALS:
     void inactiveColorRawChanged();
     void borderColorRawChanged();
     void labelFontColorRawChanged();
+    /// The drop indicator's two raw strings, same pairing with their resolved
+    /// ISettings twins as the four above.
+    void scrollingDropIndicatorColorRawChanged();
+    void scrollingDropIndicatorBorderColorRawChanged();
 
     /// Emitted when the whole animation Profile blob is replaced via
     /// `setAnimationProfile`. Fires alongside every per-field *Changed
@@ -2016,15 +2036,19 @@ private:
     // the baseline anywhere but a load/save commit point desyncs dirty tracking.
     void captureBaseline();
 
-    // Palette-following zone colours: resolve one of the four theme-fallback
-    // roles from the live application palette (with the ZoneDefaults alphas),
-    // falling back to the ConfigDefaults constants when no GUI application
-    // exists (headless config tools).
+    // Palette-following colours: resolve one of the theme-fallback roles from
+    // the live application palette (with the ZoneDefaults alphas), falling back
+    // to the ConfigDefaults constants when no GUI application exists (headless
+    // config tools). The first four are the zone overlay's; DropIndicator is
+    // the scrolling drop target's, which takes the same palette Highlight but
+    // OPAQUE — its fill alpha comes from the opacity slider and its border has
+    // no slider at all.
     enum class SystemColorRole {
         Highlight,
         Inactive,
         Border,
-        LabelFont
+        LabelFont,
+        DropIndicator
     };
     static QColor resolvedSystemColor(SystemColorRole role);
 
@@ -2123,12 +2147,15 @@ private:
     // isAnnouncingPaletteChange(). Never true outside that synchronous window.
     bool m_announcingPaletteChange = false;
 
-    // The last-announced resolved values of the four theme-fallback zone
-    // colours (Highlight, Inactive, Border, LabelFont — in that order),
-    // seeded by trackSystemPaletteChanges(). eventFilter() compares against
-    // these so an ApplicationPaletteChange that moved no relevant role stays
-    // silent instead of re-running the aggregate consumers.
-    std::array<QColor, 4> m_paletteBaseline{};
+    // The last-announced resolved values of the theme-fallback colours
+    // (Highlight, Inactive, Border, LabelFont, then the drop indicator's fill
+    // and border — in that order), seeded by trackSystemPaletteChanges().
+    // eventFilter() compares against these so an ApplicationPaletteChange that
+    // moved no relevant role stays silent instead of re-running the aggregate
+    // consumers. The last two share one role and so always hold the same
+    // colour; they are separate slots because their stored sentinels are
+    // independent, and the gate is per key, not per role.
+    std::array<QColor, 6> m_paletteBaseline{};
 
     // Last-announced "light" / "dark" token for the systemColorSchemeChanged
     // signal, seeded from the live palette in trackSystemPaletteChanges so

--- a/src/config/settings/scrolling.cpp
+++ b/src/config/settings/scrolling.cpp
@@ -372,22 +372,49 @@ P_STORE_SET_STRING(setScrollingTabIndicatorUrgentColor, scrollingTabIndicatorGro
 // ── Scrolling drop indicator (Scrolling.DropIndicator) ──────────────────────
 // The drop-target highlight painted during a drag re-insert. Paint-only: the
 // engine never reads these, it resolves the indicator's rect from the same
-// layout math the drop uses. Like the tab colours above, the colour is a
-// free-form string whose EMPTY value means "follow the theme", so it carries
-// canonicalThemeFallbackColor rather than a closed set (the disk path's only
-// guard against a black-painting unparseable string).
+// layout math the drop uses. Like the tab colours above, each colour is stored
+// as a free-form string whose EMPTY value means "follow the theme", so it
+// carries canonicalThemeFallbackColor rather than a closed set (the disk path's
+// only guard against a black-painting unparseable string).
+//
+// UNLIKE the tab colours, the sentinel is resolved HERE rather than in the
+// overlay's QML: the Raw accessors own the stored string and the ISettings
+// getters hand every consumer a concrete colour, which is the zone quartet's
+// split (settings/storescalars.cpp). Both colours resolve through the same
+// DropIndicator role — one drop target, one palette answer — and the fill's
+// alpha is replaced by the opacity slider downstream either way.
 
 P_STORE_GET(bool, scrollingDropIndicatorEnabled, scrollingDropIndicatorGroup, enabledKey, bool)
 P_STORE_SET_BOOL(setScrollingDropIndicatorEnabled, scrollingDropIndicatorGroup, enabledKey,
                  scrollingDropIndicatorEnabledChanged)
 
-P_STORE_GET(QString, scrollingDropIndicatorColor, scrollingDropIndicatorGroup, colorKey, QString)
-P_STORE_SET_STRING(setScrollingDropIndicatorColor, scrollingDropIndicatorGroup, colorKey,
-                   scrollingDropIndicatorColorChanged)
+P_STORE_GET(QString, scrollingDropIndicatorColorRaw, scrollingDropIndicatorGroup, colorKey, QString)
+P_STORE_SET_STRING2(setScrollingDropIndicatorColorRaw, scrollingDropIndicatorGroup, colorKey,
+                    scrollingDropIndicatorColorRawChanged, scrollingDropIndicatorColorChanged)
 
-P_STORE_GET(QString, scrollingDropIndicatorBorderColor, scrollingDropIndicatorGroup, borderColorKey, QString)
-P_STORE_SET_STRING(setScrollingDropIndicatorBorderColor, scrollingDropIndicatorGroup, borderColorKey,
-                   scrollingDropIndicatorBorderColorChanged)
+P_STORE_GET(QString, scrollingDropIndicatorBorderColorRaw, scrollingDropIndicatorGroup, borderColorKey, QString)
+P_STORE_SET_STRING2(setScrollingDropIndicatorBorderColorRaw, scrollingDropIndicatorGroup, borderColorKey,
+                    scrollingDropIndicatorBorderColorRawChanged, scrollingDropIndicatorBorderColorChanged)
+
+QColor Settings::scrollingDropIndicatorColor() const
+{
+    return resolveThemeColor(scrollingDropIndicatorColorRaw(), SystemColorRole::DropIndicator);
+}
+// Invalid means "no colour", which here is the follow-the-theme sentinel —
+// same guard and same reasoning as the zone quartet's QColor setters, where an
+// invalid QColor's name() would otherwise pin opaque black.
+void Settings::setScrollingDropIndicatorColor(const QColor& color)
+{
+    setScrollingDropIndicatorColorRaw(color.isValid() ? color.name(QColor::HexArgb) : QString());
+}
+QColor Settings::scrollingDropIndicatorBorderColor() const
+{
+    return resolveThemeColor(scrollingDropIndicatorBorderColorRaw(), SystemColorRole::DropIndicator);
+}
+void Settings::setScrollingDropIndicatorBorderColor(const QColor& color)
+{
+    setScrollingDropIndicatorBorderColorRaw(color.isValid() ? color.name(QColor::HexArgb) : QString());
+}
 
 // `double`, not the `qreal` every other floating getter in this file spells,
 // because the type has to match the ISettings virtual it overrides and that

--- a/src/config/settings/scrolling.cpp
+++ b/src/config/settings/scrolling.cpp
@@ -49,15 +49,15 @@ static_assert(ConfigDefaults::scrollingTabIndicatorCornerRadius() == 0,
               "ISettings::scrollingTabIndicatorCornerRadius defaults to 0 (square) — update it with this default");
 // The drop indicator's paint keys, same story: the overlay service reads them
 // through ISettings, so a stub answering from the interface body must agree.
-// The two COLOUR defaults have no assert here and cannot get one: they return
-// a default-constructed QString, which is not a constant expression, and their
-// agreement rests on the doc comment in isettings.h. That is the whole
-// unasserted set in THIS indicator's family — the opacity joined the checked
-// ones when it became constexpr. The three tab-indicator colours are equally
-// unasserted for the same non-constexpr reason; test_scrolling_settings.cpp
-// pins their SCHEMA defaults (via ConfigDefaults) at runtime, while their
-// ISettings-body agreement, like the drop indicator's, rests on the doc
-// comment in isettings.h.
+// The two COLOUR defaults have no assert here and cannot get one: QColor is not
+// a literal type, so neither ConfigDefaults::scrollingDropIndicatorFallbackColor()
+// nor the isettings_detail twin it must agree with is a constant expression.
+// That agreement is pinned at runtime instead, by
+// dropIndicatorFallbackMatchesInterfaceDefault in test_settings_core.cpp.
+// The three tab-indicator colours are unasserted here for the same
+// non-constexpr reason, and test_scrolling_settings.cpp pins their SCHEMA
+// defaults (via ConfigDefaults) at runtime. Their ISettings-body agreement
+// still rests on the doc comment in isettings.h.
 static_assert(ConfigDefaults::scrollingDropIndicatorEnabled(),
               "ISettings::scrollingDropIndicatorEnabled defaults to true — update it with this default");
 static_assert(ConfigDefaults::scrollingDropIndicatorOpacity() == 0.25,

--- a/src/config/settings/systemcolors.cpp
+++ b/src/config/settings/systemcolors.cpp
@@ -120,7 +120,7 @@ bool Settings::eventFilter(QObject* watched, QEvent* event)
         // Re-announce whichever colours FOLLOW the palette (stored sentinel
         // empty) AND actually moved. Qt delivers ApplicationPaletteChange
         // after the palette is already updated, so the "before" values come
-        // from the cached quartet rather than a re-read — without the value
+        // from the cached baseline rather than a re-read — without the value
         // gate every palette event (a style change, a plasma-integration
         // re-push with identical roles) would run the aggregate consumers
         // (daemon refreshConfigFromSettings, KWin effect reload) for
@@ -129,7 +129,7 @@ bool Settings::eventFilter(QObject* watched, QEvent* event)
         // dirty tracking never engages, and a colour the user pinned to a
         // concrete value stays silent. One aggregate settingsChanged,
         // batched like the setters, so aggregate consumers run once per
-        // theme switch rather than four times.
+        // theme switch rather than six times.
         const QColor newHighlight = resolvedSystemColor(SystemColorRole::Highlight);
         const QColor newInactive = resolvedSystemColor(SystemColorRole::Inactive);
         const QColor newBorder = resolvedSystemColor(SystemColorRole::Border);
@@ -226,13 +226,20 @@ QColor Settings::resolvedSystemColor(SystemColorRole role)
     }
     case SystemColorRole::LabelFont:
         return pal.color(QPalette::Active, QPalette::Text);
-    // Same palette role as Highlight but at FULL alpha. The drop indicator's
-    // fill takes its alpha from the opacity slider, which replaces whatever the
-    // colour carries, and its border has no slider — so ZoneDefaults'
-    // HighlightAlpha would show up there as an unset border quietly drawing
-    // half transparent.
-    case SystemColorRole::DropIndicator:
-        return pal.color(QPalette::Active, QPalette::Highlight);
+    // Same palette role as Highlight but forced to FULL alpha. The drop
+    // indicator's fill takes its alpha from the opacity slider, which replaces
+    // whatever the colour carries, and its border has no slider — so any alpha
+    // below 255 would show up there as an unset border quietly drawing half
+    // transparent. The setAlpha is what guarantees that, not the absence of
+    // ZoneDefaults' HighlightAlpha: a platform theme is free to ship a
+    // translucent Highlight, and the two no-palette fallbacks
+    // (ConfigDefaults::scrollingDropIndicatorFallbackColor and the
+    // isettings_detail twin) both force 255 the same way.
+    case SystemColorRole::DropIndicator: {
+        QColor drop = pal.color(QPalette::Active, QPalette::Highlight);
+        drop.setAlpha(255);
+        return drop;
+    }
     }
     return pal.color(QPalette::Active, QPalette::Highlight);
 }

--- a/src/config/settings/systemcolors.cpp
+++ b/src/config/settings/systemcolors.cpp
@@ -15,9 +15,10 @@
 
 namespace PlasmaZones {
 
-// ── Appearance: palette-following zone colours ───────────────────────────────
-// The four zone-colour keys are theme-fallback strings: EMPTY means "follow
-// the system palette". Resolution lives here, in the getters' shared helper,
+// ── Appearance: palette-following colours ────────────────────────────────────
+// The four zone-colour keys (and the scrolling drop indicator's two, which
+// share the machinery) are theme-fallback strings: EMPTY means "follow the
+// system palette". Resolution lives here, in the getters' shared helper,
 // so a palette change needs no writes, no baseline bookkeeping, and no
 // squelch flags — the old useSystemColors machinery that WROTE derived
 // colours into config is gone with the bool itself.
@@ -73,9 +74,13 @@ void Settings::trackSystemPaletteChanges()
         qGuiApp->installEventFilter(this);
         // Seed the change gate so the first ApplicationPaletteChange can
         // compare against what the process started with.
-        m_paletteBaseline = {
-            resolvedSystemColor(SystemColorRole::Highlight), resolvedSystemColor(SystemColorRole::Inactive),
-            resolvedSystemColor(SystemColorRole::Border), resolvedSystemColor(SystemColorRole::LabelFont)};
+        const QColor drop = resolvedSystemColor(SystemColorRole::DropIndicator);
+        m_paletteBaseline = {resolvedSystemColor(SystemColorRole::Highlight),
+                             resolvedSystemColor(SystemColorRole::Inactive),
+                             resolvedSystemColor(SystemColorRole::Border),
+                             resolvedSystemColor(SystemColorRole::LabelFont),
+                             drop,
+                             drop};
     }
 }
 
@@ -129,14 +134,22 @@ bool Settings::eventFilter(QObject* watched, QEvent* event)
         const QColor newInactive = resolvedSystemColor(SystemColorRole::Inactive);
         const QColor newBorder = resolvedSystemColor(SystemColorRole::Border);
         const QColor newLabelFont = resolvedSystemColor(SystemColorRole::LabelFont);
+        // The scrolling drop indicator's two keys ride the same fan-out: they
+        // are theme-fallback keys resolved in their getters exactly like the
+        // quartet, so a theme switch moves their resolved view with nothing
+        // written. One resolve for both, since they share the role.
+        const QColor newDrop = resolvedSystemColor(SystemColorRole::DropIndicator);
         const bool highlightMoved = highlightColorRaw().isEmpty() && newHighlight != m_paletteBaseline[0];
         const bool inactiveMoved = inactiveColorRaw().isEmpty() && newInactive != m_paletteBaseline[1];
         const bool borderMoved = borderColorRaw().isEmpty() && newBorder != m_paletteBaseline[2];
         const bool labelFontMoved = labelFontColorRaw().isEmpty() && newLabelFont != m_paletteBaseline[3];
+        const bool dropMoved = scrollingDropIndicatorColorRaw().isEmpty() && newDrop != m_paletteBaseline[4];
+        const bool dropBorderMoved =
+            scrollingDropIndicatorBorderColorRaw().isEmpty() && newDrop != m_paletteBaseline[5];
         // Refresh the baseline unconditionally (pinned colours included) so
         // a later un-pin compares against the current palette, not a stale
         // capture.
-        m_paletteBaseline = {newHighlight, newInactive, newBorder, newLabelFont};
+        m_paletteBaseline = {newHighlight, newInactive, newBorder, newLabelFont, newDrop, newDrop};
         // The NOTIFYs below are palette-driven, not user edits; the flag lets
         // SettingsController::onSettingsPropertyChanged() keep the
         // unsaved-changes footer quiet through a theme switch. RAII so an
@@ -150,7 +163,11 @@ bool Settings::eventFilter(QObject* watched, QEvent* event)
             Q_EMIT borderColorChanged();
         if (labelFontMoved)
             Q_EMIT labelFontColorChanged();
-        if (highlightMoved || inactiveMoved || borderMoved || labelFontMoved)
+        if (dropMoved)
+            Q_EMIT scrollingDropIndicatorColorChanged();
+        if (dropBorderMoved)
+            Q_EMIT scrollingDropIndicatorBorderColorChanged();
+        if (highlightMoved || inactiveMoved || borderMoved || labelFontMoved || dropMoved || dropBorderMoved)
             Q_EMIT settingsChanged();
     }
     return ISettings::eventFilter(watched, event);
@@ -177,6 +194,8 @@ QColor Settings::resolvedSystemColor(SystemColorRole role)
             return ConfigDefaults::borderFallbackColor();
         case SystemColorRole::LabelFont:
             return ConfigDefaults::labelFontFallbackColor();
+        case SystemColorRole::DropIndicator:
+            return ConfigDefaults::scrollingDropIndicatorFallbackColor();
         }
         return ConfigDefaults::highlightFallbackColor();
     }
@@ -207,6 +226,13 @@ QColor Settings::resolvedSystemColor(SystemColorRole role)
     }
     case SystemColorRole::LabelFont:
         return pal.color(QPalette::Active, QPalette::Text);
+    // Same palette role as Highlight but at FULL alpha. The drop indicator's
+    // fill takes its alpha from the opacity slider, which replaces whatever the
+    // colour carries, and its border has no slider — so ZoneDefaults'
+    // HighlightAlpha would show up there as an unset border quietly drawing
+    // half transparent.
+    case SystemColorRole::DropIndicator:
+        return pal.color(QPalette::Active, QPalette::Highlight);
     }
     return pal.color(QPalette::Active, QPalette::Highlight);
 }

--- a/src/core/interfaces/isettings.h
+++ b/src/core/interfaces/isettings.h
@@ -15,6 +15,11 @@
 #include "core/types/enums.h"
 #include "settings_interfaces.h"
 
+// Explicit rather than transitive: the drop indicator's no-palette colour IS
+// the zone overlay's highlight, so this header genuinely depends on that
+// symbol.
+#include <PhosphorZones/ZoneDefaults.h>
+
 #include <QColor>
 #include <QObject>
 #include <QString>
@@ -25,6 +30,18 @@ class DecorationProfileTree;
 }
 
 namespace PlasmaZones {
+
+namespace isettings_detail {
+/// The drop indicator's colour when nothing can resolve one: the shipped zone
+/// highlight forced opaque. Shared by the two colour defaults below so the
+/// value is written once. See scrollingDropIndicatorColor() for why opaque.
+inline QColor opaqueDropIndicatorFallback()
+{
+    QColor color = ::PhosphorZones::ZoneDefaults::HighlightColor;
+    color.setAlpha(255);
+    return color;
+}
+} // namespace isettings_detail
 
 /**
  * @brief Abstract interface for settings management
@@ -416,20 +433,34 @@ public:
     virtual void setScrollingDropIndicatorEnabled(bool /*enabled*/)
     {
     }
-    /// Fill and border colours; empty means "follow the theme" (see
-    /// ConfigDefaults).
-    virtual QString scrollingDropIndicatorColor() const
+    /// Fill and border colours. Theme-fallback keys resolved the way the zone
+    /// quartet's are (settings_interfaces.h documents that contract): the
+    /// getters return RESOLVED colours, palette-derived while the stored string
+    /// is empty, and the setters pin a concrete colour, with an INVALID QColor
+    /// storing the follow-the-theme sentinel. The stored-string surface lives
+    /// on the concrete Settings as scrollingDropIndicator*ColorRaw, for the
+    /// settings UI. Resolving here rather than in the overlay's QML keeps the
+    /// sentinel inside the config layer, so every consumer of this interface
+    /// gets a colour it can paint without knowing the fallback rule.
+    ///
+    /// The default is the shipped zone highlight at full alpha, which is what
+    /// Settings resolves to with no palette to read (ConfigDefaults spells the
+    /// same value as scrollingDropIndicatorFallbackColor, unreachable from here
+    /// because config depends on core and not the other way round). A backend
+    /// that cannot resolve still hands the overlay a paintable colour rather
+    /// than the invalid one that renders as black.
+    virtual QColor scrollingDropIndicatorColor() const
     {
-        return QString();
+        return isettings_detail::opaqueDropIndicatorFallback();
     }
-    virtual void setScrollingDropIndicatorColor(const QString& /*color*/)
+    virtual void setScrollingDropIndicatorColor(const QColor& /*color*/)
     {
     }
-    virtual QString scrollingDropIndicatorBorderColor() const
+    virtual QColor scrollingDropIndicatorBorderColor() const
     {
-        return QString();
+        return isettings_detail::opaqueDropIndicatorFallback();
     }
-    virtual void setScrollingDropIndicatorBorderColor(const QString& /*color*/)
+    virtual void setScrollingDropIndicatorBorderColor(const QColor& /*color*/)
     {
     }
     /// Fill opacity; the border always draws opaque.

--- a/src/core/interfaces/isettings.h
+++ b/src/core/interfaces/isettings.h
@@ -368,10 +368,12 @@ public:
     // Each NUMERIC default below is pinned against its ConfigDefaults twin by a
     // static_assert in settings/scrolling.cpp, the way the toggle above is
     // (that covers the drop-indicator opacity/border-width literals further
-    // down too). The five colour defaults cannot be — ConfigDefaults returns
-    // a non-constexpr QString for them (the tab trio here plus the
-    // drop-indicator fill/border pair below). They are pinned at runtime
-    // instead, by the schema assertions in test_scrolling_settings.cpp.
+    // down too). The five colour defaults cannot be, for two different reasons.
+    // The tab trio returns a non-constexpr QString from ConfigDefaults, and
+    // test_scrolling_settings.cpp pins their SCHEMA defaults at runtime. The
+    // drop-indicator pair below returns a QColor, which is not a literal type
+    // either; its agreement with ConfigDefaults is pinned at runtime by
+    // dropIndicatorFallbackMatchesInterfaceDefault in test_settings_core.cpp.
 
     /// 0 = title chips, 1 = segment bar (ConfigDefaults' TabIndicatorStyle).
     /// The bar is the default: it is niri's own indicator, and the only one it
@@ -463,7 +465,8 @@ public:
     virtual void setScrollingDropIndicatorBorderColor(const QColor& /*color*/)
     {
     }
-    /// Fill opacity; the border always draws opaque.
+    /// Fill opacity. Applies to the fill only: the border's transparency comes
+    /// from its own colour's alpha channel, which nothing downstream replaces.
     virtual double scrollingDropIndicatorOpacity() const
     {
         return 0.25;
@@ -619,7 +622,8 @@ Q_SIGNALS:
     // palette change while the colour follows the theme (the resolved value
     // moved with no write). An ISettings-holding consumer cannot tell the
     // two apart; the concrete Settings exposes isAnnouncingPaletteChange()
-    // for the one consumer that needs to.
+    // for the one consumer that needs to. The drop indicator's fill and
+    // border NOTIFYs further down share this dual-source behaviour.
     void highlightColorChanged();
     void inactiveColorChanged();
     void borderColorChanged();
@@ -910,6 +914,9 @@ Q_SIGNALS:
 
     // Scrolling drop indicator (Scrolling.DropIndicator)
     void scrollingDropIndicatorEnabledChanged();
+    // These two are dual-source in exactly the way the zone-colour block
+    // above describes: a user edit, or a palette change while the colour
+    // follows the theme.
     void scrollingDropIndicatorColorChanged();
     void scrollingDropIndicatorBorderColorChanged();
     void scrollingDropIndicatorOpacityChanged();

--- a/src/daemon/overlayservice/rekey.cpp
+++ b/src/daemon/overlayservice/rekey.cpp
@@ -156,12 +156,16 @@ bool OverlayService::rekeyOverlayState(const QString& oldKey, const QString& new
     //    enable toggle replays, so left under the dead key, re-enabling the
     //    indicator would replay nothing until the next structural strip
     //    change.
-    //  - m_scrollTabsHidePending is an inert bit for a hide that belonged to
-    //    the old key's shell; drop it rather than carry it.
-    //  - m_scrollTabsHideGuard is deliberately abandoned. It is monotonic per
-    //    key, and the new key's counter (absent or already higher) can only
-    //    make an old in-flight completion stale-return, which is the safe
-    //    direction.
+    //  - m_scrollTabsHidePending is NOT an inert bit. The rekey preserves the
+    //    slot and the animator track, so a hide in flight still completes;
+    //    dropping the bit alone strands the slot. It is cleared together with
+    //    the teardown it owns, below.
+    //  - m_scrollTabsHideGuard is deliberately abandoned for the NEW key: it
+    //    is monotonic per key, and the new key's counter (absent or already
+    //    higher) can only make an old in-flight completion stale-return, which
+    //    is the safe direction. The OLD key's counter is bumped when a hide
+    //    was pending, so the completion this rekey pre-empts stale-returns
+    //    rather than running the teardown twice.
     //  - m_scrollTabInputRegions MUST follow. The rekey preserves the live
     //    surface, so the slot can still be visible; left under the dead key,
     //    syncScrollTabShellSurfaceState(newKey) would read an empty region and
@@ -178,9 +182,9 @@ bool OverlayService::rekeyOverlayState(const QString& oldKey, const QString& new
     //    (the next push hides the old id first), but a rekey with no further
     //    push before the drop leaves the rectangle painted with no drag left
     //    to dismiss it.
-    //  - m_scrollDropIndicatorHidePending is dropped like its tab twin, and
-    //    m_scrollDropIndicatorHideGuard is abandoned for the same monotonic
-    //    reason: a stale-returning completion is the safe direction.
+    //  - m_scrollDropIndicatorHidePending is handled like its tab twin: the
+    //    pending teardown is finished here rather than dropped, and
+    //    m_scrollDropIndicatorHideGuard follows the same bump-the-old-key rule.
     // After the rekey the old key has no removal path of its own (the rekeyed
     // key never reaches unwirePassiveShellSlots, and the by-key clears in
     // updateScrollingScreens name the LIVE screen), so failing to move these
@@ -213,8 +217,29 @@ bool OverlayService::rekeyOverlayState(const QString& oldKey, const QString& new
         m_scrollDropIndicatorOverrides.insert(newKey, dropOverrideIt.value());
         m_scrollDropIndicatorOverrides.remove(oldKey);
     }
-    m_scrollTabsHidePending.remove(oldKey);
-    m_scrollDropIndicatorHidePending.remove(oldKey);
+    // A hide in flight under oldKey cannot simply have its bit dropped. The
+    // animator's track is keyed by {surface, item}, neither of which the rekey
+    // touches, so the completion still fires — and it captured oldKey, whose
+    // guard the rekey abandons UNCHANGED. It therefore passes its own guard
+    // check, then fails the m_screenStates lookup (the state now lives under
+    // newKey) and returns early, never running the teardown it owns. That
+    // leaves the slot visible at opacity 0: the drop indicator stops painting
+    // until the drag ends, and the tab strips stay INVISIBLE BUT CLICKABLE,
+    // because syncScrollTabShellSurfaceState keys the input region on
+    // slot->isVisible(). Neither self-heals through the normal update path,
+    // which early-returns on a slot that is already visible.
+    // So finish the teardown here, against the migrated state, and bump the
+    // old key's guard so the in-flight completion stale-returns instead of
+    // running twice. Deferred to after the surface re-announce below, which
+    // needs the pre-teardown state.
+    const bool tabsHideWasPending = m_scrollTabsHidePending.remove(oldKey);
+    const bool dropHideWasPending = m_scrollDropIndicatorHidePending.remove(oldKey);
+    if (tabsHideWasPending) {
+        ++m_scrollTabsHideGuard[oldKey];
+    }
+    if (dropHideWasPending) {
+        ++m_scrollDropIndicatorHideGuard[oldKey];
+    }
 
     // The geometryChanged lambda captured the OLD sid by value. After the
     // state moved to newKey, the lambda's m_screenStates.find(oldSid) lookup
@@ -288,6 +313,27 @@ bool OverlayService::rekeyOverlayState(const QString& oldKey, const QString& new
     announceScrollTabSurface(oldKey, nullptr);
     if (rekeyed.tabShell) {
         announceScrollTabSurface(newKey, rekeyed.tabShell->shellWindow());
+    }
+
+    // Finish the hides the rekey inherited (see the pending-bit block above).
+    // Same teardown the abandoned completions would have run, addressed to the
+    // migrated key. The tab retraction comes after the re-announce on purpose:
+    // the announce is unconditional on tabShell, so retracting first would let
+    // it re-publish a surface for a slot that is about to go invisible.
+    if (tabsHideWasPending) {
+        if (QQuickItem* slot = rekeyed.scrollTabsSlot()) {
+            slot->setVisible(false);
+            writeQmlProperty(slot, QStringLiteral("loaded"), false);
+            announceScrollTabSurface(newKey, nullptr);
+        }
+        syncScrollTabShellSurfaceState(newKey);
+    }
+    if (dropHideWasPending) {
+        if (QQuickItem* slot = rekeyed.scrollDropIndicatorSlot()) {
+            slot->setVisible(false);
+            writeQmlProperty(slot, QStringLiteral("loaded"), false);
+        }
+        syncPassiveShellSurfaceState(newKey);
     }
 
     qCInfo(lcOverlay) << "rekeyOverlayState: migrated overlay" << oldKey << "->" << newKey

--- a/src/daemon/overlayservice/scrolldropindicator.cpp
+++ b/src/daemon/overlayservice/scrolldropindicator.cpp
@@ -30,6 +30,7 @@
 #include <PhosphorLayer/Surface.h>
 #include <PhosphorScreens/Manager.h>
 
+#include <QColor>
 #include <QQuickItem>
 #include <QQuickWindow>
 #include <QScreen>
@@ -212,12 +213,13 @@ void OverlayService::updateScrollDropIndicator(const QString& screenId, const QR
     // a mid-drag settings edit lands on the next target change rather than
     // immediately — deliberate, per the no-replay note at the top). A drag is short enough that a settings change
     // almost never lands mid-drag, but writing an unchanged QML property emits no change notification, so the cost of
-    // being correct here is five compares. EMPTY colours mean "follow the theme" and the content item resolves that.
+    // being correct here is five compares. Every colour that reaches the content item is CONCRETE: the
+    // follow-the-theme sentinel is resolved in Settings, and both override tiers are shape-checked hex.
     if (m_settings) {
         // Three layers, narrowest first: the DRAGGED WINDOW's rule beats the
-        // screen's CONTEXT rule, which beats the setting, which the content
-        // item resolves against the theme when it is the empty sentinel. That
-        // is the tab colours' order, and niri's.
+        // screen's CONTEXT rule, which beats the setting, which Settings has
+        // already resolved against the palette when it holds the empty
+        // sentinel. That is the tab colours' order, and niri's.
         const QVariantMap& ctx = screenOverrides;
         const QVariantMap& win = m_scrollDropIndicatorWindowOverrides;
         const auto layered = [&ctx, &win](const QString& key, const QVariant& fromSettings) {
@@ -234,11 +236,17 @@ void OverlayService::updateScrollDropIndicator(const QString& screenId, const QR
         // name this slot exposes — the same string in both argument positions,
         // which is exactly the pair a typo used to break silently. The three
         // non-colour properties below carry no shared key and stay literal.
+        //
+        // The settings values arrive RESOLVED (Settings owns the theme
+        // fallback), so they are spelled back as #AARRGGBB to keep every tier
+        // of `layered` the same type — the two override tiers carry hex
+        // strings, checked for that shape before they are admitted.
         writeQmlProperty(slot, WindowColorKeys::indicatorColor(),
-                         layered(WindowColorKeys::indicatorColor(), m_settings->scrollingDropIndicatorColor()));
-        writeQmlProperty(
-            slot, WindowColorKeys::indicatorBorderColor(),
-            layered(WindowColorKeys::indicatorBorderColor(), m_settings->scrollingDropIndicatorBorderColor()));
+                         layered(WindowColorKeys::indicatorColor(),
+                                 m_settings->scrollingDropIndicatorColor().name(QColor::HexArgb)));
+        writeQmlProperty(slot, WindowColorKeys::indicatorBorderColor(),
+                         layered(WindowColorKeys::indicatorBorderColor(),
+                                 m_settings->scrollingDropIndicatorBorderColor().name(QColor::HexArgb)));
         writeQmlProperty(slot, QStringLiteral("indicatorOpacity"),
                          layered(QStringLiteral("indicatorOpacity"), m_settings->scrollingDropIndicatorOpacity()));
         writeQmlProperty(

--- a/src/dbus/settingsadaptor/settingsadaptor.cpp
+++ b/src/dbus/settingsadaptor/settingsadaptor.cpp
@@ -294,9 +294,10 @@ bool SettingsAdaptor::setSetting(const QString& key, const QDBusVariant& value)
     // pointers, exotic Q_DECLARE_METATYPE payloads) fall through to the
     // full setter to avoid false negatives from a non-structural operator==.
     //
-    // For the RESOLVING colour keys (the zone quartet and the three window
-    // colours, whose getters resolve the empty theme-fallback sentinel to a
-    // concrete colour) this guard gives echo writes a defined meaning:
+    // For the RESOLVING colour keys (the zone quartet, the three window
+    // colours and the scrolling drop indicator's fill and border, whose
+    // getters resolve the empty theme-fallback sentinel to a concrete
+    // colour) this guard gives echo writes a defined meaning:
     // writing back the currently-resolved colour keeps the key FOLLOWING
     // the theme rather than pinning it. That is deliberate — it is what
     // makes a get→set echo non-destructive — and a caller that wants an

--- a/src/dbus/settingsadaptor/settingsadaptor_batch.cpp
+++ b/src/dbus/settingsadaptor/settingsadaptor_batch.cpp
@@ -158,9 +158,10 @@ bool SettingsAdaptor::setSettings(const QVariantMap& settings)
                 // windowTintColor ISettings property); alias each to its
                 // twin's NOTIFY so a batch that changes only the stored
                 // follow/pin state (e.g. pinning a colour to the value it
-                // already resolved to) still announces per-key. The four
-                // zone raws need no row here — they have real Q_PROPERTYs
-                // with their own *RawChanged NOTIFYs.
+                // already resolved to) still announces per-key. The other
+                // six raws need no row here (the zone quartet and the
+                // drop-indicator pair) — they have real Q_PROPERTYs with
+                // their own *RawChanged NOTIFYs.
                 {QStringLiteral("windowBorderColorActiveRaw"), QByteArrayLiteral("windowBorderColorActive")},
                 {QStringLiteral("windowBorderColorInactiveRaw"), QByteArrayLiteral("windowBorderColorInactive")},
                 {QStringLiteral("windowTintColorRaw"), QByteArrayLiteral("windowTintColor")},

--- a/src/dbus/settingsadaptor/settingsadaptor_registry_scrolling.cpp
+++ b/src/dbus/settingsadaptor/settingsadaptor_registry_scrolling.cpp
@@ -250,8 +250,10 @@ void SettingsAdaptor::initializeRegistryScrolling()
     // because keys are applied in sorted order, so "<key>Raw" lands after
     // "<key>" and the sentinel wins. (That holds ON A CONCRETE Settings
     // backend: the two Raw keys register inside the `concrete` guard below, so
-    // a bare-ISettings backend still pins both colours on a round-trip — every
-    // production composition root passes the concrete Settings.)
+    // on anything else the sentinel does not survive a round-trip — the
+    // interface's own setter bodies are empty, so a literally-bare ISettings
+    // drops the write rather than storing it. Every production composition
+    // root passes the concrete Settings.)
     REGISTER_COLOR_SETTING("scrollingDropIndicatorColor", scrollingDropIndicatorColor, setScrollingDropIndicatorColor)
     REGISTER_COLOR_SETTING("scrollingDropIndicatorBorderColor", scrollingDropIndicatorBorderColor,
                            setScrollingDropIndicatorBorderColor)

--- a/src/dbus/settingsadaptor/settingsadaptor_registry_scrolling.cpp
+++ b/src/dbus/settingsadaptor/settingsadaptor_registry_scrolling.cpp
@@ -76,8 +76,8 @@ void SettingsAdaptor::initializeRegistryScrolling()
 // the boundary so it never reaches a QML `color` property, and the false
 // return surfaces the rejection to the D-Bus caller instead of silently
 // dropping the write. Schema token "themeColor" (shared with the *Raw
-// companion keys in the core TU) tells a schema-aware client the empty
-// value is the follow-the-scheme sentinel, not a missing string.
+// companion keys) tells a schema-aware client the empty value is the
+// follow-the-scheme sentinel, not a missing string.
 #define REGISTER_THEME_FALLBACK_COLOR_SETTING(name, getter, setter)                                                    \
     m_getters[QStringLiteral(name)] = [this]() {                                                                       \
         return m_settings->getter();                                                                                   \
@@ -248,7 +248,10 @@ void SettingsAdaptor::initializeRegistryScrolling()
     // the plain key carries the RESOLVED colour and the "Raw" companion carries
     // the stored sentinel. A round-trip through a QVariantMap stays lossless
     // because keys are applied in sorted order, so "<key>Raw" lands after
-    // "<key>" and the sentinel wins.
+    // "<key>" and the sentinel wins. (That holds ON A CONCRETE Settings
+    // backend: the two Raw keys register inside the `concrete` guard below, so
+    // a bare-ISettings backend still pins both colours on a round-trip — every
+    // production composition root passes the concrete Settings.)
     REGISTER_COLOR_SETTING("scrollingDropIndicatorColor", scrollingDropIndicatorColor, setScrollingDropIndicatorColor)
     REGISTER_COLOR_SETTING("scrollingDropIndicatorBorderColor", scrollingDropIndicatorBorderColor,
                            setScrollingDropIndicatorBorderColor)

--- a/src/dbus/settingsadaptor/settingsadaptor_registry_scrolling.cpp
+++ b/src/dbus/settingsadaptor/settingsadaptor_registry_scrolling.cpp
@@ -95,6 +95,55 @@ void SettingsAdaptor::initializeRegistryScrolling()
     };                                                                                                                 \
     m_schemas[QStringLiteral(name)] = QStringLiteral("themeColor");
 
+// The resolved half of a theme-fallback pair whose sentinel is resolved in the
+// config layer: the getter serves a concrete #AARRGGBB and the setter pins one,
+// with empty (or the legacy accent token) storing the sentinel through the
+// QColor setter's invalid-means-unset guard. The resolution chain cannot
+// produce an invalid QColor, so no isValid() guard is needed before name().
+// Copied from the core TU's REGISTER_COLOR_SETTING per the sync rule above,
+// with the accent token spelled inline: kAccentToken is that TU's file-local
+// constant and a second definition here would collide in a unity batch.
+#define REGISTER_COLOR_SETTING(keyName, getter, setter)                                                                \
+    m_getters[QStringLiteral(keyName)] = [this]() {                                                                    \
+        QColor color = m_settings->getter();                                                                           \
+        return color.name(QColor::HexArgb);                                                                            \
+    };                                                                                                                 \
+    m_setters[QStringLiteral(keyName)] = [this](const QVariant& v) {                                                   \
+        const QString s = v.toString();                                                                                \
+        if (s.isEmpty() || s == QLatin1String("accent")) {                                                             \
+            m_settings->setter(QColor());                                                                              \
+            return true;                                                                                               \
+        }                                                                                                              \
+        const QColor parsed(s);                                                                                        \
+        if (!parsed.isValid()) {                                                                                       \
+            return false;                                                                                              \
+        }                                                                                                              \
+        m_settings->setter(parsed);                                                                                    \
+        return true;                                                                                                   \
+    };                                                                                                                 \
+    m_schemas[QStringLiteral(keyName)] = QStringLiteral("color");
+
+// The stored half of that pair, on the concrete Settings: the sentinel itself,
+// readable and writable so a round-trip can restore "follow the theme". Same
+// body as the core TU's REGISTER_RAW_THEME_COLOR, accent token inlined for the
+// reason above.
+#define REGISTER_RAW_THEME_COLOR(keyName, capture, obj, getter, setter)                                                \
+    m_getters[QStringLiteral(keyName)] = [capture]() {                                                                 \
+        return obj->getter();                                                                                          \
+    };                                                                                                                 \
+    m_setters[QStringLiteral(keyName)] = [capture](const QVariant& v) {                                                \
+        QString s = v.toString();                                                                                      \
+        if (s == QLatin1String("accent")) {                                                                            \
+            s = QString();                                                                                             \
+        }                                                                                                              \
+        if (!s.isEmpty() && !QColor(s).isValid()) {                                                                    \
+            return false;                                                                                              \
+        }                                                                                                              \
+        obj->setter(s);                                                                                                \
+        return true;                                                                                                   \
+    };                                                                                                                 \
+    m_schemas[QStringLiteral(keyName)] = QStringLiteral("themeColor");
+
 #define REGISTER_CONCRETE_BOOL(name, getter, setter)                                                                   \
     m_getters[QStringLiteral(name)] = [concrete]() {                                                                   \
         return concrete->getter();                                                                                     \
@@ -194,10 +243,21 @@ void SettingsAdaptor::initializeRegistryScrolling()
                                           setScrollingTabIndicatorInactiveColor)
     REGISTER_THEME_FALLBACK_COLOR_SETTING("scrollingTabIndicatorUrgentColor", scrollingTabIndicatorUrgentColor,
                                           setScrollingTabIndicatorUrgentColor)
-    REGISTER_THEME_FALLBACK_COLOR_SETTING("scrollingDropIndicatorColor", scrollingDropIndicatorColor,
-                                          setScrollingDropIndicatorColor)
-    REGISTER_THEME_FALLBACK_COLOR_SETTING("scrollingDropIndicatorBorderColor", scrollingDropIndicatorBorderColor,
-                                          setScrollingDropIndicatorBorderColor)
+    // The drop indicator's two colours resolve in the config layer instead
+    // (Settings::resolvedSystemColor), so they take the zone quartet's shape:
+    // the plain key carries the RESOLVED colour and the "Raw" companion carries
+    // the stored sentinel. A round-trip through a QVariantMap stays lossless
+    // because keys are applied in sorted order, so "<key>Raw" lands after
+    // "<key>" and the sentinel wins.
+    REGISTER_COLOR_SETTING("scrollingDropIndicatorColor", scrollingDropIndicatorColor, setScrollingDropIndicatorColor)
+    REGISTER_COLOR_SETTING("scrollingDropIndicatorBorderColor", scrollingDropIndicatorBorderColor,
+                           setScrollingDropIndicatorBorderColor)
+    if (concrete) {
+        REGISTER_RAW_THEME_COLOR("scrollingDropIndicatorColorRaw", concrete, concrete, scrollingDropIndicatorColorRaw,
+                                 setScrollingDropIndicatorColorRaw)
+        REGISTER_RAW_THEME_COLOR("scrollingDropIndicatorBorderColorRaw", concrete, concrete,
+                                 scrollingDropIndicatorBorderColorRaw, setScrollingDropIndicatorBorderColorRaw)
+    }
     REGISTER_DOUBLE_SETTING("scrollingDropIndicatorOpacity", scrollingDropIndicatorOpacity,
                             setScrollingDropIndicatorOpacity)
     REGISTER_INT_SETTING("scrollingDropIndicatorBorderWidth", scrollingDropIndicatorBorderWidth,
@@ -457,6 +517,8 @@ void SettingsAdaptor::initializeRegistryScrolling()
 #undef REGISTER_INT_SETTING
 #undef REGISTER_DOUBLE_SETTING
 #undef REGISTER_THEME_FALLBACK_COLOR_SETTING
+#undef REGISTER_COLOR_SETTING
+#undef REGISTER_RAW_THEME_COLOR
 #undef REGISTER_CONCRETE_BOOL
 #undef REGISTER_CONCRETE_INT
 #undef REGISTER_CONCRETE_DOUBLE

--- a/src/settings/qml/pages/scrolling/ScrollingDropIndicatorCard.qml
+++ b/src/settings/qml/pages/scrolling/ScrollingDropIndicatorCard.qml
@@ -75,8 +75,13 @@ SettingsCard {
             description: i18n("Color filling the space the window will land in. Follows the color scheme unless you pick one.")
             enabled: root.indicatorOn
 
-            storedColor: appSettings.scrollingDropIndicatorColor
-            themeColor: Kirigami.Theme.highlightColor
+            storedColor: appSettings.scrollingDropIndicatorColorRaw
+            // The RESOLVED colour, not Kirigami.Theme's own highlight: Settings
+            // owns the fallback now (resolvedSystemColor), and previewing a
+            // second resolution here could show a swatch the indicator never
+            // paints. Its NOTIFY rides the palette-change fan-out, so the
+            // preview still follows a theme switch live.
+            themeColor: appSettings.scrollingDropIndicatorColor
             picker: root.picker
             onColorChosen: function (hex) {
                 // The FILL alpha is owned by the opacity slider below (the
@@ -86,7 +91,7 @@ SettingsCard {
                 // indicator never draws. The border row keeps its alpha:
                 // it has no slider, so the colour's alpha is its single
                 // control.
-                appSettings.scrollingDropIndicatorColor = hex === dropFillColorRow.sentinel ? hex : "#FF" + hex.slice(3);
+                appSettings.scrollingDropIndicatorColorRaw = hex === dropFillColorRow.sentinel ? hex : "#FF" + hex.slice(3);
             }
         }
 
@@ -123,11 +128,13 @@ SettingsCard {
             description: i18n("Color of the indicator's edge. Follows the color scheme unless you pick one.")
             enabled: root.indicatorOn
 
-            storedColor: appSettings.scrollingDropIndicatorBorderColor
-            themeColor: Kirigami.Theme.highlightColor
+            storedColor: appSettings.scrollingDropIndicatorBorderColorRaw
+            // See the fill row: the resolved colour, which is opaque so an
+            // unset border previews as solid as it draws.
+            themeColor: appSettings.scrollingDropIndicatorBorderColor
             picker: root.picker
             onColorChosen: function (hex) {
-                appSettings.scrollingDropIndicatorBorderColor = hex;
+                appSettings.scrollingDropIndicatorBorderColorRaw = hex;
             }
         }
 

--- a/src/settings/qml/pages/scrolling/ScrollingDropIndicatorCard.qml
+++ b/src/settings/qml/pages/scrolling/ScrollingDropIndicatorCard.qml
@@ -37,14 +37,11 @@ SettingsCard {
     /// Page-level for the same reason the Tabs page shares one: a page rebuild
     /// while a row-scoped dialog is open would tear the popup down under the
     /// user.
-    property var picker: null
+    required property var picker
 
     /// Bounds, read through the controller so C++ stays the single home for
     /// these numbers (the same accessor the Columns and Tabs pages use).
     readonly property var _scrollConsts: settingsController.scrollingConstants()
-    /// Every row below the master switch is dead while the indicator is off.
-    /// Named once so the gate cannot drift, matching the Tabs page.
-    readonly property bool indicatorOn: appSettings.scrollingDropIndicatorEnabled
     /// The opacity slider is integral, so the stored 0..1 fraction rides it as
     /// whole percent. Matches the snapping Appearance page's opacity rows.
     readonly property int opacitySliderMax: 100
@@ -73,7 +70,6 @@ SettingsCard {
             swatchAccessibleName: i18nc("@action:button", "Drop indicator fill color")
             searchAnchor: "scrollingDropIndicatorColor"
             description: i18n("Color filling the space the window will land in. Follows the color scheme unless you pick one.")
-            enabled: root.indicatorOn
 
             storedColor: appSettings.scrollingDropIndicatorColorRaw
             // The RESOLVED colour, not Kirigami.Theme's own highlight: Settings
@@ -95,15 +91,12 @@ SettingsCard {
             }
         }
 
-        SettingsSeparator {
-            enabled: root.indicatorOn
-        }
+        SettingsSeparator {}
 
         SettingsRow {
             title: i18n("Fill opacity")
             searchAnchor: "scrollingDropIndicatorOpacity"
             description: i18n("How solid the fill is. This replaces any transparency carried by the fill color.")
-            enabled: root.indicatorOn
 
             SettingsSlider {
                 accessibleName: i18n("Fill opacity")
@@ -116,9 +109,7 @@ SettingsCard {
             }
         }
 
-        SettingsSeparator {
-            enabled: root.indicatorOn
-        }
+        SettingsSeparator {}
 
         ThemeFallbackColorRow {
             title: i18n("Border color")
@@ -126,7 +117,6 @@ SettingsCard {
             swatchAccessibleName: i18nc("@action:button", "Drop indicator border color")
             searchAnchor: "scrollingDropIndicatorBorderColor"
             description: i18n("Color of the indicator's edge. Follows the color scheme unless you pick one.")
-            enabled: root.indicatorOn
 
             storedColor: appSettings.scrollingDropIndicatorBorderColorRaw
             // See the fill row: the resolved colour, which is opaque so an
@@ -138,15 +128,12 @@ SettingsCard {
             }
         }
 
-        SettingsSeparator {
-            enabled: root.indicatorOn
-        }
+        SettingsSeparator {}
 
         SettingsRow {
             title: i18n("Border width")
             searchAnchor: "scrollingDropIndicatorBorderWidth"
             description: i18n("Thickness of the indicator's edge in pixels. Zero draws the fill with no edge.")
-            enabled: root.indicatorOn
 
             SettingsSpinBox {
                 id: dropBorderWidthSpin
@@ -170,15 +157,12 @@ SettingsCard {
             }
         }
 
-        SettingsSeparator {
-            enabled: root.indicatorOn
-        }
+        SettingsSeparator {}
 
         SettingsRow {
             title: i18n("Corner radius")
             searchAnchor: "scrollingDropIndicatorBorderRadius"
             description: i18n("Corner rounding of the indicator in pixels.")
-            enabled: root.indicatorOn
 
             SettingsSpinBox {
                 id: dropBorderRadiusSpin

--- a/src/ui/PassiveOverlayShell.qml
+++ b/src/ui/PassiveOverlayShell.qml
@@ -408,13 +408,15 @@ Window {
         // arrives here: the daemon hides the slot instead.
         property rect indicatorRect: Qt.rect(0, 0, 0, 0)
         // Indicator colour (Scrolling.DropIndicator/Color), pushed by C++ on
-        // every rect update. EMPTY means "follow the theme" and the content
-        // item resolves that. Must be declared here AND forwarded below:
-        // setProperty on an undeclared name silently creates a dynamic
-        // property that no binding ever sees (see the zoneSelectorSlot
-        // contract note).
-        property string indicatorColor: ""
-        property string indicatorBorderColor: ""
+        // every rect update, always CONCRETE — the follow-the-theme sentinel is
+        // resolved in Settings before it reaches the overlay. Must be declared
+        // here AND forwarded below: setProperty on an undeclared name silently
+        // creates a dynamic property that no binding ever sees (see the
+        // zoneSelectorSlot contract note). The initialisers are placeholders
+        // that are never painted: C++ writes both colours before it writes
+        // `loaded`, so the content item is instantiated with the real values.
+        property color indicatorColor: Kirigami.Theme.highlightColor
+        property color indicatorBorderColor: Kirigami.Theme.highlightColor
         property real indicatorOpacity: 0.25
         property int indicatorBorderWidth: 2
         property int indicatorBorderRadius: 8

--- a/src/ui/PassiveOverlayShell.qml
+++ b/src/ui/PassiveOverlayShell.qml
@@ -262,8 +262,8 @@ Window {
         // above the passive content types (main overlay z=0, zone
         // selector z=1) so a layout-OSD or nav-OSD reads cleanly over an
         // active zone overlay or drag-time selector. While a MODAL slot
-        // (snap-assist, layout picker, or the shortcut cheatsheet, all
-        // z=2) is visible the OSD
+        // (snap-assist, layout picker, or the shortcut cheatsheet, hosted in
+        // the z=2 modal container) is visible the OSD
         // drops to 1.5 — still above the passive tiers, but below the
         // modal — so a concurrently-fired OSD card neither occludes
         // modal content for its ~1.5s display nor lets its
@@ -432,9 +432,11 @@ Window {
         property bool loaded: false
 
         anchors.fill: parent
-        // Indicator tier: directly above the tab strips, so a drop target that
-        // lands on a tabbed column is not hidden by that column's own
-        // indicator. Still below the zone selector, the OSDs and the modals.
+        // Indicator tier: above the main overlay (z=0) and below the zone
+        // selector (z=1), the OSDs and the modals. Ordering against the
+        // scrolling tab strips is NOT decided here — they live on their own
+        // layer-shell surface (ScrollTabShell.qml), and z only orders siblings
+        // inside this window's scene graph.
         z: 0.6
         opacity: 0
         visible: false

--- a/src/ui/ScrollDropIndicatorContent.qml
+++ b/src/ui/ScrollDropIndicatorContent.qml
@@ -31,10 +31,11 @@ Item {
 
     /// Drop-target rect in shell-window coordinates.
     required property rect indicatorRect
-    /// Configured fill and border colours, always CONCRETE. The
-    /// follow-the-theme sentinel is resolved before it gets here, in Settings
-    /// (resolvedSystemColor), so this component holds no fallback rule of its
-    /// own and cannot disagree with the swatch the settings page previews.
+    /// Configured fill and border colours, always CONCRETE. The bottom tier
+    /// resolves the follow-the-theme sentinel in Settings (resolvedSystemColor)
+    /// before it gets here; the window-rule and screen-context tiers above it
+    /// supply shape-checked hex. So this component holds no fallback rule of
+    /// its own and cannot disagree with the swatch the settings page previews.
     required property color indicatorColor
     required property color indicatorBorderColor
     /// Fill opacity. Applies to the fill only; the border's transparency

--- a/src/ui/ScrollDropIndicatorContent.qml
+++ b/src/ui/ScrollDropIndicatorContent.qml
@@ -31,10 +31,12 @@ Item {
 
     /// Drop-target rect in shell-window coordinates.
     required property rect indicatorRect
-    /// Configured fill and border colours. EMPTY means "follow the theme",
-    /// which is the shipped default for both.
-    required property string indicatorColor
-    required property string indicatorBorderColor
+    /// Configured fill and border colours, always CONCRETE. The
+    /// follow-the-theme sentinel is resolved before it gets here, in Settings
+    /// (resolvedSystemColor), so this component holds no fallback rule of its
+    /// own and cannot disagree with the swatch the settings page previews.
+    required property color indicatorColor
+    required property color indicatorBorderColor
     /// Fill opacity. Applies to the fill only; the border's transparency
     /// comes from its own colour's alpha channel.
     required property real indicatorOpacity
@@ -50,20 +52,6 @@ Item {
     /// paint properties above, so a host that forgets the forward fails at
     /// instantiation instead of silently never gating.
     required property bool animateMoves
-
-    /// Resolved paint colours. The empty test is the only fallback: the D-Bus
-    /// boundary rejects anything that is neither empty nor a colour QColor can
-    /// parse, so nothing the SETTINGS APP writes can arrive unparseable.
-    ///
-    /// A hand-edited config.json is not covered by that guard — it reaches
-    /// here through P_STORE_GET unvalidated. Qt turns an unparseable string
-    /// into an invalid QColor, which paints as black rather than falling back
-    /// to the scheme colour, so the failure is a visibly wrong indicator
-    /// rather than a crash or a silently absent one. Left as is deliberately:
-    /// re-validating in QML would duplicate the boundary check in a second
-    /// place that cannot report the problem to anyone.
-    readonly property color fillColor: root.indicatorColor === "" ? Kirigami.Theme.highlightColor : root.indicatorColor
-    readonly property color edgeColor: root.indicatorBorderColor === "" ? Kirigami.Theme.highlightColor : root.indicatorBorderColor
 
     anchors.fill: parent
 
@@ -82,13 +70,13 @@ Item {
         // multiplying would make a picked colour that carries alpha come out
         // darker than the slider says, with no way to tell which of the two
         // was responsible.
-        color: Qt.rgba(root.fillColor.r, root.fillColor.g, root.fillColor.b, root.indicatorOpacity)
+        color: Qt.rgba(root.indicatorColor.r, root.indicatorColor.g, root.indicatorColor.b, root.indicatorOpacity)
         // The border carries the picked colour's alpha straight through,
         // matching the snapping zone overlay's border. There is no border
         // opacity slider, so the colour's own channel is the ONE control and
-        // no double-apply is possible; the theme fallback is opaque, so an
-        // unset border still draws solid.
-        border.color: root.edgeColor
+        // no double-apply is possible; the theme fallback resolves opaque, so
+        // an unset border still draws solid.
+        border.color: root.indicatorBorderColor
         // Zero width is legal and means a fill with no edge, so this is NOT
         // floored at 1 the way a fixed hairline would be.
         border.width: root.indicatorBorderWidth

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -1090,8 +1090,13 @@ target_compile_definitions(test_settings_registry_contract
 # PhosphorAnimation: the fixture builds a real PhosphorProfileRegistry, because
 # initializeRegistry() gates the motionProfileTree getter behind a non-null one — with
 # a null registry the test would report a correctly-registered key as missing.
+# Qt6::Gui is explicit because this test uses QColor directly and its
+# QTEST_MAIN needs a QGuiApplication for the palette-resolving colour getters.
+# plasmazones_core links Qt6::Gui PUBLIC today, so this changes nothing now —
+# it stops the test depending on that staying true, per the note at the top of
+# this file.
 target_link_libraries(test_settings_registry_contract
-                      PRIVATE Qt6::Test Qt6::Core Qt6::DBus plasmazones_core
+                      PRIVATE Qt6::Test Qt6::Core Qt6::DBus Qt6::Gui plasmazones_core
                               PhosphorAnimation::PhosphorAnimation)
 add_test(NAME test_settings_registry_contract COMMAND test_settings_registry_contract)
 

--- a/tests/unit/config/settings/test_settings_core.cpp
+++ b/tests/unit/config/settings/test_settings_core.cpp
@@ -380,6 +380,38 @@ private Q_SLOTS:
     }
 
     /**
+     * The scrolling drop indicator's two colours are the same theme-fallback
+     * pair as the zone quartet, so they owe the same four guarantees: the raw
+     * accessor owns the stored sentinel, the resolved getter never serves an
+     * invalid colour, the QColor setter pins through the raw key, and an
+     * INVALID QColor un-pins rather than storing opaque black.
+     */
+    void testDropIndicatorColorsResolveAndPin()
+    {
+        IsolatedConfigGuard guard;
+
+        Settings settings;
+        QCOMPARE(settings.scrollingDropIndicatorColorRaw(), QString());
+        QCOMPARE(settings.scrollingDropIndicatorBorderColorRaw(), QString());
+        // Following the palette: concrete and, for the border's sake, OPAQUE.
+        QVERIFY(settings.scrollingDropIndicatorColor().isValid());
+        QCOMPARE(settings.scrollingDropIndicatorBorderColor().alpha(), 255);
+
+        settings.setScrollingDropIndicatorColor(QColor(QStringLiteral("#80112233")));
+        QCOMPARE(settings.scrollingDropIndicatorColorRaw(), QStringLiteral("#80112233"));
+        QCOMPARE(settings.scrollingDropIndicatorColor(), QColor(QStringLiteral("#80112233")));
+
+        settings.setScrollingDropIndicatorColor(QColor());
+        QCOMPARE(settings.scrollingDropIndicatorColorRaw(), QString());
+        QVERIFY(settings.scrollingDropIndicatorColor().isValid());
+
+        // A hand-edited config can hold junk the D-Bus boundary would refuse;
+        // it must resolve like the sentinel rather than paint black.
+        settings.setScrollingDropIndicatorBorderColorRaw(QStringLiteral("not-a-colour"));
+        QVERIFY(settings.scrollingDropIndicatorBorderColor().isValid());
+    }
+
+    /**
      * reset() must return the four colour keys to the empty theme-fallback
      * sentinel (the schema default), after which the resolved getters follow
      * the palette again.

--- a/tests/unit/config/settings/test_settings_core.cpp
+++ b/tests/unit/config/settings/test_settings_core.cpp
@@ -395,16 +395,22 @@ private Q_SLOTS:
         Settings settings;
         QCOMPARE(settings.scrollingDropIndicatorColorRaw(), QString());
         QCOMPARE(settings.scrollingDropIndicatorBorderColorRaw(), QString());
-        // Following the palette: the resolved value IS the live Highlight, and
-        // opaque for the border's sake. Read from qGuiApp rather than compared
-        // against a literal — a hardcoded colour here would be a second source
-        // of truth for the resolution rule, which
-        // test_settings_system_palette_tracking.cpp already owns.
-        const QColor livePaletteHighlight = qGuiApp->palette().color(QPalette::Active, QPalette::Highlight);
-        QCOMPARE(settings.scrollingDropIndicatorColor(), livePaletteHighlight);
-        QCOMPARE(settings.scrollingDropIndicatorBorderColor(), livePaletteHighlight);
-        QCOMPARE(settings.scrollingDropIndicatorColor().alpha(), 255);
-        QCOMPARE(settings.scrollingDropIndicatorBorderColor().alpha(), 255);
+        // Following the palette: the resolved value is the live Highlight
+        // forced opaque. Read from qGuiApp rather than compared against a
+        // literal — a hardcoded colour here would be a second source of truth
+        // for the resolution rule. The alpha is forced on the EXPECTATION too,
+        // because this file does not control the process palette: a platform
+        // theme shipping a translucent Highlight is exactly what the forcing
+        // exists for, so comparing against the raw palette colour would fail
+        // this test in the one environment the production code handles. The
+        // forcing itself is pinned against a deliberately translucent palette
+        // by dropIndicatorFollowsPaletteOpaquely in
+        // test_settings_system_palette_tracking.cpp, which owns palette state.
+        QColor expected = qGuiApp->palette().color(QPalette::Active, QPalette::Highlight);
+        expected.setAlpha(255);
+        QCOMPARE(settings.scrollingDropIndicatorColor(), expected);
+        QCOMPARE(settings.scrollingDropIndicatorBorderColor(), expected);
+        const QColor livePaletteHighlight = expected;
 
         settings.setScrollingDropIndicatorColor(QColor(QStringLiteral("#80112233")));
         QCOMPARE(settings.scrollingDropIndicatorColorRaw(), QStringLiteral("#80112233"));

--- a/tests/unit/config/settings/test_settings_core.cpp
+++ b/tests/unit/config/settings/test_settings_core.cpp
@@ -22,6 +22,8 @@
 #include <QSet>
 #include <QTest>
 #include <QColor>
+#include <QGuiApplication>
+#include <QPalette>
 #include <QSignalSpy>
 #include <QJsonDocument>
 #include <QJsonObject>
@@ -393,8 +395,15 @@ private Q_SLOTS:
         Settings settings;
         QCOMPARE(settings.scrollingDropIndicatorColorRaw(), QString());
         QCOMPARE(settings.scrollingDropIndicatorBorderColorRaw(), QString());
-        // Following the palette: concrete and, for the border's sake, OPAQUE.
-        QVERIFY(settings.scrollingDropIndicatorColor().isValid());
+        // Following the palette: the resolved value IS the live Highlight, and
+        // opaque for the border's sake. Read from qGuiApp rather than compared
+        // against a literal — a hardcoded colour here would be a second source
+        // of truth for the resolution rule, which
+        // test_settings_system_palette_tracking.cpp already owns.
+        const QColor livePaletteHighlight = qGuiApp->palette().color(QPalette::Active, QPalette::Highlight);
+        QCOMPARE(settings.scrollingDropIndicatorColor(), livePaletteHighlight);
+        QCOMPARE(settings.scrollingDropIndicatorBorderColor(), livePaletteHighlight);
+        QCOMPARE(settings.scrollingDropIndicatorColor().alpha(), 255);
         QCOMPARE(settings.scrollingDropIndicatorBorderColor().alpha(), 255);
 
         settings.setScrollingDropIndicatorColor(QColor(QStringLiteral("#80112233")));
@@ -403,31 +412,67 @@ private Q_SLOTS:
 
         settings.setScrollingDropIndicatorColor(QColor());
         QCOMPARE(settings.scrollingDropIndicatorColorRaw(), QString());
-        QVERIFY(settings.scrollingDropIndicatorColor().isValid());
+        QCOMPARE(settings.scrollingDropIndicatorColor(), livePaletteHighlight);
 
-        // A hand-edited config can hold junk the D-Bus boundary would refuse;
-        // it must resolve like the sentinel rather than paint black.
+        // The border's own pin and un-pin, not just the fill's: the two go
+        // through separate macro invocations, so a setter wired to the wrong
+        // raw key would survive a fill-only check.
+        settings.setScrollingDropIndicatorBorderColor(QColor(QStringLiteral("#ff445566")));
+        QCOMPARE(settings.scrollingDropIndicatorBorderColorRaw(), QStringLiteral("#ff445566"));
+        QCOMPARE(settings.scrollingDropIndicatorColorRaw(), QString());
+        settings.setScrollingDropIndicatorBorderColor(QColor());
+        QCOMPARE(settings.scrollingDropIndicatorBorderColorRaw(), QString());
+        QCOMPARE(settings.scrollingDropIndicatorBorderColor(), livePaletteHighlight);
+
+        // Junk in a hand-edited config. The load-bearing assertion is that the
+        // SCHEMA VALIDATOR snapped it to the sentinel on the way in: asserting
+        // only that the getter still returns something valid proves nothing,
+        // because resolveThemeColor's unparseable branch would answer the same
+        // way even with the validator gone.
         settings.setScrollingDropIndicatorBorderColorRaw(QStringLiteral("not-a-colour"));
-        QVERIFY(settings.scrollingDropIndicatorBorderColor().isValid());
+        QCOMPARE(settings.scrollingDropIndicatorBorderColorRaw(), QString());
+        QCOMPARE(settings.scrollingDropIndicatorBorderColor(), livePaletteHighlight);
     }
 
     /**
-     * reset() must return the four colour keys to the empty theme-fallback
-     * sentinel (the schema default), after which the resolved getters follow
-     * the palette again.
+     * The no-palette fallback colour is spelled twice — ConfigDefaults for the
+     * config layer, isettings_detail for the interface's own default bodies —
+     * because the dependency runs config→core and neither is constexpr, so no
+     * static_assert can pin them. This is that pin, and both spellings' doc
+     * comments name it.
      */
-    void testReset_returnsZoneColorsToSentinel()
+    void dropIndicatorFallbackMatchesInterfaceDefault()
+    {
+        QCOMPARE(ConfigDefaults::scrollingDropIndicatorFallbackColor(),
+                 isettings_detail::opaqueDropIndicatorFallback());
+        QCOMPARE(ConfigDefaults::scrollingDropIndicatorFallbackColor().alpha(), 255);
+    }
+
+    /**
+     * reset() must return the theme-fallback colour keys to the empty sentinel
+     * (the schema default), after which the resolved getters follow the palette
+     * again. The drop indicator's pair is included because reset() only reaches
+     * a group listed in managedGroupNames(), and a group left off that list
+     * fails exactly here and nowhere else.
+     */
+    void testReset_returnsThemeFallbackColorsToSentinel()
     {
         IsolatedConfigGuard guard;
 
         Settings settings;
         settings.setHighlightColorRaw(QStringLiteral("#80112233"));
         settings.setLabelFontColorRaw(QStringLiteral("#ffddeeff"));
+        settings.setScrollingDropIndicatorColorRaw(QStringLiteral("#ff778899"));
+        settings.setScrollingDropIndicatorBorderColorRaw(QStringLiteral("#ffaabbcc"));
         settings.reset();
         QCOMPARE(settings.highlightColorRaw(), QString());
         QCOMPARE(settings.labelFontColorRaw(), QString());
+        QCOMPARE(settings.scrollingDropIndicatorColorRaw(), QString());
+        QCOMPARE(settings.scrollingDropIndicatorBorderColorRaw(), QString());
         QVERIFY(settings.highlightColor().isValid());
         QVERIFY(settings.labelFontColor().isValid());
+        QVERIFY(settings.scrollingDropIndicatorColor().isValid());
+        QVERIFY(settings.scrollingDropIndicatorBorderColor().isValid());
     }
 
     /**

--- a/tests/unit/config/settings/test_settings_system_palette_tracking.cpp
+++ b/tests/unit/config/settings/test_settings_system_palette_tracking.cpp
@@ -257,6 +257,40 @@ private Q_SLOTS:
         QCOMPARE(aggregateSpy.count(), 0);
     }
 
+    /**
+     * The drop indicator resolves QPalette::Highlight forced OPAQUE, unlike the
+     * zone highlight which carries ZoneDefaults::HighlightAlpha. A platform
+     * theme is free to ship a translucent Highlight, and the indicator's border
+     * has no opacity slider to replace the alpha, so an unset border would
+     * quietly draw half transparent. This is the only place that forcing is
+     * pinned, because it needs a palette the test controls.
+     */
+    void dropIndicatorFollowsPaletteOpaquely()
+    {
+        TestHelpers::IsolatedConfigGuard guard;
+        const QPalette saved = qGuiApp->palette();
+
+        QPalette translucent = saved;
+        translucent.setColor(QPalette::Active, QPalette::Highlight, QColor(0x33, 0x66, 0x99, 0x40));
+        qGuiApp->setPalette(translucent);
+
+        Settings settings;
+        QCOMPARE(settings.scrollingDropIndicatorColorRaw(), QString());
+        QCOMPARE(settings.scrollingDropIndicatorColor(), QColor(0x33, 0x66, 0x99));
+        QCOMPARE(settings.scrollingDropIndicatorColor().alpha(), 255);
+        QCOMPARE(settings.scrollingDropIndicatorBorderColor(), QColor(0x33, 0x66, 0x99));
+        QCOMPARE(settings.scrollingDropIndicatorBorderColor().alpha(), 255);
+        // The zone highlight shares the role and deliberately does NOT force
+        // opacity, so it still carries ZoneDefaults' alpha. Asserting the
+        // contrast here is what stops a future "consistency" edit from
+        // forcing both or neither.
+        QVERIFY(settings.highlightColor().alpha() != 255);
+
+        // Restore so the process-global palette this file threads through its
+        // slots is left exactly as found.
+        qGuiApp->setPalette(saved);
+    }
+
     void everyRawSetterWritesItsOwnKey()
     {
         TestHelpers::IsolatedConfigGuard guard;

--- a/tests/unit/config/settings/test_settings_system_palette_tracking.cpp
+++ b/tests/unit/config/settings/test_settings_system_palette_tracking.cpp
@@ -15,10 +15,12 @@
 using namespace PlasmaZones;
 
 /**
- * @brief Palette-following zone colours must TRACK palette changes at runtime.
+ * @brief Palette-following colours must TRACK palette changes at runtime.
  *
- * The four zone colours are theme-fallback keys: an EMPTY stored string means
- * "follow the system palette", resolved in the getters. A palette change must
+ * The four zone colours, plus the scrolling drop indicator's fill and border
+ * which share the machinery, are theme-fallback keys: an EMPTY stored string
+ * means "follow the system palette", resolved in the getters. A palette change
+ * must
  * re-announce the following colours (or a running daemon/settings app keeps
  * serving the snapshot its bindings read last), must never dirty any config
  * key (nothing is written), and must stay silent for a colour the user pinned
@@ -41,6 +43,9 @@ private Q_SLOTS:
         QSignalSpy inactiveSpy(&settings, &Settings::inactiveColorChanged);
         QSignalSpy borderSpy(&settings, &Settings::borderColorChanged);
         QSignalSpy labelFontSpy(&settings, &Settings::labelFontColorChanged);
+        // The scrolling drop indicator's two colours ride the same fan-out.
+        QSignalSpy dropSpy(&settings, &Settings::scrollingDropIndicatorColorChanged);
+        QSignalSpy dropBorderSpy(&settings, &Settings::scrollingDropIndicatorBorderColorChanged);
         QSignalSpy aggregateSpy(&settings, &Settings::settingsChanged);
 
         QPalette pal = qGuiApp->palette();
@@ -71,6 +76,12 @@ private Q_SLOTS:
         QCOMPARE(settings.borderColor(), expectedBorder);
         QCOMPARE(settings.labelFontColor(), QColor(0xDE, 0xAD, 0xBE));
 
+        // The drop indicator takes QPalette::Highlight OPAQUE — no
+        // ZoneDefaults alpha — because its fill alpha comes from the opacity
+        // slider and its border has no slider at all.
+        QCOMPARE(settings.scrollingDropIndicatorColor(), QColor(0x12, 0xAB, 0x34));
+        QCOMPARE(settings.scrollingDropIndicatorBorderColor(), QColor(0x12, 0xAB, 0x34));
+
         // The stored sentinels are untouched: resolution happens in the
         // getters, the palette event writes nothing.
         QCOMPARE(settings.highlightColorRaw(), QString());
@@ -84,6 +95,8 @@ private Q_SLOTS:
         QCOMPARE(inactiveSpy.count(), 1);
         QCOMPARE(borderSpy.count(), 1);
         QCOMPARE(labelFontSpy.count(), 1);
+        QCOMPARE(dropSpy.count(), 1);
+        QCOMPARE(dropBorderSpy.count(), 1);
         QCOMPARE(aggregateSpy.count(), 1);
     }
 
@@ -128,6 +141,9 @@ private Q_SLOTS:
         QVERIFY(!settings.isKeyModified(ConfigDefaults::snappingZonesColorsGroup(), ConfigDefaults::inactiveKey()));
         QVERIFY(!settings.isKeyModified(ConfigDefaults::snappingZonesColorsGroup(), ConfigDefaults::borderKey()));
         QVERIFY(!settings.isKeyModified(ConfigDefaults::snappingZonesLabelsGroup(), ConfigDefaults::fontColorKey()));
+        QVERIFY(!settings.isKeyModified(ConfigDefaults::scrollingDropIndicatorGroup(), ConfigDefaults::colorKey()));
+        QVERIFY(
+            !settings.isKeyModified(ConfigDefaults::scrollingDropIndicatorGroup(), ConfigDefaults::borderColorKey()));
     }
 
     void pinnedColorsIgnorePaletteChange()
@@ -136,10 +152,15 @@ private Q_SLOTS:
         Settings settings;
         settings.setHighlightColor(QColor(0xAA, 0x00, 0xAA, 0x80));
         QCOMPARE(settings.highlightColorRaw(), QStringLiteral("#80aa00aa"));
+        // The drop indicator's pair resolves from the same palette role, so
+        // they have to be pinned too for "no follower moved" to hold.
+        settings.setScrollingDropIndicatorColor(QColor(0x11, 0x22, 0x33));
+        settings.setScrollingDropIndicatorBorderColor(QColor(0x44, 0x55, 0x66));
 
         QSignalSpy highlightSpy(&settings, &Settings::highlightColorChanged);
+        QSignalSpy dropSpy(&settings, &Settings::scrollingDropIndicatorColorChanged);
         QSignalSpy aggregateSpy(&settings, &Settings::settingsChanged);
-        // Only the Highlight ROLE moves: the pinned highlight must stay
+        // Only the Highlight ROLE moves: the pinned colours must stay
         // silent, and since no FOLLOWING colour's resolved value moved
         // either, the aggregate stays silent too (the fan-out is
         // change-gated, not merely follows-gated).
@@ -150,8 +171,10 @@ private Q_SLOTS:
         // Deliver any pending events, then confirm the pin held.
         QTest::qWait(50);
         QCOMPARE(highlightSpy.count(), 0);
+        QCOMPARE(dropSpy.count(), 0);
         QCOMPARE(aggregateSpy.count(), 0);
         QCOMPARE(settings.highlightColor(), QColor(0xAA, 0x00, 0xAA, 0x80));
+        QCOMPARE(settings.scrollingDropIndicatorColor(), QColor(0x11, 0x22, 0x33));
     }
 
     void unrelatedPaletteRoleChangeStaysSilent()

--- a/tests/unit/config/settings/test_settings_system_palette_tracking.cpp
+++ b/tests/unit/config/settings/test_settings_system_palette_tracking.cpp
@@ -20,8 +20,7 @@ using namespace PlasmaZones;
  * The four zone colours, plus the scrolling drop indicator's fill and border
  * which share the machinery, are theme-fallback keys: an EMPTY stored string
  * means "follow the system palette", resolved in the getters. A palette change
- * must
- * re-announce the following colours (or a running daemon/settings app keeps
+ * must re-announce the following colours (or a running daemon/settings app keeps
  * serving the snapshot its bindings read last), must never dirty any config
  * key (nothing is written), and must stay silent for a colour the user pinned
  * to a concrete value.
@@ -135,8 +134,8 @@ private Q_SLOTS:
         QVERIFY(!settings.isAnnouncingPaletteChange());
 
         // The palette event is a NOTIFY fan-out over UNCHANGED stored
-        // sentinels — none of the four zone-color keys may count as modified,
-        // or the settings app shows a phantom unsaved-changes footer.
+        // sentinels — none of the six theme-fallback keys may count as
+        // modified, or the settings app shows a phantom unsaved-changes footer.
         QVERIFY(!settings.isKeyModified(ConfigDefaults::snappingZonesColorsGroup(), ConfigDefaults::highlightKey()));
         QVERIFY(!settings.isKeyModified(ConfigDefaults::snappingZonesColorsGroup(), ConfigDefaults::inactiveKey()));
         QVERIFY(!settings.isKeyModified(ConfigDefaults::snappingZonesColorsGroup(), ConfigDefaults::borderKey()));
@@ -144,11 +143,26 @@ private Q_SLOTS:
         QVERIFY(!settings.isKeyModified(ConfigDefaults::scrollingDropIndicatorGroup(), ConfigDefaults::colorKey()));
         QVERIFY(
             !settings.isKeyModified(ConfigDefaults::scrollingDropIndicatorGroup(), ConfigDefaults::borderColorKey()));
+
+        // Positive control for the six assertions above. isKeyModified compares
+        // the store against the baseline, and BOTH sides are a default-
+        // constructed QVariant for a group/key pair that is not schema-
+        // declared — so a renamed accessor or a copy-pasted wrong key would
+        // make every one of them pass forever. Pinning a colour here proves the
+        // pair this test names is live. It runs AFTER the negatives on purpose:
+        // pinning before the palette event would stop the colour following,
+        // and the QTRY_VERIFY above would spin to timeout.
+        settings.setScrollingDropIndicatorColor(QColor(0x21, 0x43, 0x65));
+        QVERIFY(settings.isKeyModified(ConfigDefaults::scrollingDropIndicatorGroup(), ConfigDefaults::colorKey()));
     }
 
     void pinnedColorsIgnorePaletteChange()
     {
         TestHelpers::IsolatedConfigGuard guard;
+        // Captured BEFORE the Settings exists: this is the colour its
+        // m_paletteBaseline is seeded from, and phase two below returns the
+        // palette to it deliberately.
+        const QColor constructionHighlight = qGuiApp->palette().color(QPalette::Active, QPalette::Highlight);
         Settings settings;
         settings.setHighlightColor(QColor(0xAA, 0x00, 0xAA, 0x80));
         QCOMPARE(settings.highlightColorRaw(), QStringLiteral("#80aa00aa"));
@@ -159,6 +173,7 @@ private Q_SLOTS:
 
         QSignalSpy highlightSpy(&settings, &Settings::highlightColorChanged);
         QSignalSpy dropSpy(&settings, &Settings::scrollingDropIndicatorColorChanged);
+        QSignalSpy dropBorderSpy(&settings, &Settings::scrollingDropIndicatorBorderColorChanged);
         QSignalSpy aggregateSpy(&settings, &Settings::settingsChanged);
         // Only the Highlight ROLE moves: the pinned colours must stay
         // silent, and since no FOLLOWING colour's resolved value moved
@@ -172,9 +187,46 @@ private Q_SLOTS:
         QTest::qWait(50);
         QCOMPARE(highlightSpy.count(), 0);
         QCOMPARE(dropSpy.count(), 0);
+        QCOMPARE(dropBorderSpy.count(), 0);
         QCOMPARE(aggregateSpy.count(), 0);
         QCOMPARE(settings.highlightColor(), QColor(0xAA, 0x00, 0xAA, 0x80));
         QCOMPARE(settings.scrollingDropIndicatorColor(), QColor(0x11, 0x22, 0x33));
+        QCOMPARE(settings.scrollingDropIndicatorBorderColor(), QColor(0x44, 0x55, 0x66));
+
+        // Second phase: un-pin, then move the palette BACK to the value this
+        // Settings was constructed against. That specific value is what gives
+        // the phase teeth. The fan-out refreshes m_paletteBaseline
+        // unconditionally, including when every colour is pinned and nothing is
+        // announced; make that refresh conditional on something having moved
+        // and the baseline stays frozen at the construction colour, so an
+        // un-pinned colour returning to that colour compares equal and is
+        // silently never re-announced. Moving to a THIRD, unused colour would
+        // pass either way and prove nothing.
+        //
+        // Two other mechanics this phase depends on:
+        //  - the un-pin itself emits, so the spies are cleared after it rather
+        //    than before, or the counts below read as running totals;
+        //  - QGuiApplication::setPalette delivers nothing for an EQUAL palette,
+        //    and Highlight holds 0x556677 at this point, so returning to the
+        //    construction colour is a real change and does deliver.
+        settings.setScrollingDropIndicatorColor(QColor());
+        settings.setScrollingDropIndicatorBorderColor(QColor());
+        QCOMPARE(settings.scrollingDropIndicatorColorRaw(), QString());
+        QCOMPARE(settings.scrollingDropIndicatorBorderColorRaw(), QString());
+        dropSpy.clear();
+        dropBorderSpy.clear();
+        aggregateSpy.clear();
+
+        QVERIFY(constructionHighlight != QColor(0x55, 0x66, 0x77));
+        QPalette restored = qGuiApp->palette();
+        restored.setColor(QPalette::Active, QPalette::Highlight, constructionHighlight);
+        qGuiApp->setPalette(restored);
+
+        QTRY_COMPARE(dropSpy.count(), 1);
+        QCOMPARE(dropBorderSpy.count(), 1);
+        QCOMPARE(aggregateSpy.count(), 1);
+        QCOMPARE(settings.scrollingDropIndicatorColor(), constructionHighlight);
+        QCOMPARE(settings.scrollingDropIndicatorBorderColor(), constructionHighlight);
     }
 
     void unrelatedPaletteRoleChangeStaysSilent()
@@ -205,15 +257,23 @@ private Q_SLOTS:
         QCOMPARE(aggregateSpy.count(), 0);
     }
 
-    void allFourRawSettersWriteTheirOwnKey()
+    void everyRawSetterWritesItsOwnKey()
     {
         TestHelpers::IsolatedConfigGuard guard;
         Settings settings;
 
-        // Distinct hex per key, then per-key read-back with the other three
+        // Distinct hex per key, then per-key read-back with the others
         // asserted untouched at each step: a copy-paste key swap inside one
         // of the P_STORE macro invocations would otherwise pass the whole
         // suite (the palette tests only ever assert these raws are EMPTY).
+        //
+        // This is the ONLY place the drop indicator's pair is protected from
+        // that swap. The registry-contract scan cannot do it: its QString
+        // perturbation appends "zz", the schema's canonicalThemeFallbackColor
+        // validator rejects the result as unparseable and stores the empty
+        // sentinel, so both raws read back empty and a transposition compares
+        // equal. Here the values are valid colours, which survive the
+        // validator, so a swap actually shows up.
         settings.setHighlightColorRaw(QStringLiteral("#ff111111"));
         QCOMPARE(settings.highlightColorRaw(), QStringLiteral("#ff111111"));
         QCOMPARE(settings.inactiveColorRaw(), QString());
@@ -232,6 +292,27 @@ private Q_SLOTS:
         QCOMPARE(settings.labelFontColorRaw(), QStringLiteral("#ff444444"));
         QCOMPARE(settings.borderColorRaw(), QStringLiteral("#ff333333"));
         QCOMPARE(settings.highlightColorRaw(), QStringLiteral("#ff111111"));
+
+        // The drop indicator's pair shares the macro and the isolation
+        // contract. Their two NOTIFYs are spied here as well: they are what
+        // the settings card's storedColor bindings ride, so a misdeclared
+        // NOTIFY freezes both swatches with the rest of the suite still green.
+        QSignalSpy fillRawSpy(&settings, &Settings::scrollingDropIndicatorColorRawChanged);
+        QSignalSpy borderRawSpy(&settings, &Settings::scrollingDropIndicatorBorderColorRawChanged);
+
+        settings.setScrollingDropIndicatorColorRaw(QStringLiteral("#ff555555"));
+        QCOMPARE(settings.scrollingDropIndicatorColorRaw(), QStringLiteral("#ff555555"));
+        QCOMPARE(settings.scrollingDropIndicatorBorderColorRaw(), QString());
+        QCOMPARE(settings.labelFontColorRaw(), QStringLiteral("#ff444444"));
+        QCOMPARE(fillRawSpy.count(), 1);
+        QCOMPARE(borderRawSpy.count(), 0);
+
+        settings.setScrollingDropIndicatorBorderColorRaw(QStringLiteral("#ff666666"));
+        QCOMPARE(settings.scrollingDropIndicatorBorderColorRaw(), QStringLiteral("#ff666666"));
+        QCOMPARE(settings.scrollingDropIndicatorColorRaw(), QStringLiteral("#ff555555"));
+        QCOMPARE(settings.highlightColorRaw(), QStringLiteral("#ff111111"));
+        QCOMPARE(fillRawSpy.count(), 1);
+        QCOMPARE(borderRawSpy.count(), 1);
     }
 
     void resetRawToSentinelResumesFollowing()

--- a/tests/unit/dbus/test_settings_registry_contract.cpp
+++ b/tests/unit/dbus/test_settings_registry_contract.cpp
@@ -366,13 +366,24 @@ private Q_SLOTS:
                 perturbed = QVariant(original.toString() + QStringLiteral("zz"));
                 break;
             case QMetaType::QColor:
-                // A colour no default resolves to, so a transposition between
-                // the drop indicator's fill and border cannot hide behind the
-                // one palette role they share. Pinning it is the point: the
-                // restore below writes the RESOLVED colour back rather than the
-                // follow-the-theme sentinel, which is harmless here because the
-                // config is per-test and nothing after this reads the sentinel.
-                perturbed = QVariant::fromValue(QColor(0x12, 0x34, 0x56));
+                // A colour no default resolves to, with a non-opaque alpha so
+                // an alpha-dropping comparison (QColor::name() omits it, the
+                // bus carries #AARRGGBB) fails loudly here.
+                //
+                // What this arm does NOT establish: the restore below writes
+                // the RESOLVED colour back through the QColor setter, which
+                // PINS the raw key. Property iteration is metaobject
+                // declaration order and both QColor properties are declared
+                // before both Raw ones, so by the time the loop reaches
+                // scrollingDropIndicatorColorRaw its "original" is that pin,
+                // not the sentinel — and the QString perturbation appends "zz",
+                // which the schema validator rejects back to empty. Both raws
+                // therefore compare empty-to-empty and a transposition between
+                // them is invisible HERE. That swap is caught instead by
+                // everyRawSetterWritesItsOwnKey in
+                // test_settings_system_palette_tracking.cpp, which writes valid
+                // colours the validator preserves.
+                perturbed = QVariant::fromValue(QColor(0x12, 0x34, 0x56, 0x80));
                 break;
             default:
                 break;

--- a/tests/unit/dbus/test_settings_registry_contract.cpp
+++ b/tests/unit/dbus/test_settings_registry_contract.cpp
@@ -35,6 +35,7 @@
  */
 
 #include <QTest>
+#include <QColor>
 #include <QDBusVariant>
 #include <QDir>
 #include <QDirIterator>
@@ -364,6 +365,15 @@ private Q_SLOTS:
             case QMetaType::QString:
                 perturbed = QVariant(original.toString() + QStringLiteral("zz"));
                 break;
+            case QMetaType::QColor:
+                // A colour no default resolves to, so a transposition between
+                // the drop indicator's fill and border cannot hide behind the
+                // one palette role they share. Pinning it is the point: the
+                // restore below writes the RESOLVED colour back rather than the
+                // follow-the-theme sentinel, which is harmless here because the
+                // config is per-test and nothing after this reads the sentinel.
+                perturbed = QVariant::fromValue(QColor(0x12, 0x34, 0x56));
+                break;
             default:
                 break;
             }
@@ -375,7 +385,13 @@ private Q_SLOTS:
             }
             const QVariant direct = prop.read(m_settings);
             const QVariant perturbedViaBus = m_adaptor->getSetting(name).variant();
-            if (direct.isValid() && perturbedViaBus != direct) {
+            // A colour key crosses the bus as its #AARRGGBB spelling, so the
+            // comparison is between COLOURS, not between a colour and a string
+            // (QColor's own toString drops the alpha and would never match).
+            const bool agrees = direct.metaType().id() == QMetaType::QColor
+                ? QColor(perturbedViaBus.toString()) == direct.value<QColor>()
+                : perturbedViaBus == direct;
+            if (direct.isValid() && !agrees) {
                 transposed.append(
                     QStringLiteral("%1 (bus=%2 property=%3)").arg(name, perturbedViaBus.toString(), direct.toString()));
             }


### PR DESCRIPTION
The scrolling drop indicator's fill and border colours were theme-fallback strings whose empty sentinel travelled all the way into the overlay's QML, where `ScrollDropIndicatorContent` resolved it against `Kirigami.Theme.highlightColor`. The settings card spelled that same fallback a second time for its swatch preview, so preview and paint could drift apart with nothing tying them together.

They now take the zone quartet's split, the pattern the snapping overlay already uses.

## What changed

- **Resolved + Raw pair.** The stored string lives on `scrollingDropIndicatorColorRaw` / `scrollingDropIndicatorBorderColorRaw`; the `ISettings` getters return resolved `QColor`s. The sentinel never leaves the config layer, so every consumer paints a concrete colour. The settings card previews the resolved getter instead of resolving a second time.
- **`SystemColorRole::DropIndicator`** = `QPalette::Highlight` at **full alpha**, shared by both colours. The fill's alpha is replaced by the opacity slider downstream and the border has no slider at all, so the quartet's `HighlightAlpha` would have shown up there as an unset border quietly drawing half transparent.
- **Palette fan-out.** Both keys join `eventFilter`'s change-gated announcement (baseline array 4 → 6), so a theme switch re-announces them without writing anything or dirtying the page.
- **D-Bus.** The plain keys move to `REGISTER_COLOR_SETTING` (resolved hex on the wire) with `Raw` companions via `REGISTER_RAW_THEME_COLOR`. Sorted key order keeps a `QVariantMap` round-trip lossless, as it does for the zone colours. Both macros are copied into the scrolling registry TU per its keep-the-forms-in-sync rule, with the accent token spelled inline because `kAccentToken` is the core TU's file-local constant and a second definition would collide in a unity batch.
- **Overlay.** The daemon pushes resolved hex; the content item's colour properties are `color`, not `string`, and it carries no fallback rule of its own.

The on-disk group and keys are unchanged, so there is no migration and nothing user-visible moves. No CHANGELOG entry for the same reason — the existing drop-indicator entry already describes the behaviour.

## Testing

Full build clean (no warnings), `ctest` 358/358.

Two existing tests failed honestly against the new behaviour and were updated rather than worked around:

- `pinnedColorsIgnorePaletteChange` needed the two new followers pinned for "no follower moved" to hold.
- The registry-contract scan needed a `QColor` arm: a colour crosses the bus as `#AARRGGBB` while `QColor::toString()` drops the alpha.

Added coverage for the resolve / pin / un-pin / junk-input contract and for both colours in the palette fan-out.

## Not in scope

The tab indicator's three colours keep resolving in QML, single-sourced in `ZoneColorDefaults`. Their fallbacks are Kirigami-semantic (`negativeTextColor` comes from `KColorScheme`'s `ForegroundNegative` and has no `QPalette` role) and the inactive one is style-dependent, where the style painted is the effective one after per-screen rule layering. Folding `active` alone, or `active` + `urgent` via a `kdeglobals` read, stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)