### PR TITLE
fix(scrolling): mid-strip close no longer slides the window down off the screen

### DIFF
--- a/kwin-effect/plasmazoneseffect/drag_snap.cpp
+++ b/kwin-effect/plasmazoneseffect/drag_snap.cpp
@@ -816,6 +816,15 @@ void PlasmaZonesEffect::applyWindowGeometry(KWin::EffectWindow* window, const QR
                     // at the already-committed previous target instead of the
                     // animator's departure rect.
                     mt->fromGeometry = morphAnchor;
+                    // See ShaderTransition::fromIsSynthetic. morphAnchor is
+                    // the originOverride whenever the caller supplied one
+                    // (fresh start), and on the retarget path it is the
+                    // displaced animation's visual position — which for a leg
+                    // that STARTED from a synthetic origin is a point along a
+                    // path the window never occupied either. Conservative
+                    // choice: any origin override in play marks the from-rect
+                    // synthetic and routes the snapshot to the raw capture.
+                    mt->fromIsSynthetic = originOverride.isValid();
                     // Gate on the compiled shader actually LINKING uOldWindow,
                     // matching the two sibling request sites (the move-start
                     // hookup and beginMaximizeShaderMorph) and the bind/unbind

--- a/kwin-effect/plasmazoneseffect/drag_snap.cpp
+++ b/kwin-effect/plasmazoneseffect/drag_snap.cpp
@@ -824,7 +824,14 @@ void PlasmaZonesEffect::applyWindowGeometry(KWin::EffectWindow* window, const QR
                     // path the window never occupied either. Conservative
                     // choice: any origin override in play marks the from-rect
                     // synthetic and routes the snapshot to the raw capture.
-                    mt->fromIsSynthetic = originOverride.isValid();
+                    // STICKY within the leg: a no-override retarget on a
+                    // synthetic-origin leg re-anchors at a point on the same
+                    // never-occupied path, so the marker must survive it —
+                    // clearing it would hand a pre-first-paint capture the
+                    // composite-seed path with a rect the window never held.
+                    // (Once fromGeometry is rewritten to a REAL rect, the
+                    // writer clears the flag — see beginMaximizeShaderMorph.)
+                    mt->fromIsSynthetic = originOverride.isValid() || mt->fromIsSynthetic;
                     // Gate on the compiled shader actually LINKING uOldWindow,
                     // matching the two sibling request sites (the move-start
                     // hookup and beginMaximizeShaderMorph) and the bind/unbind

--- a/kwin-effect/plasmazoneseffect/lifecycle_wiring.cpp
+++ b/kwin-effect/plasmazoneseffect/lifecycle_wiring.cpp
@@ -659,6 +659,13 @@ void PlasmaZonesEffect::connectWindowAndScreenSignals()
             m_scrollOfferedColumn.remove(cachedId);
         }
         m_trackedScreenPerWindow.remove(w);
+        // The corpse's frozen strip displacement dies with it. This is THE
+        // remover, not a backstop: the entry exists precisely so the corpse
+        // paints displaced until this moment, and the pointer keying makes
+        // erasing here mandatory address-reuse safety besides (a reused
+        // EffectWindow address inheriting a dead corpse's offset would draw a
+        // brand-new window a pan away).
+        m_scrollCorpseFreeze.remove(w);
         // Desktop-set stamp, same raw-pointer keying and the same two reasons
         // as the tracked screen above: keep the hash bounded, and stop a reused
         // address from inheriting a dead window's desktop set (which would make

--- a/kwin-effect/plasmazoneseffect/paint_capture.cpp
+++ b/kwin-effect/plasmazoneseffect/paint_capture.cpp
@@ -208,7 +208,16 @@ void PlasmaZonesEffect::captureOldWindowSnapshot(ShaderTransition& transition, K
     // rect wearing the same resolved decoration, so the arriving side's live
     // fold already draws the pane the outgoing side is missing, in the same
     // place, at the same size.
-    if (src == window) {
+    // NOT for a synthetic departure rect (see fromIsSynthetic): the map below
+    // is anchored on the assumption that the composite was folded at
+    // fromGeometry, and a scroll-batch originOverride (an unpark's screen-edge
+    // origin) is a rect the window never occupied — while its composite is
+    // frozen at the last PRE-park fold besides. The intersection can still be
+    // non-empty for any column that scrolled off the same edge before parking,
+    // and the blit then seeds a stale, mis-registered slice as the "old"
+    // content for the whole leg. The raw capture below is
+    // position-independent and correct for exactly this case.
+    if (src == window && !transition.fromIsSynthetic) {
         if (const auto mpIt = m_surfaceMultipass.find(getWindowId(src)); mpIt != m_surfaceMultipass.end()) {
             const SurfaceMultipassState& mp = mpIt->second;
             KWin::GLTexture* const comp = mp.compositeTex[mp.finalSlot].get();

--- a/kwin-effect/plasmazoneseffect/paint_pipeline.cpp
+++ b/kwin-effect/plasmazoneseffect/paint_pipeline.cpp
@@ -1368,6 +1368,17 @@ void PlasmaZonesEffect::prePaintWindow(KWin::RenderView* view, KWin::EffectWindo
         data.setTransformed();
     }
 
+    // A close-grabbed corpse with a frozen strip displacement (see
+    // m_scrollCorpseFreeze) is moved by paintWindow's deleted-window arm, so
+    // it needs the same TRANSFORMED treatment. Membership is the whole
+    // predicate: entries are only ever written for corpses whose drawn rect
+    // was on screen, so no parked test applies, and the two conditions are
+    // mutually exclusive (a live window never has an entry; a deleted one
+    // fails scrollManagedOutputFor above).
+    if (w && !m_scrollCorpseFreeze.isEmpty() && m_scrollCorpseFreeze.contains(w)) {
+        data.setTransformed();
+    }
+
     OffscreenEffect::prePaintWindow(view, w, data);
 }
 
@@ -1785,6 +1796,15 @@ void PlasmaZonesEffect::paintWindow(const KWin::RenderTarget& renderTarget, cons
                     animatedFrame.translate(translation.x(), translation.y());
                 }
                 animatedFrame.translate(m_stripViewAnimator->offsetFor(scrollOut));
+            } else if (const auto fit = m_scrollCorpseFreeze.constFind(w); fit != m_scrollCorpseFreeze.constEnd()) {
+                // Deleted-window arm, mirroring the draw's: a decorated corpse
+                // keeps sampling its backdrop for the close animation, and the
+                // predictor has to fold in the same frozen displacement the
+                // draw applies or the corpse re-blits a slice from a pan away.
+                if (!animatedFrame.isValid()) {
+                    animatedFrame = w->frameGeometry();
+                }
+                animatedFrame.translate(fit->x(), fit->y());
             }
             captureWindowBackdrop(renderTarget, viewport, w, *backIt, deviceRegion, animatedFrame, backdropScale);
         }
@@ -1900,6 +1920,14 @@ void PlasmaZonesEffect::paintWindow(const KWin::RenderTarget& renderTarget, cons
             if (!viewOffset.isNull()) {
                 data += viewOffset;
             }
+        } else if (const auto fit = m_scrollCorpseFreeze.constFind(w); w && fit != m_scrollCorpseFreeze.constEnd()) {
+            // The deleted-window arm: scrollManagedOutputFor answers null the
+            // moment a window dies, so a close-grabbed corpse takes its
+            // displacement from the value frozen at death instead — both
+            // terms in one constant (see m_scrollCorpseFreeze). This is what
+            // keeps a panned strip's corpse playing its close animation where
+            // the window visually was rather than at its raw committed rect.
+            data += fit.value();
         }
     }
 

--- a/kwin-effect/plasmazoneseffect/paint_pipeline.cpp
+++ b/kwin-effect/plasmazoneseffect/paint_pipeline.cpp
@@ -1796,16 +1796,12 @@ void PlasmaZonesEffect::paintWindow(const KWin::RenderTarget& renderTarget, cons
                     animatedFrame.translate(translation.x(), translation.y());
                 }
                 animatedFrame.translate(m_stripViewAnimator->offsetFor(scrollOut));
-            } else if (const auto fit = m_scrollCorpseFreeze.constFind(w); fit != m_scrollCorpseFreeze.constEnd()) {
-                // Deleted-window arm, mirroring the draw's: a decorated corpse
-                // keeps sampling its backdrop for the close animation, and the
-                // predictor has to fold in the same frozen displacement the
-                // draw applies or the corpse re-blits a slice from a pan away.
-                if (!animatedFrame.isValid()) {
-                    animatedFrame = w->frameGeometry();
-                }
-                animatedFrame.translate(fit->x(), fit->y());
             }
+            // No m_scrollCorpseFreeze arm here on purpose: this whole block is
+            // gated on !w->isDeleted(), and freeze entries exist only for the
+            // slotWindowClosed→windowDeleted span, during which the window IS
+            // deleted — a corpse never re-captures its backdrop; it reuses the
+            // frozen composite (see the gate's comment above).
             captureWindowBackdrop(renderTarget, viewport, w, *backIt, deviceRegion, animatedFrame, backdropScale);
         }
     }

--- a/kwin-effect/plasmazoneseffect/plasmazoneseffect.cpp
+++ b/kwin-effect/plasmazoneseffect/plasmazoneseffect.cpp
@@ -166,10 +166,18 @@ bool PlasmaZonesEffect::isActive() const
     // transition) this clause is what keeps KWin calling us. Without it the
     // next damage in the pill band recomposited without the blit and erased
     // the pills.
+    // `!m_scrollCorpseFreeze.isEmpty()` keeps the corpse-displacement paint
+    // arms running for a closing window riding a FOREIGN close animation
+    // (ours declined: animations off, or the window excluded) — the freeze's
+    // contract is "with or without our close shader", and without this clause
+    // that promise held only while some other clause coincidentally kept the
+    // effect in the chain (the spring settling mid-fade dropped it, jumping
+    // the corpse by the frozen offset). O(1); entries are bounded by corpse
+    // lifetime (sole erase at windowDeleted).
     return m_dragTracker->isDragging() || m_windowAnimator->hasActiveAnimations() || !m_shaderManager.empty()
         || !m_windowDecorations.isEmpty() || m_desktopTransition.isRunning()
         || m_stripViewAnimator->hasActiveAnimations() || m_stripTransition.isRunning()
-        || m_scrollTabPainter->hasAnyIndicators();
+        || m_scrollTabPainter->hasAnyIndicators() || !m_scrollCorpseFreeze.isEmpty();
 }
 
 void PlasmaZonesEffect::pointerMotion(KWin::PointerMotionEvent* event)

--- a/kwin-effect/plasmazoneseffect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect/plasmazoneseffect.h
@@ -2514,6 +2514,23 @@ private:
     /// rather than inheriting this argument.
     QHash<QString, ScrollVisualPlacement> m_scrollVisualDelta;
 
+    /// Frozen strip displacement for a CLOSE-GRABBED corpse. A deleted window
+    /// cannot re-derive its relocation or view offset in the paint path —
+    /// scrollManagedOutputFor answers null on isDeleted, and the close slot's
+    /// untrack funnel scrubs the tracked screen anyway — yet the corpse keeps
+    /// painting for the whole close animation (ours via holdCloseGrab, or any
+    /// other effect's). Without this, a panned strip's corpse snapped to its
+    /// raw committed rect the frame it died (the park row, for a
+    /// parked-committed tile: a slide to the bottom of the screen). The value
+    /// is the relocation + view offset at the instant of death, applied
+    /// verbatim by paintWindow's deleted-window arm; the corpse's frame is
+    /// frozen too, so a constant is exact. Keyed by EffectWindow* because the
+    /// id caches drop at the end of the close slot. Written only in
+    /// slotWindowClosed (never for a fully-parked corpse, which paints
+    /// nothing anyone can see), erased in the windowDeleted handler with the
+    /// other pointer-keyed maps.
+    QHash<KWin::EffectWindow*, QPointF> m_scrollCorpseFreeze;
+
     /// Windows in scrolling WINDOWED FULLSCREEN: the client holds KWin
     /// fullscreen state (set by the effect from the batch flag) while the
     /// committed rect stays the column slot, stored here as the value. The

--- a/kwin-effect/plasmazoneseffect/transition_types.h
+++ b/kwin-effect/plasmazoneseffect/transition_types.h
@@ -363,6 +363,17 @@ struct ShaderTransition
     /// skip the morph uniforms.
     QRectF fromGeometry;
     QRectF toGeometry;
+    /// True when `fromGeometry` is a SYNTHETIC departure rect (an
+    /// originOverride from the scroll batch's origin/edge arms) rather than a
+    /// rect the window actually occupied. The old-snapshot SEED path maps the
+    /// multipass composite through fromGeometry on the assumption the
+    /// composite was folded there; for a synthetic origin no composite was
+    /// ever valid there, and a just-unparked column's composite is
+    /// additionally frozen at its last PRE-park fold — so the seed blits a
+    /// stale, mis-registered slice as the "old" content (the garbled
+    /// falling-content artifact on mid-strip closes after a pan). A synthetic
+    /// origin takes the raw capture instead, which is position-independent.
+    bool fromIsSynthetic = false;
     /// Armed by any leg that wants an old-content cross-fade and has not yet
     /// captured one: the geometry-morph installs (applyWindowGeometry), the
     /// held-move capture (window_connections, both sites), and the tab-swap

--- a/kwin-effect/plasmazoneseffect/window_connections.cpp
+++ b/kwin-effect/plasmazoneseffect/window_connections.cpp
@@ -1255,6 +1255,14 @@ void PlasmaZonesEffect::beginMaximizeShaderMorph(KWin::EffectWindow* window, con
     st->toGeometry = newFrame;
     if (!st->oldSnapshot) {
         st->fromGeometry = preFrame;
+        // preFrame is a REAL rect the window occupied, so any synthetic-origin
+        // marker a kept scroll leg carried no longer describes fromGeometry.
+        // Clear it, or the pending capture wrongly takes the raw path and the
+        // maximize morph's old side loses its decorated composite seed. The
+        // invariant: fromIsSynthetic tracks the provenance of the CURRENT
+        // fromGeometry, maintained at every writer (see drag_snap.cpp's
+        // sticky retarget arm for the synthetic-path counterpart).
+        st->fromIsSynthetic = false;
         // Old-content cross-fade: same guard as the move-start hookup. The
         // raw capture happens on the first paint (post-jump, so it degrades
         // to the live content for undecorated windows), but decorated

--- a/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
+++ b/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
@@ -22,6 +22,7 @@
 #include "handlers/dragtracker.h"
 #include "handlers/navigationhandler.h"
 #include "handlers/screenchangehandler.h"
+#include "compositor/stripviewanimator.h"
 #include "compositor/windowanimator.h"
 
 namespace PlasmaZones {
@@ -451,6 +452,28 @@ void PlasmaZonesEffect::slotWindowClosed(KWin::EffectWindow* w)
     if (!parkedOffAllOutputs) {
         tryBeginShaderForEvent(w, PhosphorAnimation::ProfilePaths::WindowClose, animationDurationMs(),
                                /*reverse=*/true, /*holdCloseGrab=*/true);
+        // Freeze the corpse's strip displacement BEFORE the removals below
+        // and before onWindowClosed's untrack funnel scrubs the tracked
+        // screen. The paint path cannot re-derive either term for a deleted
+        // window (scrollManagedOutputFor's isDeleted gate), so without this
+        // the delta removal below pulled the relocation out from under a
+        // still-painting corpse and it snapped to its raw committed rect —
+        // for a panned strip's parked-committed tile, the park row at the
+        // bottom of the screen. Applies with or without our close shader:
+        // KWin's own close animation paints the corpse either way. The
+        // corpse's frame is frozen at death, so a one-shot constant is
+        // exact; a mid-leg view offset freezes at its close-instant value,
+        // which just means a dying window stops riding the strip.
+        QPointF frozen = scrollVisualTranslationFor(closingWindowId, closingFrame);
+        const QString corpseScreen = m_tilingHandler->scrollTrackedScreenFor(closingWindowId);
+        if (!corpseScreen.isEmpty()) {
+            if (KWin::LogicalOutput* corpseOutput = outputForScreenId(corpseScreen)) {
+                frozen += m_stripViewAnimator->offsetFor(corpseOutput);
+            }
+        }
+        if (!frozen.isNull()) {
+            m_scrollCorpseFreeze.insert(w, frozen);
+        }
     }
     m_windowAnimator->removeAnimation(w);
     // Pairs with damage like every other remover. Note this is not the only

--- a/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
+++ b/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
@@ -464,6 +464,17 @@ void PlasmaZonesEffect::slotWindowClosed(KWin::EffectWindow* w)
         // corpse's frame is frozen at death, so a one-shot constant is
         // exact; a mid-leg view offset freezes at its close-instant value,
         // which just means a dying window stops riding the strip.
+        //
+        // Two accepted approximations. (1) The freeze derives from the
+        // TRACKED screen alone, while the live draw's predicate additionally
+        // exempts user-move/resize and floats from displacement — a tracked
+        // window closed mid-drag mid-leg would inherit an offset it was not
+        // drawn with. The pre-death exemption state is not recoverable from
+        // a Deleted window, so it cannot be honoured here. (2) Damage for
+        // the displaced draw region: our close shader's grab pump repaints
+        // the output per frame; under a purely FOREIGN close animation the
+        // foreign effect's own damage is what keeps the corpse fresh, which
+        // in practice the reflow and neighbour legs also cover.
         QPointF frozen = scrollVisualTranslationFor(closingWindowId, closingFrame);
         const QString corpseScreen = m_tilingHandler->scrollTrackedScreenFor(closingWindowId);
         if (!corpseScreen.isEmpty()) {

--- a/kwin-effect/tilinghandler/tiling.cpp
+++ b/kwin-effect/tilinghandler/tiling.cpp
@@ -2152,7 +2152,52 @@ void TilingHandler::slotWindowsTileRequested(const PhosphorProtocol::TileRequest
                         // strip position beats a point synthesized just outside
                         // the screen edge, because that is where it actually
                         // was.
-                        if (!snap.scrollEdge.isEmpty()) {
+                        // Direction of THIS entry, asked of the committed
+                        // target: a target off the union of every output is a
+                        // park, and a park-bound (LEAVING) entry needs the
+                        // opposite treatment from an arriving one in both arms
+                        // below. The historical code assumed edge+viewDelta
+                        // means ARRIVING and edge-less+viewDelta means
+                        // on-strip travel — but a mid-strip close's re-anchor
+                        // batch carries viewDelta on EVERY entry, including
+                        // the parks the re-anchor just created, and routing
+                        // those through the arrival arms produced the two
+                        // artifacts fixed here: an unmasked pop to the park
+                        // (edged), and a real animated leg sweeping the
+                        // window visibly down to the park row (edge-less) —
+                        // the "closing a mid-strip window slides down off the
+                        // screen" bug.
+                        const bool viewLeavingToPark = rectAtScrollPark(committedGeo);
+                        if (!snap.scrollEdge.isEmpty() && viewLeavingToPark) {
+                            // LEAVING to a park with a named edge, carried by
+                            // the same batch's view travel. Give it the
+                            // scrollEdge branch's leaving treatment: the
+                            // commit still goes to the park, but the VISIBLE
+                            // motion is redirected to just past the named
+                            // edge so the window slides out as itself instead
+                            // of popping straight to the (off-screen) park.
+                            // Same edge math as the scrollEdge branch below;
+                            // same teleport fallback when no output resolves.
+                            const KWin::LogicalOutput* out = m_effect->outputForScreenId(snap.screenId);
+                            const QRect screenRect = out ? QRect(out->geometry()) : QRect();
+                            if (screenRect.isValid()) {
+                                const KWin::RectF cur = snap.window->frameGeometry();
+                                QRect atEdge =
+                                    QRect(qRound(cur.x()), qRound(cur.y()), qRound(cur.width()), qRound(cur.height()));
+                                if (snap.scrollEdge == QLatin1String("left")) {
+                                    atEdge.moveLeft(screenRect.left() - atEdge.width());
+                                } else if (snap.scrollEdge == QLatin1String("top")) {
+                                    atEdge.moveTop(screenRect.top() - atEdge.height());
+                                } else if (snap.scrollEdge == QLatin1String("bottom")) {
+                                    atEdge.moveTop(screenRect.bottom() + 1);
+                                } else {
+                                    atEdge.moveLeft(screenRect.right() + 1);
+                                }
+                                visualTargetOverride = QRectF(atEdge);
+                            } else {
+                                skipScrollAnimation = true;
+                            }
+                        } else if (!snap.scrollEdge.isEmpty()) {
                             // ARRIVING from a park. Its live frameGeometry is
                             // the park itself — below the union of all outputs
                             // — which is not a visual position at all, so
@@ -2199,6 +2244,18 @@ void TilingHandler::slotWindowsTileRequested(const PhosphorProtocol::TileRequest
                             // arm above.
                             if (atScrollPark(snap.window)) {
                                 originOverride = QRectF(committedGeo);
+                            } else if (viewLeavingToPark) {
+                                // Edge-less LEAVING park (a hidden tab of an
+                                // on-screen column, or a cross-axis stack
+                                // overflow) riding a batch that also carries
+                                // view travel. The difference-origin arm
+                                // below would build a REAL leg from the live
+                                // on-screen frame down to the park — the
+                                // visible downward sweep. There is no edge to
+                                // slide out by, so the answer is the same as
+                                // the edge-less branch further down: commit
+                                // without an animation.
+                                skipScrollAnimation = true;
                             } else {
                                 // viewDelta is a signed scalar ALONG this
                                 // screen's strip axis, so the origin has to
@@ -2363,6 +2420,27 @@ void TilingHandler::slotWindowsTileRequested(const PhosphorProtocol::TileRequest
                         if (preMaximize.isValid() && !preMaximize.isEmpty()) {
                             originOverride = preMaximize;
                         }
+                    }
+                    // Terminal backstop for every arm above, and for arms that
+                    // do not exist yet: a commit whose target lies off the
+                    // union of every output (a park) must NEVER take an
+                    // animated leg unless a visualTargetOverride has
+                    // redirected the visible motion on-screen. The chain
+                    // above handles every KNOWN park shape, but its arms are
+                    // gated on wire fields and tracking state
+                    // (scrollTrackedScreenFor answers empty across a
+                    // mode-flip or output-disconnect race, and
+                    // setScrollingScreens does not bump the stagger
+                    // generation), and an entry that falls through every gate
+                    // used to reach applyWindowGeometry bare — a full
+                    // animated leg from the live on-screen frame down to the
+                    // park row. An ORIGIN override does not redeem the leg
+                    // (its destination is still the park), so it is cleared
+                    // rather than honoured.
+                    if (!skipScrollAnimation && !visualTargetOverride.isValid()
+                        && rectAtScrollPark(m_effect->constrainTileGeometry(snap.window, geo.normalized()))) {
+                        skipScrollAnimation = true;
+                        originOverride = QRectF();
                     }
                     m_effect->applyWindowGeometry(snap.window, geo, /*allowDuringDrag=*/false, skipScrollAnimation,
                                                   PhosphorAnimation::ProfilePaths::WindowSnapIn, originOverride,

--- a/kwin-effect/tilinghandler/tiling.cpp
+++ b/kwin-effect/tilinghandler/tiling.cpp
@@ -198,7 +198,7 @@ void TilingHandler::slotWindowsTileRequested(const PhosphorProtocol::TileRequest
     // drag-insert fires a batch, and each one copied the whole stacking order
     // into QPointers and carried it by value into the onComplete closure.
     QVector<QPointer<KWin::EffectWindow>> savedGlobalStack;
-    if (!allRequestsOnScrollingScreens) {
+    if (!allRequestsOnScrollingScreens && KWin::effects) {
         const auto allWindows = KWin::effects->stackingOrder();
         savedGlobalStack.reserve(allWindows.size());
         for (KWin::EffectWindow* w : allWindows) {
@@ -1172,7 +1172,7 @@ void TilingHandler::slotWindowsTileRequested(const PhosphorProtocol::TileRequest
             // activation — so the window the user is typing into stays
             // visible. Non-members are untouched: their position was already
             // restored by the saved-stack loop.
-            if (KWin::EffectWindow* active = KWin::effects->activeWindow();
+            if (KWin::EffectWindow* active = KWin::effects ? KWin::effects->activeWindow() : nullptr;
                 active && overlapMemberScreen.contains(active)) {
                 if (KWin::Window* kw = active->window()) {
                     ws->raiseWindow(kw);
@@ -1211,7 +1211,7 @@ void TilingHandler::slotWindowsTileRequested(const PhosphorProtocol::TileRequest
             // Skip (and drop) the reactivation during show-desktop/peek:
             // activateWindow() would synchronously cancel the peek. The
             // stacking restore is cosmetic, so losing it beats breaking peek.
-            if (!PlasmaZonesEffect::isShowingDesktop()) {
+            if (KWin::effects && !PlasmaZonesEffect::isShowingDesktop()) {
                 KWin::effects->activateWindow(m_pendingReactivateWindow);
             }
             m_pendingReactivateWindow = nullptr;
@@ -2100,6 +2100,31 @@ void TilingHandler::slotWindowsTileRequested(const PhosphorProtocol::TileRequest
                     // it downstream, leaving the two disagreeing about the
                     // predicted commit.
                     const QRect committedGeo = m_effect->constrainTileGeometry(snap.window, geo.normalized());
+                    // Shared four-edge anchor for both LEAVING treatments
+                    // below: move the rect just past the named departure edge
+                    // of the screen. Four departure edges since v5:
+                    // "left"/"right" on a horizontal strip, "top"/"bottom" on
+                    // a vertical one. Folding the two vertical tokens into an
+                    // else would anchor them past the RIGHT screen edge and
+                    // slide every vertical park sideways across the
+                    // neighbouring output.
+                    //
+                    // QRect::right()/bottom() are x+width-1 and y+height-1,
+                    // so +1 sits one past the edge. screenRect must stay a
+                    // QRect (KWin::Rect's right()/bottom() are x+width and
+                    // y+height and would shift the slide by a pixel).
+                    const auto anchorPastEdge = [](QRect rect, const QRect& screenRect, const QString& edge) {
+                        if (edge == QLatin1String("left")) {
+                            rect.moveLeft(screenRect.left() - rect.width());
+                        } else if (edge == QLatin1String("top")) {
+                            rect.moveTop(screenRect.top() - rect.height());
+                        } else if (edge == QLatin1String("bottom")) {
+                            rect.moveTop(screenRect.bottom() + 1);
+                        } else {
+                            rect.moveLeft(screenRect.right() + 1);
+                        }
+                        return rect;
+                    };
                     if (snap.hasVisualPos) {
                         // Parked, but drawn at its real strip position and
                         // carried by the view like every other column. There is
@@ -2180,22 +2205,22 @@ void TilingHandler::slotWindowsTileRequested(const PhosphorProtocol::TileRequest
                             // same teleport fallback when no output resolves.
                             const KWin::LogicalOutput* out = m_effect->outputForScreenId(snap.screenId);
                             const QRect screenRect = out ? QRect(out->geometry()) : QRect();
-                            if (screenRect.isValid()) {
-                                const KWin::RectF cur = snap.window->frameGeometry();
-                                QRect atEdge =
-                                    QRect(qRound(cur.x()), qRound(cur.y()), qRound(cur.width()), qRound(cur.height()));
-                                if (snap.scrollEdge == QLatin1String("left")) {
-                                    atEdge.moveLeft(screenRect.left() - atEdge.width());
-                                } else if (snap.scrollEdge == QLatin1String("top")) {
-                                    atEdge.moveTop(screenRect.top() - atEdge.height());
-                                } else if (snap.scrollEdge == QLatin1String("bottom")) {
-                                    atEdge.moveTop(screenRect.bottom() + 1);
-                                } else {
-                                    atEdge.moveLeft(screenRect.right() + 1);
-                                }
-                                visualTargetOverride = QRectF(atEdge);
-                            } else {
+                            if (!screenRect.isValid()) {
+                                qCDebug(lcEffect) << "scroll batch: no output for" << snap.screenId << "- teleporting"
+                                                  << snap.windowId << "to its target";
                                 skipScrollAnimation = true;
+                            } else if (atScrollPark(snap.window)) {
+                                // Already sitting at a park: both ends of the
+                                // slide-out would be off the union, so the
+                                // animated leg (and its shader arm) buys
+                                // nothing visible. Commit plain, matching the
+                                // at-park-now treatment of the sibling arms.
+                                skipScrollAnimation = true;
+                            } else {
+                                const KWin::RectF cur = snap.window->frameGeometry();
+                                const QRect liveRect =
+                                    QRect(qRound(cur.x()), qRound(cur.y()), qRound(cur.width()), qRound(cur.height()));
+                                visualTargetOverride = QRectF(anchorPastEdge(liveRect, screenRect, snap.scrollEdge));
                             }
                         } else if (!snap.scrollEdge.isEmpty()) {
                             // ARRIVING from a park. Its live frameGeometry is
@@ -2293,27 +2318,8 @@ void TilingHandler::slotWindowsTileRequested(const PhosphorProtocol::TileRequest
                                 atEdge =
                                     QRect(qRound(cur.x()), qRound(cur.y()), qRound(cur.width()), qRound(cur.height()));
                             }
-                            // Four departure edges since v5: "left"/"right"
-                            // on a horizontal strip, "top"/"bottom" on a
-                            // vertical one. Folding the two vertical tokens
-                            // into an else would anchor them past the RIGHT
-                            // screen edge and slide every vertical park
-                            // sideways across the neighbouring output.
-                            //
-                            // QRect::right()/bottom() are x+width-1 and
-                            // y+height-1, so +1 sits one past the edge.
-                            // screenRect must stay a QRect (KWin::Rect's
-                            // right()/bottom() are x+width and y+height and
-                            // would shift the slide by a pixel).
-                            if (snap.scrollEdge == QLatin1String("left")) {
-                                atEdge.moveLeft(screenRect.left() - atEdge.width());
-                            } else if (snap.scrollEdge == QLatin1String("top")) {
-                                atEdge.moveTop(screenRect.top() - atEdge.height());
-                            } else if (snap.scrollEdge == QLatin1String("bottom")) {
-                                atEdge.moveTop(screenRect.bottom() + 1);
-                            } else {
-                                atEdge.moveLeft(screenRect.right() + 1);
-                            }
+                            // Edge semantics documented at anchorPastEdge.
+                            atEdge = anchorPastEdge(atEdge, screenRect, snap.scrollEdge);
                             if (arriving) {
                                 originOverride = QRectF(atEdge);
                             } else {
@@ -2437,8 +2443,7 @@ void TilingHandler::slotWindowsTileRequested(const PhosphorProtocol::TileRequest
                     // park row. An ORIGIN override does not redeem the leg
                     // (its destination is still the park), so it is cleared
                     // rather than honoured.
-                    if (!skipScrollAnimation && !visualTargetOverride.isValid()
-                        && rectAtScrollPark(m_effect->constrainTileGeometry(snap.window, geo.normalized()))) {
+                    if (!skipScrollAnimation && !visualTargetOverride.isValid() && rectAtScrollPark(committedGeo)) {
                         skipScrollAnimation = true;
                         originOverride = QRectF();
                     }
@@ -3018,7 +3023,7 @@ void TilingHandler::slotWindowFrameGeometryChanged(KWin::EffectWindow* w, const 
     // (already-enforced) frame size from `centered`. Same contract, different
     // input source and rect type (QRectF here, QRect there). Keep the four
     // shift formulas in sync at the contract level.
-    if (auto* output = KWin::effects->screenAt(targetZone.center())) {
+    if (auto* output = KWin::effects ? KWin::effects->screenAt(targetZone.center()) : nullptr) {
         const QRect screenGeo = output->geometry();
         // Use exclusive edges (x + width / y + height) since QRectF::right()
         // and QRect::right() disagree (QRect is x+width-1, QRectF is x+width).
@@ -3156,7 +3161,9 @@ void TilingHandler::slotFocusWindowRequested(const QString& windowId)
     // which would then miss and silently skip the raise. Every other resolve
     // site in this file re-keys for the same reason.
     m_pendingAutotileFocusWindowId = m_effect->getWindowId(w);
-    KWin::effects->activateWindow(w);
+    if (KWin::effects) {
+        KWin::effects->activateWindow(w);
+    }
 }
 
 void TilingHandler::reportDiscoveredMinSize(const QString& windowId, int minWidth, int minHeight)

--- a/kwin-effect/tilinghandler/tilinghandler.cpp
+++ b/kwin-effect/tilinghandler/tilinghandler.cpp
@@ -586,7 +586,7 @@ void TilingHandler::notifyWindowsAddedBatch(const QList<KWin::EffectWindow*>& wi
     // then send one batch D-Bus call instead of per-window round-trips.
     PhosphorProtocol::WindowOpenedList batchEntries;
     QStringList batchWindowIds; // for error rollback
-    QStringList batchFreshWindowIds; // spawn-provenance markers consumed below, restored on error
+    QSet<QString> batchFreshWindowIds; // spawn-provenance markers consumed below, restored on error
     // Announce stamps, one PER ENTRY rather than one for the batch: a single
     // batch-wide stamp would let one superseded window (re-announced on its own
     // between dispatch and reply, or closed) disarm the rollback for every other
@@ -661,7 +661,7 @@ void TilingHandler::notifyWindowsAddedBatch(const QList<KWin::EffectWindow*>& wi
         // the initial screen query was pending retains explicit spawn provenance.
         const bool wasFresh = m_pendingFreshWindows.remove(windowId) > 0;
         if (wasFresh) {
-            batchFreshWindowIds.append(windowId);
+            batchFreshWindowIds.insert(windowId);
         }
         const bool knownFreeFloating =
             wasFresh || (enteringAutotile && !TilingStateHelpers::isTiledWindow(m_border, windowId));

--- a/kwin-effect/tilinghandler/tilinghandler.cpp
+++ b/kwin-effect/tilinghandler/tilinghandler.cpp
@@ -414,6 +414,18 @@ bool TilingHandler::atScrollPark(KWin::EffectWindow* w) const
         // animated leg, which is what a non-parked window should get.
         return false;
     }
+    return rectAtScrollPark(frame);
+}
+
+bool TilingHandler::rectAtScrollPark(const QRect& rect) const
+{
+    // Shared tail of atScrollPark, split out so the batch apply can ask the
+    // same question of a commit TARGET (see the header doc). The frame-side
+    // preconditions (null window, degenerate geometry) stay in atScrollPark;
+    // this half owns the union test and its fail-closed arms.
+    if (rect.isEmpty()) {
+        return false;
+    }
     if (!KWin::effects) {
         // The doc promises fail-closed on "no resolvable outputs", and every
         // sibling m_scrollVisualDelta damage pair guards this pointer — an
@@ -427,7 +439,7 @@ bool TilingHandler::atScrollPark(KWin::EffectWindow* w) const
     }
     // No resolvable outputs (disconnect race): the union is empty and every
     // rect is trivially "off" it. Fail closed for the same reason as above.
-    return !unionRect.isEmpty() && !unionRect.intersects(frame);
+    return !unionRect.isEmpty() && !unionRect.intersects(rect);
 }
 
 bool TilingHandler::notifyWindowAdded(KWin::EffectWindow* w, bool knownFreeFloating)

--- a/kwin-effect/tilinghandler/tilinghandler.h
+++ b/kwin-effect/tilinghandler/tilinghandler.h
@@ -289,6 +289,11 @@ public:
     /// the bit is owed back. The new session heals it, because the first batch resolves an absent wire flag against
     /// surviving membership to a Release. Adding to the teardown list is a separate decision — see the
     /// serviceUnregistered handler for what belongs there and why.
+    ///
+    /// Two further deliberate exceptions, both self-healing rather than drained: m_maximizeToggleInFlight entries
+    /// expire on read via MaximizeToggleFlightMs, and m_windowedFsClearInFlight is reply-gated — a toggle or clear
+    /// dispatched to the dead daemon gets a D-Bus error for the vanished peer and its error arm drops the marker,
+    /// so a drain here would only race the same cleanup.
     void clearPerSessionDaemonState();
 
     /**

--- a/kwin-effect/tilinghandler/tilinghandler.h
+++ b/kwin-effect/tilinghandler/tilinghandler.h
@@ -594,6 +594,17 @@ public:
     /// window, degenerate geometry, or no resolvable outputs.
     bool atScrollPark(KWin::EffectWindow* w) const;
 
+    /// The rect form of the same question, asked of a TARGET rect instead of
+    /// a live frame: true when @p rect lies entirely off the union of every
+    /// connected output. This is the "is this commit heading to a park?"
+    /// test the batch apply's animation guards need — a commit whose target
+    /// intersects no output must never receive an animated leg (the leg
+    /// would sweep the window visibly across the screen to a rect chosen
+    /// purely for being invisible). Fails closed (false) on an empty rect or
+    /// no resolvable outputs, mirroring atScrollPark: the fallback is the
+    /// ordinary animated leg, which is what an on-screen target should get.
+    bool rectAtScrollPark(const QRect& rect) const;
+
     /// Cheap gate for callers that want to skip scroll-specific work in a
     /// session with no scrolling screens at all. RAW set, deliberately NOT
     /// the isScrollingScreen intersection — the clip / input-filter /

--- a/libs/phosphor-scroll-engine/CMakeLists.txt
+++ b/libs/phosphor-scroll-engine/CMakeLists.txt
@@ -46,6 +46,7 @@ add_library(PhosphorScrollEngine SHARED
     src/scrollengine/drag_autoscroll.cpp
     src/scrollengine/drag_preview.cpp
     src/scrollengine/engine_lifecycle.cpp
+    src/scrollengine/engine_closehold.cpp
     src/scrollengine/engine_minsize.cpp
     src/scrollengine/engine_reopen.cpp
     src/scrollengine/engine_handoff.cpp

--- a/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/IScrollSettings.h
+++ b/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/IScrollSettings.h
@@ -49,6 +49,18 @@ public:
     /// ConfigDefaults::scrollingSmartGaps.)
     virtual bool scrollingSmartGaps() const = 0;
 
+    /// Milliseconds to hold a CLOSE-triggered reflow so the closing window's
+    /// disappear animation plays over an unchanged strip before the
+    /// neighbours move in. The daemon derives it from the animation
+    /// duration (0 when animations are off). DEFAULTED, not pure: 0 —
+    /// reflow immediately — is the historical behaviour and the answer for
+    /// every implementor that has not heard of the option, including the
+    /// test stubs.
+    virtual int scrollingCloseReflowDelayMs() const
+    {
+        return 0;
+    }
+
     /// CenterFocusedColumn as int (0 = never, 1 = always, 2 = on-overflow).
     virtual int scrollingCenterFocusedColumn() const = 0;
     virtual bool scrollingAlwaysCenterSingleColumn() const = 0;

--- a/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/ScrollEngine.h
+++ b/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/ScrollEngine.h
@@ -1175,6 +1175,19 @@ private:
     void queueSelfActivation(const QString& windowId);
     /// Cap for m_pendingSelfActivations (enforced in queueSelfActivation).
     static constexpr int kMaxPendingSelfActivations = 16;
+    /// Queue-time stamps for m_pendingSelfActivations (latest-wins per id),
+    /// against m_selfActivationClock. An echo the compositor genuinely
+    /// DROPPED (show desktop, focus-stealing prevention) leaves its entry
+    /// stranded — there is no reclaim-on-genuine-focus any more (see the
+    /// windowFocused drain for why that reclaim was wrong) — and without an
+    /// expiry the stranded entry ate the FIRST real click on that window.
+    /// An entry older than kSelfActivationEchoExpiryMs cannot be a live echo
+    /// (echo round trips are milliseconds), so the drain treats a match on
+    /// one as genuine focus. Entries are unstamped/removed at every sweep
+    /// that removes them from the list.
+    QHash<QString, qint64> m_pendingSelfActivationQueuedAt;
+    QElapsedTimer m_selfActivationClock;
+    static constexpr qint64 kSelfActivationEchoExpiryMs = 10000;
     /// The one arrival whose focus an `openFocused = false` rule declined, held
     /// until its compositor focus report arrives and is consumed exactly once.
     ///
@@ -1264,7 +1277,15 @@ private:
     /// animations-off answer) keeps the historical immediate reflow.
     /// User-driven verbs deliberately bypass the hold: a deliberate action
     /// mid-animation outranks the settle, and the scheduled flush behind it
-    /// is an idempotent re-apply.
+    /// is an idempotent re-apply. windowOpened bypasses it too, accepted
+    /// knowingly: an arrival must place itself (and usually takes focus, so
+    /// its apply cannot wait), which means a close-then-immediate-open chain
+    /// (a file dialog handing back to its parent) reflows over the corpse as
+    /// it always did — best-effort degradation to the pre-hold behaviour,
+    /// not a correctness bug. Only windowClosed and windowFocused defer.
+    /// scheduleRetileForScreen's queued apply is outside the hold for the
+    /// same reason and on the same terms: a config/per-screen change or a
+    /// min-size report landing mid-hold reflows on its own turn.
     int m_closeReflowDelayMs = 0;
     /// Per-screen monotonic deadline for the hold, plus the flush-scheduled
     /// guard that keeps one timer per screen however many closes land inside

--- a/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/ScrollEngine.h
+++ b/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/ScrollEngine.h
@@ -24,6 +24,7 @@
 #include <PhosphorScrollEngine/ScrollTypes.h>
 #include <PhosphorScrollEngine/StripAxis.h>
 
+#include <QElapsedTimer>
 #include <QHash>
 #include <QJsonObject>
 #include <QList>
@@ -1254,6 +1255,27 @@ private:
     /// updateStickyScreenPins stays unconditional, matching autotile.
     PhosphorEngine::StickyWindowHandling m_stickyWindowHandling = PhosphorEngine::StickyWindowHandling::TreatAsNormal;
     bool m_respectMinimumSize = true;
+    /// Close-settle hold (refreshConfigFromSettings, derived daemon-side from
+    /// the animation duration): a close-triggered reflow — and the
+    /// focus-adoption reflow the compositor's successor pick fires
+    /// milliseconds later — waits this long so the closing window's
+    /// disappear animation plays over an unchanged strip before the
+    /// neighbours move in. 0 (the no-IScrollSettings seed and the
+    /// animations-off answer) keeps the historical immediate reflow.
+    /// User-driven verbs deliberately bypass the hold: a deliberate action
+    /// mid-animation outranks the settle, and the scheduled flush behind it
+    /// is an idempotent re-apply.
+    int m_closeReflowDelayMs = 0;
+    /// Per-screen monotonic deadline for the hold, plus the flush-scheduled
+    /// guard that keeps one timer per screen however many closes land inside
+    /// one hold window (each close pushes the deadline; the flush lambda
+    /// reschedules itself for the remainder instead of applying early).
+    QHash<QString, qint64> m_closeReflowHoldUntil;
+    QSet<QString> m_closeReflowFlushScheduled;
+    QElapsedTimer m_closeReflowClock;
+    void startCloseReflowHold(const QString& screenId);
+    bool deferForCloseReflowHold(const QString& screenId);
+    void scheduleCloseReflowFlush(const QString& screenId);
     /// Scrolling's OWN Scrolling.Behavior/SmartGaps value, not a forward of the
     /// tiling one. Seeded to match ConfigDefaults::scrollingSmartGaps(), which
     /// is false: tiling defaults this on because a sole window fills the screen

--- a/libs/phosphor-scroll-engine/src/scrollengine/engine_apply.cpp
+++ b/libs/phosphor-scroll-engine/src/scrollengine/engine_apply.cpp
@@ -965,9 +965,10 @@ void ScrollEngine::applyLayout(const QString& screenId, bool focusWindowAfter)
             // Remember the request so windowFocused can tell this
             // activation's echo apart from genuine user focus (the echo
             // contract on windowFocused's drain). Bounded: an effect-side
-            // drop leaves an entry behind until the clear-on-mismatch
-            // reclaims it, and the cap keeps a pathological run of drops
-            // from growing the queue without limit.
+            // drop leaves an entry behind until the per-entry expiry lets
+            // the next genuine click on that window through (see
+            // kSelfActivationEchoExpiryMs), and the cap keeps a pathological
+            // run of drops from growing the queue without limit.
             queueSelfActivation(active);
             Q_EMIT activateWindowRequested(active);
         }
@@ -982,9 +983,19 @@ void ScrollEngine::applyLayout(const QString& screenId, bool focusWindowAfter)
 
 void ScrollEngine::queueSelfActivation(const QString& windowId)
 {
+    if (!m_selfActivationClock.isValid()) {
+        m_selfActivationClock.start();
+    }
     m_pendingSelfActivations.append(windowId);
+    // Latest-wins stamp per id: a re-queue refreshes the entry's liveness,
+    // which is the right answer for the expiry (the newest request's echo is
+    // the one still plausibly in flight).
+    m_pendingSelfActivationQueuedAt.insert(windowId, m_selfActivationClock.elapsed());
     while (m_pendingSelfActivations.size() > kMaxPendingSelfActivations) {
-        m_pendingSelfActivations.removeFirst();
+        const QString dropped = m_pendingSelfActivations.takeFirst();
+        if (!m_pendingSelfActivations.contains(dropped)) {
+            m_pendingSelfActivationQueuedAt.remove(dropped);
+        }
     }
 }
 

--- a/libs/phosphor-scroll-engine/src/scrollengine/engine_closehold.cpp
+++ b/libs/phosphor-scroll-engine/src/scrollengine/engine_closehold.cpp
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <PhosphorScrollEngine/ScrollEngine.h>
+
+#include <QTimer>
+
+namespace PhosphorScrollEngine {
+
+// The close-settle reflow hold: windowClosed (engine_lifecycle.cpp) starts a
+// hold instead of reflowing immediately, so the closing window's disappear
+// animation plays over an unchanged strip; windowFocused defers its viewport
+// scroll through the same hold. The three helpers live in their own TU
+// because engine_lifecycle.cpp is over the file-size ceiling and this feature
+// is a self-contained state machine (m_closeReflowHoldUntil /
+// m_closeReflowFlushScheduled / m_closeReflowClock, all declared together in
+// ScrollEngine.h).
+
+void ScrollEngine::startCloseReflowHold(const QString& screenId)
+{
+    if (!m_closeReflowClock.isValid()) {
+        m_closeReflowClock.start();
+    }
+    // Latest close wins: a second close inside the hold pushes the deadline
+    // so ITS animation also plays out before the one flush runs.
+    m_closeReflowHoldUntil[screenId] = m_closeReflowClock.elapsed() + m_closeReflowDelayMs;
+    scheduleCloseReflowFlush(screenId);
+}
+
+bool ScrollEngine::deferForCloseReflowHold(const QString& screenId)
+{
+    const auto it = m_closeReflowHoldUntil.constFind(screenId);
+    if (it == m_closeReflowHoldUntil.constEnd()) {
+        return false;
+    }
+    if (!m_closeReflowClock.isValid() || m_closeReflowClock.elapsed() >= *it) {
+        m_closeReflowHoldUntil.remove(screenId);
+        return false;
+    }
+    // Still inside the hold: make sure a flush is coming, and tell the
+    // caller to skip its immediate applyLayout — the flush is that apply.
+    scheduleCloseReflowFlush(screenId);
+    return true;
+}
+
+void ScrollEngine::scheduleCloseReflowFlush(const QString& screenId)
+{
+    if (m_closeReflowFlushScheduled.contains(screenId)) {
+        return;
+    }
+    m_closeReflowFlushScheduled.insert(screenId);
+    const qint64 remaining = qMax<qint64>(0, m_closeReflowHoldUntil.value(screenId) - m_closeReflowClock.elapsed());
+    QTimer::singleShot(static_cast<int>(remaining) + 1, this, [this, screenId] {
+        m_closeReflowFlushScheduled.remove(screenId);
+        const auto it = m_closeReflowHoldUntil.constFind(screenId);
+        if (it != m_closeReflowHoldUntil.constEnd() && m_closeReflowClock.elapsed() < *it) {
+            // A later close pushed the deadline while this timer was armed —
+            // re-arm for the remainder rather than flushing early.
+            scheduleCloseReflowFlush(screenId);
+            return;
+        }
+        m_closeReflowHoldUntil.remove(screenId);
+        // applyLayout resolves the screen's CURRENT context itself, so a
+        // desktop switch during the hold lands this on the right strip; on
+        // a screen that stopped scrolling meanwhile it no-ops.
+        applyLayout(screenId, false);
+    });
+}
+
+} // namespace PhosphorScrollEngine

--- a/libs/phosphor-scroll-engine/src/scrollengine/engine_context.cpp
+++ b/libs/phosphor-scroll-engine/src/scrollengine/engine_context.cpp
@@ -107,6 +107,7 @@ int ScrollEngine::pruneStaleWindows(const QSet<QString>& aliveWindowIds)
         // left behind it would eat the first genuine focus of a reused id
         // (windowClosed and releaseScreenState sweep for the same reason).
         m_pendingSelfActivations.removeAll(windowId);
+        m_pendingSelfActivationQueuedAt.remove(windowId);
         // The declined-open marker with it. This sweep matters more for that
         // map than for the one above: the marker's other three sweeps all hang
         // off a windowClosed signal, and a window that dies WITHOUT one — the
@@ -514,6 +515,7 @@ void ScrollEngine::dropWindowBookkeeping(const ScrollState* state)
         // a stale entry would swallow the first genuine focus of a reused
         // id (windowClosed and releaseScreenState sweep the same way).
         m_pendingSelfActivations.removeAll(windowId);
+        m_pendingSelfActivationQueuedAt.remove(windowId);
         // Identical reasoning, and the same reused-id hazard: a declined-open
         // marker left behind swallows the first genuine focus the next window
         // to take this id receives. Unlike its sibling above it carries no

--- a/libs/phosphor-scroll-engine/src/scrollengine/engine_core.cpp
+++ b/libs/phosphor-scroll-engine/src/scrollengine/engine_core.cpp
@@ -1094,6 +1094,11 @@ void ScrollEngine::refreshConfigFromSettings()
         : PhosphorEngine::StickyWindowHandling::TreatAsNormal;
     m_respectMinimumSize = settings->scrollingRespectMinimumSize();
     m_smartGaps = settings->scrollingSmartGaps();
+    // Bounded like every other cast/derived read here: the value is derived
+    // daemon-side from the animation duration, but nothing stops a future
+    // implementor handing back garbage, and a multi-second hold would read
+    // as the strip hanging after every close.
+    m_closeReflowDelayMs = qBound(0, settings->scrollingCloseReflowDelayMs(), 2000);
 
     // Tab-indicator geometry. The numeric fields are taken as-is: the config
     // schema already clamps every one of them, and re-clamping here with a

--- a/libs/phosphor-scroll-engine/src/scrollengine/engine_core.cpp
+++ b/libs/phosphor-scroll-engine/src/scrollengine/engine_core.cpp
@@ -282,6 +282,7 @@ void ScrollEngine::releaseScreenState(ScrollState* state, QStringList& releasedW
     for (const QString& windowId : windows) {
         m_floatRestore.remove(windowId);
         m_pendingSelfActivations.removeAll(windowId);
+        m_pendingSelfActivationQueuedAt.remove(windowId);
         m_declinedOpenFocus.remove(windowId);
         m_parkedScrollEdge.remove(windowId);
         m_lastAppliedWindowedFs.remove(windowId);
@@ -1098,7 +1099,7 @@ void ScrollEngine::refreshConfigFromSettings()
     // daemon-side from the animation duration, but nothing stops a future
     // implementor handing back garbage, and a multi-second hold would read
     // as the strip hanging after every close.
-    m_closeReflowDelayMs = qBound(0, settings->scrollingCloseReflowDelayMs(), 2000);
+    m_closeReflowDelayMs = qBound(0, settings->scrollingCloseReflowDelayMs(), kMaxCloseReflowDelayMs);
 
     // Tab-indicator geometry. The numeric fields are taken as-is: the config
     // schema already clamps every one of them, and re-clamping here with a

--- a/libs/phosphor-scroll-engine/src/scrollengine/engine_handoff.cpp
+++ b/libs/phosphor-scroll-engine/src/scrollengine/engine_handoff.cpp
@@ -53,6 +53,7 @@ void ScrollEngine::handoffRelease(const QString& rawWindowId)
     // report, and a mark surviving the release would eat the first genuine
     // focus after re-adoption.
     m_pendingSelfActivations.removeAll(windowId);
+    m_pendingSelfActivationQueuedAt.remove(windowId);
     m_declinedOpenFocus.remove(windowId);
     // m_lastAppliedRect deliberately retained (same rationale as
     // windowClosed: a close/capture racing the handoff still needs the

--- a/libs/phosphor-scroll-engine/src/scrollengine/engine_lifecycle.cpp
+++ b/libs/phosphor-scroll-engine/src/scrollengine/engine_lifecycle.cpp
@@ -1060,9 +1060,20 @@ void ScrollEngine::windowFocused(const QString& rawWindowId, const QString& scre
     if (m_declinedOpenFocus.remove(windowId)) {
         return;
     }
-    // A genuine focus report implies every previously-sent echo already
-    // landed, so whatever is left in the queue was dropped — reclaim it.
-    m_pendingSelfActivations.clear();
+    // Deliberately NO reclaim of m_pendingSelfActivations here. An earlier
+    // form cleared the queue on every genuine report, reasoning that a
+    // genuine focus implies every previously-sent echo already landed. That
+    // inference is false ACROSS DIRECTIONS: on a window close the compositor
+    // activates its own successor pick and that genuine report is in flight
+    // BEFORE this engine queues its competing self-activation (the close
+    // handler's focusWindowAfter), so the queued entry's echo is still
+    // legitimately in flight when the genuine report lands. The clear wiped
+    // it, the echo then arrived against an empty queue, was mis-read as user
+    // focus, and the two picks re-anchored the strip against each other —
+    // the post-close anchor ping-pong (0↔1916 several times in two seconds,
+    // re-parking live windows on every bounce). The queue stays bounded
+    // without the reclaim: the prefix-drop at match above, the close-time
+    // removeAll, and the kMaxPendingSelfActivations cap all still run.
     PhosphorEngine::PlacementStateKey key;
     ScrollState* state = stateForWindow(windowId, &key);
     if (!state) {

--- a/libs/phosphor-scroll-engine/src/scrollengine/engine_lifecycle.cpp
+++ b/libs/phosphor-scroll-engine/src/scrollengine/engine_lifecycle.cpp
@@ -967,6 +967,7 @@ void ScrollEngine::windowClosed(const QString& rawWindowId)
     // lands can never be answered; without this a later genuine focus of a
     // reused id would be eaten as that echo.
     m_pendingSelfActivations.removeAll(windowId);
+    m_pendingSelfActivationQueuedAt.remove(windowId);
     // Same reasoning for the declined-open mark: the arrival that was denied
     // focus can close before its one report arrives, and a stale mark would
     // then eat the first genuine focus of a reused id.
@@ -1037,56 +1038,8 @@ void ScrollEngine::windowClosed(const QString& rawWindowId)
     Q_EMIT placementChanged(key.screenId);
 }
 
-void ScrollEngine::startCloseReflowHold(const QString& screenId)
-{
-    if (!m_closeReflowClock.isValid()) {
-        m_closeReflowClock.start();
-    }
-    // Latest close wins: a second close inside the hold pushes the deadline
-    // so ITS animation also plays out before the one flush runs.
-    m_closeReflowHoldUntil[screenId] = m_closeReflowClock.elapsed() + m_closeReflowDelayMs;
-    scheduleCloseReflowFlush(screenId);
-}
-
-bool ScrollEngine::deferForCloseReflowHold(const QString& screenId)
-{
-    const auto it = m_closeReflowHoldUntil.constFind(screenId);
-    if (it == m_closeReflowHoldUntil.constEnd()) {
-        return false;
-    }
-    if (!m_closeReflowClock.isValid() || m_closeReflowClock.elapsed() >= *it) {
-        m_closeReflowHoldUntil.remove(screenId);
-        return false;
-    }
-    // Still inside the hold: make sure a flush is coming, and tell the
-    // caller to skip its immediate applyLayout — the flush is that apply.
-    scheduleCloseReflowFlush(screenId);
-    return true;
-}
-
-void ScrollEngine::scheduleCloseReflowFlush(const QString& screenId)
-{
-    if (m_closeReflowFlushScheduled.contains(screenId)) {
-        return;
-    }
-    m_closeReflowFlushScheduled.insert(screenId);
-    const qint64 remaining = qMax<qint64>(0, m_closeReflowHoldUntil.value(screenId) - m_closeReflowClock.elapsed());
-    QTimer::singleShot(static_cast<int>(remaining) + 1, this, [this, screenId] {
-        m_closeReflowFlushScheduled.remove(screenId);
-        const auto it = m_closeReflowHoldUntil.constFind(screenId);
-        if (it != m_closeReflowHoldUntil.constEnd() && m_closeReflowClock.elapsed() < *it) {
-            // A later close pushed the deadline while this timer was armed —
-            // re-arm for the remainder rather than flushing early.
-            scheduleCloseReflowFlush(screenId);
-            return;
-        }
-        m_closeReflowHoldUntil.remove(screenId);
-        // applyLayout resolves the screen's CURRENT context itself, so a
-        // desktop switch during the hold lands this on the right strip; on
-        // a screen that stopped scrolling meanwhile it no-ops.
-        applyLayout(screenId, false);
-    });
-}
+// startCloseReflowHold / deferForCloseReflowHold / scheduleCloseReflowFlush
+// live in engine_closehold.cpp (this TU is over the file-size ceiling).
 
 void ScrollEngine::windowFocused(const QString& rawWindowId, const QString& screenId)
 {
@@ -1109,9 +1062,25 @@ void ScrollEngine::windowFocused(const QString& rawWindowId, const QString& scre
     // never this engine's emit, so its echo still drives the strip
     // (signals.cpp documents that contract).
     if (const int selfIdx = m_pendingSelfActivations.indexOf(windowId); selfIdx >= 0) {
+        // Expiry check BEFORE swallowing: an entry whose echo the compositor
+        // dropped (show desktop, focus-stealing prevention) has no reclaim
+        // path any more (see below), and without this it ate the FIRST real
+        // click on its window. Echo round trips are milliseconds; a stamp
+        // this old means the echo is dead and this report is the user.
+        const qint64 queuedAt = m_pendingSelfActivationQueuedAt.value(windowId, -1);
+        const bool expired = queuedAt < 0 || !m_selfActivationClock.isValid()
+            || m_selfActivationClock.elapsed() - queuedAt > kSelfActivationEchoExpiryMs;
         m_pendingSelfActivations.erase(m_pendingSelfActivations.begin(),
                                        m_pendingSelfActivations.begin() + selfIdx + 1);
-        return;
+        for (auto stampIt = m_pendingSelfActivationQueuedAt.begin();
+             stampIt != m_pendingSelfActivationQueuedAt.end();) {
+            stampIt = m_pendingSelfActivations.contains(stampIt.key()) ? std::next(stampIt)
+                                                                       : m_pendingSelfActivationQueuedAt.erase(stampIt);
+        }
+        if (!expired) {
+            return;
+        }
+        // Fall through: adopt as genuine focus.
     }
     // Declined-open consume, m_declinedOpenFocus' read side. An
     // `openFocused = false` arrival was focused by the compositor anyway, and
@@ -1139,7 +1108,9 @@ void ScrollEngine::windowFocused(const QString& rawWindowId, const QString& scre
     // the post-close anchor ping-pong (0↔1916 several times in two seconds,
     // re-parking live windows on every bounce). The queue stays bounded
     // without the reclaim: the prefix-drop at match above, the close-time
-    // removeAll, and the kMaxPendingSelfActivations cap all still run.
+    // removeAll, and the kMaxPendingSelfActivations cap all still run — and
+    // the dropped-echo case the reclaim used to (over-)serve is now handled
+    // precisely by the per-entry expiry at the match above.
     PhosphorEngine::PlacementStateKey key;
     ScrollState* state = stateForWindow(windowId, &key);
     if (!state) {

--- a/libs/phosphor-scroll-engine/src/scrollengine/engine_lifecycle.cpp
+++ b/libs/phosphor-scroll-engine/src/scrollengine/engine_lifecycle.cpp
@@ -10,6 +10,7 @@
 #include "enginelimits.h"
 #include "scrollenginelogging.h"
 
+#include <QTimer>
 #include <QVariant>
 
 #include <algorithm>
@@ -1017,9 +1018,74 @@ void ScrollEngine::windowClosed(const QString& rawWindowId)
         // CURRENT context, so a close on another desktop's state would
         // relayout the wrong strip (the mutated one must stay silent
         // until its desktop returns).
-        applyLayout(key.screenId, wasActive && !state->strip().activeWindowId().isEmpty());
+        //
+        // Close-settle hold: with a configured delay, the reflow waits out
+        // the closing window's disappear animation instead of moving the
+        // neighbours over the still-painting corpse (the two animations
+        // fighting for the vacated slot is exactly the visual mess the hold
+        // exists to prevent). The deferred flush passes focusAfter=false on
+        // purpose: the compositor activates its own successor immediately
+        // and windowFocused adopts it long before the flush fires, so the
+        // engine re-asserting its pick a delay later would only re-open the
+        // dueling-activations bounce the pending-self-activation fix closed.
+        if (m_closeReflowDelayMs > 0) {
+            startCloseReflowHold(key.screenId);
+        } else {
+            applyLayout(key.screenId, wasActive && !state->strip().activeWindowId().isEmpty());
+        }
     }
     Q_EMIT placementChanged(key.screenId);
+}
+
+void ScrollEngine::startCloseReflowHold(const QString& screenId)
+{
+    if (!m_closeReflowClock.isValid()) {
+        m_closeReflowClock.start();
+    }
+    // Latest close wins: a second close inside the hold pushes the deadline
+    // so ITS animation also plays out before the one flush runs.
+    m_closeReflowHoldUntil[screenId] = m_closeReflowClock.elapsed() + m_closeReflowDelayMs;
+    scheduleCloseReflowFlush(screenId);
+}
+
+bool ScrollEngine::deferForCloseReflowHold(const QString& screenId)
+{
+    const auto it = m_closeReflowHoldUntil.constFind(screenId);
+    if (it == m_closeReflowHoldUntil.constEnd()) {
+        return false;
+    }
+    if (!m_closeReflowClock.isValid() || m_closeReflowClock.elapsed() >= *it) {
+        m_closeReflowHoldUntil.remove(screenId);
+        return false;
+    }
+    // Still inside the hold: make sure a flush is coming, and tell the
+    // caller to skip its immediate applyLayout — the flush is that apply.
+    scheduleCloseReflowFlush(screenId);
+    return true;
+}
+
+void ScrollEngine::scheduleCloseReflowFlush(const QString& screenId)
+{
+    if (m_closeReflowFlushScheduled.contains(screenId)) {
+        return;
+    }
+    m_closeReflowFlushScheduled.insert(screenId);
+    const qint64 remaining = qMax<qint64>(0, m_closeReflowHoldUntil.value(screenId) - m_closeReflowClock.elapsed());
+    QTimer::singleShot(static_cast<int>(remaining) + 1, this, [this, screenId] {
+        m_closeReflowFlushScheduled.remove(screenId);
+        const auto it = m_closeReflowHoldUntil.constFind(screenId);
+        if (it != m_closeReflowHoldUntil.constEnd() && m_closeReflowClock.elapsed() < *it) {
+            // A later close pushed the deadline while this timer was armed —
+            // re-arm for the remainder rather than flushing early.
+            scheduleCloseReflowFlush(screenId);
+            return;
+        }
+        m_closeReflowHoldUntil.remove(screenId);
+        // applyLayout resolves the screen's CURRENT context itself, so a
+        // desktop switch during the hold lands this on the right strip; on
+        // a screen that stopped scrolling meanwhile it no-ops.
+        applyLayout(screenId, false);
+    });
 }
 
 void ScrollEngine::windowFocused(const QString& rawWindowId, const QString& screenId)
@@ -1142,7 +1208,14 @@ void ScrollEngine::windowFocused(const QString& rawWindowId, const QString& scre
     // now — a background one re-derives on the applyLayout its own desktop
     // return runs, which is the pass that used to return early.
     if (key == currentKeyForScreen(key.screenId)) {
-        applyLayout(key.screenId, false);
+        // Close-settle hold, second arm: the compositor's successor pick
+        // lands here milliseconds after a close, and its reanchor reflow
+        // moving the neighbours would defeat the hold windowClosed just
+        // started. The anchor/focus state above is already updated — only
+        // the geometry emission waits; the scheduled flush replays it.
+        if (!deferForCloseReflowHold(key.screenId)) {
+            applyLayout(key.screenId, false);
+        }
     }
     // Focus and view anchor are persisted (serializeStripState), and
     // placementChanged is the only thing that marks DirtyScrollStrips.

--- a/libs/phosphor-scroll-engine/src/scrollengine/enginelimits.h
+++ b/libs/phosphor-scroll-engine/src/scrollengine/enginelimits.h
@@ -70,6 +70,16 @@ inline constexpr qint64 kFuzzyClaimGraceMs = 60'000;
 inline constexpr int kMaxRestoredColumnsPerKey = 64;
 inline constexpr int kMaxRestoredTilesPerColumn = 32;
 
+/// Ceiling for the close-settle reflow hold (refreshConfigFromSettings'
+/// qBound on scrollingCloseReflowDelayMs). Numerically equal to
+/// PhosphorAnimation::Limits::MaxAnimationDurationMs, hand-mirrored like
+/// MinColumnWidthFraction rather than included (this LGPL engine does not
+/// depend on phosphor-animation): the config setter clamps the duration to
+/// that same max, so this cap can never truncate a legal config value — it
+/// bounds a misbehaving embedder-injected ISettings, whose multi-second
+/// value would read as the strip hanging after every close.
+inline constexpr int kMaxCloseReflowDelayMs = 2000;
+
 /// Sanity ceiling for a PIXEL extent minted from an untrusted qreal (the
 /// per-screen override map, which applyPerScreenConfig stores verbatim, and
 /// the injected ISettings an embedder implements). Both channels reach

--- a/libs/phosphor-scroll-engine/tests/CMakeLists.txt
+++ b/libs/phosphor-scroll-engine/tests/CMakeLists.txt
@@ -142,4 +142,8 @@ pse_add_test(test_scrollengine_draginsert test_scrollengine_draginsert.cpp scrol
 pse_add_test(test_scrollengine_snapshot test_scrollengine_snapshot.cpp)
 pse_add_test(test_scrollengine_boundary test_scrollengine_boundary.cpp scrollstubsettings.h)
 pse_add_test(test_scrollengine_verbs test_scrollengine_verbs.cpp)
+# The close-settle reflow hold's observable contract (deferred windowsTiled
+# batch, deadline push, zero-delay immediacy). Needs the settings stub: the
+# interface default is 0, so without one the hold never arms.
+pse_add_test(test_scrollengine_closehold test_scrollengine_closehold.cpp scrollstubsettings.h)
 pse_add_test(test_scrollengine_maximize test_scrollengine_maximize.cpp)

--- a/libs/phosphor-scroll-engine/tests/scrollstubsettings.h
+++ b/libs/phosphor-scroll-engine/tests/scrollstubsettings.h
@@ -70,6 +70,12 @@ public:
     // suite that never touches them behaves exactly like the no-settings
     // fixtures; a case driving one must call refreshConfigFromSettings()
     // afterwards, same as stripAxis.
+    /// Close-settle reflow hold. 0 (the interface default) keeps the
+    /// historical immediate reflow; the closehold suite drives it non-zero.
+    /// A case setting it must call refreshConfigFromSettings() afterwards,
+    /// same as stripAxis.
+    int closeReflowDelayMs = 0;
+
     bool dragScrollEnabled = PhosphorEngine::IScrollSettings::kDragScrollEnabledDefault;
     int dragScrollTriggerWidth = PhosphorEngine::IScrollSettings::kDragScrollTriggerWidthDefault;
     int dragScrollDelayMs = PhosphorEngine::IScrollSettings::kDragScrollDelayMsDefault;
@@ -134,6 +140,10 @@ public:
     bool scrollingCropStraddlers() const override
     {
         return cropStraddlers;
+    }
+    int scrollingCloseReflowDelayMs() const override
+    {
+        return closeReflowDelayMs;
     }
     bool scrollingDragScrollEnabled() const override
     {

--- a/libs/phosphor-scroll-engine/tests/test_scrollengine_closehold.cpp
+++ b/libs/phosphor-scroll-engine/tests/test_scrollengine_closehold.cpp
@@ -1,0 +1,126 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+// The close-settle reflow hold (engine_closehold.cpp): a configured
+// scrollingCloseReflowDelayMs makes windowClosed start a per-screen hold
+// instead of reflowing immediately, so the closing window's disappear
+// animation plays over an unchanged strip. These cases assert the observable
+// contract through the windowsTiled batch signal: no reflow batch until the
+// hold expires, a second close pushing the one deadline, and the zero-delay
+// default keeping the historical immediate reflow.
+//
+// Timing: the holds here are wall-clock (QTimer-driven), so the delays are
+// sized with wide margins — the mid-hold probes sit at less than half the
+// deadline and the expiry waits use QTRY with a multiple of it.
+
+#include <PhosphorScrollEngine/ScrollEngine.h>
+#include <PhosphorScrollEngine/ScrollState.h>
+
+#include "scrollstriptestutils.h"
+#include "scrollstubsettings.h"
+
+#include <QSignalSpy>
+#include <QtTest>
+
+using namespace PhosphorScrollEngine;
+
+using ScrollTestUtils::makeProviderEngine;
+using ScrollTestUtils::StubScrollSettings;
+
+namespace {
+const QString kS1 = QStringLiteral("S1");
+} // namespace
+
+class TestScrollEngineCloseHold : public QObject
+{
+    Q_OBJECT
+
+    static ScrollEngine* makeEngine(QObject* parent, StubScrollSettings* settings)
+    {
+        ScrollEngine* engine = makeProviderEngine(parent, {kS1});
+        engine->setEngineSettings(settings);
+        engine->refreshConfigFromSettings();
+        return engine;
+    }
+
+private Q_SLOTS:
+    void zeroDelayReflowsImmediately();
+    void holdDefersReflowUntilExpiry();
+    void secondClosePushesTheDeadline();
+};
+
+void TestScrollEngineCloseHold::zeroDelayReflowsImmediately()
+{
+    QObject owner;
+    auto* settings = new StubScrollSettings(&owner);
+    ScrollEngine* engine = makeEngine(&owner, settings);
+    engine->windowOpened(QStringLiteral("app|a"), kS1, 0, 0);
+    engine->windowOpened(QStringLiteral("app|b"), kS1, 0, 0);
+
+    // Drain the opens' own queued retiles first: scheduleRetileForScreen posts
+    // its applyLayout to the event loop, so without a turn here those land
+    // inside the hold below and would be mistaken for a hold leak.
+    QTest::qWait(50);
+    QSignalSpy tiled(engine, &ScrollEngine::windowsTiled);
+    engine->windowClosed(QStringLiteral("app|a"));
+    // The historical contract: the reflow batch goes out inside the close
+    // handler itself, no event loop needed.
+    QVERIFY(tiled.count() >= 1);
+}
+
+void TestScrollEngineCloseHold::holdDefersReflowUntilExpiry()
+{
+    QObject owner;
+    auto* settings = new StubScrollSettings(&owner);
+    settings->closeReflowDelayMs = 250;
+    ScrollEngine* engine = makeEngine(&owner, settings);
+    engine->refreshConfigFromSettings();
+    engine->windowOpened(QStringLiteral("app|a"), kS1, 0, 0);
+    engine->windowOpened(QStringLiteral("app|b"), kS1, 0, 0);
+
+    // Drain the opens' own queued retiles first: scheduleRetileForScreen posts
+    // its applyLayout to the event loop, so without a turn here those land
+    // inside the hold below and would be mistaken for a hold leak.
+    QTest::qWait(50);
+    QSignalSpy tiled(engine, &ScrollEngine::windowsTiled);
+    engine->windowClosed(QStringLiteral("app|a"));
+    // Inside the hold: the strip model already dropped the window, but no
+    // reflow batch may go out (that is the hold's whole point — the corpse
+    // keeps its slot on screen while its close animation plays).
+    QCOMPARE(tiled.count(), 0);
+    QTest::qWait(100);
+    QCOMPARE(tiled.count(), 0);
+    // Expiry: the scheduled flush runs the one deferred applyLayout.
+    QTRY_VERIFY_WITH_TIMEOUT(tiled.count() >= 1, 1000);
+}
+
+void TestScrollEngineCloseHold::secondClosePushesTheDeadline()
+{
+    QObject owner;
+    auto* settings = new StubScrollSettings(&owner);
+    settings->closeReflowDelayMs = 400;
+    ScrollEngine* engine = makeEngine(&owner, settings);
+    engine->refreshConfigFromSettings();
+    engine->windowOpened(QStringLiteral("app|a"), kS1, 0, 0);
+    engine->windowOpened(QStringLiteral("app|b"), kS1, 0, 0);
+    engine->windowOpened(QStringLiteral("app|c"), kS1, 0, 0);
+
+    // Drain the opens' own queued retiles first: scheduleRetileForScreen posts
+    // its applyLayout to the event loop, so without a turn here those land
+    // inside the hold below and would be mistaken for a hold leak.
+    QTest::qWait(50);
+    QSignalSpy tiled(engine, &ScrollEngine::windowsTiled);
+    engine->windowClosed(QStringLiteral("app|a"));
+    QTest::qWait(150);
+    // Latest close wins: this second close pushes the shared deadline to
+    // now+400, so the FIRST close's expiry (at 400 from its own start, 250
+    // from here) must not flush.
+    engine->windowClosed(QStringLiteral("app|b"));
+    QTest::qWait(300);
+    QCOMPARE(tiled.count(), 0);
+    // One flush serves both closes once the pushed deadline passes.
+    QTRY_VERIFY_WITH_TIMEOUT(tiled.count() >= 1, 1000);
+}
+
+QTEST_GUILESS_MAIN(TestScrollEngineCloseHold)
+#include "test_scrollengine_closehold.moc"

--- a/src/config/settings.h
+++ b/src/config/settings.h
@@ -1376,8 +1376,16 @@ public:
     void setScrollingSmartGaps(bool enabled);
     /// Derived, not stored (no config key, no setter): the close-settle hold
     /// exists to let the window-close animation play over an unchanged strip,
-    /// so its length IS the animation duration, and a session with animations
-    /// off has nothing to wait for.
+    /// so its length tracks the GLOBAL animation duration, and a session with
+    /// animations off has nothing to wait for. Deliberately an approximation:
+    /// the effect resolves the actual window.close leg per window (per-event
+    /// motion-node duration overrides, Rule timing slots, and spring curves
+    /// whose lifetime comes from settleTime()), and that per-window outcome
+    /// is what the daemon cannot observe (the tree's static per-event
+    /// duration is readable here; the resolved leg is not) — so an
+    /// overridden or spring close can outlive the hold, and a
+    /// per-window animation exclusion still pays it. Tracking the real leg
+    /// would need effect→daemon plumbing; not worth it for a cosmetic hold.
     int scrollingCloseReflowDelayMs() const override;
     bool scrollingCropStraddlers() const override;
     void setScrollingCropStraddlers(bool crop);

--- a/src/config/settings.h
+++ b/src/config/settings.h
@@ -1374,6 +1374,11 @@ public:
     void setScrollingAlwaysCenterSingleColumn(bool center);
     bool scrollingSmartGaps() const override;
     void setScrollingSmartGaps(bool enabled);
+    /// Derived, not stored (no config key, no setter): the close-settle hold
+    /// exists to let the window-close animation play over an unchanged strip,
+    /// so its length IS the animation duration, and a session with animations
+    /// off has nothing to wait for.
+    int scrollingCloseReflowDelayMs() const override;
     bool scrollingCropStraddlers() const override;
     void setScrollingCropStraddlers(bool crop);
     bool scrollingDragScrollEnabled() const override;

--- a/src/config/settings/scrolling.cpp
+++ b/src/config/settings/scrolling.cpp
@@ -134,6 +134,14 @@ P_STORE_SET_BOOL(setScrollingAlwaysCenterSingleColumn, scrollingGroup, alwaysCen
 P_STORE_GET(bool, scrollingSmartGaps, scrollingBehaviorGroup, smartGapsKey, bool)
 P_STORE_SET_BOOL(setScrollingSmartGaps, scrollingBehaviorGroup, smartGapsKey, scrollingSmartGapsChanged)
 
+// Derived, not stored — see the header. Rides the animation settings'
+// change signals into the engine because refreshConfigFromSettings re-reads
+// every IScrollSettings value on any settings change.
+int Settings::scrollingCloseReflowDelayMs() const
+{
+    return animationsEnabled() ? animationDuration() : 0;
+}
+
 P_STORE_GET(bool, scrollingCropStraddlers, scrollingGroup, cropStraddlersKey, bool)
 P_STORE_SET_BOOL(setScrollingCropStraddlers, scrollingGroup, cropStraddlersKey, scrollingCropStraddlersChanged)
 

--- a/src/config/settings/scrolling.cpp
+++ b/src/config/settings/scrolling.cpp
@@ -134,9 +134,10 @@ P_STORE_SET_BOOL(setScrollingAlwaysCenterSingleColumn, scrollingGroup, alwaysCen
 P_STORE_GET(bool, scrollingSmartGaps, scrollingBehaviorGroup, smartGapsKey, bool)
 P_STORE_SET_BOOL(setScrollingSmartGaps, scrollingBehaviorGroup, smartGapsKey, scrollingSmartGapsChanged)
 
-// Derived, not stored — see the header. Rides the animation settings'
-// change signals into the engine because refreshConfigFromSettings re-reads
-// every IScrollSettings value on any settings change.
+// Derived, not stored — see the header, including why the GLOBAL duration is
+// a deliberate approximation of the per-window close leg. Rides the animation
+// settings' change signals into the engine because refreshConfigFromSettings
+// re-reads every IScrollSettings value on any settings change.
 int Settings::scrollingCloseReflowDelayMs() const
 {
     return animationsEnabled() ? animationDuration() : 0;


### PR DESCRIPTION
## Summary

Closing a window in the middle of a panned scrolling strip made the closed window visibly fall to the bottom of the screen and off — with or without close shaders. Diagnosed live over an extended session (paint-transform instrumentation, three parallel audit agents, and finally frame-by-frame analysis of a 60fps gpu-screen-recorder capture); the visible fall turned out to be drawn inside the shader pipeline, not by any window transform, with several real defects stacked underneath. All five are fixed:

1. **Synthetic-origin morph snapshot seed** (the filmed painter): a column unparking into the vacated slot seeded its movement morph's old-content crossfade by blitting the multipass decoration composite mapped through a synthetic screen-edge from-rect the window never occupied, while the composite was frozen at its last pre-park fold. The stale, mis-registered slice then descended with the stream deform behind the arriving window. Synthetic origins now take the position-independent raw capture (`ShaderTransition::fromIsSynthetic`).
2. **Close-settle reflow hold** (new behaviour): the strip now waits out the close animation before reflowing — the close plays on an unchanged strip, then the neighbours animate in. Derived hold length (animation duration; 0 with animations off), successor-focus reflow honours the hold, user verbs bypass it.
3. **Park-sweep guards**: the viewDelta-residual branch of the batch apply outranked the park handling, so a leaving-park entry could take a real animated leg down to the park row (edge-less) or pop instantly (edged). Direction is now classified with the new `rectAtScrollPark`, and a terminal backstop guarantees no commit targeting a rect off the output union ever animates.
4. **Activation-echo reclaim**: a close triggered dueling activations (compositor's successor pick vs the engine's right-neighbour pick) because a wrong queue-clear converted the engine's own in-flight activation echo into fake user focus, re-anchoring the strip back and forth (observed 0↔1916 five times in 2s) and re-parking live windows on every bounce.
5. **Corpse relocation freeze**: a panned strip's close-grabbed corpse lost its strip relocation the frame it died (deleted windows can't re-derive it) and snapped to its committed rect; its displacement is now frozen at death and applied for the corpse's whole close leg.

## Testing

- 410/410 ctest pass.
- Live-verified by the reporter on the repro protocol (pan the strip, close mid-strip, repeat): the fall is gone and the close animation plays before the strip reflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AJMwyieHmoPn85aRPsPvxP