### PR TITLE
fix(kwin-effect): evict on late transient/modal as well as late keep-above

### DIFF
--- a/kwin-effect/plasmazoneseffect/window_connections.cpp
+++ b/kwin-effect/plasmazoneseffect/window_connections.cpp
@@ -76,20 +76,48 @@ void PlasmaZonesEffect::setupWindowConnections(KWin::EffectWindow* w)
         // Track the window's screen ID so we can detect cross-screen moves for snapping windows
         // (not tracked by the autotile handler's m_notifiedWindowScreens).
         m_trackedScreenPerWindow[w] = getWindowScreenId(w);
-        // Flags-settle eviction backstop: a client can set keep-above or
-        // skip-switcher AFTER mapping (Yakuake queues both in its map-time
-        // request burst; another client may flip one seconds later). Either
-        // flag flips a structural placement filter, and without these the
-        // map-time tileability verdict was permanent — the pre-settle window
-        // got inserted, focused and column-sized. The one-tick routing defer
-        // in slotWindowAdded harvests the same-burst case before any insert;
+        // Flags-settle eviction backstop: a client can set keep-above,
+        // skip-switcher or its transient parent AFTER mapping (Yakuake
+        // queues the first two in its map-time request burst; another client
+        // may flip one seconds later). Each of those flips a structural
+        // placement filter, and without these the map-time tileability
+        // verdict was permanent — the pre-settle window got inserted,
+        // focused and column-sized. The one-tick routing defer in
+        // slotWindowAdded harvests the same-burst case before any insert;
         // these catch the late case and release the window
         // (reevaluateWindowEligibility gates itself on announced windows, so
         // the connection is free for everything else).
+        //
+        // transientChanged / modalChanged are the arms the keep-above pair
+        // could not reach: on Wayland an xdg_toplevel's set_parent and
+        // set_modal arrive as their own requests after the initial commit,
+        // so a dialog can map as a parentless normal toplevel and only
+        // become transient a beat later. Both are structural rejects in
+        // shouldHandleWindow and isTileableWindow, and window TYPE has no
+        // signal of its own, so transientChanged is also the only handle on
+        // the isDialog() reject for clients whose dialog type KWin derives
+        // from the transient relationship.
+        //
+        // What this does NOT cover, so nobody re-derives it from the
+        // Yakuake bug report: a dialog whose parent toplevel is destroyed
+        // BEFORE the dialog maps. Measured live 2026-08-30 — Yakuake's
+        // dropdown closed 32 ms before its First Run dialog arrived, so
+        // transientFor() was null permanently rather than late, and the
+        // dialog presented as a plain normal toplevel (resizable,
+        // unbounded maxSize, not special, not modal) that KWin never
+        // revises. No signal fires because no state changes, so neither
+        // these arms nor a longer settle defer can catch it; an Exclude
+        // rule is the only lever.
         connect(kw, &KWin::Window::keepAboveChanged, this, [this, safeW](bool) {
             m_tilingHandler->reevaluateWindowEligibility(safeW.data());
         });
         connect(kw, &KWin::Window::skipSwitcherChanged, this, [this, safeW]() {
+            m_tilingHandler->reevaluateWindowEligibility(safeW.data());
+        });
+        connect(kw, &KWin::Window::transientChanged, this, [this, safeW]() {
+            m_tilingHandler->reevaluateWindowEligibility(safeW.data());
+        });
+        connect(kw, &KWin::Window::modalChanged, this, [this, safeW]() {
             m_tilingHandler->reevaluateWindowEligibility(safeW.data());
         });
         connect(kw, &KWin::Window::outputChanged, this, [this, safeW]() {


### PR DESCRIPTION
The flags-settle backstop added in #1009 watched `keepAboveChanged` and `skipSwitcherChanged` only. On Wayland an `xdg_toplevel`'s `set_parent` and `set_modal` arrive as their own requests after the initial commit, so a dialog can map as a parentless normal toplevel, survive the one-tick routing defer, and only become transient a beat later. Both flags are structural rejects in `shouldHandleWindow` and `isTileableWindow`, and the window type has no signal of its own, so `transientChanged` is also the only handle on the `isDialog()` reject for clients whose dialog type KWin derives from the transient relationship.

This adds `transientChanged` and `modalChanged` alongside the existing two arms. `reevaluateWindowEligibility` already gates itself on announced windows, so the connections cost nothing for everything else.

## How the settle race breaks down

Probing a live session (KWin scripting, `workspace.windowAdded` plus per-signal dumps) put the race in three tiers:

1. **Same-batch late flags.** Already prevented rather than backstopped. `windowAdded` is emitted during the Wayland request dispatch, so the `singleShot(0)` defer fires after the whole batch drains. This is the tier #1009 fixed and it works.
2. **Later-round-trip flags.** Not preventable in principle, because xdg-shell has no initial-state-complete barrier after the first commit and a flag arriving at +2 ms is indistinguishable from one a window sets legitimately minutes later. A backstop is the correct structure, and this PR is that tier.
3. **A dialog whose parent toplevel is destroyed before the dialog maps.** Out of reach of both.

## What this does not fix

Tier 3 is worth stating plainly because it is the case in the Yakuake report, and the code comment records it so nobody re-derives it. Measured 2026-08-30 with microsecond journal timestamps: Yakuake's dropdown was destroyed 32 ms before its First Run dialog mapped, so `transientFor()` was null permanently rather than late.

```
15:39:03.360  windowClosed  yakuake|e93a5b80          <- dropdown destroyed
15:39:03.392  accepted  336x286  transient=false      <- dialog maps orphaned
```

Probed axes at map time: `resizeable=true moveable=true min=336x258 max=2^31-1 special=false modal=false skipSw=false above=false`. Nothing distinguishes it from a plain toplevel and nothing ever changes, so no signal-based backstop and no length of settle defer can catch it. An Exclude rule is the only lever. A fixed-size (`minSize == maxSize`) gate was considered and refuted by the same probe.

## Testing

- Build clean, no new warnings.
- `412/412` tests pass under `dbus-run-session`.
- Tier 2 has not been live-verified in a real session. It is a race that a nested harness cannot stage honestly, and the effect `.so` does not hot-reload, so it needs an install plus logout to exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N8VNcM4ryPae39wPaYZsAU
