### PR TITLE
ci(release): allow rebuild-only republish of an existing tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,10 @@ on:
       tag:
         description: 'Tag to release (e.g. v3.0.0). Must already exist.'
         required: true
+      pkgrel:
+        description: 'Arch pkgrel. Bump for a rebuild-only republish of an already-released tag (e.g. a Qt private-ABI break). Leave at 1 for a normal release.'
+        required: false
+        default: '1'
 
 # Default scope is read-only. Only the `release` job and the AUR publish
 # need writes — they opt in via per-job permissions blocks.
@@ -35,8 +39,10 @@ jobs:
     name: Extract Version
     runs-on: ubuntu-latest
     outputs:
+      ref: ${{ steps.version.outputs.ref }}
       version: ${{ steps.version.outputs.version }}
       is_prerelease: ${{ steps.version.outputs.is_prerelease }}
+      pkgrel: ${{ steps.version.outputs.pkgrel }}
     steps:
       - name: Extract version from tag
         id: version
@@ -46,6 +52,7 @@ jobs:
         # GitHub Actions script-injection hardening pattern.
         env:
           INPUT_TAG: ${{ github.event.inputs.tag }}
+          INPUT_PKGREL: ${{ github.event.inputs.pkgrel }}
         run: |
           set -euo pipefail
           # On push the ref is refs/tags/v<x>; on manual dispatch we
@@ -80,9 +87,22 @@ jobs:
           if [[ "$VERSION" =~ -(alpha|beta|rc)(\.?[0-9]+)?$ ]]; then
               IS_PRE=true
           fi
+          # Arch pkgrel. A tag push always means a fresh version, so it
+          # starts at 1; only a manual dispatch can raise it, and that is
+          # the rebuild-only path — same source, same tag, new package,
+          # e.g. when a Qt patch release breaks the private-API ABI the
+          # layer-shell QPA plugin is compiled against. Digits only, for
+          # the same script-injection reason the tag is gated above.
+          PKGREL="${INPUT_PKGREL:-1}"
+          if [[ ! "$PKGREL" =~ ^[0-9]+$ ]]; then
+              echo "Error: PKGREL '$PKGREL' is not a positive integer" >&2
+              exit 1
+          fi
+          echo "ref=$REF" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "is_prerelease=$IS_PRE" >> "$GITHUB_OUTPUT"
-          echo "Version: $VERSION (prerelease=$IS_PRE)"
+          echo "pkgrel=$PKGREL" >> "$GITHUB_OUTPUT"
+          echo "Version: $VERSION (prerelease=$IS_PRE, pkgrel=$PKGREL)"
 
   # ═══════════════════════════════════════════════════════════════════════════
   # Build Debian Package (KDE Neon - ships Plasma/KF6 6.7+)
@@ -103,6 +123,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.version.outputs.ref }}
 
       - name: Install build dependencies
         run: |
@@ -176,6 +198,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.version.outputs.ref }}
 
       - name: Install build dependencies
         run: |
@@ -286,6 +310,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.version.outputs.ref }}
 
       - name: Install build dependencies
         # Reuse the install-with-retry shape from the prerequisites step.
@@ -376,6 +402,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.version.outputs.ref }}
 
       - name: Install build dependencies
         run: |
@@ -464,6 +492,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.version.outputs.ref }}
 
       - name: Install build dependencies
         run: |
@@ -490,7 +520,7 @@ jobs:
           # CI Build - uses local source
           pkgname=plasmazones
           pkgver=${{ needs.version.outputs.version }}
-          pkgrel=1
+          pkgrel=${{ needs.version.outputs.pkgrel }}
           pkgdesc="Window tiling and autotiling for KDE Plasma"
           arch=('x86_64')
           url="https://github.com/fuddlesworth/PlasmaZones"
@@ -568,6 +598,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.version.outputs.ref }}
 
       - name: Install Nix
         # SHA-pinned to match ci.yml; bump together when verifying a new release.
@@ -605,6 +637,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          ref: ${{ needs.version.outputs.ref }}
           fetch-depth: 0
 
       - name: Download all artifacts
@@ -756,6 +789,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.version.outputs.ref }}
 
       - name: Download generic tarball artifact
         uses: actions/download-artifact@v8
@@ -800,6 +835,7 @@ jobs:
       - name: Clone and update AUR repository (plasmazones-bin)
         env:
           VERSION: ${{ needs.version.outputs.version }}
+          PKGREL: ${{ needs.version.outputs.pkgrel }}
           SHA256: ${{ steps.hash.outputs.sha256 }}
         run: |
           git clone ssh://aur@aur.archlinux.org/plasmazones-bin.git /tmp/aur-bin
@@ -814,7 +850,7 @@ jobs:
           # rewrite as the source PKGBUILD (below) so future additional
           # `source=` entries don't silently leave a stale second hash.
           sed -i "s/^pkgver=.*/pkgver=$VERSION/" PKGBUILD
-          sed -i "s/^pkgrel=.*/pkgrel=1/" PKGBUILD
+          sed -i "s/^pkgrel=.*/pkgrel=${{ needs.version.outputs.pkgrel }}/" PKGBUILD
           awk -v sum="$SHA256" '
             # Single-line form: sha256sums=(\047hash\047) — replace inline.
             /^sha256sums=\(.*\)$/ {
@@ -857,7 +893,11 @@ jobs:
           if git diff --cached --quiet; then
             echo "No changes to commit"
           else
-            git commit -m "Update to $VERSION"
+            if [[ "$PKGREL" == "1" ]]; then
+              git commit -m "Update to $VERSION"
+            else
+              git commit -m "Rebuild $VERSION (pkgrel $PKGREL)"
+            fi
             git push
             echo "✅ Published plasmazones-bin $VERSION to AUR"
           fi
@@ -865,6 +905,7 @@ jobs:
       - name: Clone and update AUR repository (plasmazones - source)
         env:
           VERSION: ${{ needs.version.outputs.version }}
+          PKGREL: ${{ needs.version.outputs.pkgrel }}
         run: |
           git clone ssh://aur@aur.archlinux.org/plasmazones.git /tmp/aur-src
           cd /tmp/aur-src
@@ -876,7 +917,7 @@ jobs:
 
           # Update version
           sed -i "s/^pkgver=.*/pkgver=$VERSION/" PKGBUILD
-          sed -i "s/^pkgrel=.*/pkgrel=1/" PKGBUILD
+          sed -i "s/^pkgrel=.*/pkgrel=${{ needs.version.outputs.pkgrel }}/" PKGBUILD
 
           # Calculate and update source tarball hash. Anchor inside the
           # sha256sums=(...) block via awk so future additional hashes
@@ -937,7 +978,11 @@ jobs:
           if git diff --cached --quiet; then
             echo "No changes to commit"
           else
-            git commit -m "Update to $VERSION"
+            if [[ "$PKGREL" == "1" ]]; then
+              git commit -m "Update to $VERSION"
+            else
+              git commit -m "Rebuild $VERSION (pkgrel $PKGREL)"
+            fi
             git push
             echo "✅ Published plasmazones $VERSION to AUR"
           fi
@@ -985,6 +1030,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.version.outputs.ref }}
 
       - name: Install osc (OBS command-line client)
         run: |

--- a/packaging/arch/update-aur.sh
+++ b/packaging/arch/update-aur.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Update AUR PKGBUILD with new version and hash
-# Usage: ./update-aur.sh <version> <sha256>
+# Usage: ./update-aur.sh <version> <sha256> [PKGBUILD] [pkgrel]
+# SPDX-FileCopyrightText: 2026 fuddlesworth
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 set -euo pipefail
@@ -8,10 +9,23 @@ set -euo pipefail
 VERSION="${1:-}"
 SHA256="${2:-}"
 PKGBUILD="${3:-PKGBUILD}"
+# A new version always starts at pkgrel=1. Raise it for a rebuild-only
+# republish of a version that is already out: same source, new package.
+# The case that forces this is an ABI break under us — the layer-shell QPA
+# plugin compiles against Qt private headers (QtWaylandClient/private/...),
+# whose class layouts carry no ABI guarantee, so a qt6-base/qt6-wayland
+# patch bump can leave an installed build reading members at stale offsets.
+PKGREL="${4:-1}"
 
 if [[ -z "$VERSION" || -z "$SHA256" ]]; then
-    echo "Usage: $0 <version> <sha256> [PKGBUILD]"
+    echo "Usage: $0 <version> <sha256> [PKGBUILD] [pkgrel]"
     echo "Example: $0 1.3.4 abc123..."
+    echo "Example: $0 1.3.4 abc123... PKGBUILD 2   # rebuild-only republish"
+    exit 1
+fi
+
+if [[ ! "$PKGREL" =~ ^[0-9]+$ ]]; then
+    echo "Error: pkgrel must be a positive integer, got: $PKGREL"
     exit 1
 fi
 
@@ -20,18 +34,37 @@ if [[ ! -f "$PKGBUILD" ]]; then
     exit 1
 fi
 
-echo "Updating $PKGBUILD to version $VERSION"
+echo "Updating $PKGBUILD to version $VERSION-$PKGREL"
 
 # Update pkgver
 sed -i "s/^pkgver=.*/pkgver=$VERSION/" "$PKGBUILD"
 
-# Update the package hash (first sha256sum entry)
-# This handles both single-line and the first entry of multi-line sha256sums
-sed -i "0,/^sha256sums=(/s/sha256sums=([^)]*)/sha256sums=(\n    '$SHA256'/" "$PKGBUILD" 2>/dev/null || \
-sed -i "s/^\s*'[a-f0-9]\{64\}'/    '$SHA256'/" "$PKGBUILD"
+# Update the package hash. Anchored on the sha256sums=(...) array rather
+# than on a bare hash-shaped line, and it collapses the array to the single
+# entry the source= array carries, so a stale second hash can't survive. Same
+# rewrite the release workflow's AUR publish steps use — keep the two in step.
+# The previous sed pair dropped the array's closing paren on the single-line
+# form, leaving a PKGBUILD that makepkg could not source at all.
+awk -v sum="$SHA256" '
+  # Single-line form: sha256sums=(<hash>) — replace inline.
+  /^sha256sums=\(.*\)$/ {
+    print "sha256sums=(\047" sum "\047)"
+    next
+  }
+  # Multi-line form: opening `sha256sums=(` alone, entries, then `)` alone.
+  /^sha256sums=\(/ {
+    print "sha256sums=("
+    print "    \047" sum "\047"
+    print ")"
+    in_block = 1
+    next
+  }
+  in_block && /^\)/ { in_block = 0; next }
+  in_block { next }
+  { print }
+' "$PKGBUILD" > "$PKGBUILD.new" && mv "$PKGBUILD.new" "$PKGBUILD"
 
-# Reset pkgrel to 1 for new version
-sed -i "s/^pkgrel=.*/pkgrel=1/" "$PKGBUILD"
+sed -i "s/^pkgrel=.*/pkgrel=$PKGREL/" "$PKGBUILD"
 
 echo "Updated $PKGBUILD:"
 grep -E "^(pkgver|pkgrel|sha256sums)" "$PKGBUILD" | head -5


### PR DESCRIPTION
Fixes the deployment side of #936.

## Why

qt6-base / qt6-wayland 6.11.1 → 6.11.2 broke already-installed 3.3.8 builds with no source change. The layer-shell QPA plugin compiles against Qt **private** headers (`QtWaylandClient/private/qwaylanddisplay_p.h` and 7 others), whose class layouts carry no ABI guarantee. `QWaylandDisplay::inputDevices()` is an inline accessor, so its member offset is baked into `libPhosphorWayland.so` at compile time. After the Qt bump the old binary read that `QList` from the wrong offset and faulted on the garbage pointer.

Core dump from the reporter:

```
#3  PhosphorWayland::IdleNotifier::setTimeout(std::chrono::milliseconds)
#2  libPhosphorWayland +0x160e6
#1  libPhosphorWayland +0x15f15
#0  libc.so.6 +0x1b1f6b        ← si_code: SI_KERNEL
```

`SI_KERNEL` on SIGSEGV means #GP, which is what a non-canonical (wild) pointer gives you, matching the other reporter's `general protection fault ... in libc.so.6`.

The answer is a **pkgrel bump**, not a new version. Two things stopped that from working.

## Changes

**pkgrel is no longer hardcoded.** Both AUR publish steps did `sed -i "s/^pkgrel=.*/pkgrel=1/"`, so any manual bump on the AUR side got stomped on the next run. It is now a `workflow_dispatch` input, validated digits-only in the `version` job for the same script-injection reason the `tag` input is gated, and threaded through to the arch build and both AUR publishes. The AUR commit message reads `Rebuild <ver> (pkgrel N)` when it is not a fresh version.

**All nine checkouts are pinned to the tag.** Every `actions/checkout` was unpinned, so `workflow_dispatch -f tag=v3.3.8` built whatever the *dispatched branch* held and published it under the tag's version. The `tag` input selected the version string but not the source. They now pin `ref: ${{ needs.version.outputs.ref }}`.

**`update-aur.sh`** takes the same optional pkgrel argument, and its hash rewrite is replaced with the awk-anchored one the workflow already uses. The old sed pair dropped the `sha256sums` array's closing paren on the single-line form, leaving a PKGBUILD `makepkg` could not source at all — reproducible against the unmodified script.

## Not done here

No `qt6-base=` / `qt6-wayland=` dependency pins. An exact pin makes pacman hold the dep back on `-Syu` and strands a half-upgraded Plasma, which is the same reason `PKGBUILD.bin` deliberately does not pin KWin. The durable fix is a runtime version guard that degrades instead of faulting; that is a separate change.

## Verification

- YAML parses; every checkout job carries `needs: version`; all nine pinned.
- `version` job logic exercised across tag-push and dispatch, with pkgrel empty / 1 / 2 / non-numeric (rejected).
- `update-aur.sh` round-tripped on both `PKGBUILD` (multi-line hashes) and `PKGBUILD.bin` (single-line `SKIP`); both outputs parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)