### PR TITLE
fix: keep zone geometry stable when the work area moves

### DIFF
--- a/libs/phosphor-screens/src/manager.cpp
+++ b/libs/phosphor-screens/src/manager.cpp
@@ -390,9 +390,9 @@ void ScreenManager::calculateAvailableGeometry(const PhysicalScreen& screen)
         if (dbusVert > 0 || dbusHoriz > 0) {
             source = QStringLiteral("sensor+D-Bus");
             if (dbusVert > vertReserved || dbusHoriz > horizReserved) {
-                qCDebug(lcPhosphorScreens)
-                    << "D-Bus over-reports reservation on" << screenKey << "— D-Bus vert=" << dbusVert
-                    << "sensor vert=" << vertReserved << "— scaling down (likely floating/autohide panels)";
+                qCDebug(lcPhosphorScreens) << "D-Bus over-reports reservation on" << screenKey
+                                           << "— D-Bus vert=" << dbusVert << "sensor vert=" << vertReserved
+                                           << "— attributing the sensor total (likely floating/autohide panels)";
             } else if (dbusVert < vertReserved || dbusHoriz < horizReserved) {
                 qCDebug(lcPhosphorScreens)
                     << "D-Bus under-reports reservation on" << screenKey << "— D-Bus vert=" << dbusVert

--- a/libs/phosphor-screens/src/manager.cpp
+++ b/libs/phosphor-screens/src/manager.cpp
@@ -7,6 +7,7 @@
 #include "PhosphorScreens/IPanelSource.h"
 #include "PhosphorScreens/IScreenProvider.h"
 #include "PhosphorScreens/QtScreenProvider.h"
+#include "reservationsplit.h"
 #include "screenslogging.h"
 
 #include <PhosphorIdentity/VirtualScreenId.h>
@@ -331,11 +332,12 @@ void ScreenManager::calculateAvailableGeometry(const PhysicalScreen& screen)
     //     space, and the scripting API's `panel.geometry` is undefined in
     //     recent versions. This source contributes directional ratios only.
     //
-    // Reconciliation: the sensor tells us the total reserved in each axis;
-    // D-Bus ratios distribute that total across the two edges on that axis.
-    // Truly-floating or hidden-autohide panels self-correct — the sensor
-    // shows zero reservation, the scale factor collapses to zero, and their
-    // D-Bus offsets have no effect.
+    // Reconciliation: the sensor tells us the total reserved on each axis and
+    // D-Bus tells us which edges have panels; splitReservation() attributes
+    // the total to those edges. When only some of an axis' panels actually
+    // reserve (a hidden auto-hide dock opposite a normal panel), the edge
+    // whose claim matches the sensor total takes all of it rather than the
+    // two edges sharing it out — see reservationsplit.h.
 
     IPanelSource::Offsets panel =
         m_cfg.panelSource ? m_cfg.panelSource->currentOffsets(screen.qscreen) : IPanelSource::Offsets{};
@@ -361,9 +363,10 @@ void ScreenManager::calculateAvailableGeometry(const PhysicalScreen& screen)
         const int dbusHoriz = panel.left + panel.right;
 
         if (dbusVert > 0) {
-            // Split vertReserved in the ratio D-Bus claims for top:bottom.
-            effTop = qRound(panel.top * double(vertReserved) / dbusVert);
-            effBottom = vertReserved - effTop;
+            // Attribute vertReserved to the top/bottom edges D-Bus claims.
+            const auto split = Detail::splitReservation(vertReserved, panel.top, panel.bottom);
+            effTop = split.first;
+            effBottom = split.second;
         } else if (vertReserved > 0) {
             // Sensor shows vertical reservation but D-Bus has no panels on
             // the top/bottom edges (panel source stale, absent, or non-
@@ -376,8 +379,9 @@ void ScreenManager::calculateAvailableGeometry(const PhysicalScreen& screen)
             effBottom = vertReserved;
         }
         if (dbusHoriz > 0) {
-            effLeft = qRound(panel.left * double(horizReserved) / dbusHoriz);
-            effRight = horizReserved - effLeft;
+            const auto split = Detail::splitReservation(horizReserved, panel.left, panel.right);
+            effLeft = split.first;
+            effRight = split.second;
         } else if (horizReserved > 0) {
             effLeft = 0;
             effRight = horizReserved;

--- a/libs/phosphor-screens/src/reservationsplit.h
+++ b/libs/phosphor-screens/src/reservationsplit.h
@@ -5,8 +5,6 @@
 
 #include <QtGlobal>
 
-#include <cmath>
-
 namespace PhosphorScreens::Detail {
 
 /// Per-axis split of a reserved strut across the axis' two edges.
@@ -21,8 +19,9 @@ struct EdgeSplit
 /// one axis) across that axis' two edges, using the panel source's per-edge
 /// claims for direction.
 ///
-/// The claims are thicknesses of every Plasma panel on that edge, whether or
-/// not the panel currently reserves space: an auto-hidden or floating panel
+/// A claim is the thickness of the thickest Plasma panel on that edge
+/// (PlasmaPanelSource keeps the per-edge maximum), reported whether or not
+/// that panel currently reserves space: an auto-hidden or floating panel
 /// still reports a thickness but contributes nothing to the sensor total. A
 /// straight proportional split therefore smears a non-reserving panel's
 /// thickness onto the edge that does reserve, and both edges come out wrong.
@@ -82,7 +81,7 @@ inline EdgeSplit splitReservation(int reserved, int claimFirst, int claimSecond)
         if (c.sum <= 0) {
             continue;
         }
-        const int error = std::abs(c.sum - reserved);
+        const int error = qAbs(c.sum - reserved);
         if (error > kSlack) {
             continue;
         }

--- a/libs/phosphor-screens/src/reservationsplit.h
+++ b/libs/phosphor-screens/src/reservationsplit.h
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <QtGlobal>
+
+#include <cmath>
+
+namespace PhosphorScreens::Detail {
+
+/// Per-axis split of a reserved strut across the axis' two edges.
+/// `first` is top (vertical axis) or left (horizontal axis).
+struct EdgeSplit
+{
+    int first = 0;
+    int second = 0;
+};
+
+/// Distribute `reserved` px (the layer-shell sensor's authoritative total for
+/// one axis) across that axis' two edges, using the panel source's per-edge
+/// claims for direction.
+///
+/// The claims are thicknesses of every Plasma panel on that edge, whether or
+/// not the panel currently reserves space: an auto-hidden or floating panel
+/// still reports a thickness but contributes nothing to the sensor total. A
+/// straight proportional split therefore smears a non-reserving panel's
+/// thickness onto the edge that does reserve, and both edges come out wrong.
+/// A top panel plus a hidden bottom dock ended up with zones pushed under the
+/// top panel and a matching gap at the bottom of the screen.
+///
+/// So attribute exactly when we can: if exactly one combination of edges adds
+/// up to `reserved` (within a pixel or two of rounding slack), that
+/// combination is the one actually reserving and takes the whole total. Only
+/// when no single combination stands out do we fall back to the proportional
+/// split, which is the best available guess when the claims and the total
+/// disagree in a way we cannot attribute.
+inline EdgeSplit splitReservation(int reserved, int claimFirst, int claimSecond)
+{
+    if (reserved <= 0) {
+        return {};
+    }
+    claimFirst = qMax(0, claimFirst);
+    claimSecond = qMax(0, claimSecond);
+    const int claimTotal = claimFirst + claimSecond;
+    if (claimTotal <= 0) {
+        return {};
+    }
+
+    // Proportional split of `reserved` restricted to the given edges. Always
+    // sums to exactly `reserved` — the second edge takes the remainder, so
+    // rounding never loses or invents a pixel.
+    const auto proportional = [reserved](int a, int b) {
+        EdgeSplit s;
+        s.first = (a + b) > 0 ? qRound(a * double(reserved) / (a + b)) : 0;
+        s.second = reserved - s.first;
+        return s;
+    };
+
+    // Rounding slack: panel thicknesses come from plasmashell's rounded
+    // geometry, the total from the compositor's configure. On fractionally
+    // scaled outputs the two can disagree by a pixel without meaning
+    // different panels.
+    constexpr int kSlack = 2;
+
+    struct Candidate
+    {
+        int sum;
+        bool useFirst;
+        bool useSecond;
+    };
+    const Candidate candidates[] = {
+        {claimFirst, true, false},
+        {claimSecond, false, true},
+        {claimTotal, true, true},
+    };
+
+    int bestError = -1;
+    int bestCount = 0;
+    const Candidate* best = nullptr;
+    for (const Candidate& c : candidates) {
+        if (c.sum <= 0) {
+            continue;
+        }
+        const int error = std::abs(c.sum - reserved);
+        if (error > kSlack) {
+            continue;
+        }
+        if (bestError < 0 || error < bestError) {
+            bestError = error;
+            bestCount = 1;
+            best = &c;
+        } else if (error == bestError) {
+            ++bestCount;
+        }
+    }
+
+    if (best && bestCount == 1) {
+        return proportional(best->useFirst ? claimFirst : 0, best->useSecond ? claimSecond : 0);
+    }
+
+    return proportional(claimFirst, claimSecond);
+}
+
+} // namespace PhosphorScreens::Detail

--- a/libs/phosphor-screens/tests/CMakeLists.txt
+++ b/libs/phosphor-screens/tests/CMakeLists.txt
@@ -54,6 +54,9 @@ ps_add_test(ps_test_manager_lifecycle test_manager_lifecycle.cpp)
 ps_add_test(ps_test_screenmanager_geometry test_screenmanager_geometry.cpp FakeScreenProvider.cpp FakeScreenProvider.h)
 ps_add_test(ps_test_manager_virtualscreens test_manager_virtualscreens.cpp)
 ps_add_test(ps_test_resolver test_resolver.cpp)
+ps_add_test(ps_test_reservationsplit test_reservationsplit.cpp)
+# Header-only helper that lives in the library's private src/ dir.
+target_include_directories(ps_test_reservationsplit PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
 ps_add_test(ps_test_plasma_panel_source test_plasma_panel_source.cpp)
 ps_add_test(ps_test_dbusscreenadaptor test_dbusscreenadaptor.cpp)
 

--- a/libs/phosphor-screens/tests/test_reservationsplit.cpp
+++ b/libs/phosphor-screens/tests/test_reservationsplit.cpp
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include "reservationsplit.h"
+
+#include <QTest>
+
+using PhosphorScreens::Detail::EdgeSplit;
+using PhosphorScreens::Detail::splitReservation;
+
+class TestReservationSplit : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void noReservation()
+    {
+        const EdgeSplit s = splitReservation(0, 32, 53);
+        QCOMPARE(s.first, 0);
+        QCOMPARE(s.second, 0);
+    }
+
+    void noClaims()
+    {
+        const EdgeSplit s = splitReservation(32, 0, 0);
+        QCOMPARE(s.first, 0);
+        QCOMPARE(s.second, 0);
+    }
+
+    void singleClaimingEdgeTakesAll()
+    {
+        const EdgeSplit s = splitReservation(32, 32, 0);
+        QCOMPARE(s.first, 32);
+        QCOMPARE(s.second, 0);
+    }
+
+    // Discussion #985: a 32 px top panel that reserves, plus a bottom dock
+    // that claims 53 px but is hidden and reserves nothing. The top edge
+    // matches the sensor total exactly, so it takes all of it — the old
+    // proportional split gave top=12 / bottom=20, which pushed zones under
+    // the top panel and left a 20 px gap at the bottom of the screen.
+    void hiddenOppositePanelDoesNotStealReservation()
+    {
+        const EdgeSplit s = splitReservation(32, 32, 53);
+        QCOMPARE(s.first, 32);
+        QCOMPARE(s.second, 0);
+    }
+
+    void hiddenTopPanelDoesNotStealFromBottom()
+    {
+        const EdgeSplit s = splitReservation(53, 32, 53);
+        QCOMPARE(s.first, 0);
+        QCOMPARE(s.second, 53);
+    }
+
+    void bothEdgesReserving()
+    {
+        const EdgeSplit s = splitReservation(76, 32, 44);
+        QCOMPARE(s.first, 32);
+        QCOMPARE(s.second, 44);
+    }
+
+    // A pixel of rounding slack between plasmashell's geometry and the
+    // compositor's configure still resolves to the claiming edge, and the
+    // split always sums to the sensor total.
+    void roundingSlackStillAttributes()
+    {
+        const EdgeSplit s = splitReservation(32, 33, 53);
+        QCOMPARE(s.first, 32);
+        QCOMPARE(s.second, 0);
+    }
+
+    // Equal claims on both edges with only one of them reserving is genuinely
+    // ambiguous: fall back to the proportional split rather than guessing an
+    // edge. The total is still preserved.
+    void ambiguousEqualClaimsFallBackToProportional()
+    {
+        const EdgeSplit s = splitReservation(32, 32, 32);
+        QCOMPARE(s.first, 16);
+        QCOMPARE(s.second, 16);
+    }
+
+    // No combination is anywhere near the total (stale panel data, or a
+    // non-Plasma layer surface reserving alongside). Proportional split.
+    void unattributableFallsBackToProportional()
+    {
+        const EdgeSplit s = splitReservation(100, 20, 30);
+        QCOMPARE(s.first, 40);
+        QCOMPARE(s.second, 60);
+    }
+
+    void splitAlwaysSumsToReserved()
+    {
+        for (int reserved = 1; reserved <= 120; ++reserved) {
+            for (int a = 0; a <= 60; a += 7) {
+                for (int b = 0; b <= 60; b += 5) {
+                    const EdgeSplit s = splitReservation(reserved, a, b);
+                    if (a + b == 0) {
+                        QCOMPARE(s.first + s.second, 0);
+                    } else {
+                        QCOMPARE(s.first + s.second, reserved);
+                    }
+                    QVERIFY(s.first >= 0);
+                    QVERIFY(s.second >= 0);
+                }
+            }
+        }
+    }
+};
+
+QTEST_MAIN(TestReservationSplit)
+#include "test_reservationsplit.moc"

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -1589,6 +1589,12 @@ private:
     // Geometry update debouncing to prevent cascade of redundant recalculations
     QTimer m_geometryUpdateTimer;
     bool m_geometryUpdatePending = false;
+    /// Runs while processPendingGeometryUpdates is holding a pass back for a
+    /// live drag session. Invalid whenever no hold is in progress, so
+    /// isValid() doubles as "are we currently deferring". Bounds the hold —
+    /// see the deferral block in autotile.cpp for why an unbounded one is not
+    /// safe.
+    QElapsedTimer m_geometryDeferralClock;
     void processPendingGeometryUpdates();
 
     // After geometry updates settle, request KWin effect to re-apply window positions (panel editor fix)

--- a/src/daemon/daemon/autotile.cpp
+++ b/src/daemon/daemon/autotile.cpp
@@ -18,6 +18,7 @@
 #include <PhosphorContext/ContextResolver.h>
 #include "config/settings.h"
 #include "dbus/layoutadaptor/layoutadaptor.h"
+#include "dbus/windowdragadaptor/windowdragadaptor.h"
 #include "dbus/windowtrackingadaptor/windowtrackingadaptor.h"
 #include <PhosphorEngine/PlacementEngineBase.h>
 #include <PhosphorEngine/IPlacementEngine.h>
@@ -1303,6 +1304,26 @@ void Daemon::processPendingGeometryUpdates()
         return;
     }
     if (!m_screenManager || !m_layoutManager || !m_layoutComputeService || !m_overlayService) {
+        return;
+    }
+
+    // Hold the whole pass while a drag session is live. Plasma's floating
+    // panels dock themselves the moment a dragged window touches them and
+    // float again when it moves away — stock Plasma behaviour, unrelated to
+    // our overlay, and not ours to suppress. Every toggle changes the panel's
+    // exclusive zone, our sensor reflows, and the work area moves. Running
+    // the recompute on that pulls the zone rects out from under the cursor
+    // mid-drag, and the drop then resolves against a rect that moved after
+    // the user aimed at it.
+    //
+    // Re-arm rather than wire this to drop: the debounce then flushes one
+    // interval after the drag ends, which also lets the panel settle back to
+    // whichever state it lands in. Polling the flag keeps the deferral
+    // self-healing — a drag that ends without a clean endDrag (client crash,
+    // compositor-cancelled move) still releases the update on the next tick
+    // instead of stranding m_geometryUpdatePending forever.
+    if (m_windowDragAdaptor && m_windowDragAdaptor->isDragSessionActive()) {
+        m_geometryUpdateTimer.start();
         return;
     }
 

--- a/src/daemon/daemon/autotile.cpp
+++ b/src/daemon/daemon/autotile.cpp
@@ -43,6 +43,10 @@ namespace {
 // Conceptually distinct from GEOMETRY_UPDATE_DEBOUNCE_MS in daemon.cpp (which coalesces
 // rapid geometry change events into a single update).
 constexpr int DELAYED_PANEL_REQUERY_MS = 400;
+// Upper bound (ms) on how long processPendingGeometryUpdates holds a pass back for a live
+// drag. Far longer than any real drag, so the deferral is never cut short in practice; it
+// only stops a stranded drag flag freezing zone geometry for the session.
+constexpr int GEOMETRY_DRAG_DEFERRAL_CAP_MS = 30000;
 // Reapply requested on next event loop (0); daemon state is already updated when we start the timer.
 constexpr int REAPPLY_DELAY_MS = 0;
 // Watchdog for the geometry-recalc completion barrier: a screen removed
@@ -1318,14 +1322,30 @@ void Daemon::processPendingGeometryUpdates()
     //
     // Re-arm rather than wire this to drop: the debounce then flushes one
     // interval after the drag ends, which also lets the panel settle back to
-    // whichever state it lands in. Polling the flag keeps the deferral
-    // self-healing — a drag that ends without a clean endDrag (client crash,
-    // compositor-cancelled move) still releases the update on the next tick
-    // instead of stranding m_geometryUpdatePending forever.
+    // whichever state it lands in.
+    //
+    // BOUNDED, because the polled flag can strand: beginDrag's own note in
+    // drag_protocol.cpp records that a drag which never got an endDrag stays
+    // set until the NEXT beginDrag resets it, and every other clear
+    // (handleWindowClosed, clearForCompositorReconnect, cancelSnap) needs an
+    // external event too. Unbounded, an effect that died without
+    // re-registering would freeze every zone recompute for the session. Past
+    // the cap the pass runs anyway — one recompute during a "drag" longer
+    // than any real gesture is the old behaviour, a permanently stale work
+    // area is worse.
     if (m_windowDragAdaptor && m_windowDragAdaptor->isDragSessionActive()) {
-        m_geometryUpdateTimer.start();
-        return;
+        if (!m_geometryDeferralClock.isValid()) {
+            m_geometryDeferralClock.start();
+        }
+        if (m_geometryDeferralClock.elapsed() < GEOMETRY_DRAG_DEFERRAL_CAP_MS) {
+            m_geometryUpdateTimer.start();
+            return;
+        }
+        qCWarning(lcDaemon) << "Geometry update held" << m_geometryDeferralClock.elapsed()
+                            << "ms for a drag session that is still reported active — running it anyway;"
+                            << "the drag state is most likely stale";
     }
+    m_geometryDeferralClock.invalidate();
 
     // Recalculate zone geometries for each effective screen (virtual or physical)
     // so fixed-mode zones stay normalized correctly against the correct screen geometry.

--- a/src/daemon/daemon/lifecycle.cpp
+++ b/src/daemon/daemon/lifecycle.cpp
@@ -1022,6 +1022,7 @@ void Daemon::stop()
     // Stop pending timers to prevent callbacks during shutdown
     m_geometryUpdateTimer.stop();
     m_geometryUpdatePending = false;
+    m_geometryDeferralClock.invalidate();
 
     // Disconnect scripted algorithm loader to prevent file watcher events during teardown
     if (m_scriptedAlgorithmLoader) {

--- a/src/dbus/windowdragadaptor/windowdragadaptor.h
+++ b/src/dbus/windowdragadaptor/windowdragadaptor.h
@@ -322,6 +322,25 @@ public:
     }
 
     /**
+     * True while a compositor drag session exists, whether or not the user
+     * has held an activation trigger yet — the broader question
+     * isDragInFlight() deliberately does not answer (see its note).
+     *
+     * The daemon's geometry-recompute debounce consults this. Plasma's
+     * floating panels dock themselves when a dragged window touches them and
+     * float again when it moves away, which is stock Plasma behaviour we
+     * cannot and should not suppress. Each toggle changes the panel's
+     * exclusive zone, so our layer-shell sensor reflows and the work area
+     * moves. Recomputing zone rects from that mid-drag drags the zones out
+     * from under the user's cursor, and the drop then resolves against a rect
+     * that moved after the user aimed at it.
+     */
+    bool isDragSessionActive() const
+    {
+        return !m_draggedWindowId.isEmpty() || !m_pendingSnapDragWindowId.isEmpty();
+    }
+
+    /**
      * Cancel any live drag-insert preview on either engine. The daemon's
      * context-change handlers route through these instead of hand-inlining
      * the two-engine sweep (a third engine would otherwise need every call


### PR DESCRIPTION
Two fixes for zone geometry going wrong when the work area moves. Investigated from discussion #985, though see the note at the bottom about what that report actually turned out to be.

## 1. Hold the geometry recompute while a drag is in flight

Plasma's floating panels dock themselves when a dragged window touches them and float again when it moves away. That is stock Plasma behaviour, triggered by moving any window, with or without our overlay on screen. Each toggle changes the panel's exclusive zone, so our layer-shell sensor reflows and the work area moves.

`availableGeometryChanged` then armed the geometry debounce unconditionally (`src/daemon/daemon/start.cpp:307`), and 400 ms later `processPendingGeometryUpdates` recomputed every zone rect on every screen, retiled both tiling engines, and reapplied window geometries — all mid-drag. Zones moved out from under the cursor, and the drop resolved against a rect that had shifted after the user aimed at it. Nothing on that path consulted drag state.

`processPendingGeometryUpdates` now re-arms its timer instead of running while a drag session is live, so the work area is sampled once the drag has ended and the panel has settled into whichever state it lands in. Polling the flag rather than wiring the flush to the drop keeps the deferral self-healing: a drag ending without a clean `endDrag` (client crash, compositor-cancelled move) still releases the update on the next tick instead of stranding `m_geometryUpdatePending`.

`isDragSessionActive()` is the broader predicate `isDragInFlight()` documents itself as deliberately not being. It also covers a snap drag whose activation trigger was never held, which still moves a window past the panels.

## 2. Attribute panel struts to the edge that actually reserves

`ScreenManager::calculateAvailableGeometry` has three sources. Source 0 is KWin's `clientArea`, pushed by the effect and directionally authoritative. Without it, the fallback reconciles the layer-shell sensor (authoritative *total* per axis, no direction) against the plasmashell D-Bus query (which edges have panels, thickness only).

That reconciliation split the sensor total *proportionally* across every edge D-Bus reports a panel on. Thickness is reported whether or not the panel currently reserves space, so any edge whose panel is not reserving steals part of the total from the edge that is. A 32 px top panel alongside a non-reserving bottom dock came out as `T=12 B=20`.

New header-only `libs/phosphor-screens/src/reservationsplit.h`. `splitReservation()` attributes the total exactly when it can: if exactly one combination of edges sums to the sensor total (within 2 px of rounding slack, for fractionally scaled outputs), that combination takes the whole total. Genuinely ambiguous cases still fall back to the proportional split, which remains the best available guess: equal claims on both edges with only one reserving, or no combination anywhere near the total.

## Tests

`ps_test_reservationsplit` covers the mismatched-claims case both ways round, both edges genuinely reserving, rounding slack, both ambiguous fallbacks, and a sweep asserting the split always sums to the sensor total and never goes negative. Pulling the split out of `calculateAvailableGeometry` into a pure function is what makes it reachable at all from a headless test — inline it needs a live compositor sensor.

Full suite: 405/405 passing. Build clean.

The drag guard has no unit coverage; it needs a live drag session against a real compositor. Verifying it means dragging a window past a floating panel and watching that the zone rects hold still.

## Note on discussion #985

The reporter's own symptom was not either of these. Their session had a stale KWin effect after upgrading to 3.4 without logging out (`peer apiVersion 4 is below minimum 5`), so Source 0 never arrived and they fell through to the heuristic. Relogging in resolved it for them, and that part works as designed. Their log is what surfaced both defects above, and both are reachable independently of the stale effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VsAQPz9Bg4YRkosz7uHpQf
