### PR TITLE
perf: cull off-viewport parked columns, shrink backdrop captures, reclaim daemon GPU memory at idle

### DIFF
--- a/kwin-effect/plasmazoneseffect/daemon_settings.cpp
+++ b/kwin-effect/plasmazoneseffect/daemon_settings.cpp
@@ -800,6 +800,7 @@ void PlasmaZonesEffect::loadCachedSettings()
             qCWarning(lcEffect) << "Decoration pack cache cleared without a current GL context (compositor teardown?)";
         }
         m_compiledPacks.clear();
+        m_packBufferScaleCache.clear(); // metadata cache rides the compile cache's lifetime
         m_anyCompiledPackReadsCursor = false; // re-derived as packs recompile
         // Recompiling the packs invalidates every CACHED FOLD, and updateAllDecorations
         // is not a sufficient net for that: it skips windows with a live shader

--- a/kwin-effect/plasmazoneseffect/lifecycle_wiring.cpp
+++ b/kwin-effect/plasmazoneseffect/lifecycle_wiring.cpp
@@ -274,6 +274,7 @@ void PlasmaZonesEffect::initRenderingAndRegistries()
         // above uses the same helper.
         ensureGlContextCurrent();
         m_compiledPacks.clear();
+        m_packBufferScaleCache.clear(); // metadata cache rides the compile cache's lifetime
         m_anyCompiledPackReadsCursor = false; // re-derived as packs recompile
         m_opacityTintFallbackWarned = false; // re-arm the capture-fallback warning with the fresh compiles
         m_surfaceMultipass.clear();

--- a/kwin-effect/plasmazoneseffect/paint_pipeline.cpp
+++ b/kwin-effect/plasmazoneseffect/paint_pipeline.cpp
@@ -19,6 +19,7 @@
 #include "window_query.h"
 
 #include <PhosphorAnimation/AnimationLimits.h>
+#include <PhosphorSurface/SurfaceShaderEffect.h>
 
 #include <core/output.h>
 #include <core/rendertarget.h>
@@ -158,6 +159,15 @@ void PlasmaZonesEffect::prePaintScreen(KWin::ScreenPrePaintData& data)
                 continue;
             }
             if (scrollManagedOutputFor(sw) == data.screen) {
+                // A parked-offscreen column cannot anchor: paintWindow culls it
+                // (scrollParkedOffscreen), so an anchor picked here would never
+                // paint and the injection would never run — the same
+                // anchor-never-painted case the filter note above calls out,
+                // except deterministic rather than an occlusion accident. Skip
+                // it and let a visible strip member win.
+                if (scrollParkedOffscreen(sw, getWindowId(sw))) {
+                    continue;
+                }
                 m_scrollTabPaintAnchor = sw; // topmost strip member wins
             } else if (sw->screen() == data.screen && isScrollTabIndicatorSurface(sw)) {
                 m_scrollTabDeferred.insert(sw);
@@ -612,6 +622,44 @@ void PlasmaZonesEffect::postPaintScreen()
             if (!sw || getWindowId(sw) != it.key() || sw->isDeleted() || !sw->isOnCurrentDesktop()) {
                 continue;
             }
+            // The driver third of scrollParkedOffscreen's contract: stop
+            // driving a column parked off the viewport. Without this the
+            // ~30fps backdrop pump below re-armed for every parked glass
+            // column forever (backdropDue takes the focus exemption, so
+            // m_animateFocusedOnly never saved it), and each repaint forced a
+            // full invisible fold. The next tile batch that scrolls the
+            // column back damages via the visual-pos change (tiling.cpp pairs
+            // every change with addRepaintFull), so waking needs no driver.
+            if (scrollParkedOffscreen(sw, it.key())) {
+                // Long-parked columns also surrender their GL targets — the
+                // composite pair, capture and backdrop are full-canvas RGBA8
+                // (~100+ MB per 4K window) held for pixels nobody can see.
+                // The threshold keeps neighbour-to-neighbour scrolling warm:
+                // a column that returns within it still has its capture, so
+                // waking is a refold, not a realloc + drawWindow re-entry.
+                // Past it, the state is erased whole (releaseSurfaceState
+                // guards the transition case and makes the GL context
+                // current) and the first paint back rebuilds from scratch —
+                // one cold fold, paid mid-scroll when every visible window
+                // is repainting anyway. The pinned clock, like every other
+                // consumer in this loop; the parked stamp is inside the
+                // state so the erase disposes of it with everything else.
+                constexpr qint64 kParkReapMs = 10000;
+                if (const auto sit = m_surfaceMultipass.find(it.key()); sit != m_surfaceMultipass.end()) {
+                    if (sit->second.parkedSinceMs < 0) {
+                        sit->second.parkedSinceMs = frameClockMs;
+                    } else if (frameClockMs - sit->second.parkedSinceMs >= kParkReapMs) {
+                        releaseSurfaceState(it.key(), sw);
+                    }
+                }
+                continue;
+            }
+            if (const auto sit = m_surfaceMultipass.find(it.key());
+                sit != m_surfaceMultipass.end() && sit->second.parkedSinceMs >= 0) {
+                // Back on (or near) the viewport before the reap fired:
+                // clear the stamp so a later park restarts the clock.
+                sit->second.parkedSinceMs = -1;
+            }
             // needsBackdrop chains are repainted for backdrop changes that
             // land no damage on the window itself, rate-limited to ~30fps
             // (the better-blur-dx model): between refolds the present blit
@@ -898,9 +946,7 @@ void PlasmaZonesEffect::prePaintWindow(KWin::RenderView* view, KWin::EffectWindo
 
     // A parked scrolling column is drawn far from its committed rect (the paint
     // path relocates it to its strip position), so KWin must not decide where
-    // it goes from that rect. Occlusion culling is forfeited for it, which
-    // costs nothing: the window is off the viewport by definition — that is
-    // why it parked.
+    // it goes from that rect.
     //
     // Gated on the SAME predicate paintWindow relocates under, not on map
     // membership alone. A window that floats or is dragged to another output
@@ -909,7 +955,18 @@ void PlasmaZonesEffect::prePaintWindow(KWin::RenderView* view, KWin::EffectWindo
     // every frame of the drag for a window nothing is moving. windowId is the
     // one derived above rather than a second getWindowId call, which is what
     // the note at the top of this function asks for.
-    if (w && !m_scrollVisualPos.isEmpty() && scrollManagedOutputFor(w) && m_scrollVisualPos.contains(windowId)) {
+    //
+    // ONLY while its visual rect actually touches the viewport. TRANSFORMED
+    // does not just relocate — it forces KWin to keep the window in the paint
+    // set, so an unconditional flag here kept every parked column (visual rect
+    // off every output, invisible by construction) painting at full decoration
+    // cost forever. Withholding the flag lets KWin's own culling skip it;
+    // paintWindow's matching cull and the repaint driver's skip are the other
+    // two thirds of the same predicate (see scrollParkedOffscreen). The view
+    // offset is part of the tested rect, so a column scrolling back toward the
+    // viewport re-earns the flag on the frame it starts to intersect.
+    if (w && !m_scrollVisualPos.isEmpty() && scrollManagedOutputFor(w) && m_scrollVisualPos.contains(windowId)
+        && !scrollParkedOffscreen(w, windowId)) {
         data.setTransformed();
     }
 
@@ -1013,6 +1070,21 @@ void PlasmaZonesEffect::paintWindow(const KWin::RenderTarget& renderTarget, cons
         // the permissive treatment every other null-screen branch in this
         // file applies.
         if (const KWin::LogicalOutput* managed = scrollManagedOutputFor(w); managed && managed != m_currentPassOutput) {
+            return;
+        }
+        // Off-viewport park cull, the paintWindow third of scrollParkedOffscreen's
+        // three-site contract (prePaintWindow withholds TRANSFORMED, the repaint
+        // driver stops driving). A parked column's visual rect touches no part of
+        // its output, so everything below — the backdrop capture, the decoration
+        // fold, the draw itself — is work on pixels nobody can see. Behind the
+        // same m_capturingSnapshot exemption as the foreign-output cull above,
+        // and for the same reason: a snapshot capture of a parked column (close
+        // snapshot, decoration capture) is legitimate offscreen work and builds
+        // its viewport from the window's own rect. getWindowId here rather than
+        // the shared derivation below, which sits after these early returns by
+        // design; the predicate's own cheap gates keep the common case at one
+        // empty-map probe.
+        if (w && scrollParkedOffscreen(w, getWindowId(w))) {
             return;
         }
     }
@@ -1143,8 +1215,16 @@ void PlasmaZonesEffect::paintWindow(const KWin::RenderTarget& renderTarget, cons
         // absent) and answered false for a frame after every registry reload
         // cleared the cache while a pre-reload backdropRect still claimed
         // validity.
-        const auto chainReadsBackdrop = [this](const WindowDecoration& deco, const QString& windowId) {
+        // 0.0 = no compiled pack reads the backdrop (skip the capture);
+        // 1.0 = some MAIN pass samples it sharp (full-density capture);
+        // otherwise the largest bufferScale among the buffer passes that link
+        // it — a blur pyramid reads the capture at bufferScale resolution
+        // through normalized uvs, so capturing past that density stores and
+        // re-blits texels the samplers stride over. Max, not min: a chain
+        // with two blur packs must satisfy the denser reader.
+        const auto chainBackdropScale = [this](const WindowDecoration& deco, const QString& windowId) -> qreal {
             std::optional<PhosphorSurfaceShaders::DecorationProfile> profile;
+            qreal scale = 0.0;
             for (const QString& packId : deco.chain) {
                 CompiledSurfacePack* pk = nullptr;
                 if (const auto cacheIt = m_compiledPacks.find(packId); cacheIt != m_compiledPacks.end()) {
@@ -1159,19 +1239,28 @@ void PlasmaZonesEffect::paintWindow(const KWin::RenderTarget& renderTarget, cons
                     continue;
                 }
                 if (linksBackdropUniforms(pk->uBackdropLoc, pk->uHasBackdropLoc, pk->uBackdropRectLoc)) {
-                    return true;
+                    return 1.0; // a sharp main-pass read caps every other answer
                 }
                 for (const CompiledSurfaceBufferPass& bp : pk->bufferPasses) {
                     if (linksBackdropUniforms(bp.uBackdropLoc, bp.uHasBackdropLoc, bp.uBackdropRectLoc)) {
-                        return true;
+                        // Same clamp ensureSurfaceTargets applies when sizing
+                        // the buffer targets themselves, so capture density
+                        // and sampler density agree by construction.
+                        const PhosphorSurfaceShaders::SurfaceShaderEffect eff = m_surfaceShaderRegistry.effect(packId);
+                        scale =
+                            qMax(scale,
+                                 qBound(PhosphorSurfaceShaders::SurfaceShaderEffect::kMinBufferScale, eff.bufferScale,
+                                        PhosphorSurfaceShaders::SurfaceShaderEffect::kMaxBufferScale));
+                        break; // one linked buffer pass answers for the pack
                     }
                 }
             }
-            return false;
+            return scale;
         };
+        qreal backdropScale = 0.0;
         if (backIt != m_windowDecorations.constEnd() && backIt->needsBackdrop
             && (backIt->shaderApplied || m_shaderManager.findTransition(w)) && !isWithheldThisFrame()
-            && chainReadsBackdrop(*backIt, backIt.key())) {
+            && (backdropScale = chainBackdropScale(*backIt, backIt.key())) > 0.0) {
             // While an animation is drawing the window somewhere other than
             // its resting rect, capture the backdrop where the quad actually
             // IS this frame, or the pane shows the wrong slice of the scene
@@ -1277,7 +1366,7 @@ void PlasmaZonesEffect::paintWindow(const KWin::RenderTarget& renderTarget, cons
                 }
                 animatedFrame.translate(m_stripViewAnimator->offsetFor(scrollOut), 0.0);
             }
-            captureWindowBackdrop(renderTarget, viewport, w, *backIt, deviceRegion, animatedFrame);
+            captureWindowBackdrop(renderTarget, viewport, w, *backIt, deviceRegion, animatedFrame, backdropScale);
         }
     }
 

--- a/kwin-effect/plasmazoneseffect/paint_pipeline.cpp
+++ b/kwin-effect/plasmazoneseffect/paint_pipeline.cpp
@@ -21,6 +21,8 @@
 #include <PhosphorAnimation/AnimationLimits.h>
 #include <PhosphorSurface/SurfaceShaderEffect.h>
 
+#include <QTimer>
+
 #include <core/output.h>
 #include <core/rendertarget.h>
 #include <core/renderviewport.h>
@@ -173,8 +175,10 @@ void PlasmaZonesEffect::prePaintScreen(KWin::ScreenPrePaintData& data)
                 m_scrollTabDeferred.insert(sw);
             }
         }
-        // No column on this output (mode teardown race, indicators outliving
-        // their strip by a frame): nothing to stack above, so leave the
+        // No column on this output — the mode-teardown race (indicators
+        // outliving their strip by a frame), or every strip column parked
+        // off the viewport at once (short strip flung past its extent, or
+        // transiently mid-leg): nothing to stack above, so leave the
         // surfaces on their normal layer-slot paint.
         if (!m_scrollTabPaintAnchor) {
             m_scrollTabDeferred.clear();
@@ -604,12 +608,23 @@ void PlasmaZonesEffect::postPaintScreen()
     // composite degrades to single-pass there anyway). A purely static
     // decoration (border-only) is not matched, so this is a no-op in the common
     // case. windowSurfaceAnimates is per-pack-cache hash lookups.
+    //
+    // Earliest pending park reap seen this pass (-1 = none). Declared outside
+    // the decorations gate so the arm/stop block below runs even when the
+    // last decoration was just removed — a pending timer must be stopped in
+    // that case too, or its stray fire composites an idle desktop.
+    qint64 nextParkReapInMs = -1;
     if (KWin::effects && !m_windowDecorations.isEmpty()) {
         // The clock prePaintScreen pinned for this cycle (it is unpinned at the end
         // of this function, so it is still live here). Read once: a live per-window
         // sample would let two windows in the same frame disagree about the time.
         const qint64 pinnedMs = m_shaderManager.currentFrameClockMs();
         const qint64 frameClockMs = pinnedMs >= 0 ? pinnedMs : ShaderInternal::shaderClockNowMs();
+        // The park cull below removes the very repaint driver that used to
+        // keep this loop running, so once the desktop goes idle nothing
+        // composites and the reap threshold is never re-evaluated — the
+        // timer armed after the loop forces one frame at the deadline so
+        // the reap actually fires.
         for (auto it = m_windowDecorations.cbegin(); it != m_windowDecorations.cend(); ++it) {
             if (!it->shaderApplied) {
                 continue;
@@ -641,15 +656,27 @@ void PlasmaZonesEffect::postPaintScreen()
                 // guards the transition case and makes the GL context
                 // current) and the first paint back rebuilds from scratch —
                 // one cold fold, paid mid-scroll when every visible window
-                // is repainting anyway. The pinned clock, like every other
+                // is repainting anyway. (When a shader transition is live on
+                // the window, releaseSurfaceState early-returns WITHOUT
+                // erasing, and the stamp survives inside the kept state — so
+                // that case retries on every subsequent frame, driven by the
+                // transition's own repaints, until the transition drops. Two
+                // hash probes per retry.) The pinned clock, like every other
                 // consumer in this loop; the parked stamp is inside the
                 // state so the erase disposes of it with everything else.
                 constexpr qint64 kParkReapMs = 10000;
                 if (const auto sit = m_surfaceMultipass.find(it.key()); sit != m_surfaceMultipass.end()) {
+                    qint64 remainingMs = -1;
                     if (sit->second.parkedSinceMs < 0) {
                         sit->second.parkedSinceMs = frameClockMs;
+                        remainingMs = kParkReapMs;
                     } else if (frameClockMs - sit->second.parkedSinceMs >= kParkReapMs) {
                         releaseSurfaceState(it.key(), sw);
+                    } else {
+                        remainingMs = kParkReapMs - (frameClockMs - sit->second.parkedSinceMs);
+                    }
+                    if (remainingMs >= 0 && (nextParkReapInMs < 0 || remainingMs < nextParkReapInMs)) {
+                        nextParkReapInMs = remainingMs;
                     }
                 }
                 continue;
@@ -760,6 +787,37 @@ void PlasmaZonesEffect::postPaintScreen()
             }
         }
     }
+    // Out-of-band reap trigger: a parked column requests no repaints and
+    // nothing else on an idle desktop may either, so without this the GL
+    // targets the reap exists to free are held until the next incidental
+    // frame ("scrolled a column away and walked off" holds them forever).
+    // One composited frame at the deadline re-runs the loop above; the timer
+    // is restarted with the recomputed minimum on every pass while anything
+    // is pending, and after the last reap no stamp survives to arm it. The
+    // else-stop matters as much as the arm: a column that unparks inside the
+    // threshold (the designed neighbour-scroll case), or the last decoration
+    // being removed, leaves nothing pending — without the stop the previously
+    // armed deadline would still fire one full-screen wake on an idle
+    // desktop. Every pass computes the same answer over the same window set
+    // (the predicate is output-agnostic), so the stop cannot flap between
+    // output passes.
+    if (nextParkReapInMs >= 0) {
+        if (!m_parkReapTimer) {
+            m_parkReapTimer = new QTimer(this);
+            m_parkReapTimer->setSingleShot(true);
+            connect(m_parkReapTimer, &QTimer::timeout, this, []() {
+                if (KWin::effects) {
+                    KWin::effects->addRepaintFull();
+                }
+            });
+        }
+        // Small slack so the frame the timer forces lands past the
+        // threshold rather than one clock tick short of it. The value is
+        // bounded by kParkReapMs, so the int cast cannot truncate.
+        m_parkReapTimer->start(static_cast<int>(nextParkReapInMs) + 50);
+    } else if (m_parkReapTimer) {
+        m_parkReapTimer->stop();
+    }
     KWin::effects->postPaintScreen();
     // Unpin the per-frame clock. Any paintWindow() invocation outside
     // the prePaintScreen→postPaintScreen bracket (defensive bootstrap,
@@ -783,6 +841,13 @@ void PlasmaZonesEffect::prePaintWindow(KWin::RenderView* view, KWin::EffectWindo
     const QString windowId = w ? getWindowId(w) : QString();
     const auto decoIt = w ? m_windowDecorations.constFind(windowId) : m_windowDecorations.constEnd();
     const bool decorated = decoIt != m_windowDecorations.constEnd() && decoIt->shaderApplied;
+    // Park predicate, derived once for the TWO transformed-flag gates below
+    // (padded decoration and scroll-strip): both must withhold the flag for a
+    // column parked off the viewport, or KWin keeps it in the paint set at
+    // full decoration cost forever. No pre-gates here — the predicate's own
+    // cheapest-first ordering (empty map, then the visual-pos probe) already
+    // exits early for every non-strip window.
+    const bool parkedOffscreen = scrollParkedOffscreen(w, windowId);
 
     // A scroll-strip window on a FOREIGN output's pass: paintWindow will skip
     // drawing it entirely, so it must not occlude either. Leaving its opaque
@@ -847,7 +912,12 @@ void PlasmaZonesEffect::prePaintWindow(KWin::RenderView* view, KWin::EffectWindo
         // either needs a way to present the padded margin without the
         // transformed flag, which KWin's untransformed path does not offer (it
         // clips paint to the window item's bounding rect).
-        if (decorated && decoIt->outerPadding > 0) {
+        // Not for a parked column: this branch is not naturally park-aware,
+        // and every bundled backdrop pack is padded — without the gate here
+        // the park cull's prePaint third was defeated for exactly the
+        // windows it targets (the later strip gate cannot withhold what this
+        // one already set).
+        if (decorated && decoIt->outerPadding > 0 && !parkedOffscreen) {
             data.setTransformed();
         }
     }
@@ -966,7 +1036,7 @@ void PlasmaZonesEffect::prePaintWindow(KWin::RenderView* view, KWin::EffectWindo
     // offset is part of the tested rect, so a column scrolling back toward the
     // viewport re-earns the flag on the frame it starts to intersect.
     if (w && !m_scrollVisualPos.isEmpty() && scrollManagedOutputFor(w) && m_scrollVisualPos.contains(windowId)
-        && !scrollParkedOffscreen(w, windowId)) {
+        && !parkedOffscreen) {
         data.setTransformed();
     }
 
@@ -1245,14 +1315,36 @@ void PlasmaZonesEffect::paintWindow(const KWin::RenderTarget& renderTarget, cons
                     if (linksBackdropUniforms(bp.uBackdropLoc, bp.uHasBackdropLoc, bp.uBackdropRectLoc)) {
                         // Same clamp ensureSurfaceTargets applies when sizing
                         // the buffer targets themselves, so capture density
-                        // and sampler density agree by construction.
-                        const PhosphorSurfaceShaders::SurfaceShaderEffect eff = m_surfaceShaderRegistry.effect(packId);
-                        scale =
-                            qMax(scale,
-                                 qBound(PhosphorSurfaceShaders::SurfaceShaderEffect::kMinBufferScale, eff.bufferScale,
-                                        PhosphorSurfaceShaders::SurfaceShaderEffect::kMaxBufferScale));
+                        // and sampler density agree by construction. The
+                        // clamped value is cached per pack: bufferScale is
+                        // pack METADATA (unlike the linked-uniform probes
+                        // above, which are compile state and MUST resolve
+                        // through the lazy compile — see the comment above
+                        // this lambda), and the registry lookup copies a
+                        // whole SurfaceShaderEffect by value, which this
+                        // per-frame path must not pay per pack. Invalidated
+                        // alongside m_compiledPacks, since a registry
+                        // hot-reload can change the metadata too.
+                        qreal packScale = 0.0;
+                        if (const auto bsIt = m_packBufferScaleCache.find(packId);
+                            bsIt != m_packBufferScaleCache.end()) {
+                            packScale = bsIt->second;
+                        } else {
+                            packScale = qBound(PhosphorSurfaceShaders::SurfaceShaderEffect::kMinBufferScale,
+                                               m_surfaceShaderRegistry.effect(packId).bufferScale,
+                                               PhosphorSurfaceShaders::SurfaceShaderEffect::kMaxBufferScale);
+                            m_packBufferScaleCache.emplace(packId, packScale);
+                        }
+                        scale = qMax(scale, packScale);
                         break; // one linked buffer pass answers for the pack
                     }
+                }
+                // A buffer pass at the ceiling is already the maximum
+                // possible answer (the main-pass branch above returns the
+                // same value), so stop walking the chain — restores the
+                // short-circuit the pre-scale code had for every pack.
+                if (scale >= PhosphorSurfaceShaders::SurfaceShaderEffect::kMaxBufferScale) {
+                    return PhosphorSurfaceShaders::SurfaceShaderEffect::kMaxBufferScale;
                 }
             }
             return scale;

--- a/kwin-effect/plasmazoneseffect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect/plasmazoneseffect.h
@@ -818,15 +818,20 @@ private:
      * parked column; the committed rect is always off every output (that is
      * what parking IS) and answers nothing.
      *
-     * THREE consumers, and they must stay in lockstep or a column blinks or
+     * FOUR consumers, and they must stay in lockstep or a column blinks or
      * burns: prePaintWindow withholds the TRANSFORMED flag (so KWin's own
      * culling is free to skip the window instead of being forced to paint
      * it), paintWindow skips the backdrop capture / decoration fold / draw,
-     * and the postPaintScreen repaint driver stops driving the window's
-     * decoration (the ~30fps backdrop refold and the animated-pack pump).
-     * A column that scrolls back toward the viewport starts intersecting —
-     * the view offset is part of the rect, re-read every pass — and all
-     * three sites wake in the same frame.
+     * the postPaintScreen repaint driver stops driving the window's
+     * decoration (the ~30fps backdrop refold and the animated-pack pump),
+     * and prePaintScreen's tab-anchor election skips a parked column so an
+     * anchor that will never paint cannot win. Note the anchor election
+     * runs BEFORE the strip view animator advances for the frame, so its
+     * answer is one advance behind the other three mid-leg — the failure is
+     * the benign, already-documented one (indicators fall back to their
+     * layer slot for a frame). A column that scrolls back toward the
+     * viewport starts intersecting — the view offset is part of the rect,
+     * re-read every pass — and the paint-path sites wake in the same frame.
      *
      * Snapshot captures must NOT consult this: a parked column's offscreen
      * capture (close snapshot, decoration capture) is legitimate work on an
@@ -1189,6 +1194,16 @@ private:
     QHash<KWin::EffectWindow*, QString> m_lastPushedCaption;
     QTimer* m_frameGeometryFlushTimer = nullptr;
     void flushPendingFrameGeometry();
+
+    /// One-shot wake for the parked-column GL reap (postPaintScreen). The
+    /// park cull removes the repaint driver that used to keep the desktop
+    /// compositing, so with nothing else damaging, the 10 s reap threshold
+    /// would never be re-evaluated and the parked targets would be held
+    /// indefinitely. Armed (and re-armed with the recomputed minimum) each
+    /// pass while any parked window's reap is pending; fires one
+    /// addRepaintFull so the next postPaintScreen runs the reap. Lazily
+    /// created, parented to the effect.
+    QTimer* m_parkReapTimer = nullptr;
 
     /// Debounce timer for `Rules.rulesChanged`. Single-shot, 50ms;
     /// timeout fires `loadRuleAnimationsFromDbus`. Re-armed on every
@@ -1630,6 +1645,15 @@ private:
     /// and on teardown. A window's render path looks up its resolved base pack id
     /// (WindowDecoration::basePackId) here.
     std::unordered_map<QString, CompiledSurfacePack> m_compiledPacks;
+
+    /// Per-pack CLAMPED bufferScale, cached off the registry's by-value
+    /// SurfaceShaderEffect lookup for the per-frame backdrop-density resolve
+    /// (chainBackdropScale in paint_pipeline.cpp). Metadata only — the
+    /// linked-uniform verdicts are compile state and deliberately NOT cached
+    /// here (see that lambda's comment for the two bugs a raw probe caused).
+    /// Cleared wherever m_compiledPacks clears: a registry hot-reload can
+    /// change the metadata too.
+    std::unordered_map<QString, qreal> m_packBufferScaleCache;
 
     /// Has ANY compiled pack ever declared iMouse in the current compile generation?
     ///

--- a/kwin-effect/plasmazoneseffect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect/plasmazoneseffect.h
@@ -806,6 +806,35 @@ private:
      * overhang is drawn and remains interactive either way.
      */
     QRect scrollClipGeometryFor(KWin::EffectWindow* w) const;
+    /**
+     * @brief Is this strip column parked entirely off its output's viewport
+     *        right now — drawn (if at all) where nobody can see it?
+     *
+     * True only for a scroll-managed window with a strip position entry
+     * (m_scrollVisualPos) whose VISUAL rect — the padded band relocated to
+     * its strip position, plus the live view offset — intersects no part of
+     * its managed output. The visual rect is where paintWindow actually
+     * draws the quad, so this is the one honest visibility test for a
+     * parked column; the committed rect is always off every output (that is
+     * what parking IS) and answers nothing.
+     *
+     * THREE consumers, and they must stay in lockstep or a column blinks or
+     * burns: prePaintWindow withholds the TRANSFORMED flag (so KWin's own
+     * culling is free to skip the window instead of being forced to paint
+     * it), paintWindow skips the backdrop capture / decoration fold / draw,
+     * and the postPaintScreen repaint driver stops driving the window's
+     * decoration (the ~30fps backdrop refold and the animated-pack pump).
+     * A column that scrolls back toward the viewport starts intersecting —
+     * the view offset is part of the rect, re-read every pass — and all
+     * three sites wake in the same frame.
+     *
+     * Snapshot captures must NOT consult this: a parked column's offscreen
+     * capture (close snapshot, decoration capture) is legitimate work on an
+     * invisible window. Both paint-path callers sit behind the
+     * m_capturingSnapshot exemption already, matching the foreign-output
+     * cull's treatment.
+     */
+    bool scrollParkedOffscreen(KWin::EffectWindow* w, const QString& windowId) const;
 
     /**
      * @brief Draw this pass's deferred tab-indicator surfaces into the scene
@@ -1434,9 +1463,20 @@ private:
     /// follows it (scaled into the rest-rect-sized canvas) so a frost/glass
     /// pane shows the scene behind the moving quad instead of behind the
     /// resting rect. Invalid = capture at the live geometry.
+    /// backdropScale: the capture RESOLUTION relative to the composite
+    /// canvas, from chainBackdropScale in paintWindow. 1.0 when some pack's
+    /// main pass samples the backdrop sharp; the largest linked bufferScale
+    /// when only buffer passes read it — a blur pyramid samples the capture
+    /// at bufferScale resolution through normalized uvs, so texels past that
+    /// density were captured, held (a full-canvas RGBA8 per window) and
+    /// blitted every frame only to be skipped over by the sampler. The
+    /// texture stays canvas-ALIGNED (same padded rect, same normalized
+    /// backdropRect space) at reduced density; only the blit's destination
+    /// arithmetic scales.
     void captureWindowBackdrop(const KWin::RenderTarget& renderTarget, const KWin::RenderViewport& viewport,
                                KWin::EffectWindow* w, const WindowDecoration& wb,
-                               const KWin::Region& paintedDeviceRegion, const QRectF& animatedFrame = QRectF());
+                               const KWin::Region& paintedDeviceRegion, const QRectF& animatedFrame = QRectF(),
+                               qreal backdropScale = 1.0);
 
     /// Fold @p w's decoration chain into a per-window ping-pong composite, and return the
     /// texture holding the result (null on no decoration / allocation failure). drawWindow

--- a/kwin-effect/plasmazoneseffect/scroll_clip.cpp
+++ b/kwin-effect/plasmazoneseffect/scroll_clip.cpp
@@ -9,6 +9,7 @@
 
 #include "plasmazoneseffect.h"
 
+#include "compositor/stripviewanimator.h"
 #include "handlers/navigationhandler.h"
 #include "tilinghandler/tilinghandler.h"
 
@@ -80,6 +81,43 @@ QRect PlasmaZonesEffect::scrollClipGeometryFor(KWin::EffectWindow* w) const
     }
     const KWin::Rect g = managedOutput->geometry();
     return QRect(g.x(), g.y(), g.width(), g.height());
+}
+
+bool PlasmaZonesEffect::scrollParkedOffscreen(KWin::EffectWindow* w, const QString& windowId) const
+{
+    // Ordered cheapest-first: the empty-map probe is the common-case exit on a
+    // desktop with nothing parked, and the visual-pos probe answers before the
+    // predicate walk for every never-parked column.
+    if (!w || m_scrollVisualPos.isEmpty()) {
+        return false;
+    }
+    const auto vit = m_scrollVisualPos.constFind(windowId);
+    if (vit == m_scrollVisualPos.constEnd()) {
+        return false;
+    }
+    KWin::LogicalOutput* const managed = scrollManagedOutputFor(w);
+    if (!managed) {
+        return false;
+    }
+    // The rect paintWindow actually draws: the window's expanded band
+    // relocated by (visual - committed) — the same additive translate the
+    // draw applies — slid by the live view offset. Expanded geometry (not the
+    // frame) so a decoration shadow reaching into the viewport from a
+    // just-offscreen column keeps painting; the chain's outer padding is
+    // added below for the same reason.
+    const KWin::RectF committed = w->frameGeometry();
+    QRectF visual = w->expandedGeometry();
+    if (visual.isEmpty()) {
+        visual = QRectF(committed.x(), committed.y(), committed.width(), committed.height());
+    }
+    visual.translate(vit->x() - committed.x(), vit->y() - committed.y());
+    visual.translate(m_stripViewAnimator->offsetFor(managed), 0.0);
+    if (const auto decoIt = m_windowDecorations.constFind(windowId); decoIt != m_windowDecorations.constEnd()) {
+        const qreal pad = decoIt->outerPadding;
+        visual.adjust(-pad, -pad, pad, pad);
+    }
+    const KWin::Rect g = managed->geometry();
+    return !visual.intersects(QRectF(g.x(), g.y(), g.width(), g.height()));
 }
 
 } // namespace PlasmaZones

--- a/kwin-effect/plasmazoneseffect/scroll_clip.cpp
+++ b/kwin-effect/plasmazoneseffect/scroll_clip.cpp
@@ -33,11 +33,14 @@ KWin::LogicalOutput* PlasmaZonesEffect::scrollManagedOutputFor(KWin::EffectWindo
     }
     // Memoised per pass, and ONLY within a pass: prePaintWindow and
     // paintWindow both ask, for every window, on every output pass, and one
-    // pass guarantees the strip state cannot change under the answer. The
-    // INPUT filter also routes through here (via scrollClipGeometryFor) but
-    // runs outside any pass — a tile batch can land between passes and is
-    // exactly what moves a column across the boundary — so outside a pass
-    // the predicate is always computed fresh and never cached. Stale keys
+    // pass guarantees the strip state cannot change under the answer. TWO
+    // caller classes run outside any pass and always compute fresh: the
+    // INPUT filter (via scrollClipGeometryFor — a tile batch can land
+    // between passes and is exactly what moves a column across the
+    // boundary), and postPaintScreen's park-reap driver (m_currentPassOutput
+    // is deliberately cleared at its top, so its per-parked-window resolve
+    // is uncached by design — bounded by the parked population, and the
+    // per-pass validity argument would not hold there either). Stale keys
     // for windows that died between passes CAN sit in the map until the
     // next prePaintScreen's clear, but they are never read before that
     // clear (every read is behind the same in-pass gate) and keys are only
@@ -109,6 +112,14 @@ bool PlasmaZonesEffect::scrollParkedOffscreen(KWin::EffectWindow* w, const QStri
     QRectF visual = w->expandedGeometry();
     if (visual.isEmpty()) {
         visual = QRectF(committed.x(), committed.y(), committed.width(), committed.height());
+    }
+    if (visual.isEmpty()) {
+        // Degenerate geometry (mid-unmap, zero-size commit): an empty rect
+        // never intersects anything, so falling through would answer PARKED
+        // for a window we cannot actually locate — and the reap consumer
+        // would release its surface state on that answer. Fail open like
+        // every other unknown in this predicate.
+        return false;
     }
     visual.translate(vit->x() - committed.x(), vit->y() - committed.y());
     visual.translate(m_stripViewAnimator->offsetFor(managed), 0.0);

--- a/kwin-effect/plasmazoneseffect/shader_config_dbus.cpp
+++ b/kwin-effect/plasmazoneseffect/shader_config_dbus.cpp
@@ -406,18 +406,28 @@ void PlasmaZonesEffect::tryBeginShaderForEvent(KWin::EffectWindow* window, const
     // stay in lockstep.
     effectiveDurationMs = ShaderInternal::resolveTransitionLifetimeMs(effectiveDurationMs, progressCurve.get());
     if (profile.effectiveEffectId().isEmpty()) {
-        // Default-state path: a fresh user with no shader overrides
-        // anywhere in the tree resolves every event to empty effectId,
-        // which is correct ("no shader assigned"). Logging at WARNING
-        // for that floods the journal with bogus failures every time a
-        // window opens, closes, or moves. Only WARN when the tree has
-        // overrides (so an empty resolve here is genuinely surprising —
-        // the documented prune / D-Bus-race scenarios), otherwise
-        // demote to DEBUG.
+        // An empty resolve is the NORMAL state for any event whose cascade
+        // chain carries no override — not just for an empty tree. The old
+        // demotion keyed on the whole tree being empty, so a user with nine
+        // overrides on open/close/move legs got a WARNING three times per
+        // focus change, forever, because window.appearance.focus had none.
+        // Only an override ON THIS PATH'S CASCADE (exact, or a dotted-path
+        // ancestor like "window.appearance" / "window") makes an empty
+        // resolve genuinely surprising (the documented prune / D-Bus-race
+        // scenarios) — cascade resolution would otherwise have inherited it.
+        // Rules keep their term: a rule can assign per-window on any path,
+        // which this static check cannot see.
         const int ruleCount = m_shaderManager.animationRuleSet().count();
-        if (profileTree.overriddenPaths().isEmpty() && ruleCount == 0) {
+        bool cascadeCovered = false;
+        for (const QString& overridden : profileTree.overriddenPaths()) {
+            if (profilePath == overridden || profilePath.startsWith(overridden + QLatin1Char('.'))) {
+                cascadeCovered = true;
+                break;
+            }
+        }
+        if (!cascadeCovered && ruleCount == 0) {
             qCDebug(lcEffect) << "tryBeginShader[" << profilePath
-                              << "]: no shader assigned (tree empty — default state)";
+                              << "]: no shader assigned (no override on this path's cascade)";
         } else {
             qCWarning(lcEffect) << "tryBeginShader[" << profilePath
                                 << "]: no shader assigned (cascade returned empty effectId, tree size="

--- a/kwin-effect/plasmazoneseffect/shader_config_dbus.cpp
+++ b/kwin-effect/plasmazoneseffect/shader_config_dbus.cpp
@@ -71,9 +71,10 @@ constexpr int kRuleFetchRetryDelayMs = 1000;
 constexpr int kRuleFetchTimeoutMs = 5000;
 
 /// Hard cap on the getAllRules payload before it reaches QJsonDocument::fromJson.
-/// The reply crosses a process boundary and the parse allocates proportionally
-/// to the payload, so a malformed or hostile daemon-side string must not be
-/// able to drive an unbounded allocation inside the compositor. Sized far above
+/// The receive-side QString allocation is bounded by libdbus's own
+/// message-size limit, not by this cap — what it genuinely bounds is the
+/// JSON parse (and, via the call site's pre-check on the QString length,
+/// the UTF-8 conversion copy). Sized far above
 /// any plausible rule store (a rule serialises to a few hundred bytes, so this
 /// admits tens of thousands of them) — the cap is a safety net, not a limit
 /// users can reach by authoring rules.
@@ -415,23 +416,37 @@ void PlasmaZonesEffect::tryBeginShaderForEvent(KWin::EffectWindow* window, const
         // ancestor like "window.appearance" / "window") makes an empty
         // resolve genuinely surprising (the documented prune / D-Bus-race
         // scenarios) — cascade resolution would otherwise have inherited it.
-        // Rules keep their term: a rule can assign per-window on any path,
-        // which this static check cannot see.
-        const int ruleCount = m_shaderManager.animationRuleSet().count();
+        // Rules keep a term, but only for the ONE action that can assign a
+        // shader per-window: OverrideAnimationShader (timing/curve overrides
+        // carry no effectId). Gating on the whole rule set restored the
+        // warning for any border/opacity/layer rule — the exact population
+        // the demotion exists to silence.
+        const bool shaderAssigningRules = m_shaderManager.hasAnimationShaderRules();
         bool cascadeCovered = false;
-        for (const QString& overridden : profileTree.overriddenPaths()) {
-            if (profilePath == overridden || profilePath.startsWith(overridden + QLatin1Char('.'))) {
+        // The by-value QStringList is built ONCE and reused by both the loop
+        // and the warn diagnostic below — the pre-change code paid it twice
+        // (once for the range-for, once for .size() in the warn branch).
+        const QStringList overriddenPaths = profileTree.overriddenPaths();
+        for (const QString& overridden : overriddenPaths) {
+            // The literal "global" root is a genuine chain member of every
+            // path (parentPath terminates every cascade at Global), so an
+            // override stored there covers this resolve too. Ancestry is a
+            // prefix-plus-dot test rather than a per-entry concatenation.
+            if (overridden == PhosphorAnimation::ProfilePaths::Global || profilePath == overridden
+                || (profilePath.size() > overridden.size() && profilePath.startsWith(overridden)
+                    && profilePath.at(overridden.size()) == QLatin1Char('.'))) {
                 cascadeCovered = true;
                 break;
             }
         }
-        if (!cascadeCovered && ruleCount == 0) {
+        if (!cascadeCovered && !shaderAssigningRules) {
             qCDebug(lcEffect) << "tryBeginShader[" << profilePath
                               << "]: no shader assigned (no override on this path's cascade)";
         } else {
             qCWarning(lcEffect) << "tryBeginShader[" << profilePath
                                 << "]: no shader assigned (cascade returned empty effectId, tree size="
-                                << profileTree.overriddenPaths().size() << " rules=" << ruleCount << ")";
+                                << overriddenPaths.size() << " rules=" << m_shaderManager.animationRuleSet().count()
+                                << " shaderAssigningRules=" << shaderAssigningRules << ")";
         }
         return;
     }
@@ -660,6 +675,18 @@ void PlasmaZonesEffect::fetchAllRulesOnce()
                 // (a spare re-drive is one redundant fetch).
                 m_activeLayoutRulesWithheld = true;
             }
+            return;
+        }
+        // Pre-check on the QString length before toUtf8() allocates a second
+        // full copy: UTF-8 output is never SHORTER than the UTF-16 unit
+        // count, so a unit count over the byte cap is already over. The
+        // byte-exact check below still runs (UTF-8 can inflate up to 3x).
+        // Same marker re-arm contract as every other early return here.
+        if (reply.value().size() > kRuleFetchMaxPayloadBytes) {
+            qCWarning(lcEffect) << "loadRuleAnimationsFromDbus: getAllRules payload of" << reply.value().size()
+                                << "UTF-16 units exceeds the" << kRuleFetchMaxPayloadBytes
+                                << "byte cap — refusing to convert";
+            m_activeLayoutRulesWithheld = true;
             return;
         }
         const QByteArray payload = reply.value().toUtf8();

--- a/kwin-effect/plasmazoneseffect/surface_backdrop.cpp
+++ b/kwin-effect/plasmazoneseffect/surface_backdrop.cpp
@@ -32,7 +32,7 @@ namespace PlasmaZones {
 void PlasmaZonesEffect::captureWindowBackdrop(const KWin::RenderTarget& renderTarget,
                                               const KWin::RenderViewport& viewport, KWin::EffectWindow* w,
                                               const WindowDecoration& wb, const KWin::Region& paintedDeviceRegion,
-                                              const QRectF& animatedFrame)
+                                              const QRectF& animatedFrame, qreal backdropScale)
 {
     // Mirror renderSurfaceChainComposite's canvas math EXACTLY (padded
     // logical rect, capped capture scale, derived texture size) so uBackdrop
@@ -56,8 +56,18 @@ void PlasmaZonesEffect::captureWindowBackdrop(const KWin::RenderTarget& renderTa
     // through the live `viewport`; only the destination canvas is pinned.
     const SurfaceCanvas canvas = surfaceCanvasFor(windowRect, pad, windowSurfaceScale(w));
     const QRectF logicalGeometry = canvas.logicalGeometry;
-    const QSize textureSize = canvas.textureSize;
-    if (textureSize.isEmpty()) {
+    // The capture texture's density, decoupled from the canvas rect it maps.
+    // A blur-only chain samples the backdrop exclusively at its packs'
+    // bufferScale resolution (through normalized uvs), so holding it at full
+    // canvas density stored and re-blitted texels the samplers stride
+    // straight over — a fifth of a decorated 4K window's VRAM for nothing.
+    // The RECT stays the full padded canvas either way: backdropRect,
+    // backdropTexel's clamp and the alignment contract with the composite
+    // are all normalized, so density is the only thing that moves.
+    const qreal texScale = qBound(0.05, backdropScale, 1.0);
+    const QSize textureSize(qMax(1, qRound(canvas.textureSize.width() * texScale)),
+                            qMax(1, qRound(canvas.textureSize.height() * texScale)));
+    if (canvas.textureSize.isEmpty()) {
         return;
     }
     const QString windowId = getWindowId(w);

--- a/kwin-effect/plasmazoneseffect/surface_backdrop.cpp
+++ b/kwin-effect/plasmazoneseffect/surface_backdrop.cpp
@@ -36,8 +36,11 @@ void PlasmaZonesEffect::captureWindowBackdrop(const KWin::RenderTarget& renderTa
 {
     // Mirror renderSurfaceChainComposite's canvas math EXACTLY (padded
     // logical rect, capped capture scale, derived texture size) so uBackdrop
-    // and the composite canvas are texel-aligned — a pack samples both with
-    // the same uv (backdropTexel / surfaceTexel).
+    // and the composite canvas are canvas-aligned in normalized uv — a pack
+    // samples both with the same uv (backdropTexel / surfaceTexel). The
+    // capture's texel DENSITY may be lower than the composite's (see the
+    // texScale note below); alignment is a property of the rects, not of
+    // the densities.
     const qreal pad = wb.outerPadding;
     QRectF windowRect = w->expandedGeometry();
     if (windowRect.isEmpty()) {
@@ -64,12 +67,16 @@ void PlasmaZonesEffect::captureWindowBackdrop(const KWin::RenderTarget& renderTa
     // The RECT stays the full padded canvas either way: backdropRect,
     // backdropTexel's clamp and the alignment contract with the composite
     // are all normalized, so density is the only thing that moves.
-    const qreal texScale = qBound(0.05, backdropScale, 1.0);
-    const QSize textureSize(qMax(1, qRound(canvas.textureSize.width() * texScale)),
-                            qMax(1, qRound(canvas.textureSize.height() * texScale)));
     if (canvas.textureSize.isEmpty()) {
         return;
     }
+    // Clamp with the canonical bounds: backdropScale arrives already clamped
+    // into [kMinBufferScale, kMaxBufferScale] by chainBackdropScale, so this
+    // is a contract restatement, not a second policy.
+    const qreal texScale = qBound(PhosphorSurfaceShaders::SurfaceShaderEffect::kMinBufferScale, backdropScale,
+                                  PhosphorSurfaceShaders::SurfaceShaderEffect::kMaxBufferScale);
+    const QSize textureSize(qMax(1, qRound(canvas.textureSize.width() * texScale)),
+                            qMax(1, qRound(canvas.textureSize.height() * texScale)));
     const QString windowId = getWindowId(w);
     if (windowId.isEmpty()) {
         return; // no stable id — don't orphan a default-inserted entry under ""
@@ -247,13 +254,26 @@ void PlasmaZonesEffect::captureWindowBackdrop(const KWin::RenderTarget& renderTa
                            source.width() / sourceRect.width() * texW, source.height() / sourceRect.height() * texH);
         const KWin::Rect destination(qRound(destF.x()), qRound(destF.y()), qRound(destF.width()),
                                      qRound(destF.height()));
+        if (destination.isEmpty()) {
+            // A sub-texel slice — reachable at reduced capture density,
+            // where one texture px spans several device px — rounds to a
+            // zero-extent destination. The blit would be a no-op, but
+            // letting the fractional destF into the coverage / union /
+            // largest-slice tracking below could publish a sub-texel valid
+            // rect that collapses every sample to one texel. Skip it
+            // entirely so all three trackers stay consistent.
+            continue;
+        }
         if (!fbo.blitFromRenderTarget(renderTarget, viewport, source, destination)) {
             continue;
         }
         // Record what this blit actually covered, grown by 1 px: the inward
         // source rounding at fractional scale can open sub-pixel seams between
         // adjacent slices, and without the growth those seams would read as
-        // coverage gaps below and needlessly shrink the published rect.
+        // coverage gaps below and needlessly shrink the published rect. The
+        // margin is in TEXTURE px, so at reduced capture density it spans
+        // 1/texScale device px — a deliberately coarser seam tolerance, in
+        // proportion to the coarser texels themselves.
         state.backdropWritten += destination.grownBy(QMargins(1, 1, 1, 1));
         destUnion = destUnion.isEmpty() ? destF : destUnion.united(destF);
         if (destF.width() * destF.height() > largestSlice.width() * largestSlice.height()) {

--- a/kwin-effect/plasmazoneseffect/surface_types.h
+++ b/kwin-effect/plasmazoneseffect/surface_types.h
@@ -260,9 +260,13 @@ struct SurfaceFoldPlan
 /// (renderSurfaceChainComposite): the raw window capture, the cached static-prefix
 /// fold, the ping-pong composite pair, the per-pack buffer-pass textures
 /// (chainBufferTex), the backdrop capture, and a framebuffer pooled beside every
-/// one of those textures. Keyed by getWindowId(w) in m_surfaceMultipass; freed by
+/// one of those textures — plus `parkedSinceMs`, which is not GL state but
+/// bookkeeping deliberately colocated with it so the reap disposes of both
+/// together. Keyed by getWindowId(w) in m_surfaceMultipass; freed by
 /// removeWindowDecoration (a decoration REFRESH keeps it — see its keepSurfaceState
-/// parameter) and by the windowDeleted backstop.
+/// parameter), by the windowDeleted backstop, and by the postPaintScreen park
+/// reap (a column parked off the viewport past its threshold surrenders the
+/// whole state via releaseSurfaceState).
 struct SurfaceMultipassState
 {
     // ── Multi-pack chain compositing path (renderSurfaceChainComposite) ──────
@@ -441,8 +445,11 @@ struct SurfaceMultipassState
 
     /// Backdrop capture for needsBackdrop chains: the scene behind the
     /// window blitted from the live render target over the SAME padded
-    /// canvas as the composite (texel-aligned — a pack samples both with one
-    /// uv). Reallocated on size change; freed with the rest of this state in
+    /// canvas as the composite — canvas-aligned in normalized uv, so a pack
+    /// samples both with one uv; the capture's texel DENSITY may be lower
+    /// than the composite's (chainBackdropScale caps it at the densest
+    /// linked reader's bufferScale). Reallocated on size change; freed with
+    /// the rest of this state in
     /// removeWindowDecoration, and NEVER sampled on the deleted/close path (the
     /// fold doesn't run there; the frozen composite carries the last-alive
     /// frost baked in).

--- a/kwin-effect/plasmazoneseffect/surface_types.h
+++ b/kwin-effect/plasmazoneseffect/surface_types.h
@@ -532,6 +532,20 @@ struct SurfaceMultipassState
     /// a fold every ~33ms instead of every vsync. Damage to the window
     /// itself still refolds immediately (its paint runs regardless).
     qint64 lastFoldMs = -1;
+
+    /// When this window's column was first seen parked off the viewport
+    /// (shader clock, ms); negative while visible. Stamped and read only by
+    /// the postPaintScreen repaint driver: a column parked past the reap
+    /// threshold has its whole surface state released (releaseSurfaceState),
+    /// reclaiming the full-canvas GL targets a window nobody can see was
+    /// holding. The timestamp lives HERE, not in a side map, precisely so
+    /// the reap erases it with everything else — after the reap there is no
+    /// state to re-reap and nothing stale to clean up. The threshold exists
+    /// so ping-pong scrolling between neighbour columns never pays the cold
+    /// re-capture + re-fold on return; only a column parked for a while
+    /// pays it, once, on a frame where scrolling is repainting everything
+    /// anyway.
+    qint64 parkedSinceMs = -1;
 };
 
 /// Per-window border + rounded corners, rendered by sampling the redirected

--- a/kwin-effect/transitions/shadertransitionmanager.cpp
+++ b/kwin-effect/transitions/shadertransitionmanager.cpp
@@ -49,6 +49,7 @@ void ShaderTransitionManager::rebuildAnimationRuleSet()
     // force the per-window query build.
     m_hasOpacityRules = false;
     m_hasWindowLayerRules = false;
+    m_hasAnimationShaderRules = false;
     for (const PhosphorRules::Rule& rule : m_ruleAnimationRules) {
         if (!rule.enabled) {
             continue;
@@ -58,9 +59,11 @@ void ShaderTransitionManager::rebuildAnimationRuleSet()
                 m_hasOpacityRules = true;
             } else if (action.type == PhosphorRules::ActionType::SetWindowLayer) {
                 m_hasWindowLayerRules = true;
+            } else if (action.type == PhosphorRules::ActionType::OverrideAnimationShader) {
+                m_hasAnimationShaderRules = true;
             }
         }
-        if (m_hasOpacityRules && m_hasWindowLayerRules) {
+        if (m_hasOpacityRules && m_hasWindowLayerRules && m_hasAnimationShaderRules) {
             break;
         }
     }

--- a/kwin-effect/transitions/shadertransitionmanager.h
+++ b/kwin-effect/transitions/shadertransitionmanager.h
@@ -148,6 +148,18 @@ public:
         return m_hasWindowLayerRules;
     }
 
+    /// True when at least one enabled rule carries an `OverrideAnimationShader`
+    /// action — the sole rule action that can assign a shader effectId
+    /// per-window (timing/curve overrides cannot). Gates the empty-resolve
+    /// warning in tryBeginShader: without it, any Tag::Effect rule (border,
+    /// opacity, layer) restored the per-focus warning the demotion exists to
+    /// silence. Recomputed by `rebuildAnimationRuleSet()` on every rule-set
+    /// change.
+    bool hasAnimationShaderRules() const
+    {
+        return m_hasAnimationShaderRules;
+    }
+
     /// Rebuild the effect-VERDICT `RuleSet` from `m_effectVerdictRules` — the
     /// rules carrying any `Tag::EffectVerdict` action (OpenFullscreen /
     /// ScrollFactor). Separate from the animation/appearance set above because
@@ -416,6 +428,8 @@ private:
     bool m_hasOpacityRules = false;
     // Same shape for SetWindowLayer. See hasWindowLayerRules().
     bool m_hasWindowLayerRules = false;
+    // Same shape for OverrideAnimationShader. See hasAnimationShaderRules().
+    bool m_hasAnimationShaderRules = false;
     // Same shape for OpenFullscreen, recomputed over the VERDICT list. See
     // hasOpenFullscreenRules().
     bool m_hasOpenFullscreenRules = false;

--- a/libs/phosphor-animation/include/PhosphorAnimation/SurfaceAnimator.h
+++ b/libs/phosphor-animation/include/PhosphorAnimation/SurfaceAnimator.h
@@ -322,6 +322,28 @@ public:
     void setEnabled(bool enabled);
     bool isEnabled() const;
 
+    /// Destroy every parked (pending-reuse) shader tower now.
+    ///
+    /// Parking exists so rapid show/hide toggling reuses one ShaderEffect /
+    /// ShaderEffectSource / render-node tower per (surface, target) instead
+    /// of flooding deleteLater — but a parked tower holds its FBOs and
+    /// pipelines for the SURFACE's lifetime, and the keep-alive overlay
+    /// shells never die, so after the first animated show the towers are
+    /// immortal. A consumer with an idle notion (the daemon's quiesce grace)
+    /// calls this once genuine rest is established: destruction goes through
+    /// the same deleteLater path a superseding non-shader leg uses, active
+    /// tracks are untouched (their pieces live on the track, not in the
+    /// reuse stash), and the next animated leg simply builds a fresh tower —
+    /// the cost parking amortises is per-toggle, not per-rest.
+    void releaseParkedShaders();
+
+    /// Any parked towers currently held? The consumer's idle scheduler
+    /// gates on this: a rest period with towers parked is worth arming a
+    /// reclaim for even when nothing else (render loop, audio capture)
+    /// needs winding down — an OSD-only session parks towers without ever
+    /// starting either.
+    bool hasParkedShaders() const;
+
 private:
     class Private;
     std::unique_ptr<Private> d;

--- a/libs/phosphor-animation/include/PhosphorAnimation/SurfaceAnimator.h
+++ b/libs/phosphor-animation/include/PhosphorAnimation/SurfaceAnimator.h
@@ -328,7 +328,8 @@ public:
     /// ShaderEffectSource / render-node tower per (surface, target) instead
     /// of flooding deleteLater — but a parked tower holds its FBOs and
     /// pipelines for the SURFACE's lifetime, and the keep-alive overlay
-    /// shells never die, so after the first animated show the towers are
+    /// shells outlive every animation (they are destroyed only on screen
+    /// removal), so after the first animated show the towers are effectively
     /// immortal. A consumer with an idle notion (the daemon's quiesce grace)
     /// calls this once genuine rest is established: destruction goes through
     /// the same deleteLater path a superseding non-shader leg uses, active

--- a/libs/phosphor-animation/src/surfaceanimator.cpp
+++ b/libs/phosphor-animation/src/surfaceanimator.cpp
@@ -376,10 +376,15 @@ void SurfaceAnimator::releaseParkedShaders()
     // are never in m_pendingReuse, so active animations cannot be torn out
     // from under themselves here. destroyPendingReuseEntry disconnects the
     // anchor hookups before deleteLater, same as the superseding-leg path.
-    for (auto it = d->m_pendingReuse.begin(); it != d->m_pendingReuse.end(); ++it) {
-        d->destroyPendingReuseEntry(it->second);
-    }
+    // Move-then-iterate, mirroring the destructor's drain: the entry
+    // destroyer is deleteLater-only today, but connectSurfaceCleanup's
+    // lambda already warns that a future synchronous-delete change would
+    // re-enter this animator, and iterating the live map would then be UB.
+    auto parked = std::move(d->m_pendingReuse);
     d->m_pendingReuse.clear();
+    for (auto& [_, pending] : parked) {
+        d->destroyPendingReuseEntry(pending);
+    }
 }
 
 bool SurfaceAnimator::hasParkedShaders() const

--- a/libs/phosphor-animation/src/surfaceanimator.cpp
+++ b/libs/phosphor-animation/src/surfaceanimator.cpp
@@ -370,6 +370,23 @@ void SurfaceAnimator::cancel(PhosphorLayer::Surface* surface)
     d->cancelAllForSurface(surface);
 }
 
+void SurfaceAnimator::releaseParkedShaders()
+{
+    // Only the reuse stash — an in-flight leg's pieces live on its Track and
+    // are never in m_pendingReuse, so active animations cannot be torn out
+    // from under themselves here. destroyPendingReuseEntry disconnects the
+    // anchor hookups before deleteLater, same as the superseding-leg path.
+    for (auto it = d->m_pendingReuse.begin(); it != d->m_pendingReuse.end(); ++it) {
+        d->destroyPendingReuseEntry(it->second);
+    }
+    d->m_pendingReuse.clear();
+}
+
+bool SurfaceAnimator::hasParkedShaders() const
+{
+    return !d->m_pendingReuse.empty();
+}
+
 void SurfaceAnimator::beginShow(PhosphorLayer::Surface* surface, QQuickItem* rootItem,
                                 const PhosphorLayer::Role& configRole, CompletionCallback onComplete)
 {

--- a/libs/phosphor-animation/tests/test_surface_animator.cpp
+++ b/libs/phosphor-animation/tests/test_surface_animator.cpp
@@ -1119,6 +1119,110 @@ private Q_SLOTS:
 
         delete surface;
     }
+
+    /// Contract of the idle-reclaim pair (hasParkedShaders /
+    /// releaseParkedShaders): a completed shader HIDE leg parks its tower in
+    /// the pending-reuse stash (hasParkedShaders flips true), a release
+    /// empties the stash (flips false), and both calls are safe no-ops on an
+    /// animator that never parked anything. The daemon's idle quiesce gates
+    /// its arming on exactly this observable, so a silent regression here
+    /// strands full-window FBOs for the shells' lifetime.
+    void released_parked_shaders_empties_the_reuse_stash()
+    {
+        // Both calls must be harmless before any leg ever ran.
+        {
+            SurfaceAnimator::Config cfg;
+            cfg.showProfile = QStringLiteral("test.show");
+            cfg.hideProfile = QStringLiteral("test.hide");
+            SurfaceAnimator idle(m_registry, cfg);
+            QVERIFY(!idle.hasParkedShaders());
+            idle.releaseParkedShaders();
+            QVERIFY(!idle.hasParkedShaders());
+        }
+
+        // Daemon-eligible pack (appliesTo includes "appearance"), so runLeg
+        // attaches a real tower instead of refusing it.
+        QTemporaryDir tmp;
+        QVERIFY(tmp.isValid());
+        const QString packDir = tmp.path() + QStringLiteral("/park-probe");
+        QVERIFY(QDir(tmp.path()).mkpath(QStringLiteral("park-probe")));
+        {
+            QFile meta(packDir + QStringLiteral("/metadata.json"));
+            QVERIFY(meta.open(QIODevice::WriteOnly));
+            meta.write(R"({"id":"park-probe","name":"Park","description":"probe",)"
+                       R"("author":"test","version":"1.0","category":"Test",)"
+                       R"("fragmentShader":"effect.frag","parameters":[],"appliesTo":["appearance"]})");
+        }
+        {
+            QFile frag(packDir + QStringLiteral("/effect.frag"));
+            QVERIFY(frag.open(QIODevice::WriteOnly));
+            frag.write("void main(){}\n");
+        }
+
+        PhosphorAnimationShaders::AnimationShaderRegistry shaderRegistry;
+        shaderRegistry.addSearchPath(tmp.path());
+        shaderRegistry.refresh();
+        QVERIFY2(shaderRegistry.effect(QStringLiteral("park-probe")).isValid(), "fixture pack must resolve");
+
+        SurfaceAnimator::Config cfg;
+        cfg.showProfile = QStringLiteral("test.show");
+        cfg.hideProfile = QStringLiteral("test.hide");
+        cfg.hideShaderEffectId = QStringLiteral("park-probe");
+        cfg.hideShaderProfile = QStringLiteral("test.hide");
+        SurfaceAnimator anim(m_registry, cfg);
+        anim.setAnimationShaderRegistry(&shaderRegistry);
+
+        PhosphorLayer::Testing::MockTransport t;
+        PhosphorLayer::Testing::MockScreenProvider s;
+        auto deps = PhosphorLayer::Testing::makeDeps(&t, &s);
+        SurfaceFactory f(deps);
+
+        PhosphorLayer::SurfaceConfig sc;
+        sc.role = PhosphorShellPatterns::Modal();
+        sc.contentItem = std::make_unique<QQuickItem>();
+        sc.screen = s.primary();
+        sc.keepMappedOnHide = true;
+        sc.debugName = QStringLiteral("park-probe-test");
+
+        auto* surface = f.create(std::move(sc));
+        QVERIFY(surface);
+        surface->warmUp();
+        QQuickItem* target = animatedItem(surface);
+        QVERIFY(target);
+
+        int shows = 0;
+        anim.beginShow(surface, target, [&shows]() {
+            ++shows;
+        });
+        QVERIFY(waitFor(
+            [&shows] {
+                return shows == 1;
+            },
+            500));
+        // Leg teardown parks unconditionally for any completed shader leg;
+        // this show leg simply carries no shader (showShaderEffectId is
+        // unset), so there is nothing to park yet.
+        QVERIFY2(!anim.hasParkedShaders(), "the shaderless show leg must leave the reuse stash empty");
+
+        int hides = 0;
+        anim.beginHide(surface, target, [&hides]() {
+            ++hides;
+        });
+        QVERIFY(waitFor(
+            [&hides] {
+                return hides == 1;
+            },
+            500));
+        QVERIFY2(anim.hasParkedShaders(), "hide-leg teardown must park the shader tower in the reuse stash");
+
+        anim.releaseParkedShaders();
+        QVERIFY2(!anim.hasParkedShaders(), "releaseParkedShaders must empty the stash");
+        // Second release on the now-empty stash stays a no-op.
+        anim.releaseParkedShaders();
+        QVERIFY(!anim.hasParkedShaders());
+
+        delete surface;
+    }
 };
 
 QTEST_MAIN(TestSurfaceAnimator)

--- a/libs/phosphor-rendering/CMakeLists.txt
+++ b/libs/phosphor-rendering/CMakeLists.txt
@@ -46,6 +46,7 @@ set(phosphorrendering_SRCS
     src/shadernoderhisetters.cpp
     src/shadereffect.cpp
     src/shadereffect_params.cpp
+    src/shadereffect_setters.cpp
     src/zonelabeltexture.cpp
     src/zoneshadernoderhi.cpp
 )

--- a/libs/phosphor-rendering/include/PhosphorRendering/ShaderEffect.h
+++ b/libs/phosphor-rendering/include/PhosphorRendering/ShaderEffect.h
@@ -22,6 +22,7 @@
 #include <array>
 #include <atomic>
 #include <memory>
+#include <mutex>
 
 QT_BEGIN_NAMESPACE
 class QSGNode;
@@ -301,8 +302,10 @@ public:
     /// thread-safe per Qt docs: each call constructs its own
     /// QSvgRenderer / QImage instance with no shared mutable state)
     /// and call `setUserTexture(slot, image)` on the GUI thread to
-    /// install the result. Bitmap formats are loaded via `QImage` and
-    /// carry the same synchronous-IO caveat but no rasterisation cost.
+    /// install the result. Bitmap formats are decoded via `QImageReader`
+    /// under the same `kMaxSvgPixelBytes` budget — an oversized file is
+    /// downscaled during decode with a warning, never materialised at
+    /// full resolution — and carry the same synchronous-IO caveat.
     ///
     /// **Subclass contract.** Overrides MUST chain to
     /// `ShaderEffect::setShaderParams(params)` (or replicate the full
@@ -313,8 +316,10 @@ public:
     virtual void setShaderParams(const QVariantMap& params);
 
     /// Static helper that loads a user-texture file (PNG/JPG/etc. via
-    /// QImage; SVG/SVGZ via QSvgRenderer rasterised at @p svgMaxDim
-    /// max-axis with the same byte-budget guard as `setShaderParams`).
+    /// QImageReader, downscaled during decode when the file exceeds the
+    /// `kMaxSvgPixelBytes` budget; SVG/SVGZ via QSvgRenderer rasterised
+    /// at @p svgMaxDim max-axis with the same byte-budget guard as
+    /// `setShaderParams`).
     /// Thread-safe: each invocation constructs its own QSvgRenderer /
     /// QImage instance — callers may invoke from a worker thread (e.g.
     /// `QtConcurrent::run`) to off-load the cost from the GUI thread.
@@ -659,6 +664,10 @@ public:
      * through the ensure* paths on the next painted frame (the same recovery
      * the device-loss path exercises), so the cost of calling this on a
      * window that immediately resumes is one warm-up frame, not a teardown.
+     * Note the call itself always requests one composited frame of the
+     * window (QQuickWindow::update()): that frame is what dispatches the
+     * release on an otherwise idle window and what flushes any park state
+     * the caller latched alongside.
      *
      * Intended for long-lived, kept-alive windows whose content goes
      * invisible for long stretches (the daemon's idle-quiesced overlays):
@@ -696,17 +705,23 @@ Q_SIGNALS:
     void wallpaperTextureChanged();
     void useWallpaperChanged();
     void useDepthBufferChanged();
-    /// Emitted when status() transitions. May be raised on the render
-    /// thread under Qt's threaded render loop (setStatus is called from
-    /// updatePaintNode). Connect with Qt::AutoConnection or
-    /// Qt::QueuedConnection only — Qt::DirectConnection from a slot on
-    /// another thread will run that slot on the render thread, which is
-    /// almost always wrong (V4 / QML JS / most app code is GUI-thread-
-    /// only).
+    /// Emitted when status() transitions. Always delivered on the object's
+    /// (GUI) thread: setStatus is called from updatePaintNode on the render
+    /// thread under Qt's threaded loop, and notifyOnGuiThread marshals the
+    /// emission there via a queued call — so any connection type is safe,
+    /// including DirectConnection. Consequence of the marshalling: when a
+    /// transition originates in the sync phase, delivery is asynchronous
+    /// relative to the m_status write, and two rapid transitions can
+    /// coalesce from a handler's point of view (both handlers run with the
+    /// final status). Handlers MUST gate on the current status() value and
+    /// must not assume one delivery per transition.
     void statusChanged();
-    /// Emitted from setError(), which runs on the RENDER thread (from
-    /// updatePaintNode) — the same hazard statusChanged() documents above. A
-    /// DirectConnection here would run QML JS off the GUI thread.
+    /// Emitted from setError(). Same delivery contract as statusChanged():
+    /// marshalled to the object's thread by notifyOnGuiThread, so any
+    /// connection type is safe, and a handler should read errorLog() rather
+    /// than assume one delivery per write (the log itself is written
+    /// synchronously under its mutex before the notify is posted, so the
+    /// handler always observes the updated value).
     void errorLogChanged();
 
 protected:
@@ -986,12 +1001,25 @@ private:
     /// A QPointer is not documented thread-safe against concurrent destruction
     /// (a NoStage job can sit queued for an unbounded interval and pass a
     /// QPointer null-check just as ~QObject begins on the GUI thread). The
-    /// job captures this shared_ptr by value and bails when the atomic loads
-    /// null; the destructor stores null as its FIRST statement, before any
-    /// member teardown. This NARROWS the destruction race to the destructor
-    /// body (versus QPointer's clear inside ~QObject, last) — it does not
-    /// close it; closing it needs real synchronisation and a design pass.
-    std::shared_ptr<std::atomic<ShaderEffect*>> m_selfToken = std::make_shared<std::atomic<ShaderEffect*>>(nullptr);
+    /// job captures this shared_ptr by value, takes the mutex, and bails when
+    /// the pointer is null; the destructor takes the same mutex and nulls the
+    /// pointer as its FIRST statement, before any member teardown. Because
+    /// the job holds the lock across its node access, a destructor that
+    /// begins mid-job blocks until the job finishes — this CLOSES the
+    /// destruction race (an earlier atomic-only token merely narrowed it to
+    /// the destructor body). Contention is one uncontended lock per idle
+    /// grace.
+    struct SelfToken
+    {
+        std::mutex mutex;
+        ShaderEffect* effect = nullptr;
+    };
+    std::shared_ptr<SelfToken> m_selfToken = std::make_shared<SelfToken>();
+
+    /// Emit @p signal on the GUI thread regardless of the calling thread.
+    /// setStatus/setError run in the sync phase on the render thread; a
+    /// direct emit there hands DirectConnection consumers the wrong thread.
+    void notifyOnGuiThread(void (ShaderEffect::*signal)());
 
     // ── Thread-safe dirty flags for main -> render thread sync ───────
     std::atomic<bool> m_shaderDirty{false};

--- a/libs/phosphor-rendering/src/internal.h
+++ b/libs/phosphor-rendering/src/internal.h
@@ -15,10 +15,42 @@
 
 #include <QByteArray>
 #include <QLoggingCategory>
+#include <QUrl>
 
 namespace PhosphorRendering {
 
 Q_DECLARE_LOGGING_CATEGORY(lcShaderNode)
+
+/// True for URLs the shader loader can read: file://, qrc:, scheme-less
+/// local paths, and the empty/invalid URL (an intentional "no shader").
+/// Shared by the setter guards (shadereffect_setters.cpp) and kept beside
+/// its path-resolving sibling below so the two can never drift.
+inline bool isLocalShaderUrl(const QUrl& url)
+{
+    if (!url.isValid() || url.isEmpty()) {
+        return true;
+    }
+    const QString scheme = url.scheme();
+    return url.isLocalFile() || scheme.isEmpty() || scheme == QLatin1String("file") || scheme == QLatin1String("qrc");
+}
+
+/// Resolve a shader URL (already vetted by isLocalShaderUrl) to the local
+/// path QFile can open — ":"-prefixed for qrc:, toLocalFile() for file://,
+/// the raw path otherwise. Used by the load path (shadereffect.cpp).
+inline QString localPathFromShaderUrl(const QUrl& url)
+{
+    if (!url.isValid() || url.isEmpty()) {
+        return QString();
+    }
+    if (url.scheme() == QLatin1String("qrc")) {
+        return QLatin1Char(':') + url.path();
+    }
+    const QString local = url.toLocalFile();
+    if (!local.isEmpty()) {
+        return local;
+    }
+    return url.path();
+}
 
 /// Clear the filename+mtime cache that lives in shadernoderhicore.cpp.
 /// Called from ShaderCompiler::clearCache() so a single public clearCache()

--- a/libs/phosphor-rendering/src/shadereffect.cpp
+++ b/libs/phosphor-rendering/src/shadereffect.cpp
@@ -747,6 +747,16 @@ void ShaderEffect::releaseIdleGraphicsResources()
         std::shared_ptr<std::atomic<ShaderEffect*>> m_token;
     };
     win->scheduleRenderJob(new ReleaseIdleResourcesJob(m_selfToken), QQuickWindow::NoStage);
+    // Force one render-loop pass so the NoStage job actually dispatches. The
+    // field-verifiable caveat above is real: for a mapped-but-undamaged
+    // window (the keep-alive overlay shells sit exactly there while idle)
+    // the render loop has no reason to wake, and a job with no frame behind
+    // it can sit queued indefinitely — the whole reclaim silently never
+    // runs. update() requests a frame through the normal damage path; the
+    // surface is still mapped (keepMappedOnHide), so the compositor grants
+    // it, the render thread runs once, and the queued job executes. One
+    // extra composited frame of an invisible overlay, once per idle grace.
+    win->update();
 }
 
 // ============================================================================

--- a/libs/phosphor-rendering/src/shadereffect.cpp
+++ b/libs/phosphor-rendering/src/shadereffect.cpp
@@ -9,12 +9,13 @@
 #include <PhosphorShaders/CustomParamsKey.h>
 #include <PhosphorShaders/IUniformExtension.h>
 
-#include <QElapsedTimer>
+#include <QImageReader>
 #include <QMutexLocker>
 #include <QPainter>
 #include <QPointer>
 #include <QQuickWindow>
 #include <QRunnable>
+#include <QThread>
 #if QT_VERSION < QT_VERSION_CHECK(6, 11, 0)
 #include <QScreen>
 #endif
@@ -77,32 +78,6 @@ void main() {
 )");
 
 // ============================================================================
-// DRY helpers
-// ============================================================================
-
-// Setter macro for vec4 custom params (index into array)
-#define PR_VEC4_SETTER(Name, idx)                                                                                      \
-    void ShaderEffect::set##Name(const QVector4D& params)                                                              \
-    {                                                                                                                  \
-        if (m_customParams[idx] == params)                                                                             \
-            return;                                                                                                    \
-        m_customParams[idx] = params;                                                                                  \
-        Q_EMIT customParamsChanged();                                                                                  \
-        update();                                                                                                      \
-    }
-
-// Setter macro for QColor custom colors (index into array)
-#define PR_COLOR_SETTER(Name, idx)                                                                                     \
-    void ShaderEffect::set##Name(const QColor& color)                                                                  \
-    {                                                                                                                  \
-        if (m_customColors[idx] == color)                                                                              \
-            return;                                                                                                    \
-        m_customColors[idx] = color;                                                                                   \
-        Q_EMIT customColorsChanged();                                                                                  \
-        update();                                                                                                      \
-    }
-
-// ============================================================================
 // Construction / Destruction
 // ============================================================================
 
@@ -114,7 +89,29 @@ QImage ShaderEffect::loadUserTextureFile(const QString& path, int svgMaxDim)
     const bool isSvg = path.endsWith(QLatin1String(".svg"), Qt::CaseInsensitive)
         || path.endsWith(QLatin1String(".svgz"), Qt::CaseInsensitive);
     if (!isSvg) {
-        return QImage(path).convertToFormat(QImage::Format_RGBA8888);
+        QImageReader reader(path);
+        const QSize rasterSize = reader.size();
+        // Same byte budget the SVG branch enforces below, applied during
+        // DECODE: setScaledSize means an oversized file never materialises at
+        // full resolution, unlike a post-hoc QImage::scaled() which would need
+        // the full allocation first. A reader that cannot report size() up
+        // front returns an invalid QSize; decode unscaled in that case rather
+        // than guess. Deliberately NO setAutoTransform: QImage(path) never
+        // applied EXIF orientation, and turning it on here would silently
+        // rotate existing pack textures that carry an orientation tag.
+        if (rasterSize.isValid() && !rasterSize.isEmpty()) {
+            const qint64 rasterBytes = static_cast<qint64>(rasterSize.width()) * rasterSize.height() * 4;
+            if (rasterBytes > kMaxSvgPixelBytes) {
+                const double scale = std::sqrt(static_cast<double>(kMaxSvgPixelBytes) / rasterBytes);
+                const QSize scaledSize(qMax(1, static_cast<int>(rasterSize.width() * scale)),
+                                       qMax(1, static_cast<int>(rasterSize.height() * scale)));
+                qCWarning(lcShaderNode) << "ShaderEffect::loadUserTextureFile: raster size" << rasterSize
+                                        << "exceeds byte budget" << kMaxSvgPixelBytes << "B, downscaling to"
+                                        << scaledSize << "for path" << path;
+                reader.setScaledSize(scaledSize);
+            }
+        }
+        return reader.read().convertToFormat(QImage::Format_RGBA8888);
     }
     QSvgRenderer renderer(path);
     if (!renderer.isValid()) {
@@ -161,7 +158,10 @@ QImage ShaderEffect::loadUserTextureFile(const QString& path, int svgMaxDim)
 ShaderEffect::ShaderEffect(QQuickItem* parent)
     : QQuickItem(parent)
 {
-    m_selfToken->store(this, std::memory_order_release);
+    // No lock needed: the token is not shared with any render job until
+    // releaseIdleGraphicsResources hands it to scheduleRenderJob, which
+    // synchronises the publication.
+    m_selfToken->effect = this;
     setFlag(ItemHasContents, true);
 
     m_userTextureSvgSizes.fill(kDefaultUserTextureSvgSize);
@@ -225,8 +225,15 @@ ShaderEffect::~ShaderEffect()
 {
     // FIRST statement, before any member teardown: invalidate the liveness
     // token so a queued ReleaseIdleResourcesJob that runs from here on
-    // observes null and never touches this object (see m_selfToken's doc).
-    m_selfToken->store(nullptr, std::memory_order_release);
+    // observes null and never touches this object. Taking the token's mutex
+    // also BLOCKS this destructor until a job that is mid-run finishes — the
+    // job holds the lock across its node access — which closes the
+    // destruction race the previous atomic-only token merely narrowed (see
+    // m_selfToken's doc).
+    {
+        const std::lock_guard<std::mutex> tokenLock(m_selfToken->mutex);
+        m_selfToken->effect = nullptr;
+    }
 
     // Disconnect the DirectConnection sceneGraphAboutToStop callback FIRST.
     // That lambda executes on the render thread and touches this object.
@@ -274,398 +281,6 @@ std::shared_ptr<PhosphorShaders::IUniformExtension> ShaderEffect::uniformExtensi
 }
 
 // ============================================================================
-// Shadertoy Uniform Setters
-// ============================================================================
-
-void ShaderEffect::setITime(qreal time)
-{
-    // Relative comparison: a fixed 1e-9 absolute epsilon falls below ULP for
-    // m_iTime once it grows past ~1, so animation would silently freeze after
-    // a short runtime. Compare via qFuzzyCompare with +1.0 offset to handle
-    // both near-zero and large values uniformly.
-    if (qFuzzyCompare(m_iTime + 1.0, time + 1.0)) {
-        return;
-    }
-    m_iTime = time;
-    Q_EMIT iTimeChanged();
-    update();
-}
-
-void ShaderEffect::setITimeDelta(qreal delta)
-{
-    if (qFuzzyCompare(m_iTimeDelta + 1.0, delta + 1.0)) {
-        return;
-    }
-    m_iTimeDelta = delta;
-    Q_EMIT iTimeDeltaChanged();
-    update();
-}
-
-void ShaderEffect::setIFrame(int frame)
-{
-    if (m_iFrame == frame) {
-        return;
-    }
-    m_iFrame = frame;
-    Q_EMIT iFrameChanged();
-    update();
-}
-
-void ShaderEffect::setPlaying(bool playing)
-{
-    if (m_playing == playing) {
-        return;
-    }
-    m_playing = playing;
-    if (m_playing) {
-        // Reset the wall-clock baseline so the next tick produces a sensible
-        // delta (not a several-second jump from the time the property was
-        // last toggled). iTime is *not* reset — toggling playing off and on
-        // resumes from whatever iTime value the shader was at.
-        m_playingLastFrameSeconds = 0.0;
-    }
-    updatePlayingConnection();
-    Q_EMIT playingChanged();
-}
-
-void ShaderEffect::updatePlayingConnection()
-{
-    // Always tear down the previous connection before deciding whether to
-    // re-establish it. itemChange (window changes) and setPlaying both call
-    // through here; tearing down unconditionally avoids leaking a stale
-    // connection to a previous window.
-    QObject::disconnect(m_playingConnection);
-    m_playingConnection = {};
-    if (!m_playing) {
-        return;
-    }
-    QQuickWindow* w = window();
-    if (!w) {
-        // Item not parented to a window yet. itemChange(ItemSceneChange)
-        // will re-call us when the item gets a window.
-        return;
-    }
-    // afterAnimating fires once per frame on the GUI thread, immediately
-    // before the render thread is asked to synchronize. That's the right
-    // place to advance per-frame uniforms — the values we set here land in
-    // the next sync without thread-marshalling. afterFrameEnd would fire on
-    // the render thread under Qt's threaded render loop, and emitting our
-    // *Changed signals from there could trigger QML JS bindings on the
-    // wrong thread (V4 is GUI-thread-only).
-    m_playingConnection = QObject::connect(w, &QQuickWindow::afterAnimating, this, &ShaderEffect::onPlayingTick);
-    // Kick a first frame so the shader paints the new state immediately
-    // (otherwise it'd wait until something else dirties the scene).
-    update();
-}
-
-void ShaderEffect::onPlayingTick()
-{
-    if (!m_playing) {
-        return;
-    }
-    // QElapsedTimer wall-clock seconds — monotonic, immune to NTP jumps.
-    // Static across this TU because nsecsElapsed() needs a fixed start
-    // anchor; the monotonic value is read into a per-instance baseline
-    // (m_playingLastFrameSeconds) so each instance's delta is fully
-    // independent of every other.
-    static QElapsedTimer s_clock;
-    if (!s_clock.isValid()) {
-        s_clock.start();
-    }
-    const qreal now = s_clock.nsecsElapsed() * 1e-9;
-
-    // Skip the per-frame property pump for invisible / off-screen /
-    // zero-sized items, and for shaders that aren't ready (compile
-    // failure, still loading, no source set). afterAnimating fires on
-    // EVERY frame of the host window, so without these gates every
-    // playing ShaderEffect on the window pays setITime / setITimeDelta /
-    // setIFrame / 3×update cost regardless. The visual side-effect of
-    // skipping is that animation appears frozen — desired behaviour.
-    //
-    // Crucially, update m_playingLastFrameSeconds even on the skip path
-    // so the next visible tick computes a SMALL delta (the time between
-    // two consecutive frames) instead of a huge one (the time since the
-    // item was last visible — which would produce a giant iTime jump
-    // and a visible animation skip on re-show).
-    if (!isVisible() || width() <= 0 || height() <= 0 || m_status.load(std::memory_order_acquire) != Status::Ready) {
-        m_playingLastFrameSeconds = now;
-        return;
-    }
-
-    const qreal delta = (m_playingLastFrameSeconds > 0.0) ? (now - m_playingLastFrameSeconds) : 0.0;
-    m_playingLastFrameSeconds = now;
-
-    // Increment iTime by the frame delta rather than assigning `now`
-    // directly so toggling `playing` off and on doesn't produce a giant
-    // visual jump — iTime is the shader's animation clock, not wall time.
-    setITime(m_iTime + delta);
-    setITimeDelta(delta);
-    setIFrame(m_iFrame + 1);
-    // setITime/setITimeDelta/setIFrame each call update(); the scene graph
-    // coalesces multiple update() requests on the same frame so this is
-    // cheap.
-}
-
-void ShaderEffect::setIsReversed(bool reverse)
-{
-    if (m_isReversed == reverse) {
-        return;
-    }
-    m_isReversed = reverse;
-    // Exposed as a Q_PROPERTY (isReversed) for QML-binding parity with the
-    // rest of the animation-state setters. SurfaceAnimator still pushes this
-    // imperatively at each leg attach; the property + signal close the
-    // asymmetry without changing the imperative call site.
-    Q_EMIT isReversedChanged();
-    update();
-}
-
-void ShaderEffect::setIResolution(const QSizeF& resolution)
-{
-    if (m_iResolution == resolution) {
-        return;
-    }
-    m_iResolution = resolution;
-    Q_EMIT iResolutionChanged();
-    update();
-}
-
-void ShaderEffect::setIMouse(const QPointF& mouse)
-{
-    if (m_iMouse == mouse) {
-        return;
-    }
-    m_iMouse = mouse;
-    Q_EMIT iMouseChanged();
-    update();
-}
-
-// ============================================================================
-// Shader Source / Buffer Setters
-// ============================================================================
-
-static bool isLocalShaderUrl(const QUrl& url)
-{
-    if (!url.isValid() || url.isEmpty()) {
-        return true;
-    }
-    const QString scheme = url.scheme();
-    return url.isLocalFile() || scheme.isEmpty() || scheme == QLatin1String("file") || scheme == QLatin1String("qrc");
-}
-
-static QString localPathFromShaderUrl(const QUrl& url)
-{
-    if (!url.isValid() || url.isEmpty()) {
-        return QString();
-    }
-    if (url.scheme() == QLatin1String("qrc")) {
-        return QLatin1Char(':') + url.path();
-    }
-    const QString local = url.toLocalFile();
-    if (!local.isEmpty()) {
-        return local;
-    }
-    return url.path();
-}
-
-void ShaderEffect::setShaderSource(const QUrl& source)
-{
-    if (m_shaderSource == source) {
-        return;
-    }
-    if (!isLocalShaderUrl(source)) {
-        qCWarning(lcShaderNode) << "setShaderSource: unsupported URL scheme" << source.scheme()
-                                << "— only file:// and qrc: are accepted";
-        setError(QStringLiteral("Unsupported shader URL scheme: ") + source.scheme());
-        return;
-    }
-    m_shaderSource = source;
-    m_shaderDirty = true;
-    setStatus(Status::Loading);
-    Q_EMIT shaderSourceChanged();
-    update();
-}
-
-void ShaderEffect::setVertexShaderUrl(const QUrl& source)
-{
-    if (m_vertexShaderUrl == source) {
-        return;
-    }
-    if (!isLocalShaderUrl(source)) {
-        qCWarning(lcShaderNode) << "setVertexShaderUrl: unsupported URL scheme" << source.scheme()
-                                << "— only file:// and qrc: are accepted";
-        setError(QStringLiteral("Unsupported vertex shader URL scheme: ") + source.scheme());
-        return;
-    }
-    m_vertexShaderUrl = source;
-    m_shaderDirty = true;
-    if (source.isValid() && !source.isEmpty()) {
-        setStatus(Status::Loading);
-    }
-    Q_EMIT vertexShaderUrlChanged();
-    update();
-}
-
-void ShaderEffect::setSourceItem(QQuickItem* item)
-{
-    if (m_sourceItem.data() == item) {
-        return;
-    }
-    // Self-reference (sampling literally `this`) is rejected; ANCESTOR
-    // sampling is supported and load-bearing (SurfaceAnimator parents
-    // shaderItem under shaderAnchor for coord-system mapping, then calls
-    // setSourceItem(shaderAnchor) so the anchor's layer texture binds to
-    // uTexture0). Qt's layer system uses a back-buffer so sampling an
-    // ancestor reads last-frame's content — no infinite recursion. An
-    // earlier ancestor-walk guard here silently broke every shader leg.
-    if (item == this) {
-        if (!m_warnedSelfSourceItem) {
-            qCWarning(lcShaderNode) << "setSourceItem: refused — candidate is `this`; cannot sample own output.";
-            m_warnedSelfSourceItem = true;
-        }
-        return;
-    }
-    m_sourceItem = item;
-    if (item) {
-        // Force `layer.enabled = true` so the QQuickItem becomes a
-        // texture provider. The naive single-step
-        // `item->setProperty("layer.enabled", true)` doesn't work —
-        // Qt's meta-object system doesn't auto-resolve nested property
-        // paths; the call sets a brand new dynamic property called
-        // "layer.enabled" on the item without ever touching
-        // QQuickItemLayer. Diagnostic logging confirmed this:
-        // `isTextureProvider()` stayed false immediately after a
-        // setProperty call that "succeeded".
-        //
-        // The two-step access via `item->property("layer")` resolves
-        // the QQuickItemLayer sub-object (a QObject in its own right)
-        // and `layer->setProperty("enabled", true)` flips the real
-        // backing flag, which synchronously triggers QSGLayer creation
-        // and makes `isTextureProvider()` return true. Already-true is
-        // idempotent — Qt's layer property setter early-returns on
-        // unchanged values.
-        //
-        // We don't restore the previous value on unset because we
-        // can't know whether the consumer wanted layer for other
-        // reasons; callers that need symmetric teardown should track
-        // and reset `layer.enabled` themselves.
-        if (!item->isTextureProvider()) {
-            QObject* layer = item->property("layer").value<QObject*>();
-            if (layer) {
-                layer->setProperty("enabled", true);
-            }
-        }
-    }
-    // No m_shaderDirty here. The SRB rebind is already covered:
-    // updatePaintNode() pushes the new provider via
-    // setSourceTextureProvider() which calls resetAllBindingsAndPipelines()
-    // when the pointer changes. Forcing a full shader recompile every
-    // sourceItem swap (the previous behaviour) was wasted work — the
-    // baked QShader doesn't depend on which texture is bound.
-    Q_EMIT sourceItemChanged();
-    update();
-}
-
-// ============================================================================
-// Custom Parameters (DRY macro)
-// ============================================================================
-
-PR_VEC4_SETTER(CustomParams1, 0)
-PR_VEC4_SETTER(CustomParams2, 1)
-PR_VEC4_SETTER(CustomParams3, 2)
-PR_VEC4_SETTER(CustomParams4, 3)
-PR_VEC4_SETTER(CustomParams5, 4)
-PR_VEC4_SETTER(CustomParams6, 5)
-PR_VEC4_SETTER(CustomParams7, 6)
-PR_VEC4_SETTER(CustomParams8, 7)
-
-// ============================================================================
-// Custom Colors (DRY macro)
-// ============================================================================
-
-PR_COLOR_SETTER(CustomColor1, 0)
-PR_COLOR_SETTER(CustomColor2, 1)
-PR_COLOR_SETTER(CustomColor3, 2)
-PR_COLOR_SETTER(CustomColor4, 3)
-PR_COLOR_SETTER(CustomColor5, 4)
-PR_COLOR_SETTER(CustomColor6, 5)
-PR_COLOR_SETTER(CustomColor7, 6)
-PR_COLOR_SETTER(CustomColor8, 7)
-PR_COLOR_SETTER(CustomColor9, 8)
-PR_COLOR_SETTER(CustomColor10, 9)
-PR_COLOR_SETTER(CustomColor11, 10)
-PR_COLOR_SETTER(CustomColor12, 11)
-PR_COLOR_SETTER(CustomColor13, 12)
-PR_COLOR_SETTER(CustomColor14, 13)
-PR_COLOR_SETTER(CustomColor15, 14)
-PR_COLOR_SETTER(CustomColor16, 15)
-
-#undef PR_VEC4_SETTER
-#undef PR_COLOR_SETTER
-
-// ============================================================================
-// Shader Include Paths
-// ============================================================================
-
-void ShaderEffect::setParamPreamble(const QString& preamble)
-{
-    if (m_paramPreamble == preamble) {
-        return;
-    }
-    m_paramPreamble = preamble;
-    Q_EMIT paramPreambleChanged();
-    // Same reload requirement as setShaderIncludePaths: the preamble is spliced
-    // inside the node's loadFragmentShader and the expanded+spliced source is
-    // cached, so a pure re-bake would carry the OLD defines. Force a full
-    // reload (not just a dirty flag) so the node re-splices. Inlined rather
-    // than calling reloadShader() to keep a statusChanged binding from looping
-    // back through this setter.
-    if (m_shaderSource.isValid() && !m_shaderSource.isEmpty()) {
-        setStatus(Status::Loading);
-    }
-    m_shaderDirty = true;
-    update();
-}
-
-void ShaderEffect::setEntryScaffold(const QString& prologue, const QList<PhosphorShaders::EntryCandidate>& candidates)
-{
-    if (m_entryPrologue == prologue && m_entryCandidates == candidates) {
-        return;
-    }
-    m_entryPrologue = prologue;
-    m_entryCandidates = candidates;
-    // Same reload requirement as setParamPreamble: the scaffold is applied
-    // inside the node's loadFragmentShader and the assembled+expanded source is
-    // cached, so a pure re-bake would carry the OLD scaffold. Force a full
-    // reload; inlined (not reloadShader()) to keep a statusChanged binding from
-    // looping back through this setter.
-    if (m_shaderSource.isValid() && !m_shaderSource.isEmpty()) {
-        setStatus(Status::Loading);
-    }
-    m_shaderDirty = true;
-    update();
-}
-
-void ShaderEffect::setShaderIncludePaths(const QStringList& paths)
-{
-    if (m_shaderIncludePaths == paths) {
-        return;
-    }
-    m_shaderIncludePaths = paths;
-    // Marking dirty alone is not enough: include expansion happens inside
-    // loadFragmentShader()/loadVertexShader() and the expanded source is
-    // cached on the node. A pure re-bake of the cached source would still
-    // carry the OLD include contents. Inline the two-line reload instead of
-    // calling reloadShader() so a QML binding on statusChanged can't loop
-    // back through this setter.
-    if (m_shaderSource.isValid() && !m_shaderSource.isEmpty()) {
-        setStatus(Status::Loading);
-    }
-    m_shaderDirty = true;
-    update();
-}
-
-// ============================================================================
 // Shader Loading
 // ============================================================================
 
@@ -704,13 +319,11 @@ void ShaderEffect::releaseIdleGraphicsResources()
     //     can sit for an unbounded interval (destroyPassiveShell on screen
     //     removal is a real path that deletes overlay content on the GUI
     //     thread with a quiesce job pending). The job captures the shared
-    //     token by value; the destructor nulls it as its FIRST statement.
-    //     Honest framing: this NARROWS the race window to the destructor
-    //     body (the QPointer it replaces cleared inside ~QObject, LAST) —
-    //     it does not close it, since nothing synchronises the job's load
-    //     against a destructor that begins immediately after. Mirrors the
-    //     narrow-not-closed framing of the disconnect argument in the
-    //     destructor itself.
+    //     token by value and holds its mutex across the node access; the
+    //     destructor takes the same mutex and nulls the pointer as its FIRST
+    //     statement, so it blocks until a mid-run job finishes. That CLOSES
+    //     the destruction race (an earlier atomic-only token merely narrowed
+    //     it to the destructor body).
     //   • Recovery is node-side: releaseRhiResources() retains the shader
     //     sources and re-arms the node's own dirty flags, so the next painted
     //     frame re-bakes from cached source with zero file I/O. The item-side
@@ -722,13 +335,18 @@ void ShaderEffect::releaseIdleGraphicsResources()
     class ReleaseIdleResourcesJob : public QRunnable
     {
     public:
-        explicit ReleaseIdleResourcesJob(std::shared_ptr<std::atomic<ShaderEffect*>> token)
+        explicit ReleaseIdleResourcesJob(std::shared_ptr<SelfToken> token)
             : m_token(std::move(token))
         {
         }
         void run() override
         {
-            ShaderEffect* effect = m_token->load(std::memory_order_acquire);
+            // Hold the token's mutex across the node access: a destructor
+            // that begins while this job runs blocks on the same mutex, so
+            // the effect (and its m_renderNode atomic) cannot be freed out
+            // from under the release call.
+            const std::lock_guard<std::mutex> tokenLock(m_token->mutex);
+            ShaderEffect* effect = m_token->effect;
             if (!effect) {
                 return;
             }
@@ -744,18 +362,24 @@ void ShaderEffect::releaseIdleGraphicsResources()
         }
 
     private:
-        std::shared_ptr<std::atomic<ShaderEffect*>> m_token;
+        std::shared_ptr<SelfToken> m_token;
     };
     win->scheduleRenderJob(new ReleaseIdleResourcesJob(m_selfToken), QQuickWindow::NoStage);
-    // Force one render-loop pass so the NoStage job actually dispatches. The
-    // field-verifiable caveat above is real: for a mapped-but-undamaged
-    // window (the keep-alive overlay shells sit exactly there while idle)
-    // the render loop has no reason to wake, and a job with no frame behind
-    // it can sit queued indefinitely — the whole reclaim silently never
-    // runs. update() requests a frame through the normal damage path; the
-    // surface is still mapped (keepMappedOnHide), so the compositor grants
-    // it, the render thread runs once, and the queued job executes. One
-    // extra composited frame of an invisible overlay, once per idle grace.
+    // Force one render-loop pass. Two duties ride on this frame:
+    //   • The QML overlay host latches its park state (dropping the item's
+    //     QQuickItemLayer FBO) immediately before calling in here, and on an
+    //     idle window nothing else schedules the sync pass that applies it.
+    //     This is the frame that flushes the layer drop.
+    //   • Belt for the NoStage job above: whether the render loop dispatches
+    //     a queued job for a mapped-but-undamaged window without a frame
+    //     behind it is Qt-version-dependent (the qCDebug line in the job is
+    //     the field check); a real frame removes the doubt.
+    // update() requests a frame through the normal damage path. While the
+    // surface is mapped (keepMappedOnHide — which is effects-gated, so with
+    // visual effects disabled the hidden surface is unmapped and the frame
+    // waits for the next show) the compositor grants it, the render thread
+    // runs once, and both the layer drop and the queued job apply. One extra
+    // composited frame of an invisible overlay, once per idle grace.
     win->update();
 }
 
@@ -779,7 +403,7 @@ void ShaderEffect::setError(const QString& error)
         }
     }
     if (changed) {
-        Q_EMIT errorLogChanged();
+        notifyOnGuiThread(&ShaderEffect::errorLogChanged);
     }
     setStatus(Status::Error);
 }
@@ -794,7 +418,25 @@ void ShaderEffect::setStatus(Status newStatus)
     if (previous == newStatus) {
         return;
     }
-    Q_EMIT statusChanged();
+    notifyOnGuiThread(&ShaderEffect::statusChanged);
+}
+
+void ShaderEffect::notifyOnGuiThread(void (ShaderEffect::*signal)())
+{
+    // setStatus/setError run in updatePaintNode, i.e. in the sync phase on
+    // the RENDER thread under the threaded loop. A direct Q_EMIT there hands
+    // any DirectConnection consumer (and any queued side effect a handler
+    // creates, which acquires render-thread affinity) the wrong thread — the
+    // same hazard the afterAnimating choice elsewhere in this file exists to
+    // avoid. QML's own connection path marshals, but marshal here so the
+    // signal's thread contract holds for every consumer. During sync the GUI
+    // thread is blocked, so `this` cannot be destroyed before the queued
+    // notify is posted.
+    if (QThread::currentThread() == thread()) {
+        Q_EMIT(this->*signal)();
+    } else {
+        QMetaObject::invokeMethod(this, signal, Qt::QueuedConnection);
+    }
 }
 
 // ============================================================================
@@ -804,7 +446,12 @@ void ShaderEffect::setStatus(Status newStatus)
 qreal ShaderEffect::effectiveResolutionScale() const
 {
     const bool needsPhysical = !m_uniformExtension || m_uniformExtension->requiresPhysicalResolution();
-    if (needsPhysical && window() && window()->screen()) {
+    // No screen() term: effectiveDevicePixelRatio() has its own null-screen
+    // fallback, and gating on a transiently screen-less window (output
+    // hotplug) would silently answer 1.0 on a fractional-scale display —
+    // iResolution in logical units against a physical gl_FragCoord, the
+    // exact edge-stripe bug documented at the physical/logical split below.
+    if (needsPhysical && window()) {
         return window()->effectiveDevicePixelRatio();
     }
     return 1.0;

--- a/libs/phosphor-rendering/src/shadereffect_setters.cpp
+++ b/libs/phosphor-rendering/src/shadereffect_setters.cpp
@@ -1,0 +1,421 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+// ShaderEffect's property setters, split out of shadereffect.cpp by concern
+// (that file was past the size ceiling): the PR_VEC4/PR_COLOR DRY macros and
+// the shadertoy, source/buffer, custom-parameter, custom-color and
+// preamble/scaffold/include-path setter families. Construction, texture
+// loading, status management, node sync and scene-graph integration stay in
+// shadereffect.cpp — matching the shadernoderhi{core,setters,uniforms}.cpp
+// partitioning in this library.
+
+#include <PhosphorRendering/ShaderEffect.h>
+
+#include "internal.h"
+
+#include <QElapsedTimer>
+#include <QQuickWindow>
+
+namespace PhosphorRendering {
+
+// ============================================================================
+// DRY helpers
+// ============================================================================
+
+// Setter macro for vec4 custom params (index into array)
+#define PR_VEC4_SETTER(Name, idx)                                                                                      \
+    void ShaderEffect::set##Name(const QVector4D& params)                                                              \
+    {                                                                                                                  \
+        if (m_customParams[idx] == params)                                                                             \
+            return;                                                                                                    \
+        m_customParams[idx] = params;                                                                                  \
+        Q_EMIT customParamsChanged();                                                                                  \
+        update();                                                                                                      \
+    }
+
+// Setter macro for QColor custom colors (index into array)
+#define PR_COLOR_SETTER(Name, idx)                                                                                     \
+    void ShaderEffect::set##Name(const QColor& color)                                                                  \
+    {                                                                                                                  \
+        if (m_customColors[idx] == color)                                                                              \
+            return;                                                                                                    \
+        m_customColors[idx] = color;                                                                                   \
+        Q_EMIT customColorsChanged();                                                                                  \
+        update();                                                                                                      \
+    }
+
+// ============================================================================
+// Shadertoy Uniform Setters
+// ============================================================================
+
+void ShaderEffect::setITime(qreal time)
+{
+    // Relative comparison: a fixed 1e-9 absolute epsilon falls below ULP for
+    // m_iTime once it grows past ~1, so animation would silently freeze after
+    // a short runtime. Compare via qFuzzyCompare with +1.0 offset to handle
+    // both near-zero and large values uniformly.
+    if (qFuzzyCompare(m_iTime + 1.0, time + 1.0)) {
+        return;
+    }
+    m_iTime = time;
+    Q_EMIT iTimeChanged();
+    update();
+}
+
+void ShaderEffect::setITimeDelta(qreal delta)
+{
+    if (qFuzzyCompare(m_iTimeDelta + 1.0, delta + 1.0)) {
+        return;
+    }
+    m_iTimeDelta = delta;
+    Q_EMIT iTimeDeltaChanged();
+    update();
+}
+
+void ShaderEffect::setIFrame(int frame)
+{
+    if (m_iFrame == frame) {
+        return;
+    }
+    m_iFrame = frame;
+    Q_EMIT iFrameChanged();
+    update();
+}
+
+void ShaderEffect::setPlaying(bool playing)
+{
+    if (m_playing == playing) {
+        return;
+    }
+    m_playing = playing;
+    if (m_playing) {
+        // Reset the wall-clock baseline so the next tick produces a sensible
+        // delta (not a several-second jump from the time the property was
+        // last toggled). iTime is *not* reset — toggling playing off and on
+        // resumes from whatever iTime value the shader was at.
+        m_playingLastFrameSeconds = 0.0;
+    }
+    updatePlayingConnection();
+    Q_EMIT playingChanged();
+}
+
+void ShaderEffect::updatePlayingConnection()
+{
+    // Always tear down the previous connection before deciding whether to
+    // re-establish it. itemChange (window changes) and setPlaying both call
+    // through here; tearing down unconditionally avoids leaking a stale
+    // connection to a previous window.
+    QObject::disconnect(m_playingConnection);
+    m_playingConnection = {};
+    if (!m_playing) {
+        return;
+    }
+    QQuickWindow* w = window();
+    if (!w) {
+        // Item not parented to a window yet. itemChange(ItemSceneChange)
+        // will re-call us when the item gets a window.
+        return;
+    }
+    // afterAnimating fires once per frame on the GUI thread, immediately
+    // before the render thread is asked to synchronize. That's the right
+    // place to advance per-frame uniforms — the values we set here land in
+    // the next sync without thread-marshalling. afterFrameEnd would fire on
+    // the render thread under Qt's threaded render loop, and emitting our
+    // *Changed signals from there could trigger QML JS bindings on the
+    // wrong thread (V4 is GUI-thread-only).
+    m_playingConnection = QObject::connect(w, &QQuickWindow::afterAnimating, this, &ShaderEffect::onPlayingTick);
+    // Kick a first frame so the shader paints the new state immediately
+    // (otherwise it'd wait until something else dirties the scene).
+    update();
+}
+
+void ShaderEffect::onPlayingTick()
+{
+    if (!m_playing) {
+        return;
+    }
+    // QElapsedTimer wall-clock seconds — monotonic, immune to NTP jumps.
+    // Static across this TU because nsecsElapsed() needs a fixed start
+    // anchor; the monotonic value is read into a per-instance baseline
+    // (m_playingLastFrameSeconds) so each instance's delta is fully
+    // independent of every other.
+    static QElapsedTimer s_clock;
+    if (!s_clock.isValid()) {
+        s_clock.start();
+    }
+    const qreal now = s_clock.nsecsElapsed() * 1e-9;
+
+    // Skip the per-frame property pump for invisible / off-screen /
+    // zero-sized items, and for shaders that aren't ready (compile
+    // failure, still loading, no source set). afterAnimating fires on
+    // EVERY frame of the host window, so without these gates every
+    // playing ShaderEffect on the window pays setITime / setITimeDelta /
+    // setIFrame / 3×update cost regardless. The visual side-effect of
+    // skipping is that animation appears frozen — desired behaviour.
+    //
+    // Crucially, update m_playingLastFrameSeconds even on the skip path
+    // so the next visible tick computes a SMALL delta (the time between
+    // two consecutive frames) instead of a huge one (the time since the
+    // item was last visible — which would produce a giant iTime jump
+    // and a visible animation skip on re-show).
+    if (!isVisible() || width() <= 0 || height() <= 0 || m_status.load(std::memory_order_acquire) != Status::Ready) {
+        m_playingLastFrameSeconds = now;
+        return;
+    }
+
+    const qreal delta = (m_playingLastFrameSeconds > 0.0) ? (now - m_playingLastFrameSeconds) : 0.0;
+    m_playingLastFrameSeconds = now;
+
+    // Increment iTime by the frame delta rather than assigning `now`
+    // directly so toggling `playing` off and on doesn't produce a giant
+    // visual jump — iTime is the shader's animation clock, not wall time.
+    setITime(m_iTime + delta);
+    setITimeDelta(delta);
+    setIFrame(m_iFrame + 1);
+    // setITime/setITimeDelta/setIFrame each call update(); the scene graph
+    // coalesces multiple update() requests on the same frame so this is
+    // cheap.
+}
+
+void ShaderEffect::setIsReversed(bool reverse)
+{
+    if (m_isReversed == reverse) {
+        return;
+    }
+    m_isReversed = reverse;
+    // Exposed as a Q_PROPERTY (isReversed) for QML-binding parity with the
+    // rest of the animation-state setters. SurfaceAnimator still pushes this
+    // imperatively at each leg attach; the property + signal close the
+    // asymmetry without changing the imperative call site.
+    Q_EMIT isReversedChanged();
+    update();
+}
+
+void ShaderEffect::setIResolution(const QSizeF& resolution)
+{
+    if (m_iResolution == resolution) {
+        return;
+    }
+    m_iResolution = resolution;
+    Q_EMIT iResolutionChanged();
+    update();
+}
+
+void ShaderEffect::setIMouse(const QPointF& mouse)
+{
+    if (m_iMouse == mouse) {
+        return;
+    }
+    m_iMouse = mouse;
+    Q_EMIT iMouseChanged();
+    update();
+}
+
+// ============================================================================
+// Shader Source / Buffer Setters
+// ============================================================================
+
+void ShaderEffect::setShaderSource(const QUrl& source)
+{
+    if (m_shaderSource == source) {
+        return;
+    }
+    if (!isLocalShaderUrl(source)) {
+        // Full refusal: no state changes. Setting Status::Error here while
+        // the previously-baked shader keeps rendering would make status,
+        // the property value, and the on-screen output disagree three ways
+        // (and a later reloadShader() would flip back to Ready, erasing the
+        // record). A refused write leaves everything as it was; the warning
+        // is the report.
+        qCWarning(lcShaderNode) << "setShaderSource: unsupported URL scheme" << source.scheme()
+                                << "— only file:// and qrc: are accepted; keeping" << m_shaderSource;
+        return;
+    }
+    m_shaderSource = source;
+    m_shaderDirty = true;
+    setStatus(Status::Loading);
+    Q_EMIT shaderSourceChanged();
+    update();
+}
+
+void ShaderEffect::setVertexShaderUrl(const QUrl& source)
+{
+    if (m_vertexShaderUrl == source) {
+        return;
+    }
+    if (!isLocalShaderUrl(source)) {
+        // Full refusal, same rationale as setShaderSource: a refused write
+        // must leave status, property value, and rendered output agreeing.
+        qCWarning(lcShaderNode) << "setVertexShaderUrl: unsupported URL scheme" << source.scheme()
+                                << "— only file:// and qrc: are accepted; keeping" << m_vertexShaderUrl;
+        return;
+    }
+    m_vertexShaderUrl = source;
+    m_shaderDirty = true;
+    if (source.isValid() && !source.isEmpty()) {
+        setStatus(Status::Loading);
+    }
+    Q_EMIT vertexShaderUrlChanged();
+    update();
+}
+
+void ShaderEffect::setSourceItem(QQuickItem* item)
+{
+    if (m_sourceItem.data() == item) {
+        return;
+    }
+    // Self-reference (sampling literally `this`) is rejected; ANCESTOR
+    // sampling is supported and load-bearing (SurfaceAnimator parents
+    // shaderItem under shaderAnchor for coord-system mapping, then calls
+    // setSourceItem(shaderAnchor) so the anchor's layer texture binds to
+    // uTexture0). Qt's layer system uses a back-buffer so sampling an
+    // ancestor reads last-frame's content — no infinite recursion. An
+    // earlier ancestor-walk guard here silently broke every shader leg.
+    if (item == this) {
+        if (!m_warnedSelfSourceItem) {
+            qCWarning(lcShaderNode) << "setSourceItem: refused — candidate is `this`; cannot sample own output.";
+            m_warnedSelfSourceItem = true;
+        }
+        return;
+    }
+    m_sourceItem = item;
+    if (item) {
+        // Force `layer.enabled = true` so the QQuickItem becomes a
+        // texture provider. The naive single-step
+        // `item->setProperty("layer.enabled", true)` doesn't work —
+        // Qt's meta-object system doesn't auto-resolve nested property
+        // paths; the call sets a brand new dynamic property called
+        // "layer.enabled" on the item without ever touching
+        // QQuickItemLayer. Diagnostic logging confirmed this:
+        // `isTextureProvider()` stayed false immediately after a
+        // setProperty call that "succeeded".
+        //
+        // The two-step access via `item->property("layer")` resolves
+        // the QQuickItemLayer sub-object (a QObject in its own right)
+        // and `layer->setProperty("enabled", true)` flips the real
+        // backing flag, which synchronously triggers QSGLayer creation
+        // and makes `isTextureProvider()` return true. Already-true is
+        // idempotent — Qt's layer property setter early-returns on
+        // unchanged values.
+        //
+        // We don't restore the previous value on unset because we
+        // can't know whether the consumer wanted layer for other
+        // reasons; callers that need symmetric teardown should track
+        // and reset `layer.enabled` themselves.
+        if (!item->isTextureProvider()) {
+            QObject* layer = item->property("layer").value<QObject*>();
+            if (layer) {
+                layer->setProperty("enabled", true);
+            }
+        }
+    }
+    // No m_shaderDirty here. The SRB rebind is already covered:
+    // updatePaintNode() pushes the new provider via
+    // setSourceTextureProvider() which calls resetAllBindingsAndPipelines()
+    // when the pointer changes. Forcing a full shader recompile every
+    // sourceItem swap (the previous behaviour) was wasted work — the
+    // baked QShader doesn't depend on which texture is bound.
+    Q_EMIT sourceItemChanged();
+    update();
+}
+
+// ============================================================================
+// Custom Parameters (DRY macro)
+// ============================================================================
+
+PR_VEC4_SETTER(CustomParams1, 0)
+PR_VEC4_SETTER(CustomParams2, 1)
+PR_VEC4_SETTER(CustomParams3, 2)
+PR_VEC4_SETTER(CustomParams4, 3)
+PR_VEC4_SETTER(CustomParams5, 4)
+PR_VEC4_SETTER(CustomParams6, 5)
+PR_VEC4_SETTER(CustomParams7, 6)
+PR_VEC4_SETTER(CustomParams8, 7)
+
+// ============================================================================
+// Custom Colors (DRY macro)
+// ============================================================================
+
+PR_COLOR_SETTER(CustomColor1, 0)
+PR_COLOR_SETTER(CustomColor2, 1)
+PR_COLOR_SETTER(CustomColor3, 2)
+PR_COLOR_SETTER(CustomColor4, 3)
+PR_COLOR_SETTER(CustomColor5, 4)
+PR_COLOR_SETTER(CustomColor6, 5)
+PR_COLOR_SETTER(CustomColor7, 6)
+PR_COLOR_SETTER(CustomColor8, 7)
+PR_COLOR_SETTER(CustomColor9, 8)
+PR_COLOR_SETTER(CustomColor10, 9)
+PR_COLOR_SETTER(CustomColor11, 10)
+PR_COLOR_SETTER(CustomColor12, 11)
+PR_COLOR_SETTER(CustomColor13, 12)
+PR_COLOR_SETTER(CustomColor14, 13)
+PR_COLOR_SETTER(CustomColor15, 14)
+PR_COLOR_SETTER(CustomColor16, 15)
+
+#undef PR_VEC4_SETTER
+#undef PR_COLOR_SETTER
+
+// ============================================================================
+// Shader Include Paths
+// ============================================================================
+
+void ShaderEffect::setParamPreamble(const QString& preamble)
+{
+    if (m_paramPreamble == preamble) {
+        return;
+    }
+    m_paramPreamble = preamble;
+    Q_EMIT paramPreambleChanged();
+    // Same reload requirement as setShaderIncludePaths: the preamble is spliced
+    // inside the node's loadFragmentShader and the expanded+spliced source is
+    // cached, so a pure re-bake would carry the OLD defines. Force a full
+    // reload (not just a dirty flag) so the node re-splices. Inlined rather
+    // than calling reloadShader() to keep a statusChanged binding from looping
+    // back through this setter.
+    if (m_shaderSource.isValid() && !m_shaderSource.isEmpty()) {
+        setStatus(Status::Loading);
+    }
+    m_shaderDirty = true;
+    update();
+}
+
+void ShaderEffect::setEntryScaffold(const QString& prologue, const QList<PhosphorShaders::EntryCandidate>& candidates)
+{
+    if (m_entryPrologue == prologue && m_entryCandidates == candidates) {
+        return;
+    }
+    m_entryPrologue = prologue;
+    m_entryCandidates = candidates;
+    // Same reload requirement as setParamPreamble: the scaffold is applied
+    // inside the node's loadFragmentShader and the assembled+expanded source is
+    // cached, so a pure re-bake would carry the OLD scaffold. Force a full
+    // reload; inlined (not reloadShader()) to keep a statusChanged binding from
+    // looping back through this setter.
+    if (m_shaderSource.isValid() && !m_shaderSource.isEmpty()) {
+        setStatus(Status::Loading);
+    }
+    m_shaderDirty = true;
+    update();
+}
+
+void ShaderEffect::setShaderIncludePaths(const QStringList& paths)
+{
+    if (m_shaderIncludePaths == paths) {
+        return;
+    }
+    m_shaderIncludePaths = paths;
+    // Marking dirty alone is not enough: include expansion happens inside
+    // loadFragmentShader()/loadVertexShader() and the expanded source is
+    // cached on the node. A pure re-bake of the cached source would still
+    // carry the OLD include contents. Inline the two-line reload instead of
+    // calling reloadShader() so a QML binding on statusChanged can't loop
+    // back through this setter.
+    if (m_shaderSource.isValid() && !m_shaderSource.isEmpty()) {
+        setStatus(Status::Loading);
+    }
+    m_shaderDirty = true;
+    update();
+}
+
+} // namespace PhosphorRendering

--- a/src/daemon/overlayservice.cpp
+++ b/src/daemon/overlayservice.cpp
@@ -411,6 +411,18 @@ OverlayService::~OverlayService()
         disconnect(qGuiApp, nullptr, this, nullptr);
     }
 
+    // Disarm the idle quiesce before any teardown below: drainDeferredDeletes
+    // runs a nested event loop that dispatches timers, so an armed quiesce
+    // whose deadline elapses mid-destruction would fire its lambda re-entrantly
+    // against half-destroyed members. disconnect() (not just stop()) so that a
+    // future teardown path reaching scheduleIdleQuiesce can restart the timer
+    // but never re-establish the timeout connection - it only connects when the
+    // pointer is still null.
+    if (m_idleQuiesceTimer) {
+        m_idleQuiesceTimer->stop();
+        m_idleQuiesceTimer->disconnect();
+    }
+
     if (m_prepareForSleepConnected) {
         QDBusConnection::systemBus().disconnect(QStringLiteral("org.freedesktop.login1"),
                                                 QStringLiteral("/org/freedesktop/login1"),

--- a/src/daemon/overlayservice/settings.cpp
+++ b/src/daemon/overlayservice/settings.cpp
@@ -498,7 +498,16 @@ void OverlayService::scheduleIdleQuiesce()
             // teardown-deadlock avoidance); we only pause the 60 Hz shader
             // render loop and the CAVA capture. Mirror syncCavaState's wantRun
             // predicate: a visible audio decoration also keeps CAVA alive, so it
-            // must veto the quiesce too.
+            // must veto the quiesce too. A vetoed one-shot is NOT re-armed
+            // here: every path that shows or hides a decoration or overlay
+            // routes through syncCavaState (or calls scheduleIdleQuiesce
+            // directly), so the next show or hide re-arms it. The five slot
+            // hide-completion handlers (OSD, zone selector, snap-assist,
+            // layout picker, cheatsheet) are the exception when their slot
+            // is undecorated: they call neither. Each is covered by the arm
+            // at its own next show, via applyDecoration's unconditional
+            // syncCavaState tail. New hide paths must keep that contract or
+            // parked towers strand until the next show/hide cycle.
             if (isOverlayDisplaying() || !visibleAudioDecorationSlots().isEmpty()) {
                 return;
             }
@@ -519,9 +528,17 @@ void OverlayService::scheduleIdleQuiesce()
                     // A false return means the installed shell QML no longer
                     // declares the forwarder (version skew) - without the log
                     // the PR's whole memory win would vanish untraceably.
+                    // Latched once per process: the skew is permanent for the
+                    // daemon's lifetime and the quiesce re-arms every idle
+                    // cycle, so an unlatched warning would repeat per screen
+                    // per cycle forever without adding information.
                     if (!QMetaObject::invokeMethod(slot, "releaseIdleGraphicsResources")) {
-                        qCDebug(lcOverlay) << "idle quiesce: releaseIdleGraphicsResources not invokable on slot"
-                                           << "(installed shell QML out of date?)";
+                        static bool warnedSlotSkew = false;
+                        if (!warnedSlotSkew) {
+                            warnedSlotSkew = true;
+                            qCWarning(lcOverlay) << "idle quiesce: releaseIdleGraphicsResources not invokable on slot"
+                                                 << "(installed shell QML out of date?)";
+                        }
                     }
                 }
             }
@@ -531,7 +548,13 @@ void OverlayService::scheduleIdleQuiesce()
             // too rather than leaving it the one surface that pins them.
             if (m_shaderPreviewWindow) {
                 if (!QMetaObject::invokeMethod(m_shaderPreviewWindow, "releaseIdleGraphicsResources")) {
-                    qCDebug(lcOverlay) << "idle quiesce: releaseIdleGraphicsResources not invokable on preview window";
+                    // Same once-per-process latch rationale as the slot loop.
+                    static bool warnedPreviewSkew = false;
+                    if (!warnedPreviewSkew) {
+                        warnedPreviewSkew = true;
+                        qCWarning(lcOverlay)
+                            << "idle quiesce: releaseIdleGraphicsResources not invokable on preview window";
+                    }
                 }
             }
             // Parked animation-shader towers (SurfaceAnimator's pending-reuse
@@ -541,8 +564,10 @@ void OverlayService::scheduleIdleQuiesce()
             // when the parking's amortisation argument no longer applies
             // (it defends against per-toggle deleteLater floods, and there
             // is no toggling here), so drop them; the next animated leg
-            // builds a fresh tower, warm-path cost unchanged inside the
-            // grace window since a quick re-trigger cancels this timer.
+            // builds a fresh tower. Note the grace window is deliberately
+            // NOT extended by re-triggers (see the arming comment below),
+            // so an OSD-only session can reap a tower that is about to be
+            // reused - the cost is one fresh tower build on the next leg.
             if (m_surfaceAnimator) {
                 m_surfaceAnimator->releaseParkedShaders();
             }
@@ -550,7 +575,7 @@ void OverlayService::scheduleIdleQuiesce()
     }
     // Arm only when not already pending: the grace window measures from the
     // FIRST idle, not from the last settings poke or OSD hide - syncCavaState
-    // funnels ~18 settings signals plus every decoration show/hide through
+    // funnels 15 settings signals plus every decoration show/hide through
     // here, and restarting on each would postpone the release indefinitely.
     // A genuine resume (refreshFromIdle, wantRun) stops the timer, so the next
     // idle re-arms a fresh window.

--- a/src/daemon/overlayservice/settings.cpp
+++ b/src/daemon/overlayservice/settings.cpp
@@ -475,10 +475,16 @@ void OverlayService::syncCavaState()
 
 void OverlayService::scheduleIdleQuiesce()
 {
-    // Nothing to wind down if neither the render loop nor CAVA is active.
+    // Nothing to wind down if neither the render loop nor CAVA is active —
+    // and no parked animation towers are waiting on the reap. The third term
+    // is load-bearing for the OSD-only session: navigation OSDs park a tower
+    // per show without ever starting the 60 Hz shader timer or CAVA, so
+    // without it the quiesce never armed and the towers (and their FBOs)
+    // were immortal exactly on the path that creates the most of them.
     const bool shaderTimerActive = m_shaderUpdateTimer && m_shaderUpdateTimer->isActive();
     const bool cavaActive = m_audioProvider && m_audioProvider->isRunning();
-    if (!shaderTimerActive && !cavaActive) {
+    const bool parkedTowers = m_surfaceAnimator && m_surfaceAnimator->hasParkedShaders();
+    if (!shaderTimerActive && !cavaActive && !parkedTowers) {
         return;
     }
     if (!m_idleQuiesceTimer) {
@@ -527,6 +533,18 @@ void OverlayService::scheduleIdleQuiesce()
                 if (!QMetaObject::invokeMethod(m_shaderPreviewWindow, "releaseIdleGraphicsResources")) {
                     qCDebug(lcOverlay) << "idle quiesce: releaseIdleGraphicsResources not invokable on preview window";
                 }
+            }
+            // Parked animation-shader towers (SurfaceAnimator's pending-reuse
+            // stash) hold full-window FBOs per (surface, slot) for the
+            // keep-alive shells' lifetime — i.e. forever, after the first
+            // animated OSD/popup show on each slot. Genuine rest is exactly
+            // when the parking's amortisation argument no longer applies
+            // (it defends against per-toggle deleteLater floods, and there
+            // is no toggling here), so drop them; the next animated leg
+            // builds a fresh tower, warm-path cost unchanged inside the
+            // grace window since a quick re-trigger cancels this timer.
+            if (m_surfaceAnimator) {
+                m_surfaceAnimator->releaseParkedShaders();
             }
         });
     }

--- a/src/daemon/overlayservice/shader.cpp
+++ b/src/daemon/overlayservice/shader.cpp
@@ -610,7 +610,7 @@ void OverlayService::destroyShaderPreviewWindow()
     // preview pointer was nulled above, so isOverlayDisplaying() reflects
     // only the main overlay now; a warm resume restarts the loop via
     // refreshFromIdle. Arm the idle GPU release BEFORE stopping: the quiesce
-    // guard requires an active timer, and stopping first would leave the
+    // guard needs at least one active term, and stopping first would leave the
     // warm-idled main slots' shader FBOs pinned until the next drag cycle.
     if (!isOverlayDisplaying() && m_shaderUpdateTimer && m_shaderUpdateTimer->isActive()) {
         scheduleIdleQuiesce();

--- a/src/shared/ZoneShaderRenderer.qml
+++ b/src/shared/ZoneShaderRenderer.qml
@@ -15,6 +15,14 @@ Item {
     required property var config
     // Default to empty object when config is null (callers may not always pass valid config)
     readonly property var safeConfig: config || ({})
+    // Idle-quiesce park (set by the host while the overlay sits idle): drops
+    // the private layer FBO below along with the render node's resources. A
+    // full-screen RGBA8 layer texture per screen otherwise survives every
+    // releaseIdleGraphicsResources() call, because the layer belongs to Qt's
+    // QQuickItemLayer, not to the shader node. The host MUST clear this on
+    // every wake path before the next painted frame — the layer is
+    // correctness-relevant for multipass packs (see the layer.enabled note).
+    property bool parked: false
     property alias status: zoneShaderItem.status
     property alias errorLog: zoneShaderItem.errorLog
 
@@ -42,7 +50,13 @@ Item {
         // get an isolated rendering context. Without this, the scene graph's
         // batch renderer internal pass-tracking state desynchronizes when the
         // render node manages its own passes.
-        layer.enabled: shaderSource.toString() !== ""
+        //
+        // Released while parked (idle quiesce): the FBO is screen-sized and
+        // otherwise lives for the window's whole lifetime. Safe only because
+        // a parked item never paints — the host hides the shader content
+        // while idle, and the visible binding at the call site adds !parked
+        // as a belt — so no multipass frame can render unlayered.
+        layer.enabled: shaderSource.toString() !== "" && !root.parked
         layer.textureMirroring: ShaderEffectSource.NoMirroring
         shaderSource: root.safeConfig.shaderSource || ""
         bufferShaderPath: root.safeConfig.bufferShaderPath || ""

--- a/src/shared/ZoneShaderRenderer.qml
+++ b/src/shared/ZoneShaderRenderer.qml
@@ -15,13 +15,16 @@ Item {
     required property var config
     // Default to empty object when config is null (callers may not always pass valid config)
     readonly property var safeConfig: config || ({})
-    // Idle-quiesce park (set by the host while the overlay sits idle): drops
-    // the private layer FBO below along with the render node's resources. A
-    // full-screen RGBA8 layer texture per screen otherwise survives every
-    // releaseIdleGraphicsResources() call, because the layer belongs to Qt's
-    // QQuickItemLayer, not to the shader node. The host MUST clear this on
-    // every wake path before the next painted frame — the layer is
-    // correctness-relevant for multipass packs (see the layer.enabled note).
+    // Idle-quiesce park. Only the daemon overlay host binds this (to its
+    // idleParked latch); the settings/editor dialog consumers leave it false
+    // and reclaim by deactivating their Loader instead. While parked, the
+    // private layer FBO below is dropped along with the render node's
+    // resources — for the overlay host that layer is a screen-sized RGBA8
+    // texture which otherwise survives every releaseIdleGraphicsResources()
+    // call, because it belongs to Qt's QQuickItemLayer, not to the shader
+    // node. The host MUST clear this on every wake path before the next
+    // painted frame — the layer is correctness-relevant for multipass packs
+    // (see the layer.enabled note).
     property bool parked: false
     property alias status: zoneShaderItem.status
     property alias errorLog: zoneShaderItem.errorLog
@@ -54,8 +57,11 @@ Item {
         // Released while parked (idle quiesce): the FBO is screen-sized and
         // otherwise lives for the window's whole lifetime. Safe only because
         // a parked item never paints — the host hides the shader content
-        // while idle, and the visible binding at the call site adds !parked
-        // as a belt — so no multipass frame can render unlayered.
+        // while idle and gates the renderer's visible binding on the same
+        // park state — including during the one composited frame the C++
+        // release forces (ShaderEffect::releaseIdleGraphicsResources calls
+        // win->update(); that frame is what flushes this layer drop on an
+        // otherwise idle window). So no multipass frame can render unlayered.
         layer.enabled: shaderSource.toString() !== "" && !root.parked
         layer.textureMirroring: ShaderEffectSource.NoMirroring
         shaderSource: root.safeConfig.shaderSource || ""

--- a/src/ui/RenderNodeOverlay.qml
+++ b/src/ui/RenderNodeOverlay.qml
@@ -78,7 +78,10 @@ Window {
     // Mirror-contract completion: nothing writes _idled on a preview window
     // today (the daemon's idle paths target mainOverlaySlot only), but the
     // header contract above promises a 1:1 surface, and a missing name turns
-    // a future C++ write into a dead dynamic property with no warning.
+    // a future C++ write into a dead dynamic property with no warning. The
+    // hosted content's _idled binding below folds Window visibility into it,
+    // which is the preview's only reliable wake edge for the idle park
+    // (Item.visible inside a hidden Window is not guaranteed to flip).
     property bool _idled: false
 
     /// Forward to the hosted content's reloadShader() — invoked by the
@@ -120,7 +123,10 @@ Window {
         highlightedZoneIds: root.highlightedZoneIds
         shaderParams: root.shaderParams
         zoneDataVersion: root.zoneDataVersion
-        _idled: root._idled
+        // Fold Window visibility in: a hidden preview is idled, so the idle
+        // park latched while it was hidden is guaranteed a true->false edge
+        // (and an on_IdledChanged wake) when the window is shown again.
+        _idled: root._idled || !root.visible
         iTime: root.iTime
         iTimeDelta: root.iTimeDelta
         iFrame: root.iFrame

--- a/src/ui/RenderNodeOverlayContent.qml
+++ b/src/ui/RenderNodeOverlayContent.qml
@@ -82,6 +82,21 @@ Item {
         return -1;
     }
     property bool _idled: false
+    // Set while the idle quiesce has parked the shader stack. Gates the
+    // renderer's layer FBO (screen-sized, otherwise immortal) and its
+    // visibility. Cleared on EVERY wake path, and each host has a live one:
+    // on the daemon overlay the un-idle flip covers the warm resume
+    // (lifecycle.cpp writes _idled both ways) and the slot Item's visibility
+    // toggle covers a plain show() after a full hide; on the editor preview
+    // the Window folds its own visibility into _idled (RenderNodeOverlay
+    // binds _idled to root._idled || !root.visible), so the show itself
+    // fires the un-idle flip. All of these run before the next painted
+    // frame, which is the renderer's contract for re-enabling the layer.
+    property bool idleParked: false
+    on_IdledChanged: if (!root._idled)
+        root.idleParked = false
+    onVisibleChanged: if (root.visible)
+        root.idleParked = false
 
     function reloadShader() {
         zoneShaderRenderer.reloadShader();
@@ -95,22 +110,12 @@ Item {
         flashAnimation.start();
     }
 
-    // Set while the idle quiesce has parked the shader stack. Gates the
-    // renderer's layer FBO (screen-sized, otherwise immortal) and its
-    // visibility. Cleared on EVERY wake path: the un-idle flip covers the
-    // drag-pause resume, and effective visibility covers a plain show()
-    // after a full hide (where _idled was never set, so no change signal
-    // would fire). Both run before the next painted frame, which is the
-    // renderer's contract for re-enabling the layer.
-    property bool idleParked: false
-    on_IdledChanged: if (!_idled)
-        idleParked = false
-    onVisibleChanged: if (visible)
-        idleParked = false
-
     // Idle-quiesce hook: the daemon calls this (via the hosting slot) after
     // the idle grace window so the shader item's GPU resources are freed
-    // while the overlay sits invisible. They rebuild on the next painted frame.
+    // while the overlay sits invisible. They rebuild on the next painted
+    // frame. Order matters: latch the park FIRST — the C++ call below forces
+    // one sync+render pass (win->update() in ShaderEffect), and that forced
+    // frame is what applies the layer drop on an otherwise idle window.
     function releaseIdleGraphicsResources() {
         idleParked = true;
         zoneShaderRenderer.releaseIdleGraphicsResources();
@@ -199,8 +204,12 @@ Item {
             anchors.fill: parent
             // !idleParked: a parked renderer must never paint — its layer FBO
             // is released, and an unlayered multipass frame desyncs the batch
-            // renderer (see ZoneShaderRenderer's layer.enabled note).
+            // renderer (see ZoneShaderRenderer's layer.enabled note). This
+            // term is the belt for the one composited frame the C++ release
+            // forces while the layer is down; keep it in lockstep with the
+            // parked binding below.
             visible: root.shaderSource.toString() !== "" && status !== ZoneShaderItem.Error && !root.idleParked
+            parked: root.idleParked
             config: shaderConfig
             onShaderError: function (log) {
                 console.error("RenderNodeOverlayContent: Shader error:", log);
@@ -217,7 +226,14 @@ Item {
         // overlayDisplayModeChanged re-syncs a live overlay via
         // recreateOverlayWindowsOnTypeMismatch().
         Repeater {
-            model: root.zones
+            // Gate the model on the same condition as the delegates'
+            // visibility: a Repeater instantiates delegates regardless of
+            // their visible binding, so an ungated model rebuilds the whole
+            // ZoneItem set on every idle cycle (the idle path clears zones
+            // and refreshFromIdle re-pushes them) for a fallback that never
+            // shows while the shader is Ready. When status leaves Ready the
+            // binding re-evaluates and the delegates build on that frame.
+            model: (root.shaderSource.toString() === "" || zoneShaderRenderer.status !== ZoneShaderItem.Ready) ? root.zones : []
 
             delegate: ZoneItem {
                 required property var modelData

--- a/src/ui/RenderNodeOverlayContent.qml
+++ b/src/ui/RenderNodeOverlayContent.qml
@@ -95,10 +95,24 @@ Item {
         flashAnimation.start();
     }
 
+    // Set while the idle quiesce has parked the shader stack. Gates the
+    // renderer's layer FBO (screen-sized, otherwise immortal) and its
+    // visibility. Cleared on EVERY wake path: the un-idle flip covers the
+    // drag-pause resume, and effective visibility covers a plain show()
+    // after a full hide (where _idled was never set, so no change signal
+    // would fire). Both run before the next painted frame, which is the
+    // renderer's contract for re-enabling the layer.
+    property bool idleParked: false
+    on_IdledChanged: if (!_idled)
+        idleParked = false
+    onVisibleChanged: if (visible)
+        idleParked = false
+
     // Idle-quiesce hook: the daemon calls this (via the hosting slot) after
     // the idle grace window so the shader item's GPU resources are freed
     // while the overlay sits invisible. They rebuild on the next painted frame.
     function releaseIdleGraphicsResources() {
+        idleParked = true;
         zoneShaderRenderer.releaseIdleGraphicsResources();
     }
 
@@ -183,7 +197,10 @@ Item {
             id: zoneShaderRenderer
 
             anchors.fill: parent
-            visible: root.shaderSource.toString() !== "" && status !== ZoneShaderItem.Error
+            // !idleParked: a parked renderer must never paint — its layer FBO
+            // is released, and an unlayered multipass frame desyncs the batch
+            // renderer (see ZoneShaderRenderer's layer.enabled note).
+            visible: root.shaderSource.toString() !== "" && status !== ZoneShaderItem.Error && !root.idleParked
             config: shaderConfig
             onShaderError: function (log) {
                 console.error("RenderNodeOverlayContent: Shader error:", log);

--- a/tests/unit/ui/zones/test_surface_shader_item.cpp
+++ b/tests/unit/ui/zones/test_surface_shader_item.cpp
@@ -153,14 +153,18 @@ private Q_SLOTS:
         QCOMPARE(statusSpy.count(), 1);
     }
 
-    void testSurfaceShaderItem_unsupportedUrlSchemeSetsError()
+    void testSurfaceShaderItem_unsupportedUrlSchemeIsFullyRefused()
     {
         // http:// / ftp:// can't be loaded by the RHI pipeline; the base
-        // rejects them at setShaderSource() with an Error status + log.
+        // rejects them at setShaderSource() as a FULL refusal — no state
+        // changes, only a warning — so status, the property value, and the
+        // rendered output always agree (see the zone item's sibling test
+        // for the full rationale).
         SurfaceShaderItem item;
         item.setShaderSource(QUrl(QStringLiteral("http://example.com/effect.frag")));
-        QCOMPARE(item.status(), SurfaceShaderItem::Status::Error);
-        QVERIFY(!item.errorLog().isEmpty());
+        QCOMPARE(item.status(), SurfaceShaderItem::Status::Null);
+        QVERIFY(item.errorLog().isEmpty());
+        QVERIFY(item.shaderSource().isEmpty());
     }
 };
 

--- a/tests/unit/ui/zones/test_zone_shader_item.cpp
+++ b/tests/unit/ui/zones/test_zone_shader_item.cpp
@@ -386,17 +386,21 @@ private Q_SLOTS:
         QCOMPARE(item.status(), ZoneShaderItem::Status::Loading);
     }
 
-    void testZoneShaderItem_unsupportedUrlSchemeSetsError()
+    void testZoneShaderItem_unsupportedUrlSchemeIsFullyRefused()
     {
         // http:// / ftp:// / etc. can't be loaded by the RHI pipeline; the
-        // library now rejects them at setShaderSource() (input-validation
-        // boundary) with an Error status + log, rather than silently
-        // deferring to the render thread where it would fail with a
-        // generic "Shader loading failed" message.
+        // library rejects them at setShaderSource() (input-validation
+        // boundary) as a FULL refusal: no state changes at all, only a
+        // warning. Setting Status::Error while the previous shader kept
+        // rendering made status, the property value, and the on-screen
+        // output disagree (and reloadShader() then erased the error), so
+        // the contract is now "a refused write leaves everything as it
+        // was".
         ZoneShaderItem item;
         item.setShaderSource(QUrl(QStringLiteral("http://example.com/shader.frag")));
-        QCOMPARE(item.status(), ZoneShaderItem::Status::Error);
-        QVERIFY(!item.errorLog().isEmpty());
+        QCOMPARE(item.status(), ZoneShaderItem::Status::Null);
+        QVERIFY(item.errorLog().isEmpty());
+        QVERIFY(item.shaderSource().isEmpty());
     }
 
     // ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Attacks the "70%+ GPU and 800+ MB VRAM with two windows in scrolling mode" report from both ends: the kwin effect was rendering invisible parked columns at full decoration cost, and the daemon's idle GPU reclaim existed but never actually ran.

### kwin-effect: off-viewport park cull
Parked scrolling columns (off-viewport columns, hidden tabs) were marked `PAINT_WINDOW_TRANSFORMED` unconditionally, which forces KWin to keep painting them — and the repaint driver's ~30fps backdrop pump takes the focus exemption, so every parked glass column ran its full decoration fold (backdrop blit, gaussian ping-pong, every pack at full padded canvas) at 30–60 Hz, invisibly, forever. A new shared predicate `scrollParkedOffscreen()` (visual rect: padded band relocated to the strip position plus the live view offset, intersected with the managed output) is consumed at three lockstep sites: `prePaintWindow` withholds TRANSFORMED so KWin's own culling works, `paintWindow` early-returns before backdrop/fold/draw, and the driver stops driving. Columns re-engage the frame they scroll back toward the viewport; snapshot captures are exempt via the existing `m_capturingSnapshot` latch.

### kwin-effect: backdrop capture at sampler density
Blur-family chains read the backdrop only through buffer passes at their `bufferScale` (normalized uvs), so a full-density capture stored and re-blitted texels the samplers stride over. `chainBackdropScale()` captures at the largest linking bufferScale unless some pack's main pass samples it sharp. ~33 MB → ~2 MB per 4K window and a 16× smaller per-frame blit for the bundled glass chain; mosaic/duotone-style sharp readers keep full density automatically.

### kwin-effect: 10 s park reap
A column parked past 10 s releases its whole surface state (~100+ MB of full-canvas targets per 4K window) through the sanctioned `releaseSurfaceState()` path. Under the threshold waking stays a cheap refold with a valid capture, so neighbour-to-neighbour scrolling never pays the cold re-capture.

### daemon: the idle quiesce now actually reclaims
Three independent reasons it previously reclaimed almost nothing:
- the `NoStage` release job had no frame behind it on a mapped-but-undamaged keep-alive shell, so it could sit queued forever (the code flagged this itself); a `win->update()` after scheduling forces one pass so it dispatches
- the zone shader's screen-sized `layer.enabled` FBO belongs to Qt's `QQuickItemLayer` and survived every release; it is now gated on an `idleParked` flag, cleared on both wake paths, with the renderer hidden while parked so no multipass frame renders unlayered
- parked animation-shader towers never reused (the stage anchor is recreated per OSD show) and accumulated unboundedly on surfaces that never die; `releaseParkedShaders()` drops the stash at quiesce, and the arming gate learns `hasParkedShaders()` so OSD-only sessions (which start neither the shader timer nor CAVA) still arm the reap

### fix: focus-event log flood
The no-shader-assigned warning demoted only for a fully empty profile tree, so overrides on unrelated legs caused three warnings per focus change. It now warns only when an override exists on the event's own dotted cascade yet resolution came back empty.

## Post-merge live checks (from the audit, commit 4d2c9e950)

Four items the audit could not settle by reading the code. None blocks merge; each is a specific observation to make on a live session.

1. **Does the reclaim reach the GPU in the same idle cycle?** The layer FBO drop and the parked towers' `deleteLater`'d `QSGLayer` FBOs are both freed at a later render sync that an idle window may never schedule. One GPU/RSS measurement across a quiesce (park towers, wait out the 5 s grace, compare before/after without waking the overlay) answers it. If memory only returns on the next show, the win is deferred, not absent, and the fix would need a follow-up frame after the deferred deletes drain.
2. **Backdrop quality at 0.25 density.** Every bundled glass pack declares `bufferScale: 0.25`, so the capture is now downsampled before any filtering. Look at a glass window over a playing video with a small blur radius, and again while scrolling, for shimmer or a flat-colour frost.
3. **First wake after the grace window.** This PR introduces the repo's first dynamically toggled `layer.enabled`, and the layer carries a non-default `textureMirroring`. On the first overlay show after an idle grace, check for a vertically flipped overlay. The render-node side was verified self-healing; the residual question is whether Qt re-applies the stored mirroring when the layer re-activates.
4. **Backlog, not a check:** `hoveredZoneIndex` runs an O(n) JS hit-test per drag-cursor event in `RenderNodeOverlayContent.qml`. The proper home is a C++ `Q_PROPERTY` on `OverlayService`. Structural, deferred from the audit on purpose.

## Testing
- 358/358 unit tests pass (`dbus-run-session -- ctest`)
- Live-verified on a 2×4K NVIDIA (RTX 2080) setup: the paint cull produced a user-confirmed GPU% improvement in scrolling mode, and daemon VRAM previously climbed 509→576 MB under OSD navigation with nothing returning it — it now settles back to the startup floor after the 5 s grace
- The daemon reclaim can be observed via `QT_LOGGING_RULES="phosphor.rendering.shadernode.debug=true"` → "releasing idle shader GPU resources" after idle

🤖 Generated with [Claude Code](https://claude.com/claude-code)
