### PR TITLE
fix(scrolling): scroll a maximized column with one animation, not two

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - **Short scrolling columns can be centered**: a window given a height that does not fill the screen sat at the start of its column with the leftover space after it. Center short columns, under Scrolling → Window → Window handling, centers the column's windows instead. On a horizontal strip that centers them vertically, and on a vertical strip horizontally. It is off by default, so nothing moves until you turn it on, and a column that already fills the screen is left alone either way. A window rule can turn it on or off for a particular monitor, desktop or activity.
 
+### Fixed
+
+- **Scrolling past a maximized column moves it once**: a maximized column sits flush against the edges of the monitor, and it was given that flush position only while it filled the view. Scrolling away put it back inside the gaps, so the column travelled a gap further than the strip it rides on, and that leftover ran as a second animation on top of the strip's own. On a window the size of the screen it read as two animations playing at once. The column now keeps the same offset whether or not it fills the view, so it travels exactly as far as the strip does ([#1012](https://github.com/fuddlesworth/PlasmaZones/pull/1012)).
+
 ## [3.4.3] - 2026-08-29
 
 ### Added

--- a/libs/phosphor-scroll-engine/src/scrollstrip_relayout.cpp
+++ b/libs/phosphor-scroll-engine/src/scrollstrip_relayout.cpp
@@ -774,17 +774,27 @@ ResolvedStrip ScrollStrip::relayout(const ScrollLayoutParams& params) const
         // Maximize-to-edges: the column resolves against the RAW work area on
         // both axes with the inner gap suppressed inside it. Its strip-space
         // position stays cursor-derived like every other column (the strip
-        // still scrolls it), but once its span fully covers the viewport the
-        // emitted rect snaps to the raw area exactly — cursor math is
+        // still scrolls it), shifted low by the outer gap so that a column
+        // sitting at the anchor lands on the raw area exactly — cursor math is
         // workArea-based, and any anchor policy (pin, center, overflow) then
         // differs from the raw rect only by outer-gap slivers that would
         // otherwise peek through at the screen edges.
+        //
+        // The shift is UNCONDITIONAL, not gated on the column covering the
+        // viewport. A gate makes the emitted position jump by the outer gap at
+        // the moment the column stops covering, and that jump is invisible to
+        // the view coordinate the batch's viewDelta is differenced from. The
+        // effect then sees a window whose committed move is a gap MORE than
+        // the view slide it was told about, and runs a second per-window
+        // spring for the remainder — a full-screen-sized window scrolling with
+        // two overlapping animations on it, which is what the gate actually
+        // looked like in practice. Shifting every frame by the same constant
+        // keeps the column's motion equal to the view's, so the residual leg
+        // stays degenerate and one spring carries the strip.
         const bool toEdges = col.maximizedToEdges;
         const QRect colArea = toEdges ? rawAreaFor(params) : area;
         const int colGap = toEdges ? 0 : gap;
-        const bool coversViewport =
-            toEdges && mainCursor <= axis.mainLow(area) && mainCursor + colW >= axis.mainLow(area) + mainExtent(params);
-        const int mainStart = coversViewport ? axis.mainLow(colArea) : mainCursor;
+        const int mainStart = mainCursor - (axis.mainLow(area) - axis.mainLow(colArea));
         // Published so a consumer can tell "the user asked for this extent"
         // from "this column cannot be any narrower" — columnExtentPx takes the
         // max of the two and the answer is indistinguishable afterwards. A

--- a/libs/phosphor-scroll-engine/tests/test_scrollstrip_sizing.cpp
+++ b/libs/phosphor-scroll-engine/tests/test_scrollstrip_sizing.cpp
@@ -72,6 +72,7 @@ private Q_SLOTS:
     void maximizeToggleEntersOnRenderedWidthNotIntentKind();
     void maximizeUnmaximizeSkipsAStaleFullWidthRestoreSlot();
     void maximizeToEdgesResolvesTheRawAreaGapFree();
+    void scrollingPastAMaximizedColumnMovesItByExactlyTheViewDelta();
     void maximizeToEdgesRestoreIsJustTheStoredIntentAgain();
     void widthAndHeightVerbsClearMaximizeToEdges();
     void equalizeClearsTheActiveColumnsMaximizeToEdges();
@@ -806,8 +807,65 @@ void TestScrollStripSizing::maximizeToEdgesResolvesTheRawAreaGapFree()
     // Gap-free stack: the two cross extents partition the raw cross exactly.
     QCOMPARE(Ax::crossLen(a) + Ax::crossLen(b), Ax::crossLen(params.rawWorkArea));
     // And the union is the raw rect itself, corners included — the emitted
-    // rect snaps to the raw area whenever the column covers the viewport.
+    // rect is shifted low by the outer gap, so a column at the anchor lands on
+    // the raw area exactly.
     QCOMPARE(a.united(b), params.rawWorkArea);
+}
+
+// The maximize-to-edges rect is shifted low by the outer gap on EVERY frame,
+// not only while the column covers the viewport. The batch's viewDelta is
+// differenced from the view coordinate alone, so a shift that appears and
+// disappears with coverage is motion the effect is never told about: it
+// differences the window's live rect against viewDelta, finds an outer gap of
+// residual, and runs a second per-window spring for it beside the one-spring-
+// per-output view slide. On a column the size of the screen that shows up as
+// two animations playing at once. The invariant that forbids it is here: a
+// maximized column's main position moves by exactly the view's own travel.
+void TestScrollStripSizing::scrollingPastAMaximizedColumnMovesItByExactlyTheViewDelta()
+{
+    ScrollLayoutParams params = defaultParams();
+    params.rawWorkArea = params.workArea;
+    params.workArea = params.workArea.adjusted(20, 20, -20, -20);
+
+    // Four columns so the strip is longer than the viewport and a focus
+    // change actually moves the view — with a strip that fits, the anchor
+    // policy re-centres and the view offset never leaves zero, which would
+    // make the comparison below vacuous.
+    ScrollStrip strip;
+    QVERIFY(strip.insertWindow(QStringLiteral("a"), kHalf, ColumnDisplay::Normal, params));
+    QVERIFY(strip.insertWindow(QStringLiteral("b"), kHalf, ColumnDisplay::Normal, params));
+    QVERIFY(strip.insertWindow(QStringLiteral("c"), kHalf, ColumnDisplay::Normal, params));
+    QVERIFY(strip.insertWindow(QStringLiteral("d"), kHalf, ColumnDisplay::Normal, params));
+    // "d" is the active column: maximize it, then focus its neighbour so the
+    // maximized column leaves the viewport it was covering.
+    QVERIFY(strip.toggleMaximizeToEdgesActiveColumn(params));
+    // Re-anchor onto the now-maximized column so it starts out COVERING the
+    // viewport. That is the state the old gate treated specially, and a
+    // fixture that never enters it cannot tell the two behaviours apart.
+    QVERIFY(strip.focusAdjacentColumn(-1, params));
+    QVERIFY(strip.focusAdjacentColumn(1, params));
+
+    const ResolvedStrip covering = strip.relayout(params);
+    QCOMPARE(Ax::mainPos(rectOf(covering, QStringLiteral("d"))), Ax::mainPos(params.rawWorkArea));
+    // Premise: the flag really took, so the column below is the wide one and
+    // not an ordinary column that would ride the view either way.
+    QCOMPARE(Ax::mainLen(rectOf(covering, QStringLiteral("d"))), Ax::mainLen(params.rawWorkArea));
+
+    // Move the view itself rather than leaning on the anchor policy: what is
+    // under test is that the maximized column tracks the view exactly, and a
+    // direct scroll states the travel without the fixture having to be shaped
+    // so a focus change happens to produce one.
+    QVERIFY(strip.scrollViewBy(-300, params));
+    const ResolvedStrip scrolled = strip.relayout(params);
+
+    const int viewTravel = covering.viewOffset - scrolled.viewOffset;
+    QVERIFY2(viewTravel != 0, "the fixture must actually scroll the view");
+    QCOMPARE(Ax::mainPos(rectOf(scrolled, QStringLiteral("d"))) - Ax::mainPos(rectOf(covering, QStringLiteral("d"))),
+             viewTravel);
+    // The un-maximized neighbour is the control: it rides the same view, and
+    // the maximized column must not be special.
+    QCOMPARE(Ax::mainPos(rectOf(scrolled, QStringLiteral("c"))) - Ax::mainPos(rectOf(covering, QStringLiteral("c"))),
+             viewTravel);
 }
 
 // Un-maximizing is "stop overriding": the stored width intent was never


### PR DESCRIPTION
## The bug

Scrolling the strip while a column is maximized ran two overlapping animations on the maximized window. From a live journal, scrolling off a maximized column:

```
scroll entry: ghastty ... viewDelta= -1916 ... live= (0,46 3840x2068) predicted= (1924,46 3840x2068)
Started animation from QRectF(1916,46 3840x2068) to QRectF(1924,46 3840x2068)
```

The view slid 1916 while the window's committed rect moved 1924. Every other column has a zero residual and rides the one-spring-per-output view slide rigidly, so the maximized column was the only window carrying a second per-window spring on its own curve. At the size of the screen that is what it looked like.

## Root cause

In `scrollstrip_relayout.cpp`, a maximized-to-edges column's emitted main position snapped to the raw (pre outer gap) work area **only while the column covered the viewport**, and fell back to the gapped cursor position otherwise:

```cpp
const bool coversViewport = toEdges && mainCursor <= axis.mainLow(area) && ...;
const int mainStart = coversViewport ? axis.mainLow(colArea) : mainCursor;
```

That conditional is a jump of exactly one outer gap, and it is invisible to `viewOffset`, which is what the batch's `viewDelta` is differenced from in `engine_apply.cpp`. The effect builds a carried window's animation origin as `live - viewDelta`, so the gap came back as residual and got its own spring.

## The fix

Shift by the same constant on every frame instead of gating on coverage:

```cpp
const int mainStart = mainCursor - (axis.mainLow(area) - axis.mainLow(colArea));
```

For an unmaximized column `colArea == area` and the term is zero, so nothing else changes. A maximized column sitting at the anchor still lands on the raw area exactly, leaving the edge-to-edge look untouched, and one scrolled away now moves by precisely `viewDelta`, leaving the per-window leg degenerate.

One behavioural trade: a scrolled-away maximized column abuts its neighbour with no inner gap instead of one. That is the same gap it already gives up while covering.

## Testing

- New slot `scrollingPastAMaximizedColumnMovesItByExactlyTheViewDelta` in `test_scrollstrip_sizing.cpp`, run on both strip axes. It anchors onto the maximized column so it starts out covering, scrolls the view, and pins that the column's travel equals the view's, with an unmaximized neighbour as the control.
- Mutation-checked: restoring the old gate fails the new slot with `320 != 300`, the fixture's 20px outer gap surfacing as the same residual the live logs show at 8px.
- Full suite green, 412/412.
- Verified live by the maintainer. Daemon-only change, no logout needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TxNpMb2NJzrDRvLm8pXroo