### PR TITLE
ci(release): carry the rebuild revision into rpm, deb and OBS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ on:
         description: 'Tag to release (e.g. v3.0.0). Must already exist.'
         required: true
       pkgrel:
-        description: 'Arch pkgrel. Bump for a rebuild-only republish of an already-released tag (e.g. a Qt private-ABI break). Leave at 1 for a normal release.'
+        description: 'Package revision (Arch pkgrel / RPM Release / deb revision). Bump for a rebuild-only republish of an already-released tag, e.g. after a KWin or Qt bump breaks the installed binaries. Leave at 1 for a normal release.'
         required: false
         default: '1'
 
@@ -87,12 +87,22 @@ jobs:
           if [[ "$VERSION" =~ -(alpha|beta|rc)(\.?[0-9]+)?$ ]]; then
               IS_PRE=true
           fi
-          # Arch pkgrel. A tag push always means a fresh version, so it
-          # starts at 1; only a manual dispatch can raise it, and that is
-          # the rebuild-only path — same source, same tag, new package,
-          # e.g. when a Qt patch release breaks the private-API ABI the
-          # layer-shell QPA plugin is compiled against. Digits only, for
-          # the same script-injection reason the tag is gated above.
+          # Package revision: Arch pkgrel, RPM Release, deb revision. A tag
+          # push always means a fresh version, so it starts at 1; only a
+          # manual dispatch can raise it, and that is the rebuild-only path
+          # — same source, same tag, new packages.
+          #
+          # What forces it is a dependency ABI moving under an installed
+          # build. KWin is the routine one: the effect plugin's IID embeds
+          # KWin's exact upstream version, and KWin refuses to load an
+          # effect whose IID does not match, so the overlay goes missing on
+          # every KWin bump until a rebuild. Qt is the sharp one: the
+          # layer-shell QPA plugin compiles against Qt private headers whose
+          # class layouts carry no ABI guarantee, so a qt6 patch bump can
+          # leave the daemon reading members at stale offsets and crashing.
+          #
+          # Digits only, for the same script-injection reason the tag is
+          # gated above.
           PKGREL="${INPUT_PKGREL:-1}"
           if [[ ! "$PKGREL" =~ ^[0-9]+$ ]]; then
               echo "Error: PKGREL '$PKGREL' is not a positive integer" >&2
@@ -145,7 +155,10 @@ jobs:
             || apt-get install -y --no-install-recommends kf6-kirigami-dev
 
       - name: Generate Debian changelog from CHANGELOG.md
-        run: bash packaging/generate-changelog.sh debian
+        # Third arg is the package revision — see the version job's `pkgrel`
+        # output. Stamps the newest changelog entry only, so a rebuild-only
+        # republish produces 3.3.8-2 and apt actually offers the upgrade.
+        run: bash packaging/generate-changelog.sh debian "" "${{ needs.version.outputs.pkgrel }}"
 
       - name: Build Debian package
         # Force bash: this step uses `set -o pipefail` and `compgen`, both
@@ -223,8 +236,13 @@ jobs:
       - name: Generate RPM changelog and set version from CHANGELOG.md
         run: |
           VERSION="${{ needs.version.outputs.version }}"
+          PKGREL="${{ needs.version.outputs.pkgrel }}"
           sed -i "s/^Version:.*/Version:        $VERSION/" packaging/rpm/plasmazones.spec
-          bash packaging/generate-changelog.sh rpm
+          # Release must move for a rebuild-only republish, otherwise dnf and
+          # zypper see the same NEVR and offer nothing. Same revision the deb
+          # changelog and Arch pkgrel use.
+          sed -i "s/^Release:.*/Release:        $PKGREL%{?dist}/" packaging/rpm/plasmazones.spec
+          bash packaging/generate-changelog.sh rpm "" "$PKGREL"
 
       - name: Create source tarball
         run: |
@@ -350,8 +368,13 @@ jobs:
       - name: Generate RPM changelog and set version from CHANGELOG.md
         run: |
           VERSION="${{ needs.version.outputs.version }}"
+          PKGREL="${{ needs.version.outputs.pkgrel }}"
           sed -i "s/^Version:.*/Version:        $VERSION/" packaging/rpm/plasmazones.spec
-          bash packaging/generate-changelog.sh rpm
+          # Release must move for a rebuild-only republish, otherwise dnf and
+          # zypper see the same NEVR and offer nothing. Same revision the deb
+          # changelog and Arch pkgrel use.
+          sed -i "s/^Release:.*/Release:        $PKGREL%{?dist}/" packaging/rpm/plasmazones.spec
+          bash packaging/generate-changelog.sh rpm "" "$PKGREL"
 
       - name: Create source tarball
         run: |
@@ -1068,12 +1091,17 @@ jobs:
         run: |
           set -euo pipefail
           VERSION="${{ needs.version.outputs.version }}"
+          PKGREL="${{ needs.version.outputs.pkgrel }}"
           # OBS builds from the committed spec, so it must carry the real
           # version (download_files resolves Source0's %{version}) and the
           # release changelog — not the 0.0.0 placeholder. Same templating
           # as the build-rpm-opensuse job above.
           sed -i "s/^Version:.*/Version:        $VERSION/" packaging/rpm/plasmazones.spec
-          bash packaging/generate-changelog.sh rpm
+          # Release must move for a rebuild-only republish, otherwise dnf and
+          # zypper see the same NEVR and offer nothing. Same revision the deb
+          # changelog and Arch pkgrel use.
+          sed -i "s/^Release:.*/Release:        $PKGREL%{?dist}/" packaging/rpm/plasmazones.spec
+          bash packaging/generate-changelog.sh rpm "" "$PKGREL"
 
       - name: Commit package to OBS
         env:
@@ -1081,6 +1109,7 @@ jobs:
         run: |
           set -euo pipefail
           VERSION="${{ needs.version.outputs.version }}"
+          PKGREL="${{ needs.version.outputs.pkgrel }}"
           # Check out the existing OBS package working copy — the project
           # and package must already exist (see the setup notes above).
           osc checkout "$OBS_PROJECT" plasmazones
@@ -1099,7 +1128,11 @@ jobs:
           # empty result and silently mistaken for "no changes".
           STATUS="$(osc status)"
           if [[ -n "$STATUS" ]]; then
-              osc commit -m "Update to $VERSION"
+              if [[ "$PKGREL" == "1" ]]; then
+                  osc commit -m "Update to $VERSION"
+              else
+                  osc commit -m "Rebuild $VERSION (release $PKGREL)"
+              fi
               echo "✅ Committed plasmazones $VERSION to $OBS_PROJECT — OBS will rebuild"
           else
               echo "No changes to commit"

--- a/packaging/generate-changelog.sh
+++ b/packaging/generate-changelog.sh
@@ -89,8 +89,10 @@ print(d.strftime('%a %b ') + str(d.day).rjust(2) + d.strftime(' %Y'))
 # Generate Debian changelog
 generate_debian() {
     local filter_version="${1:-}"
+    local revision="${2:-1}"
     local outfile="$SCRIPT_DIR/debian/changelog"
     local current_version="" current_date="" first_entry=1
+    local current_version_seen=""
     local tmpfile
     tmpfile=$(mktemp)
 
@@ -113,7 +115,16 @@ generate_debian() {
 
             current_version="$version"
             current_date="$date"
-            echo "plasmazones ($version-1) unstable; urgency=medium"
+            # The newest entry is the one being released, so it carries the
+            # caller's revision. Older entries keep -1: their packages were
+            # published under that revision, and restamping them would invent
+            # uploads that never happened.
+            local entry_revision=1
+            if [[ -z "$current_version_seen" ]]; then
+                entry_revision="$revision"
+                current_version_seen=1
+            fi
+            echo "plasmazones ($version-$entry_revision) unstable; urgency=medium"
             echo ""
         fi
 
@@ -144,8 +155,9 @@ generate_debian() {
 # Generate RPM %changelog section and splice into spec
 generate_rpm() {
     local filter_version="${1:-}"
+    local revision="${2:-1}"
     local specfile="$SCRIPT_DIR/rpm/plasmazones.spec"
-    local current_version="" current_date=""
+    local current_version="" current_date="" current_version_seen=""
     local tmpfile
     tmpfile=$(mktemp)
 
@@ -162,7 +174,13 @@ generate_rpm() {
 
             current_version="$version"
             current_date="$date"
-            echo "* $(iso_to_rpm "$date") fuddlesworth - $version-1"
+            # See generate_debian: only the newest entry takes the revision.
+            local entry_revision=1
+            if [[ -z "$current_version_seen" ]]; then
+                entry_revision="$revision"
+                current_version_seen=1
+            fi
+            echo "* $(iso_to_rpm "$date") fuddlesworth - $version-$entry_revision"
         fi
 
         # Escape RPM macros: a bare % in changelog text is expanded by
@@ -221,22 +239,42 @@ generate_notes() {
     ' "$CHANGELOG" | sed -e :a -e '/^[[:space:]]*$/{ $d; N; ba; }'
 }
 
+# Package revision, applied to the newest changelog entry. 1 for a normal
+# release; raised for a rebuild-only republish of a version that is already
+# out, where the source is unchanged but the binaries must be rebuilt.
+#
+# The recurring cause is a dependency ABI moving underneath an installed
+# build. KWin is the common one: the effect plugin's IID embeds KWin's exact
+# upstream version and KWin refuses to load an effect whose IID does not
+# match, so every KWin bump strands the overlay until a rebuild. Qt is the
+# sharper one: the layer-shell QPA plugin compiles against Qt private headers
+# whose class layouts carry no ABI guarantee, so a qt6 patch bump can leave
+# the daemon reading members at stale offsets and crashing outright.
+#
+# Without a revision bump apt/dnf/zypper see the same NEVR and offer no
+# upgrade, so the rebuild never reaches anyone. Mirrors Arch's pkgrel.
+REVISION="${3:-1}"
+if [[ ! "$REVISION" =~ ^[0-9]+$ ]]; then
+    echo "Error: revision must be a positive integer, got: $REVISION" >&2
+    exit 1
+fi
+
 case "${1:-}" in
     debian)
-        generate_debian "${2:-}"
+        generate_debian "${2:-}" "$REVISION"
         ;;
     rpm)
-        generate_rpm "${2:-}"
+        generate_rpm "${2:-}" "$REVISION"
         ;;
     notes)
         generate_notes "${2:-}"
         ;;
     all)
-        generate_debian "${2:-}"
-        generate_rpm "${2:-}"
+        generate_debian "${2:-}" "$REVISION"
+        generate_rpm "${2:-}" "$REVISION"
         ;;
     *)
-        echo "Usage: $0 {debian|rpm|notes|all} [version]" >&2
+        echo "Usage: $0 {debian|rpm|notes|all} [version] [revision]" >&2
         exit 1
         ;;
 esac


### PR DESCRIPTION
Follow-up to #940. That PR made a rebuild-only republish possible, but only for Arch.

## The gap

A `workflow_dispatch` with `pkgrel=2` rebuilt the deb and both rpms and replaced the release assets, but left their version strings alone:

- `packaging/rpm/plasmazones.spec:20` — `Release: 1%{?dist}`, never templated (the workflow only sed'd `^Version:`)
- `packaging/generate-changelog.sh:116` — `plasmazones ($version-1)` for deb
- `packaging/generate-changelog.sh:165` — `$version-1` for the rpm `%changelog`

So `apt`, `dnf` and `zypper` saw the same NEVR and offered no upgrade. The rebuild reached nobody.

OBS was worse than a no-op: `publish-obs` commits only when `osc status` shows a diff, and with an unchanged spec it printed "No changes to commit" and never rebuilt.

## Changes

`generate-changelog.sh` takes an optional revision as its third argument, applied to **the newest changelog entry only**. Older entries keep `-1`: their packages were published under that revision, and restamping them would invent uploads that never happened.

The workflow stamps `Release:` alongside the existing `Version:` sed at all three rpm sites (`build-rpm`, `build-rpm-opensuse`, `publish-obs`), passes the revision to every changelog invocation, and gives OBS the same rebuild-aware commit message the AUR steps got in #940.

## Reframed away from Qt

#936 made Qt the headline, but **KWin is the routine trigger**. The effect plugin's IID embeds KWin's exact upstream version and KWin refuses to load an effect whose IID doesn't match, so the overlay goes missing on every KWin bump until a rebuild — already documented in `PKGBUILD.bin:20-29`. Qt is the sharper failure (a hard crash rather than a missing overlay) but the rarer one. The input description and comments now lead with the general case.

## Verification

- At revision 1 the generated deb changelog and spec are **byte-identical** to the previous script's output, diffed directly against `origin/main`'s version.
- At revision 2: spec becomes `Release: 2%{?dist}`, newest rpm entry `3.3.8-2`, newest deb entry `3.3.8-2`, and exactly 1 of 145 deb entries restamped.
- Old no-arg call shape still works; a non-numeric revision is rejected.
- YAML parses; `PKGREL` is defined in every step's own shell that references it.

## Still not covered

COPR does not rebuild on this path. Its webhook fires on "Branch or tag creation" (`release.yml:1125`) and a `workflow_dispatch` creates neither. That needs a real tag or a manual trigger in the COPR UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)