### PR TITLE
fix(scroll-engine): hand a panned view back when the focused window is re-reported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
-- **Clicking the focused window brings it back to the middle of the strip**: scrolling the strip by hand takes the view out of the centering policy's hands, which is what lets a scrolled view stay put. Focusing a window hands it back, but a click on the window that already had focus was ignored entirely, and so was the one the compositor sends when you return to a desktop. A window you had scrolled away from stayed off to one side no matter how many times you clicked it. Both now hand the view back, and under the two policies that only move the view when they have to, a scroll that left the window fully on screen is still left alone ([#992](https://github.com/fuddlesworth/PlasmaZones/pull/992)).
+- **Clicking the focused window brings it back into view**: scrolling the strip by hand takes the view out of the centering policy's hands, which is what lets a scrolled view stay put. Focusing a window hands it back, but a click on the window that already had focus was ignored entirely, and so was the one the compositor sends when you return to a desktop. So was a switch between two windows stacked in the same column. A window you had scrolled away from stayed off to one side no matter how many times you clicked it. All three now hand the view back, and under the two policies that only move the view when they have to, a scroll that left the window fully on screen is still left alone ([#992](https://github.com/fuddlesworth/PlasmaZones/pull/992)).
 
 ## [3.4.2] - 2026-08-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to PlasmaZones are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Clicking the focused window brings it back to the middle of the strip**: scrolling the strip by hand takes the view out of the centering policy's hands, which is what lets a scrolled view stay put. Focusing a window hands it back, but a click on the window that already had focus was ignored entirely, and so was the one the compositor sends when you return to a desktop. A window you had scrolled away from stayed off to one side no matter how many times you clicked it. Both now hand the view back, and under the two policies that only move the view when they have to, a scroll that left the window fully on screen is still left alone ([#992](https://github.com/fuddlesworth/PlasmaZones/pull/992)).
+
 ## [3.4.2] - 2026-08-27
 
 ### Fixed

--- a/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/ScrollStrip.h
+++ b/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/ScrollStrip.h
@@ -51,8 +51,13 @@ namespace PhosphorScrollEngine {
 /// caller: the focus and move verbs, the inserts, an active column that
 /// vanished), the Always policy's own re-centering, or either centering verb
 /// re-attaches it and the policy takes the view back. A bystander's removal
-/// that leaves focus where it was does not. Detachment travels with the
-/// anchor through the mode-round-trip stash and the persisted blob for the
+/// that leaves focus where it was does not. One re-attach lives OUTSIDE this
+/// class, in ScrollEngine::windowFocused: a compositor report naming the
+/// window the strip already calls active reaches no re-anchor at all (it is
+/// refused, or it moves a tile inside the active column), and the engine
+/// clears the latch through `setViewDetached` there so the next layout pass
+/// lets the policy answer. Detachment travels with the anchor through the
+/// mode-round-trip stash and the persisted blob for the
 /// same reason the anchor does: restoring the position while dropping the
 /// detachment hands the view straight back to the policy that would move it.
 ///
@@ -472,6 +477,12 @@ public:
     /// Only meaningful alongside the anchor it was captured with, so a caller
     /// that drops that anchor (the stash's axis-mismatch arm) must drop this
     /// too, or the view stays pinned wherever the focus restore left it.
+    ///
+    /// Clearing it standalone is the engine-side re-attach the class doc
+    /// names (ScrollEngine::windowFocused): it hands the view to the policy
+    /// while leaving the anchor for the next updateViewForFocus to derive,
+    /// which is the one thing a re-anchor here could not do without a focus
+    /// change to derive from.
     void setViewDetached(bool detached)
     {
         m_viewDetached = detached;

--- a/libs/phosphor-scroll-engine/src/scrollengine/engine_lifecycle.cpp
+++ b/libs/phosphor-scroll-engine/src/scrollengine/engine_lifecycle.cpp
@@ -1005,31 +1005,31 @@ void ScrollEngine::windowFocused(const QString& rawWindowId, const QString& scre
     // whether or not the strip's own focus slot moves below.
     state->setFloatingHasFocus(false);
     const ScrollLayoutParams params = layoutParamsForScreen(key.screenId);
-    if (state->strip().focusWindow(windowId, params)) {
-        // The focus change may scroll the viewport; never re-activate here
-        // (the compositor initiated this focus). Background-context guard:
-        // see windowClosed.
-        if (key == currentKeyForScreen(key.screenId)) {
-            applyLayout(key.screenId, false);
-        }
-        // Focus and view anchor are persisted (serializeStripState), and
-        // placementChanged is the only thing that marks DirtyScrollStrips.
-        // Emitted for a background context too: the strip that changed is
-        // serialized whether or not it is the one on screen right now.
-        Q_EMIT placementChanged(key.screenId);
-        return;
-    }
-    // The report named the window the strip ALREADY calls active, so
-    // focusWindow refused it (scrollstrip_navigation.cpp's same-column,
-    // same-tile bail) and nothing above moved. That refusal is right about the
-    // focus SLOT and wrong about the VIEW. A pan detaches the view from the
-    // centering policy, and reanchorAfterFocusChange — the only thing that
-    // re-attaches it — sits behind the very branch this report just failed. No
-    // later pass revisits the question either: updateViewForFocus returns
-    // early while detached, so even the applyLayout a desktop return runs
-    // cannot re-centre. The result is that clicking the focused window, or
-    // switching away from its desktop and back, does nothing at all — the
-    // whole report is dropped, latch and all.
+    // DETACH-ONCE (drag_preview.cpp): a live drag-insert preview on this
+    // screen owns the view for the rest of the hold, and picking the dragged
+    // window up activates it. Handing the view back here would slide the
+    // layout under a stationary cursor, the hazard applyLayout's own
+    // dragPreviewSteersView guard exists for. screensMatch, not ==, for that
+    // guard's reason. Read before the focus move so both outcomes below share
+    // one answer.
+    const bool dragPreviewSteersView = m_dragInsertPreview
+        && PhosphorScreens::ScreenIdentity::screensMatch(m_dragInsertPreview->targetScreenId, key.screenId);
+    const bool focusMoved = state->strip().focusWindow(windowId, params);
+    // A view still detached AFTER the focus move is one no re-anchor took
+    // back, and there are two ways to arrive here holding one. focusWindow
+    // REFUSED the report, because it names the window the strip already calls
+    // active (scrollstrip_navigation.cpp's same-column, same-tile bail); or it
+    // accepted a same-COLUMN tile move, which re-anchors nothing because no
+    // strip geometry moved. Both are right about the focus SLOT and wrong
+    // about the VIEW. A pan detaches the view from the centering policy, and
+    // the re-anchor that re-attaches it (reanchorAfterFocusChange) is reached
+    // from focusWindow on a COLUMN change and on nothing else, so neither of
+    // these two outcomes gets there. No later pass revisits the question
+    // either: updateViewForFocus returns early while detached, so even the
+    // applyLayout a desktop return runs cannot re-derive the anchor. The
+    // result was that clicking the focused window, or switching away from its
+    // desktop and back, did nothing at all — the whole report was dropped,
+    // latch and all.
     //
     // Re-attach and let the POLICY answer, rather than re-anchoring outright.
     // Under Never/OnOverflow updateViewForFocus leaves a fully-visible column
@@ -1037,27 +1037,31 @@ void ScrollEngine::windowFocused(const QString& rawWindowId, const QString& scre
     // incidental activation — KWin re-fires windowActivated on restacking,
     // fullscreen exit and desktop switches, not only on real focus moves.
     // Under Always it re-centres, which is what that setting asks for.
-    if (!state->strip().viewDetached() || state->strip().activeWindowId() != windowId) {
+    //
+    // The report must NAME the active window: a minimized tile in the active
+    // column is refused by focusWindow without becoming the column's active
+    // tile, and that report has no claim on the view.
+    const bool handBackView =
+        state->strip().viewDetached() && state->strip().activeWindowId() == windowId && !dragPreviewSteersView;
+    if (!focusMoved && !handBackView) {
         return;
     }
-    // DETACH-ONCE (drag_preview.cpp): a live drag-insert preview on this
-    // screen owns the view for the rest of the hold, and picking the dragged
-    // window up activates it. Re-attaching here would slide the layout under a
-    // stationary cursor, the hazard applyLayout's own dragPreviewSteersView
-    // guard exists for. screensMatch, not ==, for that guard's reason.
-    if (m_dragInsertPreview
-        && PhosphorScreens::ScreenIdentity::screensMatch(m_dragInsertPreview->targetScreenId, key.screenId)) {
-        return;
+    if (handBackView) {
+        state->strip().setViewDetached(false);
     }
-    state->strip().setViewDetached(false);
-    // Background-context guard, as above: the latch is cleared either way (it
-    // is persisted state, and the strip that changed is serialized whether or
-    // not it is on screen), but only the on-screen context re-derives the
-    // anchor now. A background one re-derives on the applyLayout its own
-    // desktop return runs, which is the pass that used to return early.
+    // The focus change may scroll the viewport; never re-activate here (the
+    // compositor initiated this focus). Background-context guard: see
+    // windowClosed. The latch is cleared for a background context too (it is
+    // persisted state), but only the on-screen context re-derives the anchor
+    // now — a background one re-derives on the applyLayout its own desktop
+    // return runs, which is the pass that used to return early.
     if (key == currentKeyForScreen(key.screenId)) {
         applyLayout(key.screenId, false);
     }
+    // Focus and view anchor are persisted (serializeStripState), and
+    // placementChanged is the only thing that marks DirtyScrollStrips.
+    // Emitted for a background context too: the strip that changed is
+    // serialized whether or not it is the one on screen right now.
     Q_EMIT placementChanged(key.screenId);
 }
 

--- a/libs/phosphor-scroll-engine/src/scrollengine/engine_lifecycle.cpp
+++ b/libs/phosphor-scroll-engine/src/scrollengine/engine_lifecycle.cpp
@@ -5,6 +5,7 @@
 
 #include <PhosphorEngine/IWindowTrackingService.h>
 #include <PhosphorEngine/WindowPlacementStore.h>
+#include <PhosphorScreens/ScreenIdentity.h>
 
 #include "enginelimits.h"
 #include "scrollenginelogging.h"
@@ -1016,7 +1017,48 @@ void ScrollEngine::windowFocused(const QString& rawWindowId, const QString& scre
         // Emitted for a background context too: the strip that changed is
         // serialized whether or not it is the one on screen right now.
         Q_EMIT placementChanged(key.screenId);
+        return;
     }
+    // The report named the window the strip ALREADY calls active, so
+    // focusWindow refused it (scrollstrip_navigation.cpp's same-column,
+    // same-tile bail) and nothing above moved. That refusal is right about the
+    // focus SLOT and wrong about the VIEW. A pan detaches the view from the
+    // centering policy, and reanchorAfterFocusChange — the only thing that
+    // re-attaches it — sits behind the very branch this report just failed. No
+    // later pass revisits the question either: updateViewForFocus returns
+    // early while detached, so even the applyLayout a desktop return runs
+    // cannot re-centre. The result is that clicking the focused window, or
+    // switching away from its desktop and back, does nothing at all — the
+    // whole report is dropped, latch and all.
+    //
+    // Re-attach and let the POLICY answer, rather than re-anchoring outright.
+    // Under Never/OnOverflow updateViewForFocus leaves a fully-visible column
+    // alone, so a pan that kept the focused column on screen survives an
+    // incidental activation — KWin re-fires windowActivated on restacking,
+    // fullscreen exit and desktop switches, not only on real focus moves.
+    // Under Always it re-centres, which is what that setting asks for.
+    if (!state->strip().viewDetached() || state->strip().activeWindowId() != windowId) {
+        return;
+    }
+    // DETACH-ONCE (drag_preview.cpp): a live drag-insert preview on this
+    // screen owns the view for the rest of the hold, and picking the dragged
+    // window up activates it. Re-attaching here would slide the layout under a
+    // stationary cursor, the hazard applyLayout's own dragPreviewSteersView
+    // guard exists for. screensMatch, not ==, for that guard's reason.
+    if (m_dragInsertPreview
+        && PhosphorScreens::ScreenIdentity::screensMatch(m_dragInsertPreview->targetScreenId, key.screenId)) {
+        return;
+    }
+    state->strip().setViewDetached(false);
+    // Background-context guard, as above: the latch is cleared either way (it
+    // is persisted state, and the strip that changed is serialized whether or
+    // not it is on screen), but only the on-screen context re-derives the
+    // anchor now. A background one re-derives on the applyLayout its own
+    // desktop return runs, which is the pass that used to return early.
+    if (key == currentKeyForScreen(key.screenId)) {
+        applyLayout(key.screenId, false);
+    }
+    Q_EMIT placementChanged(key.screenId);
 }
 
 // Minimum-size bookkeeping (windowMinimumSize / windowMinSizeUpdated) and the

--- a/libs/phosphor-scroll-engine/tests/test_scrollengine_verbs.cpp
+++ b/libs/phosphor-scroll-engine/tests/test_scrollengine_verbs.cpp
@@ -516,6 +516,39 @@ void TestScrollEngineVerbs::refocusingTheActiveWindowHandsAPannedViewBack()
     engine->windowFocused(QStringLiteral("app|b"), QStringLiteral("S1"));
     QCOMPARE(viewX(), gentlePan);
     QVERIFY(!state->strip().viewDetached());
+
+    // The refusal is not the only way to reach a detached view on a report
+    // naming the active window: a same-COLUMN tile move is ACCEPTED by
+    // focusWindow and re-anchors nothing (no strip geometry moved), so it
+    // used to leave the pan owning the view exactly the way the refusal did.
+    // Switching between two windows stacked in one column has to hand the
+    // view back too, or the tab you just focused stays off screen.
+    engine->windowFocused(QStringLiteral("app|c"), QStringLiteral("S1"));
+    engine->consumeOrExpelWindow(-1, QStringLiteral("S1")); // b and c share a column
+    QCOMPARE(state->strip().columnCount(), 2);
+    QCOMPARE(state->strip().activeWindowId(), QStringLiteral("app|c"));
+    engine->scrollViewByPercent(-75, QStringLiteral("S1"));
+    QVERIFY(state->strip().viewDetached());
+    const int stackPan = viewX();
+    engine->windowFocused(QStringLiteral("app|b"), QStringLiteral("S1"));
+    QCOMPARE(state->strip().activeWindowId(), QStringLiteral("app|b"));
+    QVERIFY(!state->strip().viewDetached());
+    QVERIFY(viewX() != stackPan);
+
+    // DETACH-ONCE: a live drag-insert preview on this screen owns the view
+    // for the rest of the hold. Picking a window up activates it, and the
+    // report that follows must NOT hand the view back — re-deriving the
+    // anchor mid-hold slides the layout under a stationary cursor, which is
+    // the hazard applyLayout's own drag guard exists for.
+    engine->scrollViewByPercent(-75, QStringLiteral("S1"));
+    QVERIFY(state->strip().viewDetached());
+    QVERIFY(engine->beginDragInsertPreview(QStringLiteral("app|a"), QStringLiteral("S1")));
+    const int heldView = viewX();
+    QVERIFY(state->strip().viewDetached());
+    engine->windowFocused(state->strip().activeWindowId(), QStringLiteral("S1"));
+    QVERIFY(state->strip().viewDetached());
+    QCOMPARE(viewX(), heldView);
+    engine->cancelDragInsertPreview();
 }
 
 void TestScrollEngineVerbs::edgeAutoScrollThenCancelKeepsTheScrolledView()
@@ -622,7 +655,7 @@ void TestScrollEngineVerbs::everyVerbAnswersNoWindowsOnAnEmptyScreen()
     engine->moveFocusedToFloating(QStringLiteral("S1"));
     engine->moveFocusedToTiling(QStringLiteral("S1"));
     engine->switchFocusBetweenFloatingAndTiling(QStringLiteral("S1"));
-    engine->scrollViewByPercent(-25, QStringLiteral("S1"));
+    engine->scrollViewByPercent(25, QStringLiteral("S1"));
     engine->equalizeVisibleColumnWidths(QStringLiteral("S1"));
     engine->minimizeColumnWidth(QStringLiteral("S1"));
     engine->resetStripToDefaults(QStringLiteral("S1"));

--- a/libs/phosphor-scroll-engine/tests/test_scrollengine_verbs.cpp
+++ b/libs/phosphor-scroll-engine/tests/test_scrollengine_verbs.cpp
@@ -69,6 +69,7 @@ private Q_SLOTS:
     void centerVisibleColumnsCentersOnceThenRefuses();
     void scrollViewByPercentPansWithoutMovingFocus();
     void scrollViewSurvivesALateStashClaim();
+    void refocusingTheActiveWindowHandsAPannedViewBack();
     void edgeAutoScrollThenCancelKeepsTheScrolledView();
     void equalizeAndMinimizeReportTheirFeedback();
     void everyVerbAnswersNoWindowsOnAnEmptyScreen();
@@ -451,6 +452,72 @@ void TestScrollEngineVerbs::scrollViewSurvivesALateStashClaim()
     QCOMPARE(state->strip().viewAnchor(), pannedAnchor);
 }
 
+void TestScrollEngineVerbs::refocusingTheActiveWindowHandsAPannedViewBack()
+{
+    // A compositor focus report naming the window the strip ALREADY calls
+    // active is refused by focusWindow (same column, same tile), and the
+    // engine used to drop the whole report on that refusal. The refusal is
+    // right about the focus slot and wrong about the VIEW: a pan detaches the
+    // view, and the re-anchor that re-attaches it sits behind the very branch
+    // the report just failed. Nothing else revisits it either, since
+    // updateViewForFocus returns early while detached — so the pan outlived
+    // both a click on the focused window and a desktop round trip, and the
+    // user's window stayed off to one side. Live report
+    // plasmazones-report-20260828-194258.
+    QObject owner;
+    ScrollEngine* engine = makeProviderEngine(&owner, {QStringLiteral("S1")});
+    for (const char* id : {"app|a", "app|b", "app|c"}) {
+        engine->windowOpened(QString::fromLatin1(id), QStringLiteral("S1"), 0, 0);
+        engine->windowFocused(QString::fromLatin1(id), QStringLiteral("S1"));
+        engine->setColumnWidth(ColumnWidth::makeProportion(0.55), QStringLiteral("S1"));
+    }
+    ScrollState* state = stateFor(engine, QStringLiteral("S1"));
+    QVERIFY(state);
+    const auto params = ScrollTestUtils::engineParams();
+    const auto viewX = [&]() {
+        return state->strip().relayout(params).viewOffset;
+    };
+    const int policyView = viewX();
+    QVERIFY(!state->strip().viewDetached());
+
+    // Pan far enough to carry the focused column off the viewport, so the
+    // default Never policy has an answer to give back (a fully-visible column
+    // it would leave alone, which is the survival case the next arm pins).
+    engine->scrollViewByPercent(-75, QStringLiteral("S1"));
+    QVERIFY(state->strip().viewDetached());
+    QVERIFY(viewX() != policyView);
+
+    QSignalSpy placement(engine, &PhosphorEngine::PlacementEngineBase::placementChanged);
+    // The report the compositor sends when the user clicks the focused window,
+    // and the one it sends on a desktop return. Focus does not move — there is
+    // nowhere for it to move — but the view comes back to the policy.
+    engine->windowFocused(QStringLiteral("app|c"), QStringLiteral("S1"));
+    QCOMPARE(state->strip().activeWindowId(), QStringLiteral("app|c"));
+    QVERIFY(!state->strip().viewDetached());
+    QCOMPARE(viewX(), policyView);
+    // The latch and anchor are persisted, so the producer has to fire. Count
+    // is not pinned: applyLayout carries its own anchorMoved persist, so an
+    // on-screen context legitimately emits twice, where a background one
+    // (applyLayout skipped) emits only the report's own.
+    QVERIFY(placement.count() >= 1);
+
+    // And the re-attach is the POLICY's answer, not a forced re-centre: under
+    // Never a pan that leaves the focused column fully visible is left exactly
+    // where the user put it (updateViewForFocus's own early return). KWin
+    // re-fires windowActivated on restacking and fullscreen exit as well as on
+    // real focus moves, and none of those may yank a view the user is still
+    // reading. The middle column is the one with slack to prove it: every
+    // policy-derived view under Never sits flush against an edge, so the
+    // end column has nowhere to pan that keeps it whole.
+    engine->windowFocused(QStringLiteral("app|b"), QStringLiteral("S1"));
+    engine->scrollViewByPercent(-25, QStringLiteral("S1"));
+    const int gentlePan = viewX();
+    QVERIFY(state->strip().viewDetached());
+    engine->windowFocused(QStringLiteral("app|b"), QStringLiteral("S1"));
+    QCOMPARE(viewX(), gentlePan);
+    QVERIFY(!state->strip().viewDetached());
+}
+
 void TestScrollEngineVerbs::edgeAutoScrollThenCancelKeepsTheScrolledView()
 {
     // The drag's edge auto-scroll is a scrollViewBy under the hood, so it
@@ -555,7 +622,7 @@ void TestScrollEngineVerbs::everyVerbAnswersNoWindowsOnAnEmptyScreen()
     engine->moveFocusedToFloating(QStringLiteral("S1"));
     engine->moveFocusedToTiling(QStringLiteral("S1"));
     engine->switchFocusBetweenFloatingAndTiling(QStringLiteral("S1"));
-    engine->scrollViewByPercent(25, QStringLiteral("S1"));
+    engine->scrollViewByPercent(-25, QStringLiteral("S1"));
     engine->equalizeVisibleColumnWidths(QStringLiteral("S1"));
     engine->minimizeColumnWidth(QStringLiteral("S1"));
     engine->resetStripToDefaults(QStringLiteral("S1"));


### PR DESCRIPTION
## The bug

From a support report (`plasmazones-report-20260828-194258`): after switching desktop and back, focusing Dolphin did not scroll it to centre.

A compositor focus report naming the window the strip **already** calls active is refused by `ScrollStrip::focusWindow` (same column, same tile), and `ScrollEngine::windowFocused` gated everything on that return value, dropping the whole report.

The refusal is right about the focus *slot* and wrong about the *view*. A pan detaches the view from the centring policy, and `reanchorAfterFocusChange` — the only thing that re-attaches it — sits behind the very branch the report just failed. Nothing else revisits the question: `updateViewForFocus` returns early while detached, so even the `applyLayout` a desktop return runs cannot re-derive the anchor. So a pan outlived both a click on the focused window and a desktop round trip, and the window stayed off to one side.

The report's journal shows it: every desktop 2→1 return logs exactly one re-anchor, always `prevIdx == active` with an unchanged verdict (`applyLayout`'s own tail), and the click that followed logged nothing at all. Real focus moves in the same session log `prevIdx != active`.

## The fix

Re-attach and let the **policy** answer, rather than re-anchoring outright.

- Under `Never`/`OnOverflow`, `updateViewForFocus` leaves a fully-visible column alone, so a pan that kept the focused column on screen survives an incidental activation. KWin re-fires `windowActivated` on restacking and fullscreen exit, not only on real focus moves, and none of those may yank a view the user is still reading.
- Under `Always` it re-centres, which is what that setting asks for. That is the reporter's configuration.

Guarded three ways: the report must name `activeWindowId()` (a minimized-tile report in the active column still bails), the view must actually be detached, and a live drag-insert preview on that screen returns early for the DETACH-ONCE invariant. The latch is cleared for a background context too, since it is persisted state, but only the on-screen context re-derives the anchor — a background one does it on the `applyLayout` its own desktop return runs, which is the pass that used to return early.

## Test

`refocusingTheActiveWindowHandsAPannedViewBack()` in `test_scrollengine_verbs.cpp`, the file that owns the pan latch and activation bookkeeping. Two arms: a pan that carries the focused column off the viewport comes back to the policy's view on a re-report, and a pan that leaves the column whole is left exactly where the user put it. The middle column is the one with slack to prove the second arm — every policy-derived view under `Never` sits flush against an edge.

`ctest`: 100% of 407 pass, both strip axes, clean build.

## Not yet verified live

This is fixed against the code path, not against a compositor. Neither the reporter's session nor a local attempt reproduced it on demand — the missing ingredient is believed to be a prior pan, which the report has no log line for. The dropped-report finding is solid (the journal shows the report going nowhere); the pan being the trigger is inference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015XSDSm7doPtybB8HTPcbpg