### PR TITLE
feat(search): span both modes with per-result mode tags and auto-switch

### DIFF
--- a/libs/phosphor-control/include/PhosphorControl/PageRegistry.h
+++ b/libs/phosphor-control/include/PhosphorControl/PageRegistry.h
@@ -214,6 +214,12 @@ public:
      *  "hidden, or unverifiable" rather than strictly "hidden by tier" — the
      *  safe direction for every consumer, all of which treat false as skip. */
     bool pageAllowedInCurrentMode(const QString& id) const;
+    /** pageAllowedInCurrentMode against an EXPLICIT mode rather than the
+     *  current one. Same ancestor walk, same fail-closed behaviour and same
+     *  unknown-id semantics. Public so SearchController can classify an
+     *  entry's reachability in BOTH modes (its per-result simple/advanced
+     *  tag) without flipping the live mode back and forth. */
+    bool allowedInMode(const QString& id, bool advanced) const;
     /** Log a warning for every entry whose `counterpartId` is broken. Listed
      *  in the order the warnings are emitted, which the tests assert:
      *  the counterpart is this entry ITSELF; it names a page that does not
@@ -335,10 +341,6 @@ private:
     /// validateCounterparts can ask "would this be reachable in the mode that
     /// hides its partner" without mutating m_showAdvanced.
     static bool modeAllowsIn(PageVisibility v, bool advanced);
-    /// pageAllowedInCurrentMode against an explicit mode. Same ancestor walk,
-    /// same fail-closed behaviour; the public accessor binds `advanced` to
-    /// m_showAdvanced.
-    bool allowedInMode(const QString& id, bool advanced) const;
     /// Full visibility test for a sidebar tree accessor: the entry's own
     /// tier must match the mode AND, for a virtual node (no qmlSource), at
     /// least one descendant must itself be visible — so an emptied-out

--- a/libs/phosphor-control/include/PhosphorControl/SearchController.h
+++ b/libs/phosphor-control/include/PhosphorControl/SearchController.h
@@ -31,10 +31,14 @@ class ISearchProvider;
  *     addEntry(); dynamic content (rules/shaders/…) via registerProvider().
  *
  * QML binds `query` (the search field) and `results` (a ListView). Each result
- * map carries `title`, `subtitle`, `icon`, `kind`, `pageId`, `anchor`,
+ * map carries `title`, `subtitle`, `icon`, `kind`, `mode`, `pageId`, `anchor`,
  * `address` and `actionId` — selecting one calls
  * `SettingsController::navigateTo(address)`, except for Kind::Action results,
  * which are dispatched by `actionId` instead.
+ * The index spans BOTH simple/advanced modes: `mode` (SearchEntry::Mode as an
+ * int — 0 both, 1 simple-only, 2 advanced-only) tags each result with where it
+ * lives, and the app's search UI is expected to badge mode-specific results
+ * and flip the mode before navigating to one the live mode does not show.
  * `suggestion` holds a "did you mean …" title, populated only when a non-empty
  * query yields zero results.
  *

--- a/libs/phosphor-control/include/PhosphorControl/SearchEntry.h
+++ b/libs/phosphor-control/include/PhosphorControl/SearchEntry.h
@@ -36,7 +36,20 @@ struct SearchEntry
         Action
     };
 
+    /// Which UI mode(s) can reach this entry. COMPUTED by
+    /// SearchController::buildIndex from the host page's registry tier ANDed
+    /// with the entry's own `advancedOnly` flag — producers never set it.
+    /// The index carries every entry regardless of the live mode; this tag is
+    /// what the results surface exposes so the UI can badge a mode-specific
+    /// result and switch the mode before navigating to it.
+    enum class Mode {
+        Both, ///< Reachable in simple and advanced mode alike.
+        SimpleOnly, ///< Lives on a SimpleOnly page (a condensed simple surface).
+        AdvancedOnly ///< On an AdvancedOnly page, or an advanced-gated row.
+    };
+
     Kind kind = Kind::Page;
+    Mode mode = Mode::Both;
     /// Navigation target page id (must be a registered page). Empty for
     /// Kind::Action entries.
     QString pageId;
@@ -56,9 +69,11 @@ struct SearchEntry
     QStringList keywords;
     /// True when the target row/card is only rendered in advanced mode, on a
     /// page that itself shows in BOTH modes. The registry's page-level tier
-    /// cannot express this: the host page is visible, so without this flag a
-    /// simple-mode search offers a result that reveals nothing. Producers set
-    /// it to mirror the row's own advanced-only declaration.
+    /// cannot express this: the host page shows in simple mode too, so
+    /// without this flag the entry would classify as Mode::Both and a
+    /// simple-mode activation would reveal a collapsed row instead of
+    /// switching to advanced first. Producers set it to mirror the row's own
+    /// advanced-only declaration.
     bool advancedOnly = false;
 
     /// Search-folded copies of the matched fields, filled by

--- a/libs/phosphor-control/src/searchcontroller.cpp
+++ b/libs/phosphor-control/src/searchcontroller.cpp
@@ -29,6 +29,10 @@ QVariantMap toVariant(const SearchEntry& e)
     m.insert(QStringLiteral("subtitle"), e.subtitle);
     m.insert(QStringLiteral("icon"), e.icon);
     m.insert(QStringLiteral("kind"), static_cast<int>(e.kind));
+    // 0 = both modes, 1 = simple-only, 2 = advanced-only. The UI badges
+    // non-zero results and switches the mode before navigating to one the
+    // live mode does not show.
+    m.insert(QStringLiteral("mode"), static_cast<int>(e.mode));
     m.insert(QStringLiteral("pageId"), e.pageId);
     m.insert(QStringLiteral("anchor"), e.anchor);
     m.insert(QStringLiteral("address"), e.address());
@@ -42,16 +46,17 @@ SearchController::SearchController(ApplicationController* app, QObject* parent)
     : QObject(parent)
     , m_app(app)
 {
-    // The index is tier-filtered at build time (see buildIndex), so a
-    // simple/advanced flip changes which entries belong in it. Without this
-    // the filter would be computed once and the index would stay stale for
-    // the rest of the session — search would keep returning the previous
-    // mode's set. Wired here rather than in each app because the filter
-    // itself lives in this library.
+    // The index tags every entry with its simple/advanced mode at build time
+    // (see buildIndex), derived from the registry's page tiers. Without this
+    // a setPageVisibility restamp would leave the cached tags stale for the
+    // rest of the session. Wired here rather than in each app because the
+    // classification itself lives in this library.
     if (m_app != nullptr && m_app->registry() != nullptr) {
-        // visibleSetChanged rather than showAdvancedChanged: it covers both a
-        // mode flip and a per-entry setPageVisibility restamp, which are the
-        // two things that change what the tier filter admits.
+        // visibleSetChanged covers both a mode flip and a per-entry
+        // setPageVisibility restamp. Only the restamp changes the tags —
+        // the index is mode-independent, so a plain flip rebuilds to an
+        // identical list and recompute()'s results comparison suppresses
+        // the emit.
         connect(m_app->registry(), &PageRegistry::visibleSetChanged, this, &SearchController::invalidate);
         // The index also derives its Page entries from the catalogue, which
         // GROWS at runtime (post-startup registerPage is a supported path),
@@ -148,11 +153,11 @@ QVector<SearchEntry> SearchController::buildIndex()
     if (m_app == nullptr || m_app->registry() == nullptr) {
         // Defensive fallback (unreachable in practice — the app is alive for the
         // controller's whole lifetime). Return NOTHING rather than the static
-        // entries: without the registry there is no tier filter, so the
-        // condensed simple pages' rows and their advanced twins would ALL
-        // surface at once, which is exactly the duplication the filter below
-        // exists to prevent. An empty result list is the honest answer when the
-        // registry that defines reachability is gone.
+        // entries: without the registry there is no tier information, so every
+        // entry's simple/advanced tag (and with it the UI's auto mode-switch)
+        // would be a guess, and the unregistered-page drop below could not run
+        // at all. An empty result list is the honest answer when the registry
+        // that defines reachability is gone.
         return entries;
     }
 
@@ -192,21 +197,33 @@ QVector<SearchEntry> SearchController::buildIndex()
         return crumbs.join(breadcrumbSeparator());
     };
 
+    // An entry's mode tag from its reachability in each mode. The index is
+    // deliberately NOT filtered by the live mode any more: a result the other
+    // mode owns stays listed, badged with its mode, and the UI switches the
+    // mode before navigating so the app's gate cannot redirect it away.
+    const auto modeFor = [](bool inSimple, bool inAdvanced) {
+        return (inSimple && inAdvanced) ? SearchEntry::Mode::Both
+                                        : (inSimple ? SearchEntry::Mode::SimpleOnly : SearchEntry::Mode::AdvancedOnly);
+    };
+
     for (const PageRegistry::Entry& e : pages) {
         // Only navigable leaves are search targets; category / drill parents
         // carry no QML and aren't a destination.
         if (e.qmlSource.isEmpty()) {
             continue;
         }
-        // Nor is a page the current simple/advanced tier hides: activating
-        // such a result sends the app's mode gate somewhere else entirely,
-        // so the user lands on an unrelated page with no reveal.
-        if (!m_app->registry()->pageAllowedInCurrentMode(e.id)) {
+        // Reachable in NEITHER mode (its own tier and an ancestor's tier
+        // contradict, or the ancestry is unverifiable): no mode switch can
+        // ever land on it, so it is not a destination.
+        const bool inSimple = m_app->registry()->allowedInMode(e.id, false);
+        const bool inAdvanced = m_app->registry()->allowedInMode(e.id, true);
+        if (!inSimple && !inAdvanced) {
             continue;
         }
 
         SearchEntry se;
         se.kind = SearchEntry::Kind::Page;
+        se.mode = modeFor(inSimple, inAdvanced);
         se.pageId = e.id;
         se.title = e.title;
         se.icon = e.iconSource;
@@ -222,18 +239,20 @@ QVector<SearchEntry> SearchController::buildIndex()
     // (e.g. a rule's match summary) is respected. Actions are excluded: they
     // are commands, not page-resident targets, so a page breadcrumb would
     // mislabel them (their pageId is empty anyway).
-    // Same tier gate as the page loop above, shared by the static and
-    // provider loops: a setting/section/entity entry whose host page the
-    // current mode hides is not reachable, and the condensed simple pages
-    // deliberately register rows that duplicate their advanced twins —
-    // without this filter BOTH show up in either mode and one of them
-    // navigates nowhere useful. Actions are dispatched by actionId rather
-    // than by page address (and carry no pageId), so they are always kept.
-    // An entry may also be advanced-only WITHIN a page both modes show (a row
-    // or card the page hides in simple mode). The page-level check cannot see
-    // that, so AND in the entry's own tier: otherwise simple mode offers a
-    // result whose reveal target is collapsed to zero height.
-    const auto tierAllows = [this](const SearchEntry& e) {
+    // Same mode classification as the page loop above, shared by the static
+    // and provider loops: a setting/section/entity entry inherits its host
+    // page's tiers, ANDed with its own `advancedOnly` flag — a row or card
+    // the page renders only in advanced mode must classify AdvancedOnly even
+    // though the page itself shows in both modes, or a simple-mode activation
+    // would skip the mode switch and reveal a row collapsed to zero height.
+    // Returns false to DROP the entry (unregistered / non-navigable page, or
+    // reachable in neither mode); otherwise stamps e.mode and keeps it. The
+    // condensed simple pages deliberately register rows that duplicate their
+    // advanced twins; both surface, distinguished by their mode badge, and
+    // either navigates correctly because the UI switches the mode first.
+    // Actions are dispatched by actionId rather than by page address (and
+    // carry no pageId), so they are always kept, tagged Both.
+    const auto classifyMode = [this, &modeFor](SearchEntry& e) {
         if (e.kind == SearchEntry::Kind::Action || e.pageId.isEmpty()) {
             return true;
         }
@@ -279,14 +298,21 @@ QVector<SearchEntry> SearchController::buildIndex()
             }
             return false;
         }
-        if (!m_app->registry()->pageAllowedInCurrentMode(e.pageId)) {
+        // An advancedOnly row can only be REACHED where its page shows in
+        // advanced mode, so it zeroes the simple leg. An advancedOnly entry
+        // on a SimpleOnly page is an authoring contradiction reachable in
+        // neither mode — dropped like an unreachable page.
+        const bool inSimple = m_app->registry()->allowedInMode(e.pageId, false) && !e.advancedOnly;
+        const bool inAdvanced = m_app->registry()->allowedInMode(e.pageId, true);
+        if (!inSimple && !inAdvanced) {
             return false;
         }
-        return !e.advancedOnly || m_app->registry()->showAdvanced();
+        e.mode = modeFor(inSimple, inAdvanced);
+        return true;
     };
 
     for (SearchEntry e : m_staticEntries) {
-        if (!tierAllows(e)) {
+        if (!classifyMode(e)) {
             continue;
         }
         if (e.subtitle.isEmpty() && e.kind != SearchEntry::Kind::Page && e.kind != SearchEntry::Kind::Action) {
@@ -304,7 +330,7 @@ QVector<SearchEntry> SearchController::buildIndex()
         // QPointer. Provider lifetime stays the caller's contract.
         const QVector<SearchEntry> provided = provider->searchEntries();
         for (SearchEntry e : provided) {
-            if (!tierAllows(e)) {
+            if (!classifyMode(e)) {
                 continue;
             }
             if (e.subtitle.isEmpty() && e.kind != SearchEntry::Kind::Page && e.kind != SearchEntry::Kind::Action) {

--- a/libs/phosphor-control/src/searchcontroller.cpp
+++ b/libs/phosphor-control/src/searchcontroller.cpp
@@ -256,8 +256,8 @@ QVector<SearchEntry> SearchController::buildIndex()
         if (e.kind == SearchEntry::Kind::Action || e.pageId.isEmpty()) {
             return true;
         }
-        // Unregistered pageId — drop it, loudly. pageAllowedInCurrentMode
-        // deliberately "expresses no opinion" on an unknown id (it is a tier
+        // Unregistered pageId — drop it, loudly. allowedInMode deliberately
+        // "expresses no opinion" on an unknown id (it is a tier
         // filter, not an existence check), so without this a typo'd pageId in
         // the catalogue sails through every gate below and produces a result
         // that navigates nowhere: the app's mode gate rejects the id and
@@ -371,8 +371,9 @@ void SearchController::recompute()
         : QString();
 
     // Emit only on a real change. recompute() runs on every invalidate(), and
-    // visibleSetChanged fires it for mode flips that often do not alter what the
-    // current query matches — re-emitting there would rebuild the QML ListView
+    // visibleSetChanged fires it for mode flips, which never alter what the
+    // current query matches (the index is mode-independent; only a restamp
+    // changes the tags) — re-emitting there would rebuild the QML ListView
     // and re-evaluate the results / resultCount / suggestion bindings for
     // nothing. Compares the built variant list, so a reordering counts as a
     // change while an identical rebuild does not.

--- a/libs/phosphor-control/tests/test_search_controller.cpp
+++ b/libs/phosphor-control/tests/test_search_controller.cpp
@@ -511,19 +511,26 @@ private Q_SLOTS:
         advanced.advancedOnly = true;
         sc.addEntry(advanced);
 
+        // An ungated sibling row on the same page, matching the same query, so
+        // the flag's effect is isolated to the entry that carries it.
+        SearchEntry ungated;
+        ungated.kind = SearchEntry::Kind::Setting;
+        ungated.pageId = QStringLiteral("general");
+        ungated.anchor = QStringLiteral("borderWidth");
+        ungated.title = QStringLiteral("Borders width");
+        sc.addEntry(ungated);
+
         m_app->registry()->setShowAdvanced(true);
         sc.setQuery(QStringLiteral("borders"));
         QCOMPARE(modeForTitle(sc, QStringLiteral("Apply borders to")),
                  static_cast<int>(SearchEntry::Mode::AdvancedOnly));
+        QCOMPARE(modeForTitle(sc, QStringLiteral("Borders width")), static_cast<int>(SearchEntry::Mode::Both));
 
         m_app->registry()->setShowAdvanced(false);
         sc.setQuery(QStringLiteral("borders"));
         QCOMPARE(modeForTitle(sc, QStringLiteral("Apply borders to")),
                  static_cast<int>(SearchEntry::Mode::AdvancedOnly));
-
-        // An ungated sibling on the same page classifies Both.
-        sc.setQuery(QStringLiteral("general"));
-        QCOMPARE(modeForTitle(sc, QStringLiteral("General")), static_cast<int>(SearchEntry::Mode::Both));
+        QCOMPARE(modeForTitle(sc, QStringLiteral("Borders width")), static_cast<int>(SearchEntry::Mode::Both));
     }
 
     void advancedOnlyEntryOnSimpleOnlyPageIsDropped()

--- a/libs/phosphor-control/tests/test_search_controller.cpp
+++ b/libs/phosphor-control/tests/test_search_controller.cpp
@@ -150,6 +150,19 @@ QString subtitleForTitle(const SearchController& sc, const QString& title)
     return QString();
 }
 
+// The `mode` tag of the result whose title matches, or -1 when the title is
+// absent — so "wrong tag" and "not a result at all" fail distinguishably.
+int modeForTitle(const SearchController& sc, const QString& title)
+{
+    for (const QVariant& v : sc.results()) {
+        const QVariantMap m = v.toMap();
+        if (m.value(QStringLiteral("title")).toString() == title) {
+            return m.value(QStringLiteral("mode")).toInt();
+        }
+    }
+    return -1;
+}
+
 } // namespace
 
 class TestSearchController : public QObject
@@ -480,14 +493,15 @@ private Q_SLOTS:
         QVERIFY(sc.suggestion().isEmpty());
     }
 
-    void advancedOnlyEntryIsHiddenInSimpleMode()
+    void advancedOnlyEntryIsTaggedAdvancedInBothModes()
     {
-        // SearchEntry::advancedOnly is the ONLY thing keeping an advanced row
-        // off the simple-mode result list when its owning page is visible in
-        // BOTH modes (the page-tier gate cannot help there). Roughly 25
-        // catalogue rows depend on it, so without this test deleting the
-        // `!e.advancedOnly ||` clause in SearchController::tierAllows passes
-        // the whole suite.
+        // SearchEntry::advancedOnly is the ONLY thing classifying an
+        // advanced-gated row AdvancedOnly when its owning page is visible in
+        // BOTH modes (the page-tier walk cannot see a per-row gate). Roughly
+        // 25 catalogue rows depend on it: without the tag a simple-mode
+        // activation would skip the mode switch and reveal a collapsed row.
+        // The entry stays LISTED in simple mode — the UI badges it and flips
+        // to advanced on activation.
         SearchController sc(m_app.get());
         SearchEntry advanced;
         advanced.kind = SearchEntry::Kind::Setting;
@@ -497,21 +511,41 @@ private Q_SLOTS:
         advanced.advancedOnly = true;
         sc.addEntry(advanced);
 
-        const auto titles = [&sc]() {
-            QStringList out;
-            for (const QVariant& v : sc.results()) {
-                out << v.toMap().value(QStringLiteral("title")).toString();
-            }
-            return out;
-        };
-
         m_app->registry()->setShowAdvanced(true);
         sc.setQuery(QStringLiteral("borders"));
-        QVERIFY(titles().contains(QStringLiteral("Apply borders to")));
+        QCOMPARE(modeForTitle(sc, QStringLiteral("Apply borders to")),
+                 static_cast<int>(SearchEntry::Mode::AdvancedOnly));
 
         m_app->registry()->setShowAdvanced(false);
         sc.setQuery(QStringLiteral("borders"));
-        QVERIFY(!titles().contains(QStringLiteral("Apply borders to")));
+        QCOMPARE(modeForTitle(sc, QStringLiteral("Apply borders to")),
+                 static_cast<int>(SearchEntry::Mode::AdvancedOnly));
+
+        // An ungated sibling on the same page classifies Both.
+        sc.setQuery(QStringLiteral("general"));
+        QCOMPARE(modeForTitle(sc, QStringLiteral("General")), static_cast<int>(SearchEntry::Mode::Both));
+    }
+
+    void advancedOnlyEntryOnSimpleOnlyPageIsDropped()
+    {
+        // An advanced-gated row on a SimpleOnly page is an authoring
+        // contradiction: no mode can ever render it, so listing it would
+        // produce a result whose activation reveals nothing in EITHER mode.
+        ApplicationController app;
+        app.registerPage(new StubPage(QStringLiteral("condensed")), {}, QStringLiteral("Condensed"),
+                         QUrl(QStringLiteral("qrc:/condensed.qml")), QString(), false, false,
+                         PageRegistry::PageVisibility::SimpleOnly);
+
+        SearchController sc(&app);
+        SearchEntry contradiction;
+        contradiction.kind = SearchEntry::Kind::Setting;
+        contradiction.pageId = QStringLiteral("condensed");
+        contradiction.title = QStringLiteral("Unreachable knob");
+        contradiction.advancedOnly = true;
+        sc.addEntry(contradiction);
+
+        sc.setQuery(QStringLiteral("unreachable"));
+        QCOMPARE(sc.resultCount(), 0);
     }
 
     void providerEntitiesAreSearchable()
@@ -692,19 +726,22 @@ private Q_SLOTS:
         QCOMPARE(spy.count(), 1);
     }
 
-    void hidesEntriesForPagesTheCurrentModeFilters()
+    void modeSpecificPagesAreTaggedNotFiltered()
     {
-        // A result the active tier hides is unreachable: activating it lets
-        // the app's mode gate send the user somewhere else entirely. Both
-        // page entries and page-resident static entries must drop out, and
-        // the index must REBUILD on the flip rather than serving the mode's
-        // set from the session's first query onwards.
+        // The index spans BOTH modes: a page only one mode shows stays a
+        // result in the other mode, tagged with the mode that owns it, so the
+        // UI can badge it and switch modes on activation. Both page entries
+        // and page-resident static entries carry the tag, and a mode flip
+        // must NOT change the result list (it is mode-independent now).
         ApplicationController app;
         app.registerPage(new StubPage(QStringLiteral("always")), {}, QStringLiteral("Always"),
                          QUrl(QStringLiteral("qrc:/always.qml")));
         app.registerPage(new StubPage(QStringLiteral("advanced")), {}, QStringLiteral("Advanced"),
                          QUrl(QStringLiteral("qrc:/advanced.qml")), QString(), false, false,
                          PageRegistry::PageVisibility::AdvancedOnly);
+        app.registerPage(new StubPage(QStringLiteral("condensed")), {}, QStringLiteral("Condensed"),
+                         QUrl(QStringLiteral("qrc:/condensed.qml")), QString(), false, false,
+                         PageRegistry::PageVisibility::SimpleOnly);
 
         SearchController sc(&app);
         SearchEntry setting;
@@ -713,36 +750,36 @@ private Q_SLOTS:
         setting.title = QStringLiteral("Advanced knob");
         sc.addEntry(setting);
 
-        // Advanced mode (the registry default): both are reachable.
+        // Advanced mode (the registry default): everything is listed, each
+        // tagged with the mode that owns it.
         sc.setQuery(QStringLiteral("advanced"));
         QCOMPARE(sc.resultCount(), 2);
+        QCOMPARE(modeForTitle(sc, QStringLiteral("Advanced")), static_cast<int>(SearchEntry::Mode::AdvancedOnly));
+        QCOMPARE(modeForTitle(sc, QStringLiteral("Advanced knob")), static_cast<int>(SearchEntry::Mode::AdvancedOnly));
+        const QVariantList advancedModeResults = sc.results();
 
-        // Flip to simple WITHOUT touching the query: the live results must
-        // refresh, which only happens if the flip invalidated the index.
-        app.registry()->setShowAdvanced(false);
-        QCOMPARE(sc.resultCount(), 0);
+        sc.setQuery(QStringLiteral("condensed"));
+        QCOMPARE(modeForTitle(sc, QStringLiteral("Condensed")), static_cast<int>(SearchEntry::Mode::SimpleOnly));
+        sc.setQuery(QStringLiteral("always"));
+        QCOMPARE(modeForTitle(sc, QStringLiteral("Always")), static_cast<int>(SearchEntry::Mode::Both));
 
-        // And back again.
-        app.registry()->setShowAdvanced(true);
-        QCOMPARE(sc.resultCount(), 2);
-        // Assert WHICH entries survive, not just how many — a future entry
-        // matching "advanced" would otherwise keep the count assertion
-        // passing for the wrong reason.
-        QVERIFY(resultPageIds(sc).contains(QStringLiteral("advanced")));
-
-        // The flip must re-emit so QML's resultCount/results bindings
-        // refresh; a rebuild without the signal leaves the UI stale.
+        // Flip to simple WITHOUT touching the query: the results are
+        // identical (the tags are reachability, not the live mode), and the
+        // suppressed-emit path keeps QML from rebuilding its list for
+        // nothing.
+        sc.setQuery(QStringLiteral("advanced"));
         QSignalSpy spy(&sc, &SearchController::resultsChanged);
         app.registry()->setShowAdvanced(false);
-        QVERIFY(spy.count() > 0);
+        QCOMPARE(sc.results(), advancedModeResults);
+        QCOMPARE(spy.count(), 0);
     }
 
-    void hidesProviderEntriesForHiddenPagesToo()
+    void providerEntriesOnModeSpecificPagesAreTaggedToo()
     {
-        // The provider loop applies the same tier gate as the static loop.
-        // Pinned separately because a regression reverting only the provider
-        // call site would otherwise ship green — and providers are the
-        // highest-volume entry source in the real app.
+        // The provider loop applies the same mode classification as the
+        // static loop. Pinned separately because a regression reverting only
+        // the provider call site would otherwise ship green — and providers
+        // are the highest-volume entry source in the real app.
         ApplicationController app;
         app.registerPage(new StubPage(QStringLiteral("hidden")), {}, QStringLiteral("Hidden"),
                          QUrl(QStringLiteral("qrc:/hidden.qml")), QString(), false, false,
@@ -767,15 +804,18 @@ private Q_SLOTS:
 
         sc.setQuery(QStringLiteral("zebra"));
         QCOMPARE(sc.resultCount(), 1);
+        QCOMPARE(modeForTitle(sc, QStringLiteral("Zebra")), static_cast<int>(SearchEntry::Mode::AdvancedOnly));
 
+        // Still listed after a flip to simple, tag unchanged.
         app.registry()->setShowAdvanced(false);
-        QCOMPARE(sc.resultCount(), 0);
+        QCOMPARE(sc.resultCount(), 1);
+        QCOMPARE(modeForTitle(sc, QStringLiteral("Zebra")), static_cast<int>(SearchEntry::Mode::AdvancedOnly));
     }
 
-    void reclassifyingAPageRefreshesTheIndex()
+    void reclassifyingAPageRetagsTheIndex()
     {
         // setPageVisibility is the late-reclassification path; the cached
-        // index must learn about it.
+        // index's mode tags must learn about it.
         ApplicationController app;
         app.registerPage(new StubPage(QStringLiteral("later")), {}, QStringLiteral("Later"),
                          QUrl(QStringLiteral("qrc:/later.qml")));
@@ -783,10 +823,11 @@ private Q_SLOTS:
         SearchController sc(&app);
         sc.setQuery(QStringLiteral("later"));
         QCOMPARE(sc.resultCount(), 1);
+        QCOMPARE(modeForTitle(sc, QStringLiteral("Later")), static_cast<int>(SearchEntry::Mode::Both));
 
-        app.registry()->setShowAdvanced(false);
         app.registry()->setPageVisibility(QStringLiteral("later"), PageRegistry::PageVisibility::AdvancedOnly);
-        QCOMPARE(sc.resultCount(), 0);
+        QCOMPARE(sc.resultCount(), 1);
+        QCOMPARE(modeForTitle(sc, QStringLiteral("Later")), static_cast<int>(SearchEntry::Mode::AdvancedOnly));
     }
 
 private:

--- a/src/settings/qml/Main.qml
+++ b/src/settings/qml/Main.qml
@@ -855,6 +855,12 @@ PhosphorUi.SettingsAppWindow {
 
             property bool compact: false
 
+            // Names the CURRENT mode, not the switch's target: the switch
+            // position already reads as simple/advanced, so the label tracks
+            // it like the daemon row's Running label. Shared by the wide
+            // rail's label and the compact rail's tooltip.
+            readonly property string modeLabel: settingsController.advancedMode ? i18n("Advanced") : i18n("Simple")
+
             implicitHeight: advancedModeRow.implicitHeight + Kirigami.Units.largeSpacing * 2
 
             RowLayout {
@@ -886,10 +892,7 @@ PhosphorUi.SettingsAppWindow {
                     visible: !advancedModeFooter.compact
                     Layout.fillWidth: true
                     Layout.alignment: Qt.AlignVCenter
-                    // Names the CURRENT mode, not the switch's target: the
-                    // switch position already reads as simple/advanced, so the
-                    // label tracks it like the daemon row's Running label.
-                    text: settingsController.advancedMode ? i18n("Advanced") : i18n("Simple")
+                    text: advancedModeFooter.modeLabel
                     elide: Text.ElideRight
                 }
 
@@ -910,7 +913,7 @@ PhosphorUi.SettingsAppWindow {
 
                     // Tooltip stands in for the hidden label, matching the
                     // compact rail rows.
-                    ToolTip.text: settingsController.advancedMode ? i18n("Advanced") : i18n("Simple")
+                    ToolTip.text: advancedModeFooter.modeLabel
                     ToolTip.visible: advancedModeFooter.compact && advancedModeHover.hovered
                     ToolTip.delay: Kirigami.Units.toolTipDelay
                 }

--- a/src/settings/qml/Main.qml
+++ b/src/settings/qml/Main.qml
@@ -400,12 +400,25 @@ PhosphorUi.SettingsAppWindow {
     // default (no stored value yet) reads the controller's own default at
     // startup, so "what mode does a brand-new user get" is defined in ONE
     // place: SettingsController::m_advancedMode. The stored value is pushed
-    // into the controller at startup (Component.onCompleted below) and the
-    // sidebar footer toggle writes user flips back here.
+    // into the controller at startup (Component.onCompleted below) and every
+    // later controller-side flip writes back through the Connections below.
     Settings {
         id: uiModeSettings
         category: "UiMode"
         property bool advancedMode: settingsController.advancedMode
+    }
+
+    // Persist EVERY mode change regardless of what drove it — the sidebar
+    // footer toggle or a search result activated in the other mode (which
+    // flips the controller directly). The Settings property's binding above
+    // only supplies the first-run default: a stored value (or any explicit
+    // write) severs it, so the binding alone cannot be the persistence path.
+    Connections {
+        target: settingsController
+
+        function onAdvancedModeChanged() {
+            uiModeSettings.advancedMode = settingsController.advancedMode;
+        }
     }
 
     Component.onCompleted: {
@@ -873,7 +886,10 @@ PhosphorUi.SettingsAppWindow {
                     visible: !advancedModeFooter.compact
                     Layout.fillWidth: true
                     Layout.alignment: Qt.AlignVCenter
-                    text: i18n("Advanced")
+                    // Names the CURRENT mode, not the switch's target: the
+                    // switch position already reads as simple/advanced, so the
+                    // label tracks it like the daemon row's Running label.
+                    text: settingsController.advancedMode ? i18n("Advanced") : i18n("Simple")
                     elide: Text.ElideRight
                 }
 
@@ -881,9 +897,11 @@ PhosphorUi.SettingsAppWindow {
                     Layout.alignment: Qt.AlignVCenter
                     checked: settingsController.advancedMode
                     accessibleName: i18n("Toggle advanced settings")
+                    // Persistence rides the controller's advancedModeChanged
+                    // connection by uiModeSettings — one write path for every
+                    // mode-change source.
                     onToggled: function (newValue) {
                         settingsController.advancedMode = newValue;
-                        uiModeSettings.advancedMode = newValue;
                     }
 
                     HoverHandler {
@@ -892,7 +910,7 @@ PhosphorUi.SettingsAppWindow {
 
                     // Tooltip stands in for the hidden label, matching the
                     // compact rail rows.
-                    ToolTip.text: i18n("Advanced")
+                    ToolTip.text: settingsController.advancedMode ? i18n("Advanced") : i18n("Simple")
                     ToolTip.visible: advancedModeFooter.compact && advancedModeHover.hovered
                     ToolTip.delay: Kirigami.Units.toolTipDelay
                 }

--- a/src/settings/qml/components/GlobalSearchField.qml
+++ b/src/settings/qml/components/GlobalSearchField.qml
@@ -13,6 +13,9 @@ import org.kde.kirigami as Kirigami
  * `searchController.query` and the dropdown to `searchController.results`;
  * selecting a result calls `settingsController.navigateTo(address)`, which
  * drills to the page and (for setting/section anchors) reveals the target.
+ * Results span both simple and advanced mode: a mode-specific result carries a
+ * Simple/Advanced badge, and activating one the live mode does not show flips
+ * `settingsController.advancedMode` before navigating.
  *
  * `searchOpen` exposes dropdown state so the host can suppress page-step
  * shortcuts while searching.
@@ -45,6 +48,15 @@ Item {
             return;
         }
         if (entry.address) {
+            // A result the other mode owns (mode: 0 = both, 1 = simple-only,
+            // 2 = advanced-only) switches the mode FIRST, so the page gate
+            // cannot redirect the navigation away and an advanced-gated row
+            // is actually rendered when the reveal fires. Main.qml persists
+            // the flip via its advancedModeChanged connection.
+            if (entry.mode === 1 && settingsController.advancedMode)
+                settingsController.advancedMode = false;
+            else if (entry.mode === 2 && !settingsController.advancedMode)
+                settingsController.advancedMode = true;
             settingsController.navigateTo(entry.address);
             root.dismiss();
         }
@@ -221,6 +233,10 @@ Item {
                     required property int index
                     required property var modelData
 
+                    // Mode badge text for a result only one mode shows;
+                    // empty for a result reachable in both modes.
+                    readonly property string modeLabel: modelData.mode === 1 ? i18nc("@info search result mode badge", "Simple") : modelData.mode === 2 ? i18nc("@info search result mode badge", "Advanced") : ""
+
                     // Reserve the scrollbar's gutter so the row content ends
                     // at the scrollbar's left edge instead of running
                     // underneath it (mirrors the LayoutComboBox popup list).
@@ -228,7 +244,17 @@ Item {
                     highlighted: ListView.isCurrentItem
                     topPadding: Kirigami.Units.smallSpacing
                     bottomPadding: Kirigami.Units.smallSpacing
-                    Accessible.name: resultDelegate.modelData.subtitle.length > 0 ? i18nc("@info:whatsthis search result: title, breadcrumb", "%1, %2", resultDelegate.modelData.title, resultDelegate.modelData.subtitle) : resultDelegate.modelData.title
+                    // Title, then breadcrumb, then the mode badge — each
+                    // appended only when present, so screen readers hear the
+                    // same context the row shows.
+                    Accessible.name: {
+                        var parts = [resultDelegate.modelData.title];
+                        if (resultDelegate.modelData.subtitle.length > 0)
+                            parts.push(resultDelegate.modelData.subtitle);
+                        if (resultDelegate.modeLabel.length > 0)
+                            parts.push(resultDelegate.modeLabel);
+                        return parts.join(i18nc("@info:whatsthis joiner between search-result context parts", ", "));
+                    }
                     onClicked: root.activate(resultDelegate.index)
 
                     contentItem: RowLayout {
@@ -263,6 +289,30 @@ Item {
                                 color: resultDelegate.highlighted ? Kirigami.Theme.highlightedTextColor : Kirigami.Theme.disabledTextColor
                                 opacity: resultDelegate.highlighted ? 0.85 : 1.0
                                 elide: Text.ElideRight
+                            }
+                        }
+
+                        // Mode badge: which mode owns this result. Activating
+                        // it from the other mode switches automatically (see
+                        // activate()), so the pill is information, not a
+                        // warning.
+                        Rectangle {
+                            visible: resultDelegate.modeLabel.length > 0
+                            Layout.alignment: Qt.AlignVCenter
+                            implicitWidth: modeBadgeLabel.implicitWidth + Kirigami.Units.smallSpacing * 2
+                            implicitHeight: modeBadgeLabel.implicitHeight + Kirigami.Units.smallSpacing
+                            radius: height / 2
+                            color: "transparent"
+                            border.width: 1
+                            border.color: resultDelegate.highlighted ? Kirigami.Theme.highlightedTextColor : Kirigami.Theme.disabledTextColor
+
+                            Label {
+                                id: modeBadgeLabel
+
+                                anchors.centerIn: parent
+                                text: resultDelegate.modeLabel
+                                font: Kirigami.Theme.smallFont
+                                color: resultDelegate.highlighted ? Kirigami.Theme.highlightedTextColor : Kirigami.Theme.disabledTextColor
                             }
                         }
                     }

--- a/src/settings/qml/components/SettingsFlickable.qml
+++ b/src/settings/qml/components/SettingsFlickable.qml
@@ -458,9 +458,9 @@ Flickable {
                 //     row — the user has to flip a switch on screen. Scroll to
                 //     and pulse the nearest ancestor card, whose header carries
                 //     that toggle. (An advanced-only row in simple mode also
-                //     lands here; the tier index normally filters it, so it is
-                //     an index/row disagreement, and the card is still a real
-                //     destination.)
+                //     lands here; search switches the mode before navigating,
+                //     so it is an index/row disagreement, and the card is
+                //     still a real destination.)
                 //   - It has none (a bare page-level row): nothing to show it
                 //     inside, so fall back to the top of the page.
                 settingsFlickable._revertRevealCards(pendingCards);

--- a/src/settings/qml/components/SettingsFlickable.qml
+++ b/src/settings/qml/components/SettingsFlickable.qml
@@ -314,10 +314,11 @@ Flickable {
             //     that is on screen — so scroll to and pulse the nearest
             //     ancestor card, whose header carries that toggle, rather than
             //     dead-ending at the top of the page. An advanced-only row
-            //     reached in simple mode also lands here; the search index
-            //     filters those by tier (SearchEntry.advancedOnly), so it is an
-            //     index/row disagreement, and the card is at least a real,
-            //     on-screen destination.
+            //     reached in simple mode also lands here; search switches the
+            //     mode before navigating (SearchEntry.advancedOnly tags the
+            //     result), so reaching one in simple mode is an index/row
+            //     disagreement, and the card is at least a real, on-screen
+            //     destination.
             //   - It has no ancestor card (a bare page-level row): there is
             //     nothing to show it inside, so fall back to the top of the
             //     page, which is at least a real destination.

--- a/src/settings/search/searchcatalog_p.h
+++ b/src/settings/search/searchcatalog_p.h
@@ -18,10 +18,12 @@ namespace SearchCatalogDetail {
 
 // `advancedOnly` mirrors the `advancedOnly:` declaration on the row or card
 // this anchor points at, for anchors whose HOST PAGE shows in both modes. The
-// registry's page tier cannot express a per-row tier, so without it a
-// simple-mode search offers a result that reveals a collapsed row. The two
-// declarations are cross-checked by tests/unit/settings/
-// test_search_catalog_tiers.cpp, so they cannot drift apart silently.
+// registry's page tier cannot express a per-row tier; the flag classifies the
+// entry AdvancedOnly, which badges the result and makes a simple-mode
+// activation switch to advanced first — without it the activation would skip
+// the switch and reveal a collapsed row. The two declarations are
+// cross-checked by tests/unit/settings/test_search_catalog_tiers.cpp, so they
+// cannot drift apart silently.
 inline void addSetting(PhosphorControl::SearchController* search, const QString& pageId, const QString& anchor,
                        const QString& title, const QStringList& keywords = {}, bool advancedOnly = false)
 {

--- a/tests/unit/settings/test_search_catalog_tiers.cpp
+++ b/tests/unit/settings/test_search_catalog_tiers.cpp
@@ -16,9 +16,10 @@
  * This test removes the drift: it parses the QML for anchors that sit inside an
  * advanced-gated block, parses the catalogue for the entries carrying
  * `advancedOnly=`, and fails when the two disagree in either direction. Getting
- * it wrong is user-visible both ways: a missing flag offers a simple-mode search
- * result that reveals a collapsed row, and a spurious one hides a setting the
- * user can actually reach.
+ * it wrong is user-visible both ways: a missing flag skips the search UI's
+ * automatic switch to advanced mode, so a simple-mode activation reveals a
+ * collapsed row; a spurious one badges the result Advanced and needlessly
+ * flips a simple-mode user into advanced mode for a row simple mode shows.
  *
  * Scope limit, stated honestly: attribution is per FILE. An anchor declared
  * inside a shared card component (WindowFilterCard's `windowFiltering`) whose

--- a/tests/unit/settings/test_search_catalog_tiers.cpp
+++ b/tests/unit/settings/test_search_catalog_tiers.cpp
@@ -888,7 +888,7 @@ private Q_SLOTS:
     }
 
     /// Every pageId the catalogue registers must be a page the app registers.
-    /// SearchController::tierAllows now DROPS entries whose pageId is unknown
+    /// SearchController::classifyMode now DROPS entries whose pageId is unknown
     /// to the registry (they produced results that navigated nowhere), so a
     /// stale id here is no longer a dead link — it is a setting that silently
     /// cannot be found at all, with only a runtime warning as evidence. The
@@ -934,7 +934,7 @@ private Q_SLOTS:
         QSet<QString> unregistered;
         // setPageKeywords takes the page id directly. A stale id there costs
         // the page its entire synonym list SILENTLY: the call never reaches
-        // tierAllows, so nothing warns and the page just stops answering to
+        // classifyMode, so nothing warns and the page just stops answering to
         // its synonyms.
         static const QRegularExpression kKeywords(
             QStringLiteral("\\bsetPageKeywords\\(\\s*QStringLiteral\\(\"([^\"]+)\"\\)"));


### PR DESCRIPTION
## Summary

Global settings search previously filtered its index by the live simple/advanced mode, so a simple-mode user could not find settings that live on advanced pages (and vice versa). This PR makes search span both modes:

- **Mode tags instead of filtering**: `SearchEntry` gains a `Mode` tag (both / simple-only / advanced-only), computed at index build from the page's registry tier in each mode (`PageRegistry::allowedInMode`, promoted to public) ANDed with the entry's existing `advancedOnly` flag. Nothing new to author — pages and rows keep their existing markings.
- **Mode badge in the dropdown**: mode-specific results carry a Simple/Advanced pill (also included in `Accessible.name`).
- **Auto mode switch on activation**: activating a result the current mode does not show flips `settingsController.advancedMode` before navigating, so the page gate cannot redirect the navigation and advanced-gated rows are rendered when the reveal fires.
- **Centralized mode persistence**: Main.qml persists every `advancedModeChanged` (the Settings-property binding severs on the first stored value, so it was never a reliable path); the footer toggle's duplicate write is removed.
- **Footer label tracks the mode**: the sidebar footer (and its compact-rail tooltip) now reads *Simple* in simple mode and *Advanced* in advanced mode.

Entries reachable in neither mode (an advanced-gated row on a SimpleOnly page) are still dropped. A mode flip now rebuilds the index to an identical list, so the results comparison suppresses spurious QML refreshes; the invalidate wiring remains for late `setPageVisibility` restamps.

Known behavior change: the condensed simple pages' rows that duplicate their advanced twins now both surface, distinguished by badge. Intended — a dedup-prefer-current-mode pass is a small follow-up if it proves noisy.

## Testing

- 358/358 tests pass (`dbus-run-session ctest`); the four framework tests pinning the old hide-by-mode behavior were rewritten to the tag semantics, plus a new contradiction-drop test.
- The QML↔catalogue `advancedOnly` cross-check (`test_search_catalog_tiers`) is semantically unchanged and still green.
- Offscreen boot of the settings app is clean in both modes (fresh fakehome and seeded `UiMode advancedMode=true`); qmllint on the edited QML shows only the pre-existing unqualified-context-property notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)