### PR TITLE
fix(scrolling): allow any whole percent for default column width

### DIFF
--- a/src/config/configdefaults_scrolling.h
+++ b/src/config/configdefaults_scrolling.h
@@ -221,12 +221,12 @@ public:
     }
     /// Editing granularity for the two width controls, shipped to QML through
     /// SettingsController::scrollingConstants(). The proportion step is a
-    /// work-area fraction (5% per slider notch); the fixed step is whole
+    /// work-area fraction (1% per slider notch); the fixed step is whole
     /// pixels. Both are doubles so the pair travels through one QVariantMap
     /// shape alongside the min/max accessors above.
     static constexpr qreal scrollingDefaultColumnWidthProportionStep()
     {
-        return 0.05;
+        return 0.01;
     }
     static constexpr qreal scrollingDefaultColumnWidthFixedStep()
     {

--- a/src/settings/qml/components/SettingsSlider.qml
+++ b/src/settings/qml/components/SettingsSlider.qml
@@ -21,6 +21,12 @@ RowLayout {
     property real from: 0
     property real to: 100
     property real stepSize: 1
+    //* @brief Spacing between drawn tick marks, in the slider's own units.
+    //* 0 leaves the style's default (a tick per step), which is unreadable
+    //* once the step is fine-grained; negative disables tick marks. The
+    //* style hint is an int, so a slider that wants sparse ticks over a
+    //* fine step has to work in whole units (percent rather than fraction).
+    property int tickMarkStepSize: 0
     property real value: 0
     property string valueSuffix: "%"
     property int sliderWidth: Kirigami.Units.gridUnit * 16
@@ -56,6 +62,7 @@ RowLayout {
         id: slider
 
         Accessible.name: root.accessibleName
+        Kirigami.StyleHints.tickMarkStepSize: root.tickMarkStepSize
         Layout.preferredWidth: root.sliderWidth
         from: root.from
         to: root.to

--- a/src/settings/qml/pages/scrolling/ScrollingColumnsPage.qml
+++ b/src/settings/qml/pages/scrolling/ScrollingColumnsPage.qml
@@ -174,15 +174,19 @@ SettingsFlickable {
 
                     SettingsSlider {
                         accessibleName: i18n("Proportion of the strip")
-                        from: root._scrollConsts.proportionMin
-                        to: root._scrollConsts.proportionMax
-                        stepSize: root._scrollConsts.proportionStep
-                        value: root.settingValue("DefaultColumnWidthValue", appSettings.scrollingDefaultColumnWidthValue)
+                        // Percent units, not the stored fraction: the step is
+                        // 1% and the tick-mark hint is an int, so ticks can
+                        // only stay readable (one per 5%) in whole percent.
+                        from: Math.round(root._scrollConsts.proportionMin * 100)
+                        to: Math.round(root._scrollConsts.proportionMax * 100)
+                        stepSize: Math.max(1, Math.round(root._scrollConsts.proportionStep * 100))
+                        tickMarkStepSize: 5
+                        value: root.settingValue("DefaultColumnWidthValue", appSettings.scrollingDefaultColumnWidthValue) * 100
                         formatValue: function (v) {
-                            return Math.round(v * 100) + "%";
+                            return Math.round(v) + "%";
                         }
                         onMoved: function (newValue) {
-                            root.writeSetting("DefaultColumnWidthValue", newValue, function (v) {
+                            root.writeSetting("DefaultColumnWidthValue", Math.round(newValue) / 100, function (v) {
                                 appSettings.scrollingDefaultColumnWidthValue = v;
                             });
                         }

--- a/src/settings/qml/pages/scrolling/ScrollingSimplePage.qml
+++ b/src/settings/qml/pages/scrolling/ScrollingSimplePage.qml
@@ -150,15 +150,19 @@ SettingsFlickable {
 
                     SettingsSlider {
                         accessibleName: i18n("Proportion of the strip")
-                        from: root._scrollConsts.proportionMin
-                        to: root._scrollConsts.proportionMax
-                        stepSize: root._scrollConsts.proportionStep
-                        value: appSettings.scrollingDefaultColumnWidthValue
+                        // Percent units, not the stored fraction: the step is
+                        // 1% and the tick-mark hint is an int, so ticks can
+                        // only stay readable (one per 5%) in whole percent.
+                        from: Math.round(root._scrollConsts.proportionMin * 100)
+                        to: Math.round(root._scrollConsts.proportionMax * 100)
+                        stepSize: Math.max(1, Math.round(root._scrollConsts.proportionStep * 100))
+                        tickMarkStepSize: 5
+                        value: appSettings.scrollingDefaultColumnWidthValue * 100
                         formatValue: function (v) {
-                            return Math.round(v * 100) + "%";
+                            return Math.round(v) + "%";
                         }
                         onMoved: function (newValue) {
-                            appSettings.scrollingDefaultColumnWidthValue = newValue;
+                            appSettings.scrollingDefaultColumnWidthValue = Math.round(newValue) / 100;
                         }
                     }
                 }


### PR DESCRIPTION
The "Proportion of the strip" slider stepped in 5% notches, so a width like 33% or 67% was unreachable.

## Changes
- `configdefaults_scrolling.h` — proportion step 0.05 to 0.01.
- `SettingsSlider.qml` — new `tickMarkStepSize` property forwarded to `Kirigami.StyleHints.tickMarkStepSize` on the inner Slider, so tick density is no longer tied to the step.
- `ScrollingColumnsPage.qml` / `ScrollingSimplePage.qml` — the proportion sliders now work in whole-percent units (5 to 100, step 1) with ticks every 5%, converting to and from the stored fraction. The unit change is forced by the style hint being an `int`, which cannot express a 0.05 spacing over a 0..1 range.

The kind-aware setter clamps but never quantizes, so a 1% value reaches storage intact.

## Testing
Build clean with no new warnings. 404/404 ctest pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018PM6TEfot42ceHPgW6Vjb6