### PR TITLE
fix(scroll-engine): unbreak first-click focus on multi-desktop strips

### DIFF
--- a/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/ScrollEngine.h
+++ b/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/ScrollEngine.h
@@ -1185,9 +1185,18 @@ private:
     /// (echo round trips are milliseconds), so the drain treats a match on
     /// one as genuine focus. Entries are unstamped/removed at every sweep
     /// that removes them from the list.
+    ///
+    /// The expiry sits at echo scale, NOT human scale. Multi-desktop use
+    /// strands entries systematically — an activation fired just as the user
+    /// switches desktops never echoes (the compositor refuses or redirects
+    /// the focus) — and every stranded entry eats the FIRST real click on
+    /// its window for the whole expiry window (the 3.4.2→3.4.3 regression:
+    /// clicking a parked window in the taskbar appeared to do nothing, and
+    /// only the second click worked). One second still dwarfs a D-Bus round
+    /// trip under load while sitting below any deliberate re-click.
     QHash<QString, qint64> m_pendingSelfActivationQueuedAt;
     QElapsedTimer m_selfActivationClock;
-    static constexpr qint64 kSelfActivationEchoExpiryMs = 10000;
+    static constexpr qint64 kSelfActivationEchoExpiryMs = 1000;
     /// The one arrival whose focus an `openFocused = false` rule declined, held
     /// until its compositor focus report arrives and is consumed exactly once.
     ///

--- a/libs/phosphor-scroll-engine/src/scrollengine/engine_lifecycle.cpp
+++ b/libs/phosphor-scroll-engine/src/scrollengine/engine_lifecycle.cpp
@@ -1078,6 +1078,10 @@ void ScrollEngine::windowFocused(const QString& rawWindowId, const QString& scre
                                                                        : m_pendingSelfActivationQueuedAt.erase(stampIt);
         }
         if (!expired) {
+            // The swallow is silent to every other observer; without this
+            // line a report eaten here is indistinguishable in the journal
+            // from one that never arrived.
+            qCDebug(lcScrollEngine) << "windowFocused: swallowed self-activation echo for" << windowId;
             return;
         }
         // Fall through: adopt as genuine focus.
@@ -1164,9 +1168,26 @@ void ScrollEngine::windowFocused(const QString& rawWindowId, const QString& scre
     // The report must NAME the active window: a minimized tile in the active
     // column is refused by focusWindow without becoming the column's active
     // tile, and that report has no claim on the view.
-    const bool handBackView =
-        state->strip().viewDetached() && state->strip().activeWindowId() == windowId && !dragPreviewSteersView;
-    if (!focusMoved && !handBackView) {
+    const bool activeReport = state->strip().activeWindowId() == windowId && !dragPreviewSteersView;
+    const bool handBackView = state->strip().viewDetached() && activeReport;
+    // ATTACHED-view twin of the hand-back: the report names the active window,
+    // focusWindow refused it (same column), and there is no detach latch to
+    // clear — but the active column sits entirely OFF the viewport, so the
+    // user just activated a window they cannot see. That state is reachable
+    // without any pan: a desktop return renders from the stored per-context
+    // anchor, and when that anchor and the active column disagree the column
+    // renders parked off-screen while the view stays attached. Dropping the
+    // report here left every click on the parked window dead (the tester's
+    // "missing from the strip" windows). Let it through: applyLayout's own
+    // updateViewForFocus re-anchors an attached view whose active column is
+    // off-screen, under every anchor policy. Viewport INTERSECTION on
+    // purpose, not full visibility — a partially visible column stays put, so
+    // KWin's incidental re-activations (restacking, fullscreen exit, desktop
+    // switch) still cannot nudge a view the user can see their window in.
+    const int activeIdx = state->strip().activeColumnIndex();
+    const bool activeOffViewport = activeReport && !state->strip().viewDetached() && activeIdx >= 0
+        && !state->strip().visibleColumnIndices(params).contains(activeIdx);
+    if (!focusMoved && !handBackView && !activeOffViewport) {
         return;
     }
     if (handBackView) {


### PR DESCRIPTION
## Summary
Fixes the 3.4.3 regression where, with multiple virtual desktops in scrolling mode, windows on a freshly toggled or switched-away desktop went missing from the strip and the first taskbar click on them did nothing (the second click healed). Reported as: clicking dolphin brought the PlasmaZones settings window into view instead, with dolphin and systemsettings invisible until clicked again.

Two independent fixes in `windowFocused`:

1. **Self-activation echo expiry: 10s → 1s** (plus a debug log at the swallow point, which was journal-invisible). Multi-desktop use strands pending self-activation entries systematically: an activation fired just before a desktop switch never echoes back. Since 995f135ea removed the reclaim-on-genuine-focus, the expiry is the only unstranding path, and at 10s every stranded entry ate the first real click on its window. 1s still dwarfs a D-Bus echo round trip while sitting below any deliberate re-click.

2. **Accept a genuine report naming the active window whose column is entirely off the viewport with an attached view.** A desktop return renders from the stored per-context anchor; when that anchor and the active column disagree, the column renders parked off-screen and the same-column refusal dropped every click on it. The report now falls through to `applyLayout`, whose `updateViewForFocus` re-anchors an attached view's off-screen active column under every anchor policy. Gated on viewport intersection, not full visibility, so KWin's incidental re-activations (restacking, fullscreen exit, desktop switch) still cannot nudge a view whose window is even partially visible.

## Testing
- Full build clean (no new warnings)
- `ctest`: 411 tests pass (1 pre-existing skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01342j8pVozmw7jUrM7PS2KL