### PR TITLE
fix(scrolling): stop parked windows leaking across virtual desktops

### DIFF
--- a/kwin-effect/tilinghandler/screenschanged.cpp
+++ b/kwin-effect/tilinghandler/screenschanged.cpp
@@ -657,7 +657,27 @@ void TilingHandler::slotScreensChanged(const QStringList& screenIds, bool isDesk
                         continue;
                     }
                     const QString windowId = m_effect->getWindowId(w);
-                    if (!m_notifiedWindows.contains(windowId)) {
+                    if (m_savedNotifiedForDesktopReturn.contains(windowId)) {
+                        // PARKED, not moved. The park set means exactly "the
+                        // daemon STILL holds this window in this desktop's
+                        // state" (see the resetNotified comment in
+                        // tilinghandler.cpp), and a window that genuinely
+                        // changed desktops was un-parked by
+                        // cleanupAutotileTracking on its way out. So this is a
+                        // RE-TRACK, never a notify: notifyWindowAdded would
+                        // append the window to the arrived-at desktop's state
+                        // a second time, which on scrolling screens leaks the
+                        // other desktop's windows into this strip and destroys
+                        // the column order.
+                        //
+                        // The `added`-keyed re-track loop above does the same
+                        // thing, but `added` is empty on an identical-set
+                        // switch — every desktop assigned the same mode, which
+                        // is the ordinary multi-desktop scrolling setup — so
+                        // this scan is the only pass those windows reach.
+                        m_notifiedWindows.insert(windowId);
+                        m_notifiedWindowScreens[windowId] = screenId;
+                    } else if (!m_notifiedWindows.contains(windowId)) {
                         // Restore preserved pre-autotile geometry so float-restore
                         // returns to the original position, not the tiled frame from
                         // the source desktop. Only apply when the source screen


### PR DESCRIPTION
## The bug

With scrolling active on more than one virtual desktop, windows from the other desktop leak into the current strip and the column order is scrambled.

The logs show it plainly: every desktop switch re-announced six windows belonging to the desktop being left.

```
15:03:28 slotScreensChanged: desktop return, added screens: QSet() managed screens: QSet("LG…")
15:03:28 Desktop switch: re-adding moved window to autotile: "systemsettings|6398cb0a…"
15:03:28 Desktop switch: re-adding moved window to autotile: "org.plasmazones.settings|44e680b4…"
15:03:28 … vesktop, ghostty, firefox, obsidian
```

## Root cause

The desktop-switch demote pass parks a window in `m_savedNotifiedForDesktopReturn`, whose documented meaning is "the daemon still holds this window in that desktop's state, so re-track on return without re-notifying".

On return, two passes can pick a window back up:

- the `added`-keyed re-track loop, which checks `m_savedNotifiedForDesktopReturn || m_notifiedWindows` and re-tracks silently;
- the catch-scan over `m_managedScreens`, which only checked `!m_notifiedWindows.contains(...)` and therefore called `notifyWindowAdded` on parked windows.

When every desktop is assigned the same mode, the engine re-emits the identical screen set with `isDesktopSwitch=true`, so `added` is empty and the first loop is vacuous. The catch-scan is then the only pass those windows reach, and it appended every parked window to the arrived-at desktop's state a second time.

That empty-`added` case is the ordinary multi-desktop scrolling setup, which is why the bug is so visible there.

## Fix

The catch-scan now treats a parked window as already known and re-tracks it (`m_notifiedWindows` + `m_notifiedWindowScreens`) instead of notifying.

This does not weaken the scan's real purpose. A window that genuinely changed desktops goes through `releaseWindowTracking` → `cleanupAutotileTracking`, which un-parks it, so "parked" and "moved here while I was away" are disjoint sets.

`kwin-effect/tilinghandler/screenschanged.cpp:659`

## Testing

- `cmake --build build --parallel 6` clean, no new warnings
- `ctest --test-dir build` — 404/404 pass
- Confirmed live: switching desktops with scrolling on both no longer leaks windows or reorders columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoZ57kPioc98Bkh9J53dMH