### PR TITLE
fix(config): guard Steam's fixed-size launch dialog in the premade rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Steam's game-launch dialog is kept out of placement**: the built-in Steam rule guarded Steam's notification toasts and nothing else, so the small dialog Steam opens while a game starts was placed into a zone or a column as though it were an ordinary window. Nothing about that dialog tells it apart from the main Steam window except that it cannot be resized, so the rule now covers any Steam window with a fixed size. Steam's ordinary windows still place normally and so does every game launched from Steam, including the many that run at a fixed size themselves. A config carrying the previous version of the rule untouched is brought up to date on the next start, and a copy you edited is left as you left it.
+
 - **Scrolling past a maximized column moves it once**: a maximized column sits flush against the edges of the monitor, and it was given that flush position only while it filled the view. Scrolling away put it back inside the gaps, so the column travelled a gap further than the strip it rides on, and that leftover ran as a second animation on top of the strip's own. On a window the size of the screen it read as two animations playing at once. The column now keeps the same offset whether or not it fills the view, so it travels exactly as far as the strip does ([#1012](https://github.com/fuddlesworth/PlasmaZones/pull/1012)).
 
 ## [3.4.3] - 2026-08-29

--- a/src/config/configmigration.h
+++ b/src/config/configmigration.h
@@ -283,21 +283,24 @@ public:
     /// @return true on success or a clean no-op; false on an I/O failure.
     static bool pruneRetiredProviderDefaultRule(const QString& jsonPath);
 
-    /// Narrow the premade Steam rule in an already-converted rules.json to the
-    /// shape `appendSteamDefaultRule` seeds today.
+    /// Bring the premade Steam rule in an already-converted rules.json up to
+    /// the shape `appendSteamDefaultRule` seeds today.
     ///
-    /// The rule shipped matching `WindowClass Contains "steam"`, which is
-    /// compared against KWin's `"resourceName resourceClass"` pair — so a
-    /// Steam-launched game ("steam_app_2342813033 steam_app_2342813033")
-    /// matched, and the blanket `Exclude` action left every game unmanaged and
-    /// undecorated. Runs from the same cleanup path as
+    /// Two earlier generations are reclaimed. The rule first shipped matching
+    /// `WindowClass Contains "steam"`, which is compared against KWin's
+    /// `"resourceName resourceClass"` pair — so a Steam-launched game
+    /// ("steam_app_2342813033 steam_app_2342813033") matched, and the blanket
+    /// `Exclude` action left every game unmanaged and undecorated. The
+    /// narrowing that replaced it guarded Steam's notification toasts only,
+    /// which left its fixed-size game-launch dialog placing as though it were
+    /// an ordinary window. Runs from the same cleanup path as
     /// `pruneRetiredProviderDefaultRule` because the seeder itself only runs on
     /// the rebuild path, so an already-converted config would never otherwise
     /// see the correction.
     ///
-    /// Only rewrites a rule whose match and action are both still the retired
-    /// shape verbatim (see `isRetiredSteamRuleShape`); a rule with either half
-    /// edited is left untouched, as is an already-corrected or deleted one. A
+    /// Only rewrites a rule whose match and action are both still one of those
+    /// generations verbatim (see `isRetiredSteamRuleShape`); a rule with either
+    /// half edited is left untouched, as is an already-current or deleted one. A
     /// rule that was only RENAMED is still repaired, and its name is re-stamped
     /// along with the match and action. The enabled flag and priority are
     /// carried across. Idempotent: after the rewrite the shape check no longer

--- a/src/config/configmigration_v4finalize.cpp
+++ b/src/config/configmigration_v4finalize.cpp
@@ -1054,12 +1054,16 @@ bool ConfigMigration::repairSeededSteamRule(const QString& jsonPath)
     // against KWin's `"resourceName resourceClass"` pair, and a Steam-launched
     // game reports its own app id in both halves ("steam_app_2342813033
     // steam_app_2342813033"), so every game matched — and the blanket
-    // `Exclude` action then stripped it from placement AND decorations. See
-    // `applySteamDefaultRuleShape` for the corrected shape.
+    // `Exclude` action then stripped it from placement AND decorations. The
+    // narrowing that replaced it then went one step too far the other way: it
+    // named the toasts and nothing else, so Steam's fixed-size game-launch
+    // dialog placed as though it were an ordinary window. See
+    // `applySteamDefaultRuleShape` for the current shape and
+    // `isRetiredSteamRuleShape` for both reclaimed generations.
     //
     // Rewritten in place rather than dropped and re-seeded: the seeder only
     // runs on the rebuild path, so a config that is already converted would
-    // otherwise keep the broken rule forever. Idempotent — once repaired,
+    // otherwise keep the stale rule forever. Idempotent — once repaired,
     // `isRetiredSteamRuleShape` stops recognising it and the re-run is a
     // no-op.
     bool failed = false;

--- a/src/config/configmigration_v4rules.cpp
+++ b/src/config/configmigration_v4rules.cpp
@@ -436,12 +436,34 @@ QUuid steamDefaultRuleId()
 /// caption exists and stay pinned that way for the window's life. The class is
 /// stamped at first resolve, so the class arm has no such window.
 ///
-/// Both halves are POSITIVE WindowClass/Title predicates, and WindowClass sits
-/// in the daemon's `unanswerableWindowFields()`, so this rule only ever bites
-/// on the EFFECT path, where window_query.cpp stamps both fields. That was
-/// equally true of the retired shape, whose class leaf was positive too, so it
-/// is not a change — but it is where to look when checking the rule against a
-/// live session.
+/// The Any group carries a third arm, `IsResizable Equals false`, and it is
+/// there for a window the toast arms cannot name. Steam draws its game-launch
+/// dialog as another `steamwebhelper steam` top-level, property-for-property
+/// identical to the main client window apart from its caption — no role, no
+/// distinguishing class, Normal window type, same pid (the whole CEF family
+/// shares one process). The one thing that does separate it is
+/// `WM_NORMAL_HINTS` with min == max, which KWin surfaces as
+/// `EffectWindow::isResizable() == false` and window_query.cpp stamps into the
+/// query. Keying on the caption instead would mean matching a localised,
+/// per-game string, which is not a contract worth depending on.
+///
+/// The arm is deliberately broader than that one dialog: it takes ANY
+/// fixed-size Steam window out of placement, which also covers the small
+/// confirmation popups and mini friends-list windows. That is the right
+/// default for a window the user cannot resize anyway — there is nothing for a
+/// zone or a tile to do with it. It stays inside the Any, so it never widens
+/// the rule past Steam itself, and it stays scoped to `ExcludePlacement`, so a
+/// fixed-size Steam window keeps its decorations and animations.
+///
+/// Every arm is a POSITIVE predicate, and WindowClass sits in the daemon's
+/// `unanswerableWindowFields()`, so this rule only ever bites on the EFFECT
+/// path, where window_query.cpp stamps all three fields. That was equally true
+/// of the retired shape, whose class leaf was positive too, so it is not a
+/// change — but it is where to look when checking the rule against a live
+/// session. IsResizable is NOT in `unanswerableWindowFields()` and does not
+/// need to be: it is Window-sourced and left disengaged daemon-side, and an
+/// unresolved field fails a positive leaf, so the arm is simply inert there
+/// rather than wrong.
 ///
 /// The action is `ExcludePlacement`, not the blanket `Exclude`: a toast has no
 /// business being placed, but stripping its decorations too, and cancelling its
@@ -449,20 +471,21 @@ QUuid steamDefaultRuleId()
 /// this rule was written; the scoped one landed later.
 ///
 /// Everything else Steam opens — the library window, Friends List, chat, Big
-/// Picture, Settings — is an ordinary resizable window that places like any
-/// other. The rule used to exclude all of them via a `Title Equals "Steam"`
-/// negative guard (the Hyprland `title:^(?!Steam$).*` idiom), which decided on
-/// the user's behalf that no Steam window except the library was worth tiling.
+/// Picture, Settings — is an ordinary RESIZABLE window that places like any
+/// other, and the fixed-size arm above is what keeps that true. The rule used
+/// to exclude all of them via a `Title Equals "Steam"` negative guard (the
+/// Hyprland `title:^(?!Steam$).*` idiom), which decided on the user's behalf
+/// that no Steam window except the library was worth tiling.
 void applySteamDefaultRuleShape(PhosphorRules::Rule& rule)
 {
     using namespace PhosphorRules;
-    rule.name = QStringLiteral("Steam notifications");
+    rule.name = QStringLiteral("Steam notifications and dialogs");
     rule.match = MatchExpression::makeAll(
         {MatchExpression::makeLeaf(Field::WindowClass, Operator::EndsWith, QStringLiteral("steam")),
          MatchExpression::makeAny(
              {MatchExpression::makeLeaf(Field::Title, Operator::Contains, QStringLiteral("notificationtoasts")),
-              MatchExpression::makeLeaf(Field::WindowClass, Operator::Contains,
-                                        QStringLiteral("notificationtoasts"))})});
+              MatchExpression::makeLeaf(Field::WindowClass, Operator::Contains, QStringLiteral("notificationtoasts")),
+              MatchExpression::makeLeaf(Field::IsResizable, Operator::Equals, false)})});
     rule.actions.clear();
     RuleAction action;
     action.type = QString(ActionType::ExcludePlacement);
@@ -472,20 +495,52 @@ void applySteamDefaultRuleShape(PhosphorRules::Rule& rule)
 bool isRetiredSteamRuleShape(const PhosphorRules::Rule& rule)
 {
     using namespace PhosphorRules;
-    // The exact shape seeded between the rule's introduction and this repair:
-    // All{ WindowClass Contains "steam", None{ Title Equals "Steam" } } with a
-    // single blanket Exclude action. Compared structurally rather than by a
-    // stored version stamp, so a user who edited either half keeps their
-    // edit — the repair only reclaims rules that are still verbatim ours.
-    if (rule.actions.size() != 1 || rule.actions.first().type != ActionType::Exclude) {
+    // Every shape this code has ever seeded EXCEPT the current one. Compared
+    // structurally rather than by a stored version stamp, so a user who edited
+    // either half keeps their edit — the repair only reclaims rules that are
+    // still verbatim ours.
+    //
+    // A generation is (match, action) as a PAIR, never either alone. Keeping
+    // them paired is what lets `testSteamRuleRepairLeavesAnActionOnlyEditAlone`
+    // stay meaningful: a user who kept a stock match but swapped the action has
+    // edited the rule, and matching on the match alone would silently reclaim
+    // it.
+    if (rule.actions.size() != 1) {
         return false;
     }
-    Rule retired;
-    retired.match = MatchExpression::makeAll(
-        {MatchExpression::makeLeaf(Field::WindowClass, Operator::Contains, QStringLiteral("steam")),
-         MatchExpression::makeNone(
-             {MatchExpression::makeLeaf(Field::Title, Operator::Equals, QStringLiteral("Steam"))})});
-    return rule.match.toJson() == retired.match.toJson();
+    const QString& action = rule.actions.first().type;
+
+    // Gen 1, the rule as introduced. All{ WindowClass Contains "steam",
+    // None{ Title Equals "Steam" } } with a single blanket Exclude action.
+    // Retired because `Contains "steam"` swept up every Steam-launched game.
+    if (action == ActionType::Exclude) {
+        Rule gen1;
+        gen1.match = MatchExpression::makeAll(
+            {MatchExpression::makeLeaf(Field::WindowClass, Operator::Contains, QStringLiteral("steam")),
+             MatchExpression::makeNone(
+                 {MatchExpression::makeLeaf(Field::Title, Operator::Equals, QStringLiteral("Steam"))})});
+        return rule.match.toJson() == gen1.match.toJson();
+    }
+
+    // Gen 2, the toasts-only narrowing. Correct as far as it went, but it had
+    // no arm for Steam's fixed-size game-launch dialog, which carries neither
+    // the toast token nor any other distinguishing property (see
+    // applySteamDefaultRuleShape). Reclaimed so a config converted between the
+    // narrowing and the fixed-size arm picks the arm up — the seeder only runs
+    // on the rebuild path and would never otherwise reach an already-converted
+    // config.
+    if (action == ActionType::ExcludePlacement) {
+        Rule gen2;
+        gen2.match = MatchExpression::makeAll(
+            {MatchExpression::makeLeaf(Field::WindowClass, Operator::EndsWith, QStringLiteral("steam")),
+             MatchExpression::makeAny(
+                 {MatchExpression::makeLeaf(Field::Title, Operator::Contains, QStringLiteral("notificationtoasts")),
+                  MatchExpression::makeLeaf(Field::WindowClass, Operator::Contains,
+                                            QStringLiteral("notificationtoasts"))})});
+        return rule.match.toJson() == gen2.match.toJson();
+    }
+
+    return false;
 }
 
 /// Seed the premade Steam Rule into a freshly-built v4 rule set. See

--- a/tests/unit/config/migrations/test_migration_v3_to_v4_steam.cpp
+++ b/tests/unit/config/migrations/test_migration_v3_to_v4_steam.cpp
@@ -87,7 +87,7 @@ private Q_SLOTS:
         QJsonObject steam;
         for (const QJsonValue& v : rules) {
             const QJsonObject r = v.toObject();
-            if (r.value(QStringLiteral("name")).toString() == QLatin1String("Steam notifications")) {
+            if (r.value(QStringLiteral("name")).toString() == QLatin1String("Steam notifications and dialogs")) {
                 steam = r;
             }
         }
@@ -115,7 +115,8 @@ private Q_SLOTS:
         // Match shape:
         //   All{ WindowClass endsWith "steam",
         //        Any{ Title contains "notificationtoasts",
-        //             WindowClass contains "notificationtoasts" } }
+        //             WindowClass contains "notificationtoasts",
+        //             IsResizable equals false } }
         const QJsonObject match = steam.value(QStringLiteral("match")).toObject();
         QVERIFY(match.contains(QStringLiteral("all")));
         const QJsonArray all = match.value(QStringLiteral("all")).toArray();
@@ -129,30 +130,46 @@ private Q_SLOTS:
         QCOMPARE(matchLeafValueByOp(steam, QStringLiteral("windowClass"), QStringLiteral("endsWith")),
                  QStringLiteral("steam"));
 
-        // The toast-name half is an Any{} over the same token on two fields,
-        // because which field carries `notificationtoasts_<N>_desktop` is not
-        // established (classically the WM_CLASS resourceName half; the retired
-        // rule was written as though it were the caption). Pin both arms so a
-        // future edit cannot quietly drop the one that turns out to be load-
-        // bearing.
+        // The guarded half is an Any{} with three arms. Two carry the same
+        // toast token on different fields, because which field carries
+        // `notificationtoasts_<N>_desktop` is not established (classically the
+        // WM_CLASS resourceName half; the retired rule was written as though it
+        // were the caption). The third is the fixed-size arm, which is the only
+        // thing that names Steam's game-launch dialog — that window is
+        // property-for-property identical to the main client apart from its
+        // caption. Pin all three so a future edit cannot quietly drop the one
+        // that turns out to be load-bearing.
         QJsonObject anyGroup;
         for (const QJsonValue& v : all) {
             if (v.toObject().contains(QStringLiteral("any"))) {
                 anyGroup = v.toObject();
             }
         }
-        QVERIFY2(!anyGroup.isEmpty(), "the toast-name half must be an Any{} over title and class");
+        QVERIFY2(!anyGroup.isEmpty(), "the guarded half must be an Any{} group");
         const QJsonArray anyChildren = anyGroup.value(QStringLiteral("any")).toArray();
-        QCOMPARE(anyChildren.size(), 2);
-        QStringList anyFields;
+        QCOMPARE(anyChildren.size(), 3);
+        QStringList toastFields;
+        int fixedSizeArms = 0;
         for (const QJsonValue& v : anyChildren) {
             const QJsonObject leaf = v.toObject();
+            if (leaf.value(QStringLiteral("field")).toString() == QLatin1String("isResizable")) {
+                // Equals, and equals FALSE. `Equals true` would guard every
+                // ordinary Steam window and unmanage the whole client, which
+                // is the exact failure the retired shape had.
+                QCOMPARE(leaf.value(QStringLiteral("op")).toString(), QStringLiteral("equals"));
+                QCOMPARE(leaf.value(QStringLiteral("value")).toBool(), false);
+                QVERIFY2(leaf.value(QStringLiteral("value")).isBool(),
+                         "the fixed-size arm must serialise as a JSON bool, not a string");
+                ++fixedSizeArms;
+                continue;
+            }
             QCOMPARE(leaf.value(QStringLiteral("op")).toString(), QStringLiteral("contains"));
             QCOMPARE(leaf.value(QStringLiteral("value")).toString(), QStringLiteral("notificationtoasts"));
-            anyFields.append(leaf.value(QStringLiteral("field")).toString());
+            toastFields.append(leaf.value(QStringLiteral("field")).toString());
         }
-        anyFields.sort();
-        QCOMPARE(anyFields, (QStringList{QStringLiteral("title"), QStringLiteral("windowClass")}));
+        QCOMPARE(fixedSizeArms, 1);
+        toastFields.sort();
+        QCOMPARE(toastFields, (QStringList{QStringLiteral("title"), QStringLiteral("windowClass")}));
 
         // No None{} guard any more: the rule names the windows it guards
         // rather than excluding everything that is not the library window.
@@ -221,6 +238,47 @@ private Q_SLOTS:
         // Steam's other ordinary windows place like anything else.
         QVERIFY2(!matches(QStringLiteral("steamwebhelper steam"), QStringLiteral("Friends List")),
                  "the Friends List must place normally");
+
+        // ── The fixed-size arm ────────────────────────────────────────────
+        // Steam's game-launch dialog. Same class and same pid as the main
+        // client, Normal window type, no window role — the ONLY property that
+        // separates it is WM_NORMAL_HINTS min == max, which KWin reports as
+        // isResizable() == false. Probed from a live session as a 476x430
+        // fixed-size "steamwebhelper steam" top-level.
+        const auto matchesSized = [&match](const QString& windowClass, const QString& title, bool resizable) {
+            PhosphorRules::WindowQuery q;
+            q.windowClass = windowClass;
+            q.title = title;
+            q.isResizable = resizable;
+            return match.evaluate(q);
+        };
+
+        QVERIFY2(matchesSized(QStringLiteral("steamwebhelper steam"), QStringLiteral("Tokyo Xtreme Racer"), false),
+                 "Steam's fixed-size launch dialog must be kept out of placement");
+
+        // The same window when resizable is the ordinary library window, and
+        // it must place. This is the row that falsifies the arm's POLARITY:
+        // flip the leaf to `Equals true` and the whole Steam client goes
+        // unmanaged, which is the retired shape's bug wearing a new field.
+        QVERIFY2(!matchesSized(QStringLiteral("steamwebhelper steam"), QStringLiteral("Steam"), true),
+                 "an ordinary resizable Steam window must place normally");
+
+        // The row that keeps the arm from becoming the retired bug again. A
+        // GAME is very often fixed-size (windowed mode at a locked
+        // resolution), so the fixed-size arm on its own would unmanage it. The
+        // outer `WindowClass EndsWith "steam"` guard is what holds here, and
+        // dropping it turns this green test red.
+        QVERIFY2(!matchesSized(QStringLiteral("steam_app_2634950 steam_app_2634950"),
+                               QStringLiteral("TokyoXtremeRacer  "), false),
+                 "a fixed-size Steam-LAUNCHED GAME must still place normally");
+
+        // A disengaged isResizable (the daemon path, which never stamps the
+        // field) leaves the arm inert rather than matching. `matches` above
+        // already leaves it unset, so this pins the contract explicitly.
+        PhosphorRules::WindowQuery unstamped;
+        unstamped.windowClass = QStringLiteral("steamwebhelper steam");
+        unstamped.title = QStringLiteral("Steam");
+        QVERIFY2(!match.evaluate(unstamped), "an unstamped isResizable must fail the positive leaf, not match it");
 
         // The toast token on the CLASS side is guarded too. Which field
         // carries `notificationtoasts_<N>_desktop` is not established, so the
@@ -298,7 +356,7 @@ private Q_SLOTS:
         // rule in the Advanced band where a real pre-narrowing config has it.
         QCOMPARE(repairedRule->priority, 517);
         // The name is re-stamped, so the row says what it now guards.
-        QCOMPARE(repairedRule->name, QStringLiteral("Steam notifications"));
+        QCOMPARE(repairedRule->name, QStringLiteral("Steam notifications and dialogs"));
 
         const PhosphorRules::MatchExpression& match =
             PhosphorRules::ExclusionRules::excludePlacementRulesFrom(*repairedSet).rules().first().match;
@@ -331,6 +389,97 @@ private Q_SLOTS:
         const QByteArray afterSecondRun = again.readAll();
         again.close();
         QCOMPARE(afterSecondRun, afterRepair);
+    }
+
+    /// The SECOND reclaimed generation. A config converted after the
+    /// `Contains "steam"` narrowing but before the fixed-size arm carries the
+    /// toasts-only shape, which `isRetiredSteamRuleShape` must also recognise
+    /// — otherwise every existing 3.4.x user keeps a rule that lets Steam's
+    /// game-launch dialog place as though it were an ordinary window, forever,
+    /// because the seeder only ever runs on the rebuild path.
+    void testSteamRuleToastsOnlyShapeIsUpgradedToTheFixedSizeArm()
+    {
+        IsolatedConfigGuard guard;
+        QVERIFY(convertBareV3Config());
+
+        const QString rulesPath = ConfigDefaults::rulesFilePath();
+        auto setOpt = PhosphorRules::RuleSet::loadFromFile(rulesPath);
+        QVERIFY(setOpt.has_value());
+        PhosphorRules::RuleSet stale = *setOpt;
+        const auto seeded = seededSteamRule(stale);
+        QVERIFY(seeded.has_value());
+        const QUuid steamId = seeded->id;
+
+        // The gen-2 shape verbatim: toasts only, no fixed-size arm, already on
+        // the scoped action. Carries the gen-2 NAME too, so the re-stamp is
+        // observable.
+        PhosphorRules::Rule gen2 = *seeded;
+        gen2.name = QStringLiteral("Steam notifications");
+        gen2.priority = 542;
+        gen2.match = PhosphorRules::MatchExpression::makeAll(
+            {PhosphorRules::MatchExpression::makeLeaf(PhosphorRules::Field::WindowClass,
+                                                      PhosphorRules::Operator::EndsWith, QStringLiteral("steam")),
+             PhosphorRules::MatchExpression::makeAny(
+                 {PhosphorRules::MatchExpression::makeLeaf(PhosphorRules::Field::Title,
+                                                           PhosphorRules::Operator::Contains,
+                                                           QStringLiteral("notificationtoasts")),
+                  PhosphorRules::MatchExpression::makeLeaf(PhosphorRules::Field::WindowClass,
+                                                           PhosphorRules::Operator::Contains,
+                                                           QStringLiteral("notificationtoasts"))})});
+        gen2.actions.clear();
+        PhosphorRules::RuleAction scoped;
+        scoped.type = QString(PhosphorRules::ActionType::ExcludePlacement);
+        gen2.actions.append(scoped);
+        QVERIFY(stale.updateRule(gen2));
+        QVERIFY(stale.saveToFile(rulesPath));
+
+        // Sanity: the fixture really is missing the arm before the repair, so
+        // the assertion below is not vacuous.
+        PhosphorRules::WindowQuery dialog;
+        dialog.windowClass = QStringLiteral("steamwebhelper steam");
+        dialog.title = QStringLiteral("Tokyo Xtreme Racer");
+        dialog.isResizable = false;
+        QVERIFY2(!gen2.match.evaluate(dialog), "the gen-2 fixture must NOT already guard the launch dialog");
+
+        ConfigMigration::resetMigrationGuardForTesting();
+        QVERIFY(ConfigMigration::ensureJsonConfig());
+
+        const auto after = PhosphorRules::RuleSet::loadFromFile(rulesPath);
+        QVERIFY(after.has_value());
+        const auto upgraded = after->ruleById(steamId);
+        QVERIFY2(upgraded.has_value(), "the upgrade must rewrite the rule in place, not re-id it");
+
+        QVERIFY2(upgraded->match.evaluate(dialog), "the upgraded rule must guard Steam's fixed-size launch dialog");
+
+        // The toast guard is not lost in the process.
+        PhosphorRules::WindowQuery toast;
+        toast.windowClass = QStringLiteral("steamwebhelper steam");
+        toast.title = QStringLiteral("notificationtoasts_20993166_desktop");
+        QVERIFY2(upgraded->match.evaluate(toast), "the upgraded rule must still guard a toast");
+
+        // A Steam-launched game is still left alone, fixed-size or not.
+        PhosphorRules::WindowQuery game;
+        game.windowClass = QStringLiteral("steam_app_2634950 steam_app_2634950");
+        game.title = QStringLiteral("TokyoXtremeRacer  ");
+        game.isResizable = false;
+        QVERIFY2(!upgraded->match.evaluate(game), "a fixed-size game must still place normally after the upgrade");
+
+        // User-owned fields ride across exactly as they do for gen 1.
+        QCOMPARE(upgraded->priority, 542);
+        QCOMPARE(upgraded->name, QStringLiteral("Steam notifications and dialogs"));
+
+        // Idempotent on the bytes, like the gen-1 repair.
+        QFile firstPass(rulesPath);
+        QVERIFY(firstPass.open(QIODevice::ReadOnly));
+        const QByteArray afterUpgrade = firstPass.readAll();
+        firstPass.close();
+
+        ConfigMigration::resetMigrationGuardForTesting();
+        QVERIFY(ConfigMigration::ensureJsonConfig());
+
+        QFile secondPass(rulesPath);
+        QVERIFY(secondPass.open(QIODevice::ReadOnly));
+        QCOMPARE(secondPass.readAll(), afterUpgrade);
     }
 
     /// The repair carries the user's enabled flag and priority across. A user


### PR DESCRIPTION
## What

The built-in Steam rule named Steam's notification toasts and nothing else, so the dialog Steam opens while a game starts was placed into a zone or a column as though it were an ordinary window.

## Why this window is hard to name

Probed against a live session. Steam's launch dialog is property-for-property identical to the main Steam client apart from its caption:

| | main Steam window | launch dialog |
|---|---|---|
| `WM_CLASS` | `"steamwebhelper", "steam"` | `"steamwebhelper", "steam"` |
| `_NET_WM_PID` | 1156825 | 1156825 (the CEF family shares one process) |
| `_NET_WM_WINDOW_TYPE` | `NORMAL` | `NORMAL` |
| `WM_WINDOW_ROLE` | absent | absent |
| `WM_NORMAL_HINTS` | min 1010x600, no max | **min == max == 476x430** |

A full `xprop` diff of the two windows comes back empty except for the name, the creation time, `XdndProxy`, and `_NET_WM_ALLOWED_ACTIONS` — and that last one is derived by KWin from the size hints, not set by Steam.

So the only thing that separates the dialog is that it cannot be resized. KWin surfaces that as `EffectWindow::isResizable() == false`, and `window_query.cpp:242` already stamps it into the rule query. Keying on the caption instead would mean depending on a localised, per-game string.

## The change

`IsResizable Equals false` becomes a third arm of the existing `Any` group:

```
All{ WindowClass EndsWith "steam",
     Any{ Title       Contains "notificationtoasts",
          WindowClass Contains "notificationtoasts",
          IsResizable Equals   false } }
→ excludePlacement
```

Inside the `Any`, so it never widens the rule past Steam itself. Still scoped to `ExcludePlacement`, so a fixed-size Steam window keeps its decorations and animations.

The arm is deliberately broader than that one dialog: it covers any fixed-size Steam window, including the small confirmation popups. That seems right for a window the user cannot resize anyway, since there is nothing for a zone or a tile to do with it.

## The part that is easy to miss

`isRetiredSteamRuleShape` now reclaims **two** superseded generations rather than one. Without that second arm the change would reach nobody: `appendSteamDefaultRule` only runs on the rebuild path, so every already-converted config — which is every existing 3.4.x install — would have kept the toasts-only shape permanently.

Each generation is compared as a `(match, action)` **pair**, never either half alone. That is what keeps `testSteamRuleRepairLeavesAnActionOnlyEditAlone` meaningful: a user who kept a stock match but swapped the action has edited the rule, and matching on the match alone would silently reclaim it.

`IsResizable` is not added to `unanswerableWindowFields()` and does not need to be. It is Window-sourced and left disengaged daemon-side, and an unresolved field fails a positive leaf, so the arm is inert there rather than wrong.

## Tests

Shape assertions updated to three arms, plus a new `testSteamRuleToastsOnlyShapeIsUpgradedToTheFixedSizeArm` covering the gen-2 upgrade path, and four behavioural rows:

- the launch dialog matches
- a resizable Steam window does not (falsifies the arm's polarity — flip it to `Equals true` and the whole client goes unmanaged, which is the retired shape's bug wearing a new field)
- an unstamped `isResizable` leaves the arm inert
- **a fixed-size Steam-launched game still places normally** — plenty of games run windowed at a locked resolution, so the fixed-size arm alone would unmanage them, and the outer `EndsWith "steam"` guard is what holds

Three mutations confirm the tests are not vacuous, each turning the suite red: deleting the gen-2 reclaim arm, flipping the leaf to `Equals true`, and weakening the class guard back to `Contains`.

Full suite: 414 tests, 100% passed.

## Not verified live

This is build-and-test evidence only. The arm depends on `isResizable()` being false at the moment the effect resolves its exclusion verdict, and that timing is unconfirmed — if Steam maps the dialog before setting `WM_NORMAL_HINTS`, the verdict could resolve first, and it is cached per window without invalidation. Worth launching a game once on this build to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PExNodgvuArvn8MS6XhWcN
