### PR TITLE
ci(release): force bash on the changelog steps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,6 +184,10 @@ jobs:
             || apt-get install -y --no-install-recommends kf6-kirigami-dev
 
       - name: Generate Debian changelog from CHANGELOG.md
+        # Force bash for the same reason the build step below does: the KDE
+        # Neon container's default shell resolves to dash, which has neither
+        # `set -o pipefail` nor `[[ ]]`.
+        shell: bash
         env:
           VERSION: ${{ needs.version.outputs.version }}
           PKGREL: ${{ needs.version.outputs.pkgrel }}
@@ -282,6 +286,9 @@ jobs:
       # Template the version FIRST so the source tarball baked into the
       # SRPM carries the matching spec rather than the 0.0.0 placeholder.
       - name: Generate RPM changelog and set version from CHANGELOG.md
+        # See the Debian step: the version assertion below uses `[[ ]]`, which
+        # dash does not have, and a container's default shell may resolve to it.
+        shell: bash
         run: |
           VERSION="${{ needs.version.outputs.version }}"
           PKGREL="${{ needs.version.outputs.pkgrel }}"
@@ -423,6 +430,9 @@ jobs:
         run: rpmdev-setuptree
 
       - name: Generate RPM changelog and set version from CHANGELOG.md
+        # See the Debian step: the version assertion below uses `[[ ]]`, which
+        # dash does not have, and a container's default shell may resolve to it.
+        shell: bash
         run: |
           VERSION="${{ needs.version.outputs.version }}"
           PKGREL="${{ needs.version.outputs.pkgrel }}"


### PR DESCRIPTION
The v3.3.9 tag build failed in `Build .deb (KDE Neon)`:

```
/__w/_temp/....sh: 1: set: Illegal option -o pipefail
```

The step ran under `shell: sh -e {0}` — that container's default shell resolves to dash, which has neither `set -o pipefail` nor `[[ ]]`. The `Build Debian package` step two steps below already sets `shell: bash` and carries a comment about this exact trap. The changelog step I added in #942 did not. My miss.

The two RPM changelog steps gained `[[ ]]` in the same batch and also run in containers, so they get `shell: bash` too rather than relying on those images resolving to bash by luck (they did, this time).

## Why not a workflow-level default

`defaults.run.shell: bash` would cover the whole class in one line, but GitHub's bash shell implies `-o pipefail`. Turning that on for every existing step risks breaking ones that currently tolerate a failing command in a pipeline, and I'd rather not discover that during a release. Audited: neither changelog step contains a pipeline, so `shell: bash` is inert beyond selecting the interpreter. The systemic version is worth doing separately, on its own CI run.

## State of v3.3.9

Nothing was published. `Create GitHub Release`, `Publish to AUR` and `Publish to OBS` were all skipped, so **no release exists for the tag and it is still usable** — the immutable-tag trap that killed v3.3.8 has not been sprung here. All other builds passed (Arch, Fedora, openSUSE, generic tarball, Nix).

After merge, `gh workflow run release.yml --ref main -f tag=v3.3.9` re-runs it. The workflow file comes from the dispatched branch while the source checkout pins to the tag, so the fix applies without needing to move the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)