### PR TITLE
fix(restore): log every cross-screen reclaim decline, and fix the appId derivation behind them

### DIFF
--- a/libs/phosphor-engine/include/PhosphorEngine/IWindowRegistry.h
+++ b/libs/phosphor-engine/include/PhosphorEngine/IWindowRegistry.h
@@ -21,13 +21,27 @@ public:
      *
      * The mapping is seeded once and never re-seeded, so a mid-session class
      * mutation keeps resolving to the identity the stores were keyed with.
-     * An id whose appId part is EMPTY is exempt from the freeze and returned
-     * verbatim: a blank window class is a not-yet-mapped surface, and a
-     * permanent appId-less canonical would strip the identity every
-     * appId-keyed store looks a window up by.
+     * That single stable key per window, for the window's whole life, is the
+     * invariant every keyed store depends on: engines key their membership
+     * maps at adopt time and have no re-key path, so an implementation that
+     * let the canonical CHANGE mid-life would strand live state rather than
+     * correct it.
+     *
+     * The freeze is deliberately unconditional, including for an id whose
+     * appId part is empty (KWin reports a blank class for a surface it has
+     * not finished mapping). Callers needing a window's app identity must ask
+     * appIdFor / currentAppIdFor, which read the metadata record and
+     * self-correct when the class arrives, rather than parsing it back out of
+     * the frozen id.
      */
     virtual QString canonicalizeWindowId(const QString& rawWindowId) = 0;
     virtual QString canonicalizeForLookup(const QString& rawWindowId) const = 0;
+    /// The app identity recorded for @p instanceId, or empty when the instance
+    /// is unknown. Takes a BARE instance id: unlike minimizedState, which
+    /// accepts either form, this does not split a composite `appId|instanceId`
+    /// and answers empty for one. Callers holding a window id should extract
+    /// the instance part first (or use a service-level currentAppIdFor, which
+    /// does it for them).
     virtual QString appIdFor(const QString& instanceId) const = 0;
 
     /**

--- a/libs/phosphor-engine/include/PhosphorEngine/IWindowRegistry.h
+++ b/libs/phosphor-engine/include/PhosphorEngine/IWindowRegistry.h
@@ -15,6 +15,17 @@ class PHOSPHORENGINE_EXPORT IWindowRegistry
 public:
     virtual ~IWindowRegistry() = default;
 
+    /**
+     * @brief Freeze (on first contact) and return the canonical id for
+     * @p rawWindowId's instance.
+     *
+     * The mapping is seeded once and never re-seeded, so a mid-session class
+     * mutation keeps resolving to the identity the stores were keyed with.
+     * An id whose appId part is EMPTY is exempt from the freeze and returned
+     * verbatim: a blank window class is a not-yet-mapped surface, and a
+     * permanent appId-less canonical would strip the identity every
+     * appId-keyed store looks a window up by.
+     */
     virtual QString canonicalizeWindowId(const QString& rawWindowId) = 0;
     virtual QString canonicalizeForLookup(const QString& rawWindowId) const = 0;
     virtual QString appIdFor(const QString& instanceId) const = 0;

--- a/libs/phosphor-engine/include/PhosphorEngine/WindowRegistry.h
+++ b/libs/phosphor-engine/include/PhosphorEngine/WindowRegistry.h
@@ -161,6 +161,10 @@ public:
     /// window is unknown or the field was never delivered. Accepts either a
     /// bare instance id or a composite appId|instanceId window id.
     std::optional<bool> minimizedState(const QString& windowId) const override;
+    /// Every instance currently recorded under @p appId, in UNSPECIFIED order
+    /// (QMultiHash bucket order, not insertion or arrival order). Callers that
+    /// need a deterministic sequence — anything FIFO-shaped — must sort or
+    /// otherwise order the result themselves.
     QStringList instancesWithAppId(const QString& appId) const;
     bool contains(const QString& instanceId) const;
     int size() const;

--- a/libs/phosphor-engine/src/WindowPlacementStore.cpp
+++ b/libs/phosphor-engine/src/WindowPlacementStore.cpp
@@ -39,6 +39,12 @@ bool sameWindowInstance(const QString& lhs, const QString& rhs)
 bool WindowPlacementStore::record(WindowPlacement incoming)
 {
     if (incoming.windowId.isEmpty() || incoming.appId.isEmpty() || !incoming.isValid()) {
+        // Logged: an appId-less capture is dropped here and the window then
+        // has nothing to restore on reopen, which reads downstream as "the
+        // placement was never saved" with no evidence of where it went. The
+        // common source is a window KWin had not classed when the capture ran.
+        qCDebug(lcPlacementStore) << "record: refusing" << incoming.windowId << "appId" << incoming.appId << "valid"
+                                  << incoming.isValid();
         return false;
     }
 

--- a/libs/phosphor-engine/src/WindowRegistry.cpp
+++ b/libs/phosphor-engine/src/WindowRegistry.cpp
@@ -192,6 +192,20 @@ QString WindowRegistry::canonicalizeWindowId(const QString& rawWindowId)
     if (it != m_canonicalByInstance.constEnd()) {
         return it.value();
     }
+    // An appId-less composite ("|instanceId") is a placeholder identity, not an
+    // identity: KWin reports a blank window class for a surface it has not
+    // finished mapping, and the effect's bring-up metadata walk pushes whatever
+    // it sees. Freezing that shape here would be permanent (the mapping is
+    // seeded once and deliberately never re-seeded, so class MUTATION cannot
+    // rewrite it), and every consumer that canonicalizes would then carry an id
+    // whose appId parses as empty — which is exactly the identity the appId
+    // buckets, the restore FIFO and the cross-screen reclaim key on. The
+    // window would silently stop matching its own placement records for the
+    // rest of its life. Hand the raw id back unfrozen instead and let the first
+    // well-formed contact win the freeze.
+    if (PhosphorIdentity::WindowId::extractAppId(rawWindowId).isEmpty()) {
+        return rawWindowId;
+    }
     m_canonicalByInstance.insert(instanceId, rawWindowId);
     return rawWindowId;
 }

--- a/libs/phosphor-engine/src/WindowRegistry.cpp
+++ b/libs/phosphor-engine/src/WindowRegistry.cpp
@@ -89,7 +89,12 @@ void WindowRegistry::remove(const QString& instanceId)
     const QString postEmit = m_canonicalByInstance.value(instanceId);
     if (postEmit == canonical) {
         m_canonicalByInstance.remove(instanceId);
-        if (hasPendingUpsert && !canonical.isEmpty()) {
+        // Keep the mapping alive for a re-announce that is about to replay its
+        // record — but NOT while clear() is draining, where the replay itself
+        // is dropped below. Re-inserting there left the instance behind as a
+        // canonical-only survivor of a bulk reset that promises to empty the
+        // registry, so the two conditions must agree.
+        if (hasPendingUpsert && m_clearing == 0 && !canonical.isEmpty()) {
             m_canonicalByInstance.insert(instanceId, canonical);
         }
     }
@@ -192,20 +197,22 @@ QString WindowRegistry::canonicalizeWindowId(const QString& rawWindowId)
     if (it != m_canonicalByInstance.constEnd()) {
         return it.value();
     }
-    // An appId-less composite ("|instanceId") is a placeholder identity, not an
-    // identity: KWin reports a blank window class for a surface it has not
-    // finished mapping, and the effect's bring-up metadata walk pushes whatever
-    // it sees. Freezing that shape here would be permanent (the mapping is
-    // seeded once and deliberately never re-seeded, so class MUTATION cannot
-    // rewrite it), and every consumer that canonicalizes would then carry an id
-    // whose appId parses as empty — which is exactly the identity the appId
-    // buckets, the restore FIFO and the cross-screen reclaim key on. The
-    // window would silently stop matching its own placement records for the
-    // rest of its life. Hand the raw id back unfrozen instead and let the first
-    // well-formed contact win the freeze.
-    if (PhosphorIdentity::WindowId::extractAppId(rawWindowId).isEmpty()) {
-        return rawWindowId;
-    }
+    // Frozen unconditionally, INCLUDING an appId-less composite ("|instanceId",
+    // which KWin produces for a surface whose class it has not resolved yet).
+    // Exempting that shape looks attractive — an appId-less canonical does
+    // strip the identity the appId buckets match on — but it is the wrong
+    // layer to fix it at, and the exemption is actively harmful: the canonical
+    // would then CHANGE mid-life, at the first metadata push carrying a real
+    // class, while the effect keeps sending the id it froze at first
+    // observation. Engine state keyed at open (strip/tile membership, the
+    // m_states reverse maps, min sizes, float markers) becomes unreachable at
+    // the new id, close stops removing the window, and the alive-set walk in
+    // WindowTrackingAdaptor::pruneStaleWindows force-removes the live window
+    // from its layout. One stable key per window for its whole life is the
+    // invariant every store here is built on. A window whose appId is not yet
+    // known is served by asking the REGISTRY for it (currentAppIdFor, which
+    // reads the metadata record and self-corrects on the class-change push),
+    // never by parsing it back out of the frozen id.
     m_canonicalByInstance.insert(instanceId, rawWindowId);
     return rawWindowId;
 }

--- a/libs/phosphor-scroll-engine/CMakeLists.txt
+++ b/libs/phosphor-scroll-engine/CMakeLists.txt
@@ -40,6 +40,7 @@ add_library(PhosphorScrollEngine SHARED
     src/scrollengine/engine_apply.cpp
     src/scrollengine/drag_preview.cpp
     src/scrollengine/engine_lifecycle.cpp
+    src/scrollengine/engine_reopen.cpp
     src/scrollengine/engine_handoff.cpp
     src/scrollengine/engine_float.cpp
     src/scrollengine/engine_navigation.cpp

--- a/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/ScrollEngine.h
+++ b/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/ScrollEngine.h
@@ -709,6 +709,9 @@ Q_SIGNALS:
 private:
     // engine_core.cpp
     QString canonicalizeForLookup(const QString& rawWindowId) const;
+    /// App identity from the registry record, never parsed out of the
+    /// first-contact-frozen id. Mirrors AutotileEngine's twin; see engine_core.cpp.
+    QString currentAppIdFor(const QString& anyWindowId) const;
     PhosphorEngine::PlacementStateKey currentKeyForScreen(const QString& screenId) const
     {
         return m_context.currentKeyForScreen(screenId);

--- a/libs/phosphor-scroll-engine/src/scrollengine/engine_core.cpp
+++ b/libs/phosphor-scroll-engine/src/scrollengine/engine_core.cpp
@@ -40,6 +40,23 @@ QString ScrollEngine::canonicalizeForLookup(const QString& rawWindowId) const
     return rawWindowId;
 }
 
+QString ScrollEngine::currentAppIdFor(const QString& anyWindowId) const
+{
+    if (anyWindowId.isEmpty()) {
+        return QString();
+    }
+    if (m_windowRegistry) {
+        const QString instanceId = PhosphorIdentity::WindowId::extractInstanceId(anyWindowId);
+        const QString fromRegistry = m_windowRegistry->appIdFor(instanceId);
+        if (!fromRegistry.isEmpty()) {
+            return fromRegistry;
+        }
+    }
+    // Fallback: parse the string. Note this returns the FIRST-seen class for
+    // canonical ids; accurate only when the window has never renamed.
+    return PhosphorIdentity::WindowId::extractAppId(anyWindowId);
+}
+
 // ── Screen ownership ────────────────────────────────────────────────────────
 
 bool ScrollEngine::isActiveOnScreen(const QString& screenId) const
@@ -354,6 +371,18 @@ bool ScrollEngine::restoreFromStripStash(ScrollState* state, const PhosphorEngin
         // windows map one-to-one (a claimed tile is never re-claimed —
         // claiming rewrites its id to a live one, which later arrivals
         // cannot collide with).
+        // extractAppId, NOT currentAppIdFor, unlike the capture and float
+        // restore: this prefix is matched against ids stored VERBATIM by a
+        // previous session, so it has to be built the same way those ids were
+        // spelled. A registry answer would build "ghostty|" and never match a
+        // stashed "|olduuid" — and, the case that really separates them, an
+        // Electron/CEF app that RENAMED itself would build its new class here
+        // while the stash still holds the old one. The accepted cost is that a
+        // window whose canonical was frozen before KWin classed it has an
+        // empty prefix and skips the cross-session claim entirely: it takes
+        // the ordinary insertion-order position instead of reclaiming its
+        // column, leaving the stash entry intact for a later arrival. A
+        // degraded restore, not a wrong one.
         const QString appId = PhosphorIdentity::WindowId::extractAppId(windowId);
         const QString appPrefix = appId.isEmpty() ? QString() : appId + QLatin1Char('|');
         if (!appPrefix.isEmpty()) {

--- a/libs/phosphor-scroll-engine/src/scrollengine/engine_handoff.cpp
+++ b/libs/phosphor-scroll-engine/src/scrollengine/engine_handoff.cpp
@@ -11,7 +11,6 @@
 
 #include <PhosphorEngine/IWindowTrackingService.h>
 #include <PhosphorEngine/WindowPlacementStore.h>
-#include <PhosphorIdentity/WindowId.h>
 
 #include "scrollenginelogging.h"
 
@@ -270,7 +269,16 @@ std::optional<PhosphorEngine::WindowPlacement> ScrollEngine::capturePlacement(co
     }
     PhosphorEngine::WindowPlacement placement;
     placement.windowId = windowId;
-    placement.appId = PhosphorIdentity::WindowId::extractAppId(windowId);
+    // Registry answer, not a parse of the canonical id: the canonical is
+    // frozen at first contact, so a window KWin had not yet classed carries an
+    // appId-less id for its whole life, and WindowPlacementStore::record
+    // REJECTS a record with an empty appId — the capture would vanish and the
+    // window would have nothing to restore on reopen. This narrows that hole
+    // rather than closing it: currentAppIdFor falls back to the same parse
+    // when the registry record ALSO has no class yet, so a capture taken
+    // before the class-change push still produces an empty appId and is still
+    // dropped. It converges once the class arrives, which the parse never did.
+    placement.appId = currentAppIdFor(windowId);
     placement.screenId = key.screenId;
     placement.virtualDesktop = key.desktop;
     placement.activity = key.activity;

--- a/libs/phosphor-scroll-engine/src/scrollengine/engine_lifecycle.cpp
+++ b/libs/phosphor-scroll-engine/src/scrollengine/engine_lifecycle.cpp
@@ -423,7 +423,16 @@ bool ScrollEngine::claimCrossScreenReopen(const QString& rawWindowId, const QStr
     // dispatch cannot produce an empty one, but this is public engine API and
     // an empty opening screen would defeat the predicate's same-screen bail
     // (empty compares unequal to every recorded screen).
+    // Every decline below is LOGGED. The deferring engine has already stood
+    // down by the time a claim runs, so a decline decides where the window
+    // spends the whole session (float on whatever monitor KWin opened it on,
+    // recoverable only by logging out). A silent one leaves the resulting
+    // login-restore strand with no evidence at all in the journal, which is
+    // exactly how one survived a shipped fix.
     if (windowId.isEmpty() || openingScreenId.isEmpty() || !m_scrollingModeResolver || !m_windowTracker) {
+        qCInfo(lcScrollEngine) << "claimCrossScreenReopen:" << rawWindowId << "opened on" << openingScreenId
+                               << "— declining, engine not wired for the claim (resolver"
+                               << bool(m_scrollingModeResolver) << "tracker" << bool(m_windowTracker) << ")";
         return false;
     }
     // First observation only, by MEMBERSHIP: a window this engine already
@@ -433,6 +442,9 @@ bool ScrollEngine::claimCrossScreenReopen(const QString& rawWindowId, const QStr
     // (the rule windowOpened's defer gate documents): a phantom key left by
     // a refused earlier open must not veto a legitimate claim.
     if (const ScrollState* tracked = stateForWindow(windowId); tracked && tracked->containsWindow(windowId)) {
+        qCInfo(lcScrollEngine) << "claimCrossScreenReopen:" << windowId
+                               << "is already held by this engine — declining, treating it as an in-session "
+                                  "re-announce rather than a session restore";
         return false;
     }
     // Registry-aware appId, like autotile's twin and like every record
@@ -441,6 +453,14 @@ bool ScrollEngine::claimCrossScreenReopen(const QString& rawWindowId, const QStr
     // Electron/CEF class mutation.
     const QString appId = m_windowTracker->currentAppIdFor(windowId);
     if (!PhosphorEngine::hasStableAppIdFor(appId, windowId)) {
+        // Logged, not silent: this guard swallowed a real login-restore strand
+        // (a window whose canonical id had been frozen without an appId
+        // declined here, floated on its arrival monitor, and only a relog
+        // recovered it). The deferring engine has already stood down by the
+        // time the claim runs, so a decline here decides where the window
+        // spends the session.
+        qCInfo(lcScrollEngine) << "claimCrossScreenReopen:" << windowId << "has no stable appId (" << appId
+                               << ") — declining, its placement records cannot be matched";
         return false;
     }
     // peekForReclaim, not peek: the live-instance exclusion is what stops a
@@ -460,6 +480,10 @@ bool ScrollEngine::claimCrossScreenReopen(const QString& rawWindowId, const QStr
                 });
         });
     if (!pending) {
+        qCInfo(lcScrollEngine) << "claimCrossScreenReopen:" << windowId << "appId" << appId << "opened on"
+                               << openingScreenId
+                               << "— declining, no record carries a scrolling tile homed on another "
+                                  "scrolling-mode screen";
         return false;
     }
     const QString homeScreen = pending->screenId;

--- a/libs/phosphor-scroll-engine/src/scrollengine/engine_lifecycle.cpp
+++ b/libs/phosphor-scroll-engine/src/scrollengine/engine_lifecycle.cpp
@@ -5,7 +5,6 @@
 
 #include <PhosphorEngine/IWindowTrackingService.h>
 #include <PhosphorEngine/WindowPlacementStore.h>
-#include <PhosphorIdentity/WindowId.h>
 
 #include "enginelimits.h"
 #include "scrollenginelogging.h"
@@ -41,7 +40,10 @@ void ScrollEngine::seedFloatRestoreForOpen(const QString& windowId, int minWidth
 
 void ScrollEngine::restoreFloatRecordForOpen(const QString& windowId, const QString& screenId)
 {
-    const QString appId = PhosphorIdentity::WindowId::extractAppId(windowId);
+    // Registry answer, not a parse: a canonical id frozen before KWin resolved
+    // the class has no appId to parse, and this gate would then silently skip
+    // the float restore for the window's whole life.
+    const QString appId = currentAppIdFor(windowId);
     if (!m_windowTracker || appId.isEmpty() || appId == windowId) {
         return;
     }
@@ -138,7 +140,7 @@ bool ScrollEngine::insertOpenedWindow(ScrollState* state, const QString& windowI
     // strip order from per-window records needed close-burst ledgers and rank
     // anchors that every structural mutation had to invalidate, and the
     // strip stash already restores structure where it matters.
-    const QString appId = PhosphorIdentity::WindowId::extractAppId(windowId);
+    const QString appId = currentAppIdFor(windowId);
     if (m_windowTracker && !appId.isEmpty() && appId != windowId) {
         const PhosphorEngine::PlacementStateKey currentKey = currentKeyForScreen(screenId);
         if (const auto record =
@@ -413,127 +415,6 @@ bool ScrollEngine::insertOpenedWindow(ScrollState* state, const QString& windowI
         }
     }
     return inserted;
-}
-
-bool ScrollEngine::claimCrossScreenReopen(const QString& rawWindowId, const QString& openingScreenId, int minWidth,
-                                          int minHeight)
-{
-    const QString windowId = canonicalizeForLookup(rawWindowId);
-    // openingScreenId validated here, at the library boundary: the adaptor's
-    // dispatch cannot produce an empty one, but this is public engine API and
-    // an empty opening screen would defeat the predicate's same-screen bail
-    // (empty compares unequal to every recorded screen).
-    // Every decline below is LOGGED. The deferring engine has already stood
-    // down by the time a claim runs, so a decline decides where the window
-    // spends the whole session (float on whatever monitor KWin opened it on,
-    // recoverable only by logging out). A silent one leaves the resulting
-    // login-restore strand with no evidence at all in the journal, which is
-    // exactly how one survived a shipped fix.
-    if (windowId.isEmpty() || openingScreenId.isEmpty() || !m_scrollingModeResolver || !m_windowTracker) {
-        qCInfo(lcScrollEngine) << "claimCrossScreenReopen:" << rawWindowId << "opened on" << openingScreenId
-                               << "— declining, engine not wired for the claim (resolver"
-                               << bool(m_scrollingModeResolver) << "tracker" << bool(m_windowTracker) << ")";
-        return false;
-    }
-    // First observation only, by MEMBERSHIP: a window this engine already
-    // holds anywhere is an in-session move or re-announce, never a session
-    // restore — yanking it back to the record's screen would undo the very
-    // move that re-announced it. Membership, not the raw reverse-map key
-    // (the rule windowOpened's defer gate documents): a phantom key left by
-    // a refused earlier open must not veto a legitimate claim.
-    if (const ScrollState* tracked = stateForWindow(windowId); tracked && tracked->containsWindow(windowId)) {
-        qCInfo(lcScrollEngine) << "claimCrossScreenReopen:" << windowId
-                               << "is already held by this engine — declining, treating it as an in-session "
-                                  "re-announce rather than a session restore";
-        return false;
-    }
-    // Registry-aware appId, like autotile's twin and like every record
-    // producer (captures write the tracker's current appId): parsing the
-    // frozen canonical string would look in the wrong bucket after an
-    // Electron/CEF class mutation.
-    const QString appId = m_windowTracker->currentAppIdFor(windowId);
-    if (!PhosphorEngine::hasStableAppIdFor(appId, windowId)) {
-        // Logged, not silent: this guard swallowed a real login-restore strand
-        // (a window whose canonical id had been frozen without an appId
-        // declined here, floated on its arrival monitor, and only a relog
-        // recovered it). The deferring engine has already stood down by the
-        // time the claim runs, so a decline here decides where the window
-        // spends the session.
-        qCInfo(lcScrollEngine) << "claimCrossScreenReopen:" << windowId << "has no stable appId (" << appId
-                               << ") — declining, its placement records cannot be matched";
-        return false;
-    }
-    // peekForReclaim, not peek: the live-instance exclusion is what stops a
-    // fresh second instance being pulled onto its OPEN sibling's monitor on
-    // the strength of that sibling's live record. Non-consuming either way —
-    // consumption stays with windowOpened's own restore machinery (the strip
-    // stash claim and takeForReopen), which this claim funnels the window
-    // into by re-entering the open path with the RECORDED screen. Only a
-    // TILED slot earns the pull — a scroll-floating record is screen-local,
-    // matching snap's float doctrine.
-    const auto pending = m_windowTracker->placementStore().peekForReclaim(
-        windowId, appId, [&](const PhosphorEngine::WindowPlacement& p) {
-            return PhosphorEngine::pendingCrossScreenManagedRestore(
-                p, PhosphorEngine::WindowPlacement::scrollingEngineId(), PhosphorEngine::WindowPlacement::stateTiled(),
-                openingScreenId, [this](const QString& rec, int desktop, const QString& activity) {
-                    return m_scrollingModeResolver(rec, desktop, activity);
-                });
-        });
-    if (!pending) {
-        qCInfo(lcScrollEngine) << "claimCrossScreenReopen:" << windowId << "appId" << appId << "opened on"
-                               << openingScreenId
-                               << "— declining, no record carries a scrolling tile homed on another "
-                                  "scrolling-mode screen";
-        return false;
-    }
-    const QString homeScreen = pending->screenId;
-    // The LIVE screen set must agree with the record-context verdict:
-    // windowOpened's own m_scrollingScreens gate would otherwise refuse the
-    // adoption AFTER this method already answered "claimed", stranding the
-    // window untracked (a per-desktop mode override can make the resolver
-    // and the live set disagree during a context switch).
-    if (!m_scrollingScreens.contains(homeScreen)) {
-        qCInfo(lcScrollEngine) << "claimCrossScreenReopen:" << windowId << "recorded home" << homeScreen
-                               << "is scrolling-mode by record context but absent from the live set — declining";
-        return false;
-    }
-    // Grant-context must be compatible with insert-context. The predicate
-    // granted on the RECORD's (desktop, activity); windowOpened inserts into
-    // the home screen's CURRENT key. When two CONCRETE contexts disagree,
-    // adopting would splice the window into a strip on a desktop it is not
-    // visible on (displacing that desktop's real windows) and miss its
-    // stashed column outright — the conservative skip leaves the window to
-    // the ordinary open path instead. Sticky / unknown-context records
-    // (the 0 and empty sentinels) stay eligible; see
-    // recordContextMatchesLive.
-    const PhosphorEngine::PlacementStateKey homeKey = currentKeyForScreen(homeScreen);
-    if (!PhosphorEngine::recordContextMatchesLive(*pending, homeKey.desktop, homeKey.activity)) {
-        qCInfo(lcScrollEngine) << "claimCrossScreenReopen:" << windowId << "recorded context desktop"
-                               << pending->virtualDesktop << "activity" << pending->activity << "differs from"
-                               << homeScreen << "current context — declining";
-        return false;
-    }
-    windowOpened(windowId, homeScreen, minWidth, minHeight);
-    // Return the REAL outcome, verified by membership (ScrollState-level: a
-    // legitimately floated adoption is in the floating set, not the strip).
-    // An optimistic true converted every silently-refused re-entry into a
-    // window no engine manages — the caller hands a claimed window to no
-    // other engine.
-    const ScrollState* adopted = stateForWindow(windowId);
-    if (!adopted || !adopted->containsWindow(windowId)) {
-        qCWarning(lcScrollEngine) << "claimCrossScreenReopen:" << windowId << "adoption on" << homeScreen
-                                  << "was refused — not claimed";
-        return false;
-    }
-    // The ARRIVAL screen's mode-transition seed still names this id; the
-    // arrival-screen windowOpened that would have consumed it never runs on
-    // a successful claim (the dispatch returns), and one unconsumed id pins
-    // that screen's seed for the whole session. Safe no-op for a screen with
-    // no seed.
-    consumePendingInitialOrder(openingScreenId, windowId);
-    qCInfo(lcScrollEngine) << "claimCrossScreenReopen:" << windowId << "opened on" << openingScreenId
-                           << "— reclaimed to recorded scrolling home" << homeScreen;
-    return true;
 }
 
 void ScrollEngine::windowOpened(const QString& rawWindowId, const QString& screenId, int minWidth, int minHeight)
@@ -867,6 +748,14 @@ void ScrollEngine::windowClosed(const QString& rawWindowId)
     // revisits a closed window's floating membership. A no-op for the normal
     // case, which is the whole point.
     state->removeFloating(windowId);
+    // Deliberately NOT consumePendingInitialOrder: the seed's "consumed on
+    // every outcome" contract is about OPEN outcomes (the window arrived and
+    // was placed, floated or refused), and a close is not one. Marking the id
+    // consumed here would defeat a RE-SEED — setInitialWindowOrder resets the
+    // consumed set precisely so a closed window reopens at its seeded
+    // position, and a close-time consume would send it to the ordinary
+    // next-to-focus path instead (partiallyConsumedSeedGuardsReopens covers
+    // exactly that sequence).
     m_states.removeWindow(windowId);
     // m_lastAppliedRect is deliberately RETAINED through the close: the
     // daemon's close capture consults lastManagedRect DURING windowClosed
@@ -1169,6 +1058,7 @@ void ScrollEngine::onWindowResized(const QString& rawWindowId, const QRect& oldF
 // The cross-engine handoff section (handoffRelease / handoffReceive and the
 // unified placement capture) lives in engine_handoff.cpp — split out when
 // this file crossed the size ceiling a second time, on the seam
-// engine_float.cpp's first split established.
+// engine_float.cpp's first split established. claimCrossScreenReopen went to
+// engine_reopen.cpp on the third crossing.
 
 } // namespace PhosphorScrollEngine

--- a/libs/phosphor-scroll-engine/src/scrollengine/engine_reopen.cpp
+++ b/libs/phosphor-scroll-engine/src/scrollengine/engine_reopen.cpp
@@ -53,12 +53,12 @@ bool ScrollEngine::claimCrossScreenReopen(const QString& rawWindowId, const QStr
         return false;
     }
     // Registry-aware appId, like autotile's twin and like every record
-    // producer (captures write the tracker's current appId): parsing the
-    // frozen canonical string would look in the wrong bucket after an
-    // Electron/CEF class mutation.
-    // The engine's own resolver, the same spelling the capture and float
-    // restore use — it and the tracker's are line-for-line identical, but one
-    // spelling cannot drift.
+    // producer: parsing the frozen canonical string would look in the wrong
+    // bucket after an Electron/CEF class mutation, and finds nothing at all
+    // for a window KWin had not classed when the id was frozen. The engine's
+    // own resolver rather than the tracker's — they are line-for-line
+    // identical, and it is the same spelling the capture and float restore
+    // use, so the three cannot drift apart.
     const QString appId = currentAppIdFor(windowId);
     if (!PhosphorEngine::hasStableAppIdFor(appId, windowId)) {
         // Info, not debug: an unmatchable appId means this window can never be

--- a/libs/phosphor-scroll-engine/src/scrollengine/engine_reopen.cpp
+++ b/libs/phosphor-scroll-engine/src/scrollengine/engine_reopen.cpp
@@ -1,0 +1,149 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+// Cross-screen reclaim. Split out of engine_lifecycle.cpp, which had reached
+// the file-size ceiling: KWin's session restore opens a window on a
+// nondeterministic output, so a window recorded on monitor A routinely
+// arrives on monitor B, and this is the arm that pulls it back to the strip
+// its placement record homes it on.
+
+#include <PhosphorScrollEngine/ScrollEngine.h>
+
+#include <PhosphorEngine/IWindowTrackingService.h>
+#include <PhosphorEngine/WindowPlacement.h>
+#include <PhosphorEngine/WindowPlacementStore.h>
+
+#include "scrollenginelogging.h"
+
+namespace PhosphorScrollEngine {
+
+bool ScrollEngine::claimCrossScreenReopen(const QString& rawWindowId, const QString& openingScreenId, int minWidth,
+                                          int minHeight)
+{
+    const QString windowId = canonicalizeForLookup(rawWindowId);
+    // openingScreenId validated here, at the library boundary: the adaptor's
+    // dispatch cannot produce an empty one, but this is public engine API and
+    // an empty opening screen would defeat the predicate's same-screen bail
+    // (empty compares unequal to every recorded screen).
+    // Every decline below is LOGGED. The deferring engine has already stood
+    // down by the time a claim runs, so a decline decides where the window
+    // spends the whole session (float on whatever monitor KWin opened it on,
+    // recoverable only by logging out). A silent one leaves the resulting
+    // login-restore strand with no evidence at all in the journal, which is
+    // exactly how one survived a shipped fix. The two record-shaped declines
+    // are qCDebug rather than qCInfo: they fire on every ordinary open (a
+    // brand-new window has no record to reclaim), so at info level they would
+    // bury the rare declines that actually explain a strand.
+    if (windowId.isEmpty() || openingScreenId.isEmpty() || !m_scrollingModeResolver || !m_windowTracker) {
+        qCInfo(lcScrollEngine) << "claimCrossScreenReopen: declining" << windowId << "on" << openingScreenId
+                               << "— preconditions unmet (id empty" << windowId.isEmpty() << "screen empty"
+                               << openingScreenId.isEmpty() << "resolver" << bool(m_scrollingModeResolver) << "tracker"
+                               << bool(m_windowTracker) << ")";
+        return false;
+    }
+    // First observation only, by MEMBERSHIP: a window this engine already
+    // holds anywhere is an in-session move or re-announce, never a session
+    // restore — yanking it back to the record's screen would undo the very
+    // move that re-announced it. Membership, not the raw reverse-map key
+    // (the rule windowOpened's defer gate documents): a phantom key left by
+    // a refused earlier open must not veto a legitimate claim.
+    if (const ScrollState* tracked = stateForWindow(windowId); tracked && tracked->containsWindow(windowId)) {
+        qCDebug(lcScrollEngine) << "claimCrossScreenReopen: declining" << windowId
+                                << "— already held here, so this is an in-session re-announce, not a restore";
+        return false;
+    }
+    // Registry-aware appId, like autotile's twin and like every record
+    // producer (captures write the tracker's current appId): parsing the
+    // frozen canonical string would look in the wrong bucket after an
+    // Electron/CEF class mutation.
+    // The engine's own resolver, the same spelling the capture and float
+    // restore use — it and the tracker's are line-for-line identical, but one
+    // spelling cannot drift.
+    const QString appId = currentAppIdFor(windowId);
+    if (!PhosphorEngine::hasStableAppIdFor(appId, windowId)) {
+        // Info, not debug: an unmatchable appId means this window can never be
+        // reclaimed, which is a standing condition worth seeing once per open
+        // rather than a per-open no-op.
+        qCInfo(lcScrollEngine).nospace() << "claimCrossScreenReopen: declining " << windowId
+                                         << " — no stable appId: " << appId
+                                         << " (its placement records cannot be matched)";
+        return false;
+    }
+    // peekForReclaim, not peek: the live-instance exclusion is what stops a
+    // fresh second instance being pulled onto its OPEN sibling's monitor on
+    // the strength of that sibling's live record. Non-consuming either way —
+    // consumption stays with windowOpened's own restore machinery (the strip
+    // stash claim and takeForReopen), which this claim funnels the window
+    // into by re-entering the open path with the RECORDED screen. Only a
+    // TILED slot earns the pull — a scroll-floating record is screen-local,
+    // matching snap's float doctrine.
+    const auto pending = m_windowTracker->placementStore().peekForReclaim(
+        windowId, appId, [&](const PhosphorEngine::WindowPlacement& p) {
+            return PhosphorEngine::pendingCrossScreenManagedRestore(
+                p, PhosphorEngine::WindowPlacement::scrollingEngineId(), PhosphorEngine::WindowPlacement::stateTiled(),
+                openingScreenId, [this](const QString& rec, int desktop, const QString& activity) {
+                    return m_scrollingModeResolver(rec, desktop, activity);
+                });
+        });
+    if (!pending) {
+        // Debug: the ordinary-open case. "No usable record" covers all of the
+        // store's null answers — no record at all, none whose scrolling slot
+        // is tiled on another scrolling-mode screen, and one that qualifies
+        // but belongs to a still-live sibling instance (peekForReclaim
+        // excludes those). Naming only the middle case would misreport the
+        // multi-instance one.
+        qCDebug(lcScrollEngine) << "claimCrossScreenReopen: declining" << windowId << "appId" << appId << "on"
+                                << openingScreenId << "— no usable cross-screen scrolling record";
+        return false;
+    }
+    const QString homeScreen = pending->screenId;
+    // The LIVE screen set must agree with the record-context verdict:
+    // windowOpened's own m_scrollingScreens gate would otherwise refuse the
+    // adoption AFTER this method already answered "claimed", stranding the
+    // window untracked (a per-desktop mode override can make the resolver
+    // and the live set disagree during a context switch).
+    if (!m_scrollingScreens.contains(homeScreen)) {
+        qCInfo(lcScrollEngine) << "claimCrossScreenReopen:" << windowId << "recorded home" << homeScreen
+                               << "is scrolling-mode by record context but absent from the live set — declining";
+        return false;
+    }
+    // Grant-context must be compatible with insert-context. The predicate
+    // granted on the RECORD's (desktop, activity); windowOpened inserts into
+    // the home screen's CURRENT key. When two CONCRETE contexts disagree,
+    // adopting would splice the window into a strip on a desktop it is not
+    // visible on (displacing that desktop's real windows) and miss its
+    // stashed column outright — the conservative skip leaves the window to
+    // the ordinary open path instead. Sticky / unknown-context records
+    // (the 0 and empty sentinels) stay eligible; see
+    // recordContextMatchesLive.
+    const PhosphorEngine::PlacementStateKey homeKey = currentKeyForScreen(homeScreen);
+    if (!PhosphorEngine::recordContextMatchesLive(*pending, homeKey.desktop, homeKey.activity)) {
+        qCInfo(lcScrollEngine) << "claimCrossScreenReopen:" << windowId << "recorded context desktop"
+                               << pending->virtualDesktop << "activity" << pending->activity << "differs from"
+                               << homeScreen << "current context — declining";
+        return false;
+    }
+    windowOpened(windowId, homeScreen, minWidth, minHeight);
+    // Return the REAL outcome, verified by membership (ScrollState-level: a
+    // legitimately floated adoption is in the floating set, not the strip).
+    // An optimistic true converted every silently-refused re-entry into a
+    // window no engine manages — the caller hands a claimed window to no
+    // other engine.
+    const ScrollState* adopted = stateForWindow(windowId);
+    if (!adopted || !adopted->containsWindow(windowId)) {
+        qCWarning(lcScrollEngine) << "claimCrossScreenReopen:" << windowId << "adoption on" << homeScreen
+                                  << "was refused — not claimed";
+        return false;
+    }
+    // The ARRIVAL screen's mode-transition seed still names this id; the
+    // arrival-screen windowOpened that would have consumed it never runs on
+    // a successful claim (the dispatch returns), and one unconsumed id pins
+    // that screen's seed for the whole session. Safe no-op for a screen with
+    // no seed.
+    consumePendingInitialOrder(openingScreenId, windowId);
+    qCInfo(lcScrollEngine) << "claimCrossScreenReopen:" << windowId << "opened on" << openingScreenId
+                           << "— reclaimed to recorded scrolling home" << homeScreen;
+    return true;
+}
+
+} // namespace PhosphorScrollEngine

--- a/libs/phosphor-tile-engine/src/autotileengine/window_lifecycle.cpp
+++ b/libs/phosphor-tile-engine/src/autotileengine/window_lifecycle.cpp
@@ -53,7 +53,15 @@ bool AutotileEngine::claimCrossScreenReopen(const QString& rawWindowId, const QS
     // dispatch cannot produce an empty one, but this is public engine API
     // and an empty opening screen would defeat the predicate's same-screen
     // bail (empty compares unequal to every recorded screen).
+    // Every decline below is LOGGED, for the reason the scroll twin spells
+    // out: the deferring engine has already stood down, so a decline decides
+    // where the window spends the session, and a silent one leaves the
+    // resulting login-restore strand with no journal evidence.
     if (openingScreenId.isEmpty() || !m_windowTracker || !m_layoutManager) {
+        qCInfo(PhosphorTileEngine::lcTileEngine)
+            << "claimCrossScreenReopen:" << windowId << "opened on" << openingScreenId
+            << "— declining, engine not wired for the claim (tracker" << bool(m_windowTracker) << "layouts"
+            << bool(m_layoutManager) << ")";
         return false;
     }
     // First observation only: a window this engine tracks anywhere is an
@@ -65,10 +73,19 @@ bool AutotileEngine::claimCrossScreenReopen(const QString& rawWindowId, const QS
     const PhosphorTiles::TilingState* state =
         keyIt != m_states.windowKeys().constEnd() ? m_states.stateForKey(keyIt.value()) : nullptr;
     if (state && state->containsWindow(windowId)) {
+        qCInfo(PhosphorTileEngine::lcTileEngine)
+            << "claimCrossScreenReopen:" << windowId
+            << "is already held by this engine — declining, treating it as an in-session re-announce rather "
+               "than a session restore";
         return false;
     }
     const QString appId = currentAppIdFor(windowId);
     if (!PhosphorEngine::hasStableAppIdFor(appId, windowId)) {
+        // Logged for the same reason the scroll twin logs it: the deferring
+        // engine has already stood down, so a silent decline here strands the
+        // window on whatever monitor it opened on for the session.
+        qCInfo(PhosphorTileEngine::lcTileEngine) << "claimCrossScreenReopen:" << windowId << "has no stable appId ("
+                                                 << appId << ") — declining, its placement records cannot be matched";
         return false;
     }
     // A window this engine could not TILE must not be claimed either: the
@@ -80,6 +97,8 @@ bool AutotileEngine::claimCrossScreenReopen(const QString& rawWindowId, const QS
     // adoption — autotile's refuses outright, so the precondition belongs
     // here. Do not mirror it into the scroll twin.
     if (!shouldTileWindow(windowId)) {
+        qCInfo(PhosphorTileEngine::lcTileEngine)
+            << "claimCrossScreenReopen:" << windowId << "— declining, this engine would refuse to tile it anyway";
         return false;
     }
     // peekForReclaim, not peek: the live-instance exclusion is what stops a
@@ -100,6 +119,9 @@ bool AutotileEngine::claimCrossScreenReopen(const QString& rawWindowId, const QS
                 });
         });
     if (!pending) {
+        qCInfo(PhosphorTileEngine::lcTileEngine)
+            << "claimCrossScreenReopen:" << windowId << "appId" << appId << "opened on" << openingScreenId
+            << "— declining, no record carries an autotile tile homed on another autotile-mode screen";
         return false;
     }
     const QString homeScreen = pending->screenId;

--- a/libs/phosphor-tile-engine/src/autotileengine/window_lifecycle.cpp
+++ b/libs/phosphor-tile-engine/src/autotileengine/window_lifecycle.cpp
@@ -56,12 +56,14 @@ bool AutotileEngine::claimCrossScreenReopen(const QString& rawWindowId, const QS
     // Every decline below is LOGGED, for the reason the scroll twin spells
     // out: the deferring engine has already stood down, so a decline decides
     // where the window spends the session, and a silent one leaves the
-    // resulting login-restore strand with no journal evidence.
+    // resulting login-restore strand with no journal evidence. Same info/debug
+    // split as the twin — the declines that fire on every ordinary open are
+    // debug so they cannot bury the rare ones that explain a strand.
     if (openingScreenId.isEmpty() || !m_windowTracker || !m_layoutManager) {
         qCInfo(PhosphorTileEngine::lcTileEngine)
-            << "claimCrossScreenReopen:" << windowId << "opened on" << openingScreenId
-            << "— declining, engine not wired for the claim (tracker" << bool(m_windowTracker) << "layouts"
-            << bool(m_layoutManager) << ")";
+            << "claimCrossScreenReopen: declining" << windowId << "on" << openingScreenId
+            << "— preconditions unmet (screen empty" << openingScreenId.isEmpty() << "tracker" << bool(m_windowTracker)
+            << "layouts" << bool(m_layoutManager) << ")";
         return false;
     }
     // First observation only: a window this engine tracks anywhere is an
@@ -73,10 +75,9 @@ bool AutotileEngine::claimCrossScreenReopen(const QString& rawWindowId, const QS
     const PhosphorTiles::TilingState* state =
         keyIt != m_states.windowKeys().constEnd() ? m_states.stateForKey(keyIt.value()) : nullptr;
     if (state && state->containsWindow(windowId)) {
-        qCInfo(PhosphorTileEngine::lcTileEngine)
-            << "claimCrossScreenReopen:" << windowId
-            << "is already held by this engine — declining, treating it as an in-session re-announce rather "
-               "than a session restore";
+        qCDebug(PhosphorTileEngine::lcTileEngine)
+            << "claimCrossScreenReopen: declining" << windowId
+            << "— already held here, so this is an in-session re-announce, not a restore";
         return false;
     }
     const QString appId = currentAppIdFor(windowId);
@@ -84,8 +85,9 @@ bool AutotileEngine::claimCrossScreenReopen(const QString& rawWindowId, const QS
         // Logged for the same reason the scroll twin logs it: the deferring
         // engine has already stood down, so a silent decline here strands the
         // window on whatever monitor it opened on for the session.
-        qCInfo(PhosphorTileEngine::lcTileEngine) << "claimCrossScreenReopen:" << windowId << "has no stable appId ("
-                                                 << appId << ") — declining, its placement records cannot be matched";
+        qCInfo(PhosphorTileEngine::lcTileEngine).nospace()
+            << "claimCrossScreenReopen: declining " << windowId << " — no stable appId: " << appId
+            << " (its placement records cannot be matched)";
         return false;
     }
     // A window this engine could not TILE must not be claimed either: the
@@ -119,9 +121,15 @@ bool AutotileEngine::claimCrossScreenReopen(const QString& rawWindowId, const QS
                 });
         });
     if (!pending) {
-        qCInfo(PhosphorTileEngine::lcTileEngine)
-            << "claimCrossScreenReopen:" << windowId << "appId" << appId << "opened on" << openingScreenId
-            << "— declining, no record carries an autotile tile homed on another autotile-mode screen";
+        // Debug: the ordinary-open case, and on a system with no autotile
+        // screens it fires for every open before the scroll twin is even
+        // asked. "No usable record" covers all of the store's null answers,
+        // including a qualifying record held by a still-live sibling
+        // instance, which naming only the homed-elsewhere case would
+        // misreport.
+        qCDebug(PhosphorTileEngine::lcTileEngine)
+            << "claimCrossScreenReopen: declining" << windowId << "appId" << appId << "on" << openingScreenId
+            << "— no usable cross-screen autotile record";
         return false;
     }
     const QString homeScreen = pending->screenId;
@@ -358,7 +366,17 @@ void AutotileEngine::windowOpened(const QString& rawWindowId, const QString& scr
         m_states.setKeyForWindow(windowId, newKey);
     }
 
-    // Store window minimum size from KWin (used by enforceMinSizes)
+    // Store window minimum size from KWin (used by enforceMinSizes).
+    // Gated on >0 deliberately, which does leave storeWindowMinSize's own
+    // clearing arm unreachable from THIS path: a re-announce reporting a
+    // genuine 0x0 cannot clear a stale constraint here (windowClosed
+    // documents the same inflation risk for its own entry). Calling it
+    // unconditionally to reach that arm was tried and backed out: the stored
+    // value is SCREEN-CAPPED before comparison, so a 0x0 re-announce would
+    // discard a cap the layout is currently sized around, and whether the
+    // compositor ever reports 0x0 for a window that previously reported
+    // non-zero is not something the code can answer. Closing this properly
+    // needs that observation first, not a guess.
     if (minWidth > 0 || minHeight > 0) {
         storeWindowMinSize(windowId, minWidth, minHeight);
     }

--- a/src/dbus/windowtrackingadaptor/lifecycle.cpp
+++ b/src/dbus/windowtrackingadaptor/lifecycle.cpp
@@ -839,16 +839,18 @@ void WindowTrackingAdaptor::setWindowMetadata(const QString& instanceId, const Q
         }
     }
 
-    // Universal canonical seed. setWindowMetadata is the per-window choke point —
+    // Canonical seed. setWindowMetadata is the per-window choke point —
     // the effect pushes it for every window it tracks, ahead of the other
     // per-window notifications, snap-mode included. Freezing the first-seen
-    // composite (appId|instanceId) here gives EVERY window a canonical entry from
+    // composite (appId|instanceId) here gives a window its canonical entry from
     // first contact, so the snap stores (which canonicalize their keys) resolve a
     // window even after the effect restarts and re-derives a mutated-class
     // composite for it. Idempotent: the instance id is stable, so a later push
     // carrying a mutated appId returns the original composite rather than
-    // re-seeding (issue #628). The registry's own remove() retires the mapping
-    // when the window closes.
+    // re-seeding (issue #628). A push whose appId is still EMPTY (KWin has not
+    // finished mapping the surface) is deliberately not frozen by the registry
+    // and re-seeds on the next push — see canonicalizeWindowId. The registry's
+    // own remove() retires the mapping when the window closes.
     m_windowRegistry->canonicalizeWindowId(PhosphorIdentity::WindowId::buildCompositeId(appId, instanceId));
 
     m_windowRegistry->upsert(instanceId, meta);

--- a/src/dbus/windowtrackingadaptor/lifecycle.cpp
+++ b/src/dbus/windowtrackingadaptor/lifecycle.cpp
@@ -122,10 +122,19 @@ void WindowTrackingAdaptor::captureWindowPlacement(const QString& windowId, cons
         PhosphorPlacement::WindowTrackingService::downgradeMismatchedManagedSlots(*preserved, preserved->screenId,
                                                                                   authoritativeScreen);
         preserved->screenId = authoritativeScreen;
-        const QString instanceId = PhosphorIdentity::WindowId::extractInstanceId(windowId);
-        if (const auto context = m_windowRegistry->windowContext(instanceId)) {
-            preserved->virtualDesktop = context->virtualDesktop;
-            preserved->activity = context->activity;
+        // Registry-guarded like the minimize probe at the top of this function:
+        // a registry-less service is a supported state (tests call
+        // setWindowRegistry(nullptr) on a live adaptor), and this branch is
+        // reachable with a null registry because isSuspensionFloat above needs
+        // no registry to set treatAsMinimized. Without a registry the preserve
+        // keeps the record's own desktop/activity, which is the documented
+        // degradation rather than a crash.
+        if (m_windowRegistry) {
+            const QString instanceId = PhosphorIdentity::WindowId::extractInstanceId(windowId);
+            if (const auto context = m_windowRegistry->windowContext(instanceId)) {
+                preserved->virtualDesktop = context->virtualDesktop;
+                preserved->activity = context->activity;
+            }
         }
         // Synthesize the OWNING engine's floating slot whenever the record
         // lacks one — not merely when the map is empty (recordFloatingClose's
@@ -839,18 +848,19 @@ void WindowTrackingAdaptor::setWindowMetadata(const QString& instanceId, const Q
         }
     }
 
-    // Canonical seed. setWindowMetadata is the per-window choke point —
+    // Universal canonical seed. setWindowMetadata is the per-window choke point —
     // the effect pushes it for every window it tracks, ahead of the other
     // per-window notifications, snap-mode included. Freezing the first-seen
-    // composite (appId|instanceId) here gives a window its canonical entry from
+    // composite (appId|instanceId) here gives EVERY window a canonical entry from
     // first contact, so the snap stores (which canonicalize their keys) resolve a
     // window even after the effect restarts and re-derives a mutated-class
     // composite for it. Idempotent: the instance id is stable, so a later push
     // carrying a mutated appId returns the original composite rather than
-    // re-seeding (issue #628). A push whose appId is still EMPTY (KWin has not
-    // finished mapping the surface) is deliberately not frozen by the registry
-    // and re-seeds on the next push — see canonicalizeWindowId. The registry's
-    // own remove() retires the mapping when the window closes.
+    // re-seeding (issue #628). That includes a first push whose appId is still
+    // EMPTY: the appId-less composite is frozen like any other, because a
+    // canonical that changed once the class arrived would strand the engine
+    // state keyed under the earlier id. The registry's own remove() retires the
+    // mapping when the window closes.
     m_windowRegistry->canonicalizeWindowId(PhosphorIdentity::WindowId::buildCompositeId(appId, instanceId));
 
     m_windowRegistry->upsert(instanceId, meta);
@@ -1122,16 +1132,15 @@ void WindowTrackingAdaptor::pruneStaleWindows(const QStringList& aliveWindowIds)
             ++it;
         }
     }
-    // Same defensive sweep for the last-broadcast floating shadow: an entry
-    // would otherwise leak if the window died without a windowClosed signal.
-    // Not persisted, so it does not feed the save-scheduling decision below.
     // Fan the prune out to sibling adaptors' per-window caches (see the
     // signal doc). Consumers only erase from their OWN maps — nothing here
     // depends on emit-vs-sweep ordering. The payload is the same instance-id
     // view the local sweeps use, as a marshallable list: adaptor signals are
     // auto-relayed onto the bus, and QSet has no D-Bus signature.
     Q_EMIT stalePruned(QStringList(aliveInstances.cbegin(), aliveInstances.cend()));
-    // Same defensive sweep for the last-broadcast floating shadow.
+    // Same defensive sweep for the last-broadcast floating shadow: an entry
+    // would otherwise leak if the window died without a windowClosed signal.
+    // Not persisted, so it does not feed the save-scheduling decision below.
     for (auto it = m_broadcastFloating.begin(); it != m_broadcastFloating.end();) {
         if (!aliveInstances.contains(PhosphorIdentity::WindowId::extractInstanceId(it.key()))) {
             it = m_broadcastFloating.erase(it);

--- a/tests/unit/core/windowtracking/test_window_registry.cpp
+++ b/tests/unit/core/windowtracking/test_window_registry.cpp
@@ -339,6 +339,30 @@ private Q_SLOTS:
         QCOMPARE(reg.canonicalizeForLookup(QStringLiteral("renamed|u1")), QStringLiteral("renamed|u1"));
     }
 
+    void remove_subscriberUpsertsThenRemoves_cancelsTheQueuedReplay()
+    {
+        // A re-entrant remove() for an instance already mid-disappearance
+        // CANCELS its queued upsert rather than replaying it. Without that,
+        // a subscriber that re-announces and then immediately closes a window
+        // during one emit would resurrect the record it just asked to drop.
+        // The existing re-entrancy slots only reach this line with an empty
+        // pending map, where the cancel is a no-op and proves nothing.
+        WindowRegistry reg;
+        reg.upsert(QStringLiteral("u1"), make(QStringLiteral("firefox")));
+        QSignalSpy appeared(&reg, &WindowRegistry::windowAppeared);
+        connect(&reg, &WindowRegistry::windowDisappeared, &reg, [&](const QString& instanceId) {
+            reg.upsert(instanceId, make(QStringLiteral("firefox"))); // queues a replay
+            reg.remove(instanceId); // …and cancels it
+        });
+
+        reg.remove(QStringLiteral("u1"));
+
+        QCOMPARE(reg.size(), 0);
+        QVERIFY(!reg.contains(QStringLiteral("u1")));
+        // The cancelled replay never re-announced the window.
+        QCOMPARE(appeared.size(), 0);
+    }
+
     void remove_reannouncingSubscriber_keepsCanonicalOutsideClear()
     {
         // The non-clearing leg of the same gate: outside a bulk clear the

--- a/tests/unit/core/windowtracking/test_window_registry.cpp
+++ b/tests/unit/core/windowtracking/test_window_registry.cpp
@@ -198,6 +198,41 @@ private Q_SLOTS:
     }
 
     // ────────────────────────────────────────────────────────────────────
+    // canonical freeze
+    // ────────────────────────────────────────────────────────────────────
+
+    void canonicalizeWindowId_appIdLessComposite_isNotFrozen()
+    {
+        // The effect's bring-up metadata walk pushes whatever class KWin has
+        // resolved so far, and a session-restored surface that has not
+        // finished mapping yields "|instanceId". Freezing that would be
+        // permanent (the freeze is single-shot) and would hand every consumer
+        // an id whose appId parses as empty — the login-restore strand where a
+        // window stops matching its own placement records and floats on
+        // whatever monitor KWin opened it on.
+        WindowRegistry reg;
+
+        const QString placeholder = QStringLiteral("|u1");
+        QCOMPARE(reg.canonicalizeWindowId(placeholder), placeholder);
+        // Nothing frozen: a real id still resolves to itself, appId intact.
+        QCOMPARE(reg.canonicalizeForLookup(QStringLiteral("ghostty|u1")), QStringLiteral("ghostty|u1"));
+
+        // First well-formed contact wins the freeze, and a later class
+        // mutation still resolves back to it.
+        QCOMPARE(reg.canonicalizeWindowId(QStringLiteral("ghostty|u1")), QStringLiteral("ghostty|u1"));
+        QCOMPARE(reg.canonicalizeForLookup(QStringLiteral("com.ghostty|u1")), QStringLiteral("ghostty|u1"));
+    }
+
+    void canonicalizeWindowId_firstWellFormedId_isFrozen()
+    {
+        WindowRegistry reg;
+
+        QCOMPARE(reg.canonicalizeWindowId(QStringLiteral("firefox|u1")), QStringLiteral("firefox|u1"));
+        // Single-shot: a mutated class never re-seeds the mapping.
+        QCOMPARE(reg.canonicalizeWindowId(QStringLiteral("renamed|u1")), QStringLiteral("firefox|u1"));
+    }
+
+    // ────────────────────────────────────────────────────────────────────
     // remove + clear
     // ────────────────────────────────────────────────────────────────────
 

--- a/tests/unit/core/windowtracking/test_window_registry.cpp
+++ b/tests/unit/core/windowtracking/test_window_registry.cpp
@@ -15,8 +15,19 @@
  *  - instancesWithAppId reverse index stays in sync across mutations and removes
  *  - remove emits windowDisappeared
  *  - clear emits windowDisappeared for every tracked id
+ *  - canonical freeze: the first id seen for an instance is frozen and never
+ *    re-seeded, including an appId-less "|instanceId" placeholder, so a
+ *    window keeps ONE key for its whole life; an empty id is exempt and
+ *    seeds nothing
  *  - canonical retirement: remove/clear emit before retiring the canonical
- *    record, and a subscriber-reseeded canonical survives the removal
+ *    record, and a subscriber-reseeded canonical survives the removal; a
+ *    subscriber's re-UPSERT during a bulk clear does not, since the clear
+ *    drops the replay and must not leave the mapping behind either; outside
+ *    a clear the mapping IS kept, for the record that does get replayed
+ *  - pruneStaleInstances fails closed on an empty alive set
+ *  - wide metadata: windowRole / pid / virtualDesktop / activity / windowType
+ *    round-trip and emit per-field change signals
+ *  - rejection of an empty instance id, and appIdFor on an unknown instance
  *  - re-entrancy: nested clear/remove/upsert from signal receivers (including
  *    receiver-deletes-registry) leave the registry consistent and emit once
  *  - isMinimized resolves composite windowIds to the instance record
@@ -201,35 +212,49 @@ private Q_SLOTS:
     // canonical freeze
     // ────────────────────────────────────────────────────────────────────
 
-    void canonicalizeWindowId_appIdLessComposite_isNotFrozen()
-    {
-        // The effect's bring-up metadata walk pushes whatever class KWin has
-        // resolved so far, and a session-restored surface that has not
-        // finished mapping yields "|instanceId". Freezing that would be
-        // permanent (the freeze is single-shot) and would hand every consumer
-        // an id whose appId parses as empty — the login-restore strand where a
-        // window stops matching its own placement records and floats on
-        // whatever monitor KWin opened it on.
-        WindowRegistry reg;
-
-        const QString placeholder = QStringLiteral("|u1");
-        QCOMPARE(reg.canonicalizeWindowId(placeholder), placeholder);
-        // Nothing frozen: a real id still resolves to itself, appId intact.
-        QCOMPARE(reg.canonicalizeForLookup(QStringLiteral("ghostty|u1")), QStringLiteral("ghostty|u1"));
-
-        // First well-formed contact wins the freeze, and a later class
-        // mutation still resolves back to it.
-        QCOMPARE(reg.canonicalizeWindowId(QStringLiteral("ghostty|u1")), QStringLiteral("ghostty|u1"));
-        QCOMPARE(reg.canonicalizeForLookup(QStringLiteral("com.ghostty|u1")), QStringLiteral("ghostty|u1"));
-    }
-
-    void canonicalizeWindowId_firstWellFormedId_isFrozen()
+    void canonicalizeWindowId_firstSeenId_isFrozen()
     {
         WindowRegistry reg;
 
         QCOMPARE(reg.canonicalizeWindowId(QStringLiteral("firefox|u1")), QStringLiteral("firefox|u1"));
         // Single-shot: a mutated class never re-seeds the mapping.
         QCOMPARE(reg.canonicalizeWindowId(QStringLiteral("renamed|u1")), QStringLiteral("firefox|u1"));
+        QCOMPARE(reg.canonicalizeForLookup(QStringLiteral("renamed|u1")), QStringLiteral("firefox|u1"));
+    }
+
+    void canonicalizeWindowId_appIdLessFirstContact_isStillFrozen()
+    {
+        // KWin reports a blank class for a surface it has not finished
+        // mapping, so the first push for a window can carry "|instanceId".
+        // That shape is frozen like any other ON PURPOSE. Exempting it would
+        // make the canonical CHANGE once the real class arrived, and the
+        // engines key their membership maps at adopt time with no re-key
+        // path: close would stop removing the window and the alive-set walk
+        // in pruneStaleWindows would force-remove a live one from its layout.
+        // The appId such a window is missing is served by appIdFor, which
+        // self-corrects on the class-change push — never by parsing the id.
+        WindowRegistry reg;
+
+        QCOMPARE(reg.canonicalizeWindowId(QStringLiteral("|u1")), QStringLiteral("|u1"));
+        // One key for the window's life: the later well-formed push resolves
+        // BACK to the frozen id rather than replacing it.
+        QCOMPARE(reg.canonicalizeWindowId(QStringLiteral("ghostty|u1")), QStringLiteral("|u1"));
+        QCOMPARE(reg.canonicalizeForLookup(QStringLiteral("ghostty|u1")), QStringLiteral("|u1"));
+
+        // And the identity is recoverable from the metadata record, which is
+        // where callers are told to get it.
+        reg.upsert(QStringLiteral("u1"), make(QStringLiteral("ghostty")));
+        QCOMPARE(reg.appIdFor(QStringLiteral("u1")), QStringLiteral("ghostty"));
+    }
+
+    void canonicalizeWindowId_emptyId_isNotFrozen()
+    {
+        WindowRegistry reg;
+
+        QCOMPARE(reg.canonicalizeWindowId(QString()), QString());
+        // The empty early return must not have seeded a mapping under an
+        // empty instance id.
+        QCOMPARE(reg.canonicalizeForLookup(QStringLiteral("firefox|")), QStringLiteral("firefox|"));
     }
 
     // ────────────────────────────────────────────────────────────────────
@@ -278,6 +303,61 @@ private Q_SLOTS:
         QCOMPARE(ids, (QStringList{QStringLiteral("canonical-only"), QStringLiteral("u1"), QStringLiteral("u2")}));
         QCOMPARE(reg.size(), 0);
         QVERIFY(reg.instancesWithAppId(QStringLiteral("firefox")).isEmpty());
+    }
+
+    void clear_subscriberReupsertsDuringEmit_leavesNothingBehind()
+    {
+        // clear() drops a re-entrant upsert on purpose (the bulk reset
+        // supersedes it), so the canonical must be dropped with it. Keeping
+        // the mapping for a record that is never replayed left the instance
+        // behind as a canonical-only survivor of a reset whose whole contract
+        // is that the registry ends up empty.
+        //
+        // Scoped to the re-UPSERT shape deliberately. A subscriber that seeds
+        // a canonical for an instance that had NONE takes the
+        // postEmit != canonical branch instead, which skips this retirement
+        // entirely and lets the fresh mapping live — that is a re-announce,
+        // covered by remove_subscriberReseededCanonical_survivesRemoval, and
+        // it is not what this gate governs. (A subscriber calling
+        // canonicalizeWindowId for an instance that still HAS its mapping
+        // just gets the frozen id back and changes nothing.)
+        WindowRegistry reg;
+        reg.canonicalizeWindowId(QStringLiteral("firefox|u1"));
+        reg.upsert(QStringLiteral("u1"), make(QStringLiteral("firefox")));
+        connect(&reg, &WindowRegistry::windowDisappeared, &reg, [&](const QString& instanceId) {
+            // A re-announce racing the clear.
+            reg.upsert(instanceId, make(QStringLiteral("firefox")));
+        });
+
+        reg.clear();
+
+        QCOMPARE(reg.size(), 0);
+        QVERIFY(!reg.contains(QStringLiteral("u1")));
+        // No canonical-only remnant: nothing resolves for this instance any
+        // more. (The discriminating assertion — without the m_clearing gate
+        // the retired mapping is re-inserted and this returns "firefox|u1".)
+        QCOMPARE(reg.canonicalizeForLookup(QStringLiteral("renamed|u1")), QStringLiteral("renamed|u1"));
+    }
+
+    void remove_reannouncingSubscriber_keepsCanonicalOutsideClear()
+    {
+        // The non-clearing leg of the same gate: outside a bulk clear the
+        // re-entrant upsert IS replayed, so the canonical must be kept for it
+        // rather than retired. Without this, a close racing a re-announce
+        // would strip the identity translation the replayed record needs.
+        WindowRegistry reg;
+        reg.canonicalizeWindowId(QStringLiteral("firefox|u1"));
+        reg.upsert(QStringLiteral("u1"), make(QStringLiteral("firefox")));
+        connect(&reg, &WindowRegistry::windowDisappeared, &reg, [&](const QString& instanceId) {
+            reg.upsert(instanceId, make(QStringLiteral("firefox")));
+        });
+
+        reg.remove(QStringLiteral("u1"));
+
+        // The replayed record is back, and still reachable through the id the
+        // stores were keyed with.
+        QVERIFY(reg.contains(QStringLiteral("u1")));
+        QCOMPARE(reg.canonicalizeForLookup(QStringLiteral("renamed|u1")), QStringLiteral("firefox|u1"));
     }
 
     void remove_canonicalOnly_emitsBeforeRetiringCanonical()
@@ -637,6 +717,38 @@ private Q_SLOTS:
                  QStringLiteral("konsole-renamed|dead-1"));
         // The alive window is untouched.
         QCOMPARE(reg.appIdFor(QStringLiteral("alive-1")), QStringLiteral("firefox"));
+    }
+
+    void pruneStaleInstances_emptyAliveSet_isRefused()
+    {
+        // Fail-closed guard. The effect's one-shot alive report at daemon-ready
+        // fires before session-restored apps have mapped their windows, so an
+        // empty set arrives meaning "I have not looked yet", not "everything
+        // died". Honouring it would destroy the whole registry — every window's
+        // identity translation — in one call.
+        WindowRegistry reg;
+        reg.upsert(QStringLiteral("u1"), make(QStringLiteral("firefox")));
+        reg.canonicalizeWindowId(QStringLiteral("konsole|u2"));
+        QSignalSpy disappeared(&reg, &WindowRegistry::windowDisappeared);
+
+        const int pruned = reg.pruneStaleInstances({});
+
+        QCOMPARE(pruned, 0);
+        QCOMPARE(disappeared.size(), 0);
+        QCOMPARE(reg.size(), 1);
+        QCOMPARE(reg.canonicalizeForLookup(QStringLiteral("renamed|u2")), QStringLiteral("konsole|u2"));
+    }
+
+    void pruneStaleInstances_emptySetOnEmptyRegistry_isNoop()
+    {
+        // The one legitimately-empty case: nothing tracked, nothing alive. It
+        // must fall through the guard rather than trip it.
+        WindowRegistry reg;
+        QSignalSpy disappeared(&reg, &WindowRegistry::windowDisappeared);
+
+        QCOMPARE(reg.pruneStaleInstances({}), 0);
+        QCOMPARE(disappeared.size(), 0);
+        QCOMPARE(reg.size(), 0);
     }
 
     void pruneStaleInstances_allAlive_isNoop()


### PR DESCRIPTION
## Why

Windows still land on the wrong monitor at login and only a logout recovers them. The v3.4 cross-screen reclaim works for windows that open *after* the daemon, but not for windows that already exist when it comes up.

From the 2026-08-13 09:55 login journal, the effect's bring-up sweep (`Triggered snap restore for 3 untracked windows after daemon ready`) produced this for dolphin, kate and ghostty:

```
resolveWindowRestore: … carries a cross-screen tiled record — deferring to its recorded engine
applyNoMatchFloatDefault: … reclaim declined — defaulting to floated on LG…45071
```

Snap correctly stood down for the scrolling engine, the scrolling engine refused the window, and the fallback floated it on whatever monitor KWin picked. Four windows that opened 0.6 s later through the ordinary open path were reclaimed correctly. The reclaim returned false without printing anything, so the journal cannot say which of its guards fired.

## What changed

**Every decline in both `claimCrossScreenReopen` implementations now logs which guard fired.** By the time a claim runs the deferring engine has already stood down, so a decline decides where the window spends the whole session; a silent one leaves the resulting strand with no evidence at all. The two declines that fire on every ordinary open (a brand-new window has no record to reclaim) are `qCDebug` so they cannot bury the rare ones that explain a strand.

**The appId derivation is fixed at the layer that owns it.** The scroll engine derived a placement's appId by PARSING the window's canonical id. That id is frozen at first contact, so a window KWin had not yet classed carries an appId-less id, and `WindowPlacementStore::record` rejects a record with an empty appId — the capture was dropped and the window had nothing to restore. `ScrollEngine` gains `currentAppIdFor` (mirroring `AutotileEngine`'s), and the capture plus both float-restore sites now ask the registry, whose metadata record self-corrects on the class-change push. The cross-session stash claim deliberately keeps the parse, because it matches against ids stored verbatim by a previous session, and says so.

Also, from the audit of this branch: a null `m_windowRegistry` deref on the suspension-float close path is guarded; `WindowRegistry::remove()`'s canonical re-insert is gated on `m_clearing == 0` so a bulk clear cannot leave a canonical-only survivor; `WindowPlacementStore::record`'s silent reject now logs; and `claimCrossScreenReopen` moved to its own translation unit, putting `engine_lifecycle.cpp` back under the 1150-line ceiling it had crossed.

## What was reverted, and why it matters

The first version of this PR made `WindowRegistry::canonicalizeWindowId` refuse to freeze an appId-less composite. **That was wrong and is now reverted.**

Exempting that shape made a window's canonical id CHANGE mid-life, at the first metadata push carrying a real class, while the effect keeps sending the id it froze at first observation. Engines key their membership maps at adopt time and have no re-key path, so after the flip scroll's `windowClosed` early-returns (leaving a ghost column), autotile never removes the tile, and the alive-set walk in `pruneStaleWindows` force-removes the live window from its layout — the exact failure that walk's own comment says the canonicalization exists to prevent. The exemption was also only ever active in the case where it did that damage: for a window whose class never resolves it changed nothing at all.

One stable key per window for its whole life is the invariant every keyed store here is built on. A window whose appId is not yet known is served by asking the registry for it, never by reshaping its identity.

## Verification

Build clean, `ctest` 362/362. New coverage: the canonical freeze including the appId-less and empty-id shapes, both legs of the `m_clearing` gate, and `pruneStaleInstances`' fail-closed guard.

Not verified without a live session: whether the instrumentation actually names the guard that fires on the reported strand. That is what the next login will show — grep the journal for `claimCrossScreenReopen:` near `Triggered snap restore`. It reproduces deterministically by stopping the daemon, moving a window to the snapping-mode monitor while it is down, then starting the daemon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)