### PR TITLE
fix(shaders): clip the window sample to the slab's rounded frame

### DIFF
--- a/data/surface/shared/surface_lib.glsl
+++ b/data/surface/shared/surface_lib.glsl
@@ -149,10 +149,15 @@ struct SurfaceSlab {
 };
 SurfaceSlab surfaceSlabOpen(vec2 uv, float cornerRadiusPx) {
     SurfaceSlab s;
-    s.window = surfaceTexel(uv);
     s.px = surfacePixel(uv);
     s.fs = frameSdf(s.px, cornerRadiusPx);
     s.mask = frameMask(s.fs.d);
+    // The window sample is clipped to the same rounded frame as the pane. The
+    // capture is square-cornered (the pack owns the corner radius), so an
+    // unmasked window pokes its square corners past the rounded slab at any
+    // contentOpacity below 1 — and at 1.0 the radius parameter does nothing.
+    // Premultiplied, so one multiply rounds both colour and coverage.
+    s.window = surfaceTexel(uv) * s.mask;
     return s;
 }
 


### PR DESCRIPTION
## Problem

In every backdrop-slab surface pack, the pane (blurred/frosted/duotone backdrop) is masked to the corner-radius rounded rect, but the window sample is composited over it unmasked. The capture is deliberately square-cornered because the pack owns the corner radius, so the window's square corners poke past the rounded pane at any `contentOpacity` below 1. At 1.0 the corner-radius parameter has no visible effect at all. In the decoration preview this reads as the blur escaping the corner radius; on a real window the same square corners show over the desktop.

## Fix

Mask the window sample by the frame SDF inside `surfaceSlabOpen()` in `data/surface/shared/surface_lib.glsl`, so all eight family packs (blur, glass, frosted-glass, phosphor-glass, rippled-glass, rain-glass, duotone, mosaic) inherit the clip. The sample is premultiplied, so one multiply rounds both colour and coverage with the same AA feather as the pane, leaving no seam at the corner edge. The border/glow/shadow families do not use the helper and are unchanged.

## Testing

- `shader_validate_bundled` ctest gate passes (all packs compile on both compositor and daemon branches)
- pre-commit `shader-validate-surface` hook: all 24 packs OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)