### PR TITLE
fix(effect): clip injected tab-indicator paint to the trigger's damage region

### DIFF
--- a/kwin-effect/plasmazoneseffect/paint_pipeline.cpp
+++ b/kwin-effect/plasmazoneseffect/paint_pipeline.cpp
@@ -1441,7 +1441,7 @@ void PlasmaZonesEffect::paintWindow(const KWin::RenderTarget& renderTarget, cons
         && w == m_scrollTabPaintAnchor && !m_scrollTabDeferred.isEmpty();
     const auto tabInjectGuard = qScopeGuard([&]() {
         if (injectTabsAfterThisWindow) {
-            injectScrollTabIndicators(renderTarget, viewport);
+            injectScrollTabIndicators(renderTarget, viewport, deviceRegion);
         }
     });
     // Part two-and-a-half: the anchor's paint alone is not a reliable trigger.
@@ -1460,7 +1460,7 @@ void PlasmaZonesEffect::paintWindow(const KWin::RenderTarget& renderTarget, cons
     // reads.
     if (!m_capturingSnapshot && !m_directPaintCapture && w && !m_scrollTabDeferred.isEmpty()
         && m_scrollTabDrawn.size() < m_scrollTabDeferred.size() && m_scrollTabAboveAnchor.contains(w)) {
-        injectScrollTabIndicators(renderTarget, viewport);
+        injectScrollTabIndicators(renderTarget, viewport, deviceRegion);
     }
 
     // Read the cached per-frame clock pinned by prePaintScreen. Multiple
@@ -1918,7 +1918,8 @@ void PlasmaZonesEffect::paintWindow(const KWin::RenderTarget& renderTarget, cons
 }
 
 void PlasmaZonesEffect::injectScrollTabIndicators(const KWin::RenderTarget& renderTarget,
-                                                  const KWin::RenderViewport& viewport)
+                                                  const KWin::RenderViewport& viewport,
+                                                  const KWin::Region& deviceRegion)
 {
     // Same direct-drive shape as the strip pass's above-strip composite:
     // drive each surface through OUR OWN paintWindow so the view offset
@@ -1952,7 +1953,15 @@ void PlasmaZonesEffect::injectScrollTabIndicators(const KWin::RenderTarget& rend
         KWin::WindowPaintData indicatorData;
         indicatorData.setOpacity(indicator->opacity());
         const int indicatorMask = KWin::Effect::PAINT_WINDOW_TRANSFORMED | KWin::Effect::PAINT_WINDOW_TRANSLUCENT;
-        paintWindow(renderTarget, viewport, indicator, indicatorMask, KWin::Region::infinite(), indicatorData);
+        // The trigger's deviceRegion, NEVER an infinite region. Paint order
+        // only becomes stacking order if every window above repaints the same
+        // pixels after us, and KWin hands each of them only the damage region
+        // — an unclipped injection painted indicators outside it, where no
+        // occluder ever drew again, and the strip surfaced over fullscreen
+        // windows, Spectacle's overlay, and the lock surface until the next
+        // full-damage frame. See the declaration's parameter doc for why the
+        // trigger's region is also the semantically correct clip.
+        paintWindow(renderTarget, viewport, indicator, indicatorMask, deviceRegion, indicatorData);
     }
 }
 

--- a/kwin-effect/plasmazoneseffect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect/plasmazoneseffect.h
@@ -898,8 +898,23 @@ private:
      * column but below whatever stacks over the strip — behaving like members
      * of the window layer even though the protocol has no such placement for
      * them.
+     *
+     * @param deviceRegion The triggering paintWindow call's device region. The
+     * injected draw is clipped to it, never painted unclipped: paint order
+     * only yields stacking order when every window above repaints the same
+     * pixels afterwards, and KWin hands each of them only the damage region.
+     * An unclipped injection put indicator pixels OUTSIDE that region, where
+     * no occluder ever painted again — so the strip surfaced on top of
+     * fullscreen windows, Spectacle's capture overlay, even the lock surface,
+     * persisting until the next full-damage frame. The trigger's region is
+     * also the CORRECT clip, not merely a safe one: for the anchor trigger it
+     * is damage minus the opaque regions stacked above the strip, exactly
+     * where content at the strip's slot may show; for the above-anchor
+     * trigger the occluder's own paint follows immediately and resolves its
+     * overlap the same way it would for a naturally-slotted window below it.
      */
-    void injectScrollTabIndicators(const KWin::RenderTarget& renderTarget, const KWin::RenderViewport& viewport);
+    void injectScrollTabIndicators(const KWin::RenderTarget& renderTarget, const KWin::RenderViewport& viewport,
+                                   const KWin::Region& deviceRegion);
 
     TilingHandler* tilingHandler() const
     {


### PR DESCRIPTION
## Problem

The scrolling tab strip rendered on top of surfaces stacked above it, most visibly fullscreen ones: the zone editor, Spectacle's capture overlay, even the lock screen.

## Root cause

The effect re-slots the tab-indicator surface's paint: it skips the surface's natural layer slot and injects it just above the topmost strip column (or just before the first occluder above the anchor when the column is culled). That injection painted with `KWin::Region::infinite()`.

Paint order only becomes stacking order when every window above repaints the same pixels afterwards, and KWin hands each occluder only the current damage region. On partial-damage frames, the injected indicator pixels drawn outside that region were never re-covered — so the strip persisted on top of whatever was above it until the next full-damage frame.

## Fix

Thread the triggering `paintWindow` call's `deviceRegion` into `injectScrollTabIndicators` and clip the injected draw with it. The trigger's region is also the semantically correct clip, not merely a safe one:

- **Anchor trigger**: the region is damage minus the opaque regions stacked above the strip, which is exactly where content at the strip's stacking slot may show.
- **Above-anchor trigger**: the occluder's own paint follows immediately and resolves the overlap the same way it would for a naturally-slotted window below it.

The strip transition manager's above-strip composite keeps its infinite region legitimately: it runs right after a full-output quad it drew itself, so it always overwrites its own output.

## Verification

- Clean full build, no new warnings
- `ctest` under `dbus-run-session`: 100% passed (367 tests)
- Live check pending effect reload (logout/login): fullscreen app over a tabbed column, Spectacle region capture, lock screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)