### PR TITLE
fix: tab drag-out stranding KWin's move, focus centering, and maximize-to-edges height override

### DIFF
--- a/kwin-effect/handlers/dragtracker.cpp
+++ b/kwin-effect/handlers/dragtracker.cpp
@@ -19,6 +19,13 @@ DragTracker::DragTracker(PlasmaZonesEffect* effect, QObject* parent)
 
 void DragTracker::handleWindowStartMoveResize(KWin::EffectWindow* w)
 {
+    // Stamp the compositor's own move/resize state BEFORE any tracking
+    // filter: resizes and shouldHandleWindow-rejected windows are never
+    // tracked below, but they still hold KWin's move filter, and
+    // compositorMoveResizeActive() must answer for exactly that span.
+    if (w) {
+        m_interactiveWindow = w;
+    }
     // Only track moves, not resizes
     if (!w || !w->isUserMove() || w->isUserResize()) {
         return;
@@ -44,6 +51,12 @@ void DragTracker::handleWindowStartMoveResize(KWin::EffectWindow* w)
 
 void DragTracker::handleWindowFinishMoveResize(KWin::EffectWindow* w)
 {
+    // The compositor's move is over — this signal is KWin's truth, unlike
+    // forceEnd(), which fires on LMB release while KWin can still be
+    // holding the move for other buttons.
+    if (w && w == m_interactiveWindow) {
+        m_interactiveWindow = nullptr;
+    }
     // Not our window — either already ended by forceEnd(), or was a resize we didn't track
     if (w != m_draggedWindow) {
         return;
@@ -100,6 +113,11 @@ void DragTracker::finishDrag(bool cancelled)
 
 void DragTracker::handleWindowClosed(KWin::EffectWindow* window)
 {
+    // A closed window cannot hold KWin's move filter, but its EffectWindow
+    // outlives the close (Deleted), so the QPointer would not auto-null.
+    if (window && window == m_interactiveWindow) {
+        m_interactiveWindow = nullptr;
+    }
     if (m_draggedWindow == window) {
         qCInfo(lcEffect) << "Drag: window closed, cancelled";
         // Don't call finishDrag() — it would pass the mid-destruction window pointer
@@ -120,6 +138,7 @@ void DragTracker::handleWindowClosed(KWin::EffectWindow* window)
 /// forceEnd() for that.
 void DragTracker::reset()
 {
+    m_interactiveWindow = nullptr;
     m_draggedWindow = nullptr;
     m_draggedWindowId.clear();
     m_lastCursorPos = QPointF();

--- a/kwin-effect/handlers/dragtracker.h
+++ b/kwin-effect/handlers/dragtracker.h
@@ -40,6 +40,17 @@ public:
     {
         return m_draggedWindow != nullptr;
     }
+    // The COMPOSITOR's interactive move/resize state, not this tracker's
+    // shadow of it. The two diverge on purpose: forceEnd() clears the tracked
+    // drag on LMB release while KWin keeps its move alive until ALL buttons
+    // are up, and a window shouldHandleWindow() rejected is never tracked at
+    // all yet still holds KWin's move filter. Consumers that must not steal
+    // input from KWin's move filter (the scroll tab pill interception) gate
+    // on this, not on isDragging().
+    bool compositorMoveResizeActive() const
+    {
+        return m_interactiveWindow != nullptr;
+    }
     KWin::EffectWindow* draggedWindow() const
     {
         return m_draggedWindow;
@@ -88,6 +99,11 @@ private:
 
     PlasmaZonesEffect* m_effect;
     QPointer<KWin::EffectWindow> m_draggedWindow;
+    // KWin's live interactive move/resize window, stamped from the start
+    // signal before any tracking filter and cleared only by the finish
+    // signal (or window death, via QPointer). Backs
+    // compositorMoveResizeActive().
+    QPointer<KWin::EffectWindow> m_interactiveWindow;
     QString m_draggedWindowId;
     QPointF m_lastCursorPos;
 

--- a/kwin-effect/plasmazoneseffect/drag_end.cpp
+++ b/kwin-effect/plasmazoneseffect/drag_end.cpp
@@ -167,6 +167,18 @@ void PlasmaZonesEffect::callEndDrag(KWin::EffectWindow* window, const QString& w
                     if (!safeWindow || safeWindow->isDeleted()) {
                         break;
                     }
+                    // Same rescue as ApplySnap / RestoreSize, but END rather
+                    // than cancel: a float drop keeps the window where it was
+                    // dropped, and cancelInteractiveMoveResize would revert it
+                    // to the drag-start rect. Without this, a drop where only
+                    // a non-left button is still held leaves KWin's move live,
+                    // and the window then follows every desktop switch until
+                    // the last button comes up somewhere KWin's filter can see.
+                    if (safeWindow->isUserMove() && !(m_currentMouseButtons & Qt::LeftButton)) {
+                        if (KWin::Window* kw = safeWindow->window()) {
+                            kw->endInteractiveMoveResize();
+                        }
+                    }
                     // Only run the float transition (which restores the
                     // pre-autotile size) when the window was TILED at drag
                     // start. A window that was already floating is merely being

--- a/kwin-effect/plasmazoneseffect/window_connections.cpp
+++ b/kwin-effect/plasmazoneseffect/window_connections.cpp
@@ -735,6 +735,15 @@ void PlasmaZonesEffect::setupWindowConnections(KWin::EffectWindow* w)
             notifyWindowResized(window, m_resizeStartGeometry);
         }
         m_dragTracker->handleWindowFinishMoveResize(window);
+        // Now that the COMPOSITOR's move is over (this signal, not forceEnd,
+        // is when compositorMoveResizeActive() clears), re-drive the pill
+        // hover: the dragStopped re-drive fires on LMB release and is
+        // suppressed while KWin still holds the move for other buttons, so a
+        // multi-button drop onto the pill band would otherwise stay unlit
+        // until the next pointer twitch.
+        if (m_tilingHandler && KWin::effects) {
+            m_tilingHandler->updateScrollTabHover(KWin::effects->cursorPos());
+        }
         // A maximize claim taken during the gesture was never paid: the batch
         // arms insert membership and then skip the compositor call while the
         // user is dragging, and nothing re-drives them — this lambda replays

--- a/kwin-effect/tilinghandler/scrolltabs.cpp
+++ b/kwin-effect/tilinghandler/scrolltabs.cpp
@@ -842,10 +842,18 @@ void TilingHandler::updateScrollTabHover(const QPointF& pos)
     // sequence can begin with one held) yet must NOT keep re-evaluating
     // hover, which could light new pills and re-take the interception
     // against the drag.
-    if (m_effect->m_dragTracker && m_effect->m_dragTracker->isDragging() && m_scrollTabPressHeld) {
+    // Gated on the COMPOSITOR's move state as well as the tracker's: the
+    // tracker's shadow opens early on purpose (forceEnd on LMB release while
+    // KWin holds the move for other buttons) and never opens at all for a
+    // window shouldHandleWindow rejected — in both spans KWin's move filter
+    // is live and taking the interception here would strand it (the window
+    // then follows every desktop switch, reading as stuck on all desktops).
+    const bool dragLive = m_effect->m_dragTracker
+        && (m_effect->m_dragTracker->isDragging() || m_effect->m_dragTracker->compositorMoveResizeActive());
+    if (dragLive && m_scrollTabPressHeld) {
         return;
     }
-    if (m_effect->m_dragTracker && m_effect->m_dragTracker->isDragging()) {
+    if (dragLive) {
         // Clear the PAINTER's hover too, not just the model's: a pill lit
         // when a non-pointer drag begins (a keyboard Move, a touch-initiated
         // move — a pointer drag cannot start under a lit pill, the
@@ -1074,7 +1082,16 @@ void TilingHandler::setScrollTabHoverCursor(bool overPill)
 {
     // While a pill press is held the interception stays regardless of hover
     // (see noteScrollTabPress); the release path re-evaluates.
-    const bool hold = overPill || m_scrollTabPressHeld;
+    //
+    // Defence in depth for every caller (rebuildScrollTabIndicators re-enters
+    // hover asynchronously off the daemon's tab-strip relay): never TAKE the
+    // interception while KWin's interactive move/resize is live — the
+    // interception outranks KWin's move filter, so the ending button release
+    // would land here instead and strand the move. A held pill press keeps
+    // its latch (the press/release pairing invariant; a pointer drag cannot
+    // start under one anyway).
+    const bool compositorMoveLive = m_effect->m_dragTracker && m_effect->m_dragTracker->compositorMoveResizeActive();
+    const bool hold = (overPill && !compositorMoveLive) || m_scrollTabPressHeld;
     if (!KWin::effects) {
         // No compositor to talk to (teardown): record the intent so the latch
         // does not claim an interception that was never taken.

--- a/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/ScrollEngine.h
+++ b/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/ScrollEngine.h
@@ -1341,6 +1341,18 @@ private:
     /// memory is still true; it is the inference drawn from it that does not
     /// survive the switch.
     QSet<QString> m_forceEmitScreens;
+    /// A focus report absorbed while its context was in the BACKGROUND
+    /// (windowFocused's off-current-key arm): the strip's focus and anchor
+    /// moved, but only placementChanged was emitted, so the compositor never
+    /// heard the centering. Keyed by screen, valued with the CONTEXT the
+    /// report belonged to, and promoted into m_forceEmitScreens by the first
+    /// applyLayout pass that runs with that context current — unlike the bare
+    /// force flag it cannot be spent by a pass for a different context, which
+    /// is exactly how the desktop-return centering was getting lost (the
+    /// return retile consumed the switch's arm on the old focus, or ran
+    /// before the focus report existed, and nothing forced a later emit when
+    /// every rect matched the stored baseline).
+    QHash<QString, PhosphorEngine::PlacementStateKey> m_pendingFocusEmitByScreen;
     /// Last strip epoch announced per screen, so stripContextChanged is
     /// emit-on-change rather than a re-announcement on every set push.
     ///

--- a/libs/phosphor-scroll-engine/src/scrollengine/engine_apply.cpp
+++ b/libs/phosphor-scroll-engine/src/scrollengine/engine_apply.cpp
@@ -49,6 +49,18 @@ void ScrollEngine::applyLayout(const QString& screenId, bool focusWindowAfter)
         clearTabStripsForScreen(screenId);
         return;
     }
+    // Promote a pending background-focus emit (windowFocused's off-current-key
+    // arm) now that its context is provably the one on screen. Promotion
+    // rather than a second flag at the emit gate: m_forceEmitScreens already
+    // breaks the view-delta basis at the sameBasis read below and is consumed
+    // at the gate, so folding in here inherits both behaviours. The key
+    // compare is what the bare flag lacks — a pass for a DIFFERENT context
+    // leaves the entry armed for the return that actually shows this strip.
+    if (const auto pendIt = m_pendingFocusEmitByScreen.constFind(screenId);
+        pendIt != m_pendingFocusEmitByScreen.constEnd() && *pendIt == currentKeyForScreen(screenId)) {
+        m_pendingFocusEmitByScreen.remove(screenId);
+        m_forceEmitScreens.insert(screenId);
+    }
     const ScrollLayoutParams params = layoutParamsForScreen(screenId);
     if (!params.workArea.isValid()) {
         // Screen went away or gaps swallowed it: the indicator must not

--- a/libs/phosphor-scroll-engine/src/scrollengine/engine_context.cpp
+++ b/libs/phosphor-scroll-engine/src/scrollengine/engine_context.cpp
@@ -800,6 +800,9 @@ void ScrollEngine::pruneStatesForRemovedScreen(const QString& physicalScreenId)
     for (auto it = m_forceEmitScreens.begin(); it != m_forceEmitScreens.end();) {
         it = matches(*it) ? m_forceEmitScreens.erase(it) : std::next(it);
     }
+    for (auto it = m_pendingFocusEmitByScreen.begin(); it != m_pendingFocusEmitByScreen.end();) {
+        it = matches(it.key()) ? m_pendingFocusEmitByScreen.erase(it) : std::next(it);
+    }
     m_context.removeScreensIf(matches);
     // Drop the dead output from the active set and the deferred-apply queue
     // too: until the daemon's next setActiveScreens, isActiveOnScreen would

--- a/libs/phosphor-scroll-engine/src/scrollengine/engine_core.cpp
+++ b/libs/phosphor-scroll-engine/src/scrollengine/engine_core.cpp
@@ -367,6 +367,10 @@ void ScrollEngine::setActiveScreens(const QSet<QString>& screens)
     for (const QString& screenId : removed) {
         m_announcedStripEpoch.remove(screenId);
         m_forceEmitScreens.remove(screenId);
+        // Same asymmetry fix as the force flag above: a pending focus emit
+        // for a screen leaving the set would otherwise survive to a later
+        // stint and force a batch for a report from another era.
+        m_pendingFocusEmitByScreen.remove(screenId);
     }
 
     // Sorted: QSet iteration order is unspecified across runs, and a wire

--- a/libs/phosphor-scroll-engine/src/scrollengine/engine_lifecycle.cpp
+++ b/libs/phosphor-scroll-engine/src/scrollengine/engine_lifecycle.cpp
@@ -1206,6 +1206,17 @@ void ScrollEngine::windowFocused(const QString& rawWindowId, const QString& scre
     const bool activeOffViewport = activeReport && !state->strip().viewDetached() && activeIdx >= 0
         && !state->strip().visibleColumnIndices(params).contains(activeIdx);
     if (!focusMoved && !handBackView && !activeOffViewport) {
+        // A refused report for a BACKGROUND context is not the no-op it is
+        // for the current one. All three refusal tests above measured the
+        // STORED strip state, but the compositor's own scroll view is keyed
+        // per output, not per desktop, so what it is actually showing for
+        // this strip can disagree with everything the tests trusted. Arm the
+        // pending emit anyway: the desktop return then re-asserts this
+        // strip's geometry unconditionally, which is exactly the repair a
+        // report the model could not classify still deserves.
+        if (key != currentKeyForScreen(key.screenId)) {
+            m_pendingFocusEmitByScreen.insert(key.screenId, key);
+        }
         return;
     }
     if (handBackView) {
@@ -1226,6 +1237,18 @@ void ScrollEngine::windowFocused(const QString& rawWindowId, const QString& scre
         if (!deferForCloseReflowHold(key.screenId)) {
             applyLayout(key.screenId, false);
         }
+    } else {
+        // Background context: the strip's focus and anchor moved above, but
+        // no geometry batch carries it — and the desktop return that brings
+        // this context on screen cannot be trusted to emit one on its own.
+        // Its retile's rects can all match the stored baseline (the strip is
+        // returning to where it was), and the context switch's own force arm
+        // is a screen-keyed flag any interleaved pass can spend. Record the
+        // KEY this report belongs to; applyLayout promotes it to a forced
+        // emit only when it runs with this context current, so the centering
+        // from this activation survives whatever ordering the desktop switch
+        // and the focus report arrive in.
+        m_pendingFocusEmitByScreen.insert(key.screenId, key);
     }
     // Focus and view anchor are persisted (serializeStripState), and
     // placementChanged is the only thing that marks DirtyScrollStrips.

--- a/libs/phosphor-scroll-engine/src/scrollstrip_relayout.cpp
+++ b/libs/phosphor-scroll-engine/src/scrollstrip_relayout.cpp
@@ -879,6 +879,19 @@ ResolvedStrip ScrollStrip::relayout(const ScrollLayoutParams& params) const
             int fixedTotal = 0;
             for (int vi = 0; vi < n; ++vi) {
                 const Tile& t = col.tiles.at(visible.at(vi));
+                // Maximize-to-edges wins over the tiles' height intents, the
+                // same override the tabbed branch applies to its owner's
+                // intent: the flag declares the full raw cross extent, so a
+                // Fixed/Preset tile is resolved as Auto (sharing by weight)
+                // and its stored intent survives untouched for the restore.
+                // Without this a lone Fixed/Preset tile kept its short height
+                // and the centre policy floated it mid-screen while the
+                // column's main extent — and the compositor's maximize state —
+                // said full, which is the "maximize only widens" report.
+                if (toEdges) {
+                    autoWeightTotal += qMax<qreal>(0.01, t.height.weight);
+                    continue;
+                }
                 switch (t.height.kind) {
                 case WindowHeight::Fixed:
                     heights[vi] = qBound(1, t.height.fixedPx, availH);
@@ -903,7 +916,7 @@ ResolvedStrip ScrollStrip::relayout(const ScrollLayoutParams& params) const
             // clamped to the work area in the switch above, and the
             // min-height clamp below still applies.
             if (n == 1) {
-                if (col.tiles.at(visible.at(0)).height.kind == WindowHeight::Auto) {
+                if (toEdges || col.tiles.at(visible.at(0)).height.kind == WindowHeight::Auto) {
                     heights[0] = availH;
                 }
             } else {
@@ -936,7 +949,9 @@ ResolvedStrip ScrollStrip::relayout(const ScrollLayoutParams& params) const
                 qreal weightLeft = autoWeightTotal;
                 for (int vi = 0; vi < n; ++vi) {
                     const Tile& t = col.tiles.at(visible.at(vi));
-                    if (t.height.kind != WindowHeight::Auto) {
+                    // toEdges: every tile was accumulated as Auto above, so
+                    // every tile takes its weight share here too.
+                    if (!toEdges && t.height.kind != WindowHeight::Auto) {
                         continue;
                     }
                     const qreal w = qMax<qreal>(0.01, t.height.weight);

--- a/libs/phosphor-scroll-engine/tests/test_scrollengine_stripcontext.cpp
+++ b/libs/phosphor-scroll-engine/tests/test_scrollengine_stripcontext.cpp
@@ -41,6 +41,7 @@ private Q_SLOTS:
     }
 
     void desktopSwitchBackEmitsEvenWhenNoRectMoved();
+    void backgroundFocusReportForcesTheReturnBatch();
     void identicalSetRePushWithoutASwitchStaysSuppressed();
     void stripContextIsAnnouncedOnDesktopSwitch();
     void changedSetSwitchStillAnnouncesTheStayingScreen();
@@ -98,6 +99,69 @@ void TestScrollEngineStripContext::desktopSwitchBackEmitsEvenWhenNoRectMoved()
         }
     }
     QVERIFY2(sawWindow, "the switch-back batch must name the strip's windows");
+}
+void TestScrollEngineStripContext::backgroundFocusReportForcesTheReturnBatch()
+{
+    // Activating a window that lives on another desktop (a taskbar click)
+    // can land the focus report while the engine's context for the screen
+    // still resolves the desktop being LEFT. The strip's focus and anchor
+    // move in the background state, but no geometry batch may be emitted for
+    // a context that is not on screen — so the report's centering has to
+    // ride the desktop return. The screen-keyed force flag is not a safe
+    // carrier for that (any interleaved pass can spend it); the pending
+    // focus emit is keyed to the context and is consumed only by a pass that
+    // runs with that context current.
+    QObject owner;
+    const GeometryFn geometry = [](const QString&) {
+        return defaultScreenRect();
+    };
+    ScrollEngine* engine = makeProviderEngine(&owner, {QStringLiteral("S1")}, geometry, geometry);
+    engine->setCurrentDesktopForScreen(QStringLiteral("S1"), 1);
+    engine->windowOpened(QStringLiteral("app|a"), QStringLiteral("S1"), 0, 0);
+    engine->windowOpened(QStringLiteral("app|b"), QStringLiteral("S1"), 0, 0);
+    QCoreApplication::processEvents();
+
+    // Away, with the destination populated so the return leg cannot lean on
+    // the empty-resolve bail resetting the baseline (same reasoning as the
+    // changed-set test below).
+    engine->setCurrentDesktopForScreen(QStringLiteral("S1"), 2);
+    engine->setActiveScreens({QStringLiteral("S1")});
+    engine->windowOpened(QStringLiteral("app|c"), QStringLiteral("S1"), 0, 0);
+    QCoreApplication::processEvents();
+
+    // The activation report for desktop 1's window arrives BEFORE the
+    // engine hears about the switch back — the ordering a taskbar click
+    // produces when KWin activates first and switches second. app|a is the
+    // window the strip already calls active, so the report is refused by
+    // every focus test; the pending emit is what it must still arm.
+    engine->windowFocused(QStringLiteral("app|a"), QStringLiteral("S1"));
+    QCoreApplication::processEvents();
+
+    QSignalSpy tiledSpy(engine, &ScrollEngine::windowsTiled);
+    engine->setCurrentDesktopForScreen(QStringLiteral("S1"), 1);
+    engine->setActiveScreens({QStringLiteral("S1")});
+    QCoreApplication::processEvents();
+
+    QVERIFY2(tiledSpy.count() > 0, "the return after a background focus report must emit a batch");
+    bool sawWindow = false;
+    for (const auto& emission : std::as_const(tiledSpy)) {
+        const QJsonArray batch = QJsonDocument::fromJson(emission.at(0).toString().toUtf8()).array();
+        for (const QJsonValue& v : batch) {
+            const QString id = v.toObject().value(QLatin1String("windowId")).toString();
+            if (id == QStringLiteral("app|a")) {
+                sawWindow = true;
+            }
+        }
+    }
+    QVERIFY2(sawWindow, "the return batch must re-assert the focused window's geometry");
+
+    // The pending arm must be spent by that return, not linger: an identical
+    // re-push with nothing new to say stays suppressed, exactly like the
+    // negative-control test below.
+    QSignalSpy afterSpy(engine, &ScrollEngine::windowsTiled);
+    engine->setActiveScreens({QStringLiteral("S1")});
+    QCoreApplication::processEvents();
+    QCOMPARE(afterSpy.count(), 0);
 }
 void TestScrollEngineStripContext::identicalSetRePushWithoutASwitchStaysSuppressed()
 {

--- a/libs/phosphor-scroll-engine/tests/test_scrollstrip_sizing.cpp
+++ b/libs/phosphor-scroll-engine/tests/test_scrollstrip_sizing.cpp
@@ -72,6 +72,7 @@ private Q_SLOTS:
     void maximizeToggleEntersOnRenderedWidthNotIntentKind();
     void maximizeUnmaximizeSkipsAStaleFullWidthRestoreSlot();
     void maximizeToEdgesResolvesTheRawAreaGapFree();
+    void maximizeToEdgesOverridesAnExplicitHeightIntent();
     void scrollingPastAMaximizedColumnMovesItByExactlyTheViewDelta();
     void maximizeToEdgesRestoreIsJustTheStoredIntentAgain();
     void widthAndHeightVerbsClearMaximizeToEdges();
@@ -812,6 +813,42 @@ void TestScrollStripSizing::maximizeToEdgesResolvesTheRawAreaGapFree()
     QCOMPARE(a.united(b), params.rawWorkArea);
 }
 
+// Maximize-to-edges must override an explicit Fixed/Preset height intent the
+// same way the tabbed branch overrides its owner's intent. Before the fix a
+// lone tile kept its short height while the column's main extent (and KWin's
+// maximize state) went full, and with the centre-short-columns policy on the
+// window floated mid-screen — the live "maximize only widens" report. The
+// intent itself must survive for the restore.
+void TestScrollStripSizing::maximizeToEdgesOverridesAnExplicitHeightIntent()
+{
+    ScrollLayoutParams params = defaultParams();
+    params.rawWorkArea = params.workArea;
+    params.workArea = params.workArea.adjusted(20, 20, -20, -20);
+    params.centerShortColumns = true;
+
+    ScrollStrip strip;
+    QVERIFY(strip.insertWindow(QStringLiteral("a"), kHalf, ColumnDisplay::Normal, params));
+    QVERIFY(strip.setActiveWindowHeight(WindowHeight::makeFixed(300)));
+    QVERIFY(strip.toggleMaximizeToEdgesActiveColumn(params));
+    QCOMPARE(rectOf(strip.relayout(params), QStringLiteral("a")), params.rawWorkArea);
+
+    // A two-tile stack still partitions the raw cross extent when one tile
+    // carries an explicit height. Built fresh so the insert cannot disturb
+    // the flag under test.
+    ScrollStrip stacked;
+    QVERIFY(stacked.insertWindow(QStringLiteral("a"), kHalf, ColumnDisplay::Normal, params));
+    QVERIFY(stacked.insertWindowIntoActiveColumn(QStringLiteral("b"), kHalf, ColumnDisplay::Normal, params));
+    QVERIFY(stacked.setActiveWindowHeight(WindowHeight::makeFixed(300)));
+    QVERIFY(stacked.toggleMaximizeToEdgesActiveColumn(params));
+    {
+        const ResolvedStrip resolved = stacked.relayout(params);
+        const QRect a = rectOf(resolved, QStringLiteral("a"));
+        const QRect b = rectOf(resolved, QStringLiteral("b"));
+        QCOMPARE(Ax::crossLen(a) + Ax::crossLen(b), Ax::crossLen(params.rawWorkArea));
+        QCOMPARE(a.united(b), params.rawWorkArea);
+    }
+}
+
 // The maximize-to-edges rect is shifted low by the outer gap on EVERY frame,
 // not only while the column covers the viewport. The batch's viewDelta is
 // differenced from the view coordinate alone, so a shift that appears and
@@ -1232,12 +1269,15 @@ void TestScrollStripSizing::centeringYieldsNoOffsetWhenTheStackOverflowsTheCross
     QCOMPARE(Ax::crossPos(first), 0);
 }
 
-// The seam between the two features, which neither side's suite reaches: a
-// maximized-to-edges column is laid out in the RAW work area, so a short stack
-// inside one must be centred in the raw slack, not the gapped slack. Centring
-// against the gapped extent would offset it by half an outer gap — small
-// enough to look like a rounding artefact and wrong on every screen with
-// outer gaps set.
+// The seam between the two features: with the flag overriding every height
+// intent there is no short stack inside a maximized column any more, so the
+// centre policy has no slack to act on and the tile lands on the raw rect
+// exactly. This test used to assert the opposite (the 300px intent honoured
+// and centred in the raw slack), which was the live "maximize only widens"
+// bug: full main extent and compositor maximize state beside a short centred
+// window. The asymmetric-gap fixture is kept so any regression back to
+// intent-honouring also re-exposes the raw-vs-gapped centring question it
+// originally probed.
 void TestScrollStripSizing::centeringAShortMaximizedToEdgesColumnUsesTheRawArea()
 {
     ScrollLayoutParams params = defaultParams();
@@ -1259,12 +1299,10 @@ void TestScrollStripSizing::centeringAShortMaximizedToEdgesColumnUsesTheRawArea(
     QVERIFY(strip.toggleMaximizeToEdgesActiveColumn(params));
 
     const QRect r = rectOf(strip.relayout(params), QStringLiteral("a"));
-    QCOMPARE(Ax::crossLen(r), 300);
-    // Centred in the RAW cross extent and measured from the RAW origin. The
-    // gapped answer would be 20 + (rawCross - 40 - 300) / 2, which is 20 short
-    // of this, so the assertion tells the two apart.
-    const int rawCross = Ax::crossLen(params.rawWorkArea);
-    QCOMPARE(Ax::crossPos(r), Ax::crossPos(params.rawWorkArea) + (rawCross - 300) / 2);
+    QCOMPARE(r, params.rawWorkArea);
+    // And the 300px intent survives the round trip untouched.
+    QVERIFY(strip.toggleMaximizeToEdgesActiveColumn(params));
+    QCOMPARE(Ax::crossLen(rectOf(strip.relayout(params), QStringLiteral("a"))), 300);
 }
 
 QTEST_APPLESS_MAIN(TestScrollStripSizing)


### PR DESCRIPTION
Two bugs reported against 3.4.4 (single screen, scrolling mode on virtual desktops).

## Dragging a tab out of the strip left the window on all desktops

The window was never made sticky by PlasmaZones — it was stranded in KWin's interactive move. The drop re-armed the scroll tab pill hover with DragTracker's drag state already cleared (`forceEnd` runs on LMB release while KWin keeps the move alive until every button is up), the pill under the drop point lit and took the mouse interception, and the interception outranks KWin's move filter, so the release that would end the move never arrived. A window stuck in interactive move rides along on every desktop switch, which reads as "visible on all desktops"; the reporter's session state carried 11 placement records with the all-desktops sentinel.

- `DragTracker` now tracks the compositor's own interactive move/resize state (stamped from the start signal before any tracking filter, cleared only by KWin's finish signal), exposed as `compositorMoveResizeActive()`.
- The pill hover guard and `setScrollTabHoverCursor` refuse to take (and release a stale) interception while a compositor move is live. A held pill press keeps its pairing latch, as before.
- Hover is re-driven when the move genuinely finishes, covering the multi-button drop the LMB-release re-drive now correctly declines.
- The `ApplyFloat` drop branch gains the rescue `ApplySnap`/`RestoreSize` already had, spelled `endInteractiveMoveResize()` rather than cancel so the window stays where it was dropped.

## Focusing a window on another desktop did not center its column

A `windowFocused` report can land while the engine's context for the screen still resolves the desktop being left. The strip's focus and anchor moved in the background state, but only `placementChanged` was emitted, and the desktop return could not be trusted to emit the geometry: its rects can all match the stored baseline, and the switch's screen-keyed force flag can be spent by any interleaved pass. A report the strip refused outright (already-active window, view attached, column visible per the stored anchor) was dropped even though the compositor's per-output view state can disagree with all three of those tests.

`windowFocused` now records a pending emit keyed to the report's context, on the mutate path and the refused-report path both, and `applyLayout` promotes it into the force-emit set only when it runs with that context current. The return that actually shows the strip then re-asserts its geometry unconditionally. Entries are pruned when a screen leaves the scrolling set or is removed.

## Verification

- Full build clean, zero warnings; 414/414 ctest pass, including the new `backgroundFocusReportForcesTheReturnBatch` in the strip-context suite.
- Nested `kwin_wayland --virtual` harness (`scripts/nested-kwin/`), scrolling rule seeded, 4 clients on desktop 1: activating a parked desktop-1 window from desktop 2 switched back and committed the activated column centered at (258,8) with the strip's forced context-switch emit carrying the batch ("every rect matched the previous strip's baseline" — exactly the case that used to be suppressed).
- The stranded-move half cannot be driven from the scripting harness (no way to hold a button mid-interactive-move), so that fix is verified by code path only; a live repro with a second mouse button held at the drop is the remaining check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EenDdzvaLAWqrpgTKUj4aF

## Maximize-to-edges only widened a window carrying an explicit height

Same reporter, same session. The stacked relayout branch still honored a tile's Fixed/Preset height intent while the column was flagged maximized-to-edges, so a lone sized tile went full width at its short height. With the center-short-columns policy on it floated mid-screen, while the compositor's maximize state said full, which produced the cropped-looking maximize and the "sometimes it just widens" inconsistency (windows on Auto height maximized fine).

The stack now resolves every tile as Auto while the flag is set, splitting the raw cross extent by weight, the same override the tabbed branch already applied to its owner's intent. Stored intents are untouched and the restore re-renders them exactly. The seam test asserting the old intent-honoring behavior was inverted to the new contract, and `maximizeToEdgesOverridesAnExplicitHeightIntent` covers the lone-tile and stacked cases.
