### PR TITLE
chore(release): 3.3.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [3.3.9] - 2026-08-20
+
+### Fixed
+
+- **The daemon crashed on startup after the Qt 6.11.2 update**: window tiling stopped working entirely, and the daemon restarted and crashed in a loop rather than coming up. PlasmaZones reads part of Qt's internal Wayland state directly, and the update moved that state, so the daemon read from the wrong place and crashed on whatever happened to be there. This release is built against the new Qt. Anyone who installed from a distribution package needs the rebuilt package from their distribution, not just a restart ([#936](https://github.com/fuddlesworth/PlasmaZones/discussions/936)).
+
 ## [3.3.8] - 2026-08-15
 
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 
 cmake_minimum_required(VERSION 3.16)
 
-project(PlasmaZones VERSION 3.3.8 LANGUAGES C CXX)
+project(PlasmaZones VERSION 3.3.9 LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/data/whatsnew.json
+++ b/data/whatsnew.json
@@ -1,6 +1,13 @@
 {
     "releases": [
         {
+            "version": "3.3.9",
+            "date": "2026-08-20",
+            "highlights": [
+                "Fixed: the daemon crashed on startup after the Qt 6.11.2 update and window tiling stopped working. This release is built against the new Qt (#936)"
+            ]
+        },
+        {
             "version": "3.3.8",
             "date": "2026-08-15",
             "highlights": [


### PR DESCRIPTION
Rebuild release for #936.

No source changes since 3.3.8 beyond the release pipeline itself (#940, #941, #942) and a flake.lock bump. This tag exists to publish binaries built against qt6 6.11.2.

## Why a new version rather than a rebuild of 3.3.8

The rebuild dispatch deleted the v3.3.8 release before failing to recreate it, and GitHub keeps a tag reserved once it has carried an immutable release. v3.3.8 cannot be republished, and `plasmazones-bin` is currently uninstallable because its release-download URL 404s. #942 makes that failure mode impossible going forward but cannot undo it.

A real tag also triggers the COPR webhook, which fires on tag creation and which no `workflow_dispatch` can reach.

## Changes

- `CMakeLists.txt` → `VERSION 3.3.9`
- `CHANGELOG.md` → one `### Fixed` entry
- `data/whatsnew.json` → matching highlight

The user-facing text says what happened without the internals, and flags that a restart is not enough:

> **The daemon crashed on startup after the Qt 6.11.2 update**: window tiling stopped working entirely, and the daemon restarted and crashed in a loop rather than coming up. PlasmaZones reads part of Qt's internal Wayland state directly, and the update moved that state, so the daemon read from the wrong place and crashed on whatever happened to be there. This release is built against the new Qt. Anyone who installed from a distribution package needs the rebuilt package from their distribution, not just a restart.

## Verification

- Clean configure and build in a fresh tree, **zero warnings**
- **324/324 tests pass** (`test_surface_decoration_orientation` skipped, GPU-gated)
- `generate-changelog.sh` parses the new entry for all three consumers: release notes, `plasmazones (3.3.9-1)`, and rpm `- 3.3.9-1`
- `build/generated/version.h` carries `3.3.9`

## Release path

Tagging exercises the #942 fixes on a clean path: `pkgrel=1` skips the immutability guard, no release exists for the tag so it takes the `create` branch, and no `gh release delete` remains in the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)