### PR TITLE
fix(scrolling): normalise wheel chord deltas to notches

### DIFF
--- a/kwin-effect/plasmazoneseffect/input_filter.cpp
+++ b/kwin-effect/plasmazoneseffect/input_filter.cpp
@@ -172,8 +172,9 @@ bool ScrollOverhangInputFilter::pointerAxis(KWin::PointerAxisEvent* event)
     // processAxis, so this is the same field the chords were matched against
     // while they were compositor axis shortcuts. Using the other one here
     // would be a behaviour CHANGE, not a fidelity fix.
-    if (TilingHandler* tiling = m_effect->tilingHandler();
-        tiling && tiling->handleWheelChord(event->delta, event->orientation, event->modifiers, event->buttons)) {
+    if (TilingHandler* tiling = m_effect->tilingHandler(); tiling
+        && tiling->handleWheelChord(event->delta, event->deltaV120, event->orientation, event->modifiers,
+                                    event->buttons)) {
         // A claimed chord ends whatever ScrollFactor stream was running: the
         // client never sees this tick, so its fractional remainder must not
         // survive to be applied to the next tick it does see.

--- a/kwin-effect/plasmazoneseffect/plasmazoneseffect.cpp
+++ b/kwin-effect/plasmazoneseffect/plasmazoneseffect.cpp
@@ -223,7 +223,8 @@ void PlasmaZonesEffect::pointerAxis(KWin::PointerAxisEvent* event)
     if (!event || !m_tilingHandler->scrollTabInterceptionHeld()) {
         return;
     }
-    if (m_tilingHandler->handleWheelChord(event->delta, event->orientation, event->modifiers, event->buttons)
+    if (m_tilingHandler->handleWheelChord(event->delta, event->deltaV120, event->orientation, event->modifiers,
+                                          event->buttons)
         && m_overhangInputFilter) {
         // The client never sees a claimed tick, so end the ScrollFactor
         // stream exactly as the filter's own chord branch does. Skipping this

--- a/kwin-effect/tilinghandler/state.cpp
+++ b/kwin-effect/tilinghandler/state.cpp
@@ -49,6 +49,21 @@ namespace {
 /// message. A real wheel notch is 1.0 and even a coalesced high-resolution
 /// frame stays in single digits, so this only ever truncates garbage.
 constexpr int kMaxWheelStepsPerEvent = 16;
+
+/// One discrete wheel notch, in deltaV120 units. libinput reports high
+/// resolution wheels as fractions of this and KWin passes the value through
+/// unchanged, so dividing by it yields notches directly.
+constexpr qreal kV120PerNotch = 120.0;
+
+/// One notch worth of the smooth `delta` field, used only when the event
+/// carries no deltaV120 (touchpads and other continuous sources). The wheel
+/// itself never lands here: KWin fills deltaV120 for every wheel event.
+///
+/// The value is libinput's legacy degrees-per-detent, which is also the scale
+/// KWin's smooth delta uses for a wheel, so a continuous source has to travel
+/// about as far as one notch to spend a step. Treating that field as notches
+/// directly is what made a single notch fire a whole screenful of steps.
+constexpr qreal kSmoothUnitsPerNotch = 15.0;
 } // namespace
 
 void TilingHandler::clearTiledTracking()
@@ -588,8 +603,8 @@ void TilingHandler::clearActiveLayoutsForTeardown()
     m_effect->sliceActiveLayoutRulesForUnseededMap();
 }
 
-bool TilingHandler::handleWheelChord(qreal delta, Qt::Orientation orientation, Qt::KeyboardModifiers mods,
-                                     Qt::MouseButtons buttons)
+bool TilingHandler::handleWheelChord(qreal delta, qint32 deltaV120, Qt::Orientation orientation,
+                                     Qt::KeyboardModifiers mods, Qt::MouseButtons buttons)
 {
     // Fast path first, in the order that costs least: the enable setting,
     // then "does any screen run the strip at all". Every axis event in the
@@ -636,6 +651,13 @@ bool TilingHandler::handleWheelChord(qreal delta, Qt::Orientation orientation, Q
         resetWheelAccumulators();
         return false;
     }
+    // Convert to NOTCHES before anything downstream looks at the magnitude.
+    // KWin's two delta fields are not notch counts: deltaV120 is 120 per
+    // notch, and the smooth delta is the source's own scale (degrees for a
+    // wheel, pixels for a touchpad). deltaV120 is exact and is what a wheel
+    // always carries, so prefer it and fall back to the smooth field only for
+    // the continuous sources that leave it zero.
+    const qreal notches = deltaV120 != 0 ? deltaV120 / kV120PerNotch : delta / kSmoothUnitsPerNotch;
     // Not while a window drag is in flight. The shipped defaults cannot
     // collide (drag activation is Alt, the chords are Meta and Meta+Shift),
     // but both sides are user-configurable now, and a user who binds the same
@@ -669,12 +691,12 @@ bool TilingHandler::handleWheelChord(qreal delta, Qt::Orientation orientation, Q
     }
     // Accumulate to a whole notch before acting, which is the threshold
     // KWin's axis-shortcut path applied for us before the matching moved
-    // here. A discrete wheel notch arrives as |delta| == 1.0 and so still
-    // fires on its first event; a touchpad or high-resolution wheel now
-    // spends several fractional events per step instead of one verb each.
+    // here. A discrete wheel notch normalises to exactly 1.0 and so still
+    // fires on its first event; a touchpad or high-resolution wheel spends
+    // several fractional events per step instead of one verb each.
     qreal& accum = orientation == Qt::Vertical ? m_wheelAccumVertical : m_wheelAccumHorizontal;
     qreal& other = orientation == Qt::Vertical ? m_wheelAccumHorizontal : m_wheelAccumVertical;
-    accum += delta;
+    accum += notches;
     if (qAbs(accum) < 1.0) {
         // Sub-notch, but still part of the chord gesture: consume it so the
         // app underneath does not scroll its own content while the user is
@@ -684,8 +706,8 @@ bool TilingHandler::handleWheelChord(qreal delta, Qt::Orientation orientation, Q
     // The sign is fixed for this event; only the magnitude is spent below.
     const qreal whole = accum > 0 ? 1.0 : -1.0;
     // Spend the WHOLE accumulated magnitude, not one notch of it. A fast
-    // discrete wheel and a coalesced high-resolution frame both deliver
-    // |delta| well above 1.0 in a single event, and taking one step per event
+    // discrete wheel and a coalesced high-resolution frame can both deliver
+    // more than one notch in a single event, and taking one step per event
     // there would bank the rest forever: the strip would lag the wheel by a
     // growing margin and the unspent remainder would be dropped at the end of
     // the gesture.

--- a/kwin-effect/tilinghandler/tilinghandler.h
+++ b/kwin-effect/tilinghandler/tilinghandler.h
@@ -389,7 +389,14 @@ public:
     /// firing a verb, so the app underneath does not scroll its own content
     /// while the user is mid-step on the strip.
     ///
-    /// @p delta is the event's own. The direction the strip moves is derived
+    /// @p delta and @p deltaV120 are the event's own two scroll fields, and
+    /// both are needed because neither alone counts notches on every source:
+    /// deltaV120 is exact at 120 per notch but is zero on continuous sources,
+    /// and the smooth @p delta carries the source's own scale (degrees for a
+    /// wheel, pixels for a touchpad) rather than a notch count. The handler
+    /// normalises them to notches before it acts.
+    ///
+    /// The direction the strip moves is derived
     /// here (sign of the accumulated notch, inversion setting) and the strip
     /// AXIS is resolved downstream by the engine, so one rule serves a
     /// horizontal and a vertical strip alike: a whole notch means "toward the
@@ -398,7 +405,7 @@ public:
     /// per-axis ACCUMULATOR the delta lands in, because KWin delivers
     /// horizontal and vertical scroll as two independent streams and a
     /// diagonal touchpad drift feeds both at once.
-    bool handleWheelChord(qreal delta, Qt::Orientation orientation, Qt::KeyboardModifiers mods,
+    bool handleWheelChord(qreal delta, qint32 deltaV120, Qt::Orientation orientation, Qt::KeyboardModifiers mods,
                           Qt::MouseButtons buttons);
 
     // Screen accessors (for gating drag/snap/overlay behavior per-screen)
@@ -1542,10 +1549,11 @@ private:
     // cover a case the next settingsChanged re-requests anyway.
     QVector<PhosphorCompositor::ParsedTrigger> m_wheelFocusTriggers{{4, 0}};
     QVector<PhosphorCompositor::ParsedTrigger> m_wheelViewTriggers{{11, 0}};
-    // Smooth-delta accumulators, in wheel-notch units. Matching used to run
-    // through registerAxisShortcut, whose processAxis only fires once |delta|
-    // clears 1.0; doing the matching ourselves means owning that threshold,
-    // or a touchpad sends a column step per libinput event.
+    // Scroll accumulators, in wheel-notch units (the raw event fields are
+    // normalised to notches before they land here). Matching used to run
+    // through registerAxisShortcut, which fired one verb per axis event;
+    // doing the matching ourselves means owning that threshold, or a touchpad
+    // sends a column step per libinput event.
     //
     // Per axis because KWin delivers horizontal and vertical scroll as two
     // independent streams: a diagonal drift feeds both with possibly opposite


### PR DESCRIPTION
## The regression

The scroll keys (#964) moved from KWin's `registerAxisShortcut` to per-event matching in `TilingHandler::handleWheelChord`, and the new code accumulated the event's smooth `delta` as though it counted wheel notches.

It does not. `KWin::PointerAxisEvent` carries two scroll fields, and neither is a notch count by default:

- `deltaV120` is 120 per discrete notch, and zero on continuous sources
- `delta` is the source's own scale: libinput's 15 degrees per detent for a wheel, pixels for a touchpad

So a single wheel notch spent about fifteen strip steps (capped at sixteen by `kMaxWheelStepsPerEvent`). Column focus skipped whole runs of windows, and the view chord ran to the end of the strip instead of panning it. The old shortcut path fired exactly one verb per axis event, so nothing exposed the scale before the matching moved into the effect.

## The fix

Convert to notches before the accumulator sees anything, preferring the exact `deltaV120` field and falling back to the smooth one only for the sources that leave it zero:

```cpp
const qreal notches = deltaV120 != 0 ? deltaV120 / kV120PerNotch : delta / kSmoothUnitsPerNotch;
```

Both call sites (the overhang input filter, and the tab-pill interception path in the effect) pass the extra field. A discrete notch now normalises to exactly 1.0 and fires one step on its first event, which is what the accumulator's 1.0 threshold was written against.

The comments asserting that a notch arrives as `|delta| == 1.0` are corrected, since that claim is what the mistake rested on. Everything else on the path is untouched: exact chord matching, the accumulator resets on every non-claiming bail, and the per-event step cap all stand.

## Testing

Build clean, 404/404 ctest passing. Live-verified by the user on hardware: both column focus and the view pan step one column per notch again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LMwcBdPBFW4GZdiN4bT4u9