### PR TITLE
feat(report): summarize session state and add placement-mode resolution

### DIFF
--- a/scripts/plasmazones-report.sh
+++ b/scripts/plasmazones-report.sh
@@ -149,6 +149,19 @@ trap 'rm -rf "$STAGING"' EXIT
 # Use printf to avoid heredoc delimiter collision if the report contains the delimiter.
 printf '%s\n' "$REPORT" > "$STAGING/report.md"
 
+# The daemon cannot know what this script packs around its report, so the
+# archive listing is appended here (outside the <details> block so it stays
+# visible when the report is pasted collapsed).
+cat >> "$STAGING/report.md" <<'EOF'
+
+## Archive Contents
+This report ships in an archive with the raw files behind the summaries above:
+- `config.json`, `session.json` (full window session state), `rules.json` and the remaining config-dir files (quick layouts, layout settings, settings profiles)
+- `data/` with user layouts, algorithms, shaders and animation profiles
+- `journal.log` and `kwin-effect.log` with the raw journal lines
+- `kglobalaccel.txt` with the effective shortcut bindings and `kwin-effects.txt` with the enabled/loaded KWin effects
+EOF
+
 # 2. Config directory (redact home paths in text files)
 CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/plasmazones"
 # Guard against empty or root HOME (e.g., running from a systemd service without User=,

--- a/src/core/platform/supportreport.cpp
+++ b/src/core/platform/supportreport.cpp
@@ -9,6 +9,7 @@
 #include <PhosphorZones/Zone.h>
 #include "version.h"
 #include "config/configdefaults.h"
+#include "config/configkeys.h"
 #include "core/resolve/screenmoderouter.h"
 #include <PhosphorEngine/IPlacementEngine.h>
 #include <PhosphorZones/AssignmentEntry.h>
@@ -296,6 +297,8 @@ QString SupportReport::sectionPlacementModes(const Snapshot& snapshot)
         for (const auto& mode : snapshot.screenModes)
             out += QStringLiteral("- **%1**: %2\n").arg(mode.screenId, mode.mode);
         out += QLatin1Char('\n');
+    } else if (snapshot.hasModeRouter) {
+        out += QStringLiteral("*(no screens detected — nothing to resolve a mode for)*\n\n");
     } else {
         out += QStringLiteral("*(daemon not running — per-screen mode resolution unavailable)*\n\n");
     }
@@ -400,15 +403,15 @@ QString SupportReport::sectionSession()
             + readAndRedactFile(path, QStringLiteral("session file"));
     }
 
-    const QJsonObject tracking = doc.object().value(QLatin1String("WindowTracking")).toObject();
-    const QJsonObject placements = tracking.value(QLatin1String("WindowPlacements")).toObject();
+    const QJsonObject tracking = doc.object().value(ConfigKeys::windowTrackingGroup()).toObject();
+    const QJsonObject placements = tracking.value(ConfigKeys::windowPlacementsKey()).toObject();
 
     QString out;
-    out += QStringLiteral("**Active layout:** %1\n").arg(tracking.value(QLatin1String("ActiveLayoutId")).toString());
-    const QString lastZone = tracking.value(QLatin1String("LastUsedZoneId")).toString();
+    out += QStringLiteral("**Active layout:** %1\n").arg(tracking.value(ConfigKeys::activeLayoutIdKey()).toString());
+    const QString lastZone = tracking.value(ConfigKeys::lastUsedZoneIdKey()).toString();
     out += QStringLiteral("**Last used zone:** %1\n").arg(lastZone.isEmpty() ? QStringLiteral("(none)") : lastZone);
     out += QStringLiteral("**User-snapped classes:** %1\n")
-               .arg(tracking.value(QLatin1String("UserSnappedClasses")).toArray().size());
+               .arg(tracking.value(ConfigKeys::userSnappedClassesKey()).toArray().size());
 
     int total = 0;
     QVector<QJsonObject> entries;

--- a/src/core/platform/supportreport.cpp
+++ b/src/core/platform/supportreport.cpp
@@ -9,15 +9,23 @@
 #include <PhosphorZones/Zone.h>
 #include "version.h"
 #include "config/configdefaults.h"
+#include "core/resolve/screenmoderouter.h"
 #include <PhosphorEngine/IPlacementEngine.h>
+#include <PhosphorZones/AssignmentEntry.h>
 
 #include <QCoreApplication>
+#include <QDateTime>
 #include <QDir>
 #include <QFile>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
 #include <QProcess>
 #include <QRegularExpression>
 #include <QScreen>
 #include <QSysInfo>
+
+#include <algorithm>
 
 namespace PlasmaZones {
 
@@ -49,9 +57,24 @@ QString SupportReport::redactHomePath(const QString& input)
     return result;
 }
 
+static QString modeName(PhosphorZones::AssignmentEntry::Mode mode)
+{
+    switch (mode) {
+    case PhosphorZones::AssignmentEntry::Autotile:
+        return QStringLiteral("tiling");
+    case PhosphorZones::AssignmentEntry::Scrolling:
+        return QStringLiteral("scrolling");
+    case PhosphorZones::AssignmentEntry::Snapping:
+        break;
+    }
+    return QStringLiteral("snapping");
+}
+
 SupportReport::Snapshot SupportReport::collectSnapshot(PhosphorScreens::ScreenManager* screenManager,
                                                        PhosphorZones::LayoutRegistry* layoutManager,
-                                                       PhosphorEngine::IPlacementEngine* autotileEngine)
+                                                       PhosphorEngine::IPlacementEngine* autotileEngine,
+                                                       PhosphorEngine::IPlacementEngine* scrollEngine,
+                                                       const ScreenModeRouter* modeRouter)
 {
     Snapshot snap;
 
@@ -62,6 +85,7 @@ SupportReport::Snapshot SupportReport::collectSnapshot(PhosphorScreens::ScreenMa
         for (const PhosphorScreens::PhysicalScreen& screen : screens) {
             Snapshot::ScreenInfo info;
             info.name = screen.name;
+            info.id = screen.identifier.isEmpty() ? screen.name : screen.identifier;
             info.geometry = screen.geometry;
             info.available = screenManager->actualAvailableGeometry(screen);
             if (screen.qscreen) {
@@ -69,6 +93,14 @@ SupportReport::Snapshot SupportReport::collectSnapshot(PhosphorScreens::ScreenMa
                 info.devicePixelRatio = screen.qscreen->devicePixelRatio();
             }
             snap.screens.append(info);
+        }
+    }
+
+    if (modeRouter) {
+        snap.hasModeRouter = true;
+        snap.screenModes.reserve(snap.screens.size());
+        for (const Snapshot::ScreenInfo& screen : std::as_const(snap.screens)) {
+            snap.screenModes.append({screen.id, modeName(modeRouter->modeFor(screen.id))});
         }
     }
 
@@ -94,12 +126,22 @@ SupportReport::Snapshot SupportReport::collectSnapshot(PhosphorScreens::ScreenMa
         snap.autotileScreens = QStringList(screens.begin(), screens.end());
     }
 
+    if (scrollEngine) {
+        snap.hasScrollEngine = true;
+        snap.scrollingEnabled = scrollEngine->isEnabled();
+        const auto screens = scrollEngine->activeScreens();
+        snap.scrollingScreens = QStringList(screens.begin(), screens.end());
+    }
+
     return snap;
 }
 
 QString SupportReport::sectionVersion()
 {
-    return QStringLiteral("**PlasmaZones:** %1\n").arg(VERSION_STRING);
+    // The generation timestamp anchors the log windows below: the archive
+    // filename carries one too, but report.md is often pasted standalone.
+    return QStringLiteral("**PlasmaZones:** %1\n**Generated:** %2\n")
+        .arg(VERSION_STRING, QDateTime::currentDateTime().toString(Qt::ISODate));
 }
 
 QString SupportReport::sectionEnvironment()
@@ -178,7 +220,13 @@ QString SupportReport::readAndRedactFile(const QString& path, const QString& lab
 
 QString SupportReport::sectionConfig()
 {
-    return readAndRedactFile(ConfigDefaults::configFilePath(), QStringLiteral("config file"));
+    // Persistence is sparse: default-equal values are deleted on save, so
+    // every key in the blob is a deviation from defaults. Saying so up front
+    // spares triagers diffing the dump against ConfigDefaults.
+    return QStringLiteral(
+               "*Only settings changed from their defaults are stored. "
+               "Any key absent below is at its default value.*\n\n")
+        + readAndRedactFile(ConfigDefaults::configFilePath(), QStringLiteral("config file"));
 }
 
 QString SupportReport::sectionRules()
@@ -188,7 +236,33 @@ QString SupportReport::sectionRules()
     // reports were untriageable without them (discussions #795/#796).
     if (!QFile::exists(ConfigDefaults::rulesFilePath()))
         return QStringLiteral("*(no rules file)*\n");
-    return readAndRedactFile(ConfigDefaults::rulesFilePath(), QStringLiteral("rules file"));
+
+    // A one-line-per-rule summary ahead of the blob: which rules exist,
+    // whether they are enabled, and at what priority — readable without
+    // walking the JSON. Best-effort; a parse failure just drops the summary.
+    QString summary;
+    QFile file(ConfigDefaults::rulesFilePath());
+    if (file.open(QIODevice::ReadOnly) && file.size() <= MaxFileSize) {
+        const QJsonDocument doc = QJsonDocument::fromJson(file.readAll());
+        const QJsonArray rules = doc.object().value(QLatin1String("rules")).toArray();
+        if (!rules.isEmpty()) {
+            summary += QStringLiteral("**Rules:** %1\n").arg(rules.size());
+            for (const QJsonValue& value : rules) {
+                const QJsonObject rule = value.toObject();
+                QString name = rule.value(QLatin1String("name")).toString();
+                if (name.isEmpty())
+                    name = QStringLiteral("(unnamed)");
+                summary += QStringLiteral("- %1 (%2, priority %3)\n")
+                               .arg(name,
+                                    rule.value(QLatin1String("enabled")).toBool(true) ? QStringLiteral("enabled")
+                                                                                      : QStringLiteral("disabled"))
+                               .arg(rule.value(QLatin1String("priority")).toInt());
+            }
+            summary += QLatin1Char('\n');
+        }
+    }
+
+    return redactHomePath(summary) + readAndRedactFile(ConfigDefaults::rulesFilePath(), QStringLiteral("rules file"));
 }
 
 QString SupportReport::sectionLayouts(const Snapshot& snapshot)
@@ -210,17 +284,40 @@ QString SupportReport::sectionLayouts(const Snapshot& snapshot)
     return out;
 }
 
-QString SupportReport::sectionAutotile(const Snapshot& snapshot)
+QString SupportReport::sectionPlacementModes(const Snapshot& snapshot)
 {
-    if (!snapshot.hasAutotileEngine)
-        return QStringLiteral("*(autotile engine not available)*\n");
-
     QString out;
-    out += QStringLiteral("**Enabled:** %1\n")
-               .arg(snapshot.autotileEnabled ? QStringLiteral("yes") : QStringLiteral("no"));
 
-    if (!snapshot.autotileScreens.isEmpty()) {
-        out += QStringLiteral("**Active screens:** %1\n").arg(snapshot.autotileScreens.join(QStringLiteral(", ")));
+    // Which engine actually owns each screen is the question most reports
+    // hinge on, and the config blob alone cannot answer it (rules and
+    // per-context assignments override the global toggles).
+    if (snapshot.hasModeRouter && !snapshot.screenModes.isEmpty()) {
+        out += QStringLiteral("**Resolved mode per screen (current desktop/activity):**\n");
+        for (const auto& mode : snapshot.screenModes)
+            out += QStringLiteral("- **%1**: %2\n").arg(mode.screenId, mode.mode);
+        out += QLatin1Char('\n');
+    } else {
+        out += QStringLiteral("*(daemon not running — per-screen mode resolution unavailable)*\n\n");
+    }
+
+    if (snapshot.hasAutotileEngine) {
+        out += QStringLiteral("**Tiling engine enabled:** %1\n")
+                   .arg(snapshot.autotileEnabled ? QStringLiteral("yes") : QStringLiteral("no"));
+        if (!snapshot.autotileScreens.isEmpty())
+            out += QStringLiteral("**Tiling active screens:** %1\n")
+                       .arg(snapshot.autotileScreens.join(QStringLiteral(", ")));
+    } else {
+        out += QStringLiteral("*(autotile engine not available)*\n");
+    }
+
+    if (snapshot.hasScrollEngine) {
+        out += QStringLiteral("**Scrolling engine enabled:** %1\n")
+                   .arg(snapshot.scrollingEnabled ? QStringLiteral("yes") : QStringLiteral("no"));
+        if (!snapshot.scrollingScreens.isEmpty())
+            out += QStringLiteral("**Scrolling active screens:** %1\n")
+                       .arg(snapshot.scrollingScreens.join(QStringLiteral(", ")));
+    } else {
+        out += QStringLiteral("*(scrolling engine not available)*\n");
     }
 
     return out;
@@ -253,9 +350,96 @@ QString SupportReport::sectionCompositorBridge(const Snapshot& snapshot)
         "for why the effect failed to load or register.\n");
 }
 
+// How many of the newest placement entries (by save sequence) to render in
+// the Session State summary.
+static constexpr int MaxRecentPlacements = 20;
+
+// Renders one placement entry as a single summary line.
+static QString placementLine(const QJsonObject& entry)
+{
+    QString line = QStringLiteral("- `%1`").arg(entry.value(QLatin1String("windowId")).toString());
+    line += QStringLiteral(" (seq %1, desktop %2")
+                .arg(entry.value(QLatin1String("seq")).toInt())
+                .arg(entry.value(QLatin1String("desktop")).toInt());
+
+    const QJsonObject engines = entry.value(QLatin1String("engines")).toObject();
+    QStringList engineBits;
+    for (auto it = engines.constBegin(); it != engines.constEnd(); ++it) {
+        const QJsonObject state = it.value().toObject();
+        QString bit = QStringLiteral("%1=%2").arg(it.key(), state.value(QLatin1String("state")).toString());
+        if (state.contains(QLatin1String("order")))
+            bit += QStringLiteral("/order %1").arg(state.value(QLatin1String("order")).toInt());
+        engineBits.append(bit);
+    }
+    if (!engineBits.isEmpty())
+        line += QStringLiteral(", %1").arg(engineBits.join(QStringLiteral(", ")));
+    line += QStringLiteral(")\n");
+    return line;
+}
+
 QString SupportReport::sectionSession()
 {
-    return readAndRedactFile(ConfigDefaults::sessionFilePath(), QStringLiteral("session file"));
+    // The raw session file used to be dumped verbatim and routinely dwarfed
+    // the rest of the report (a hundred-plus accumulated placement entries,
+    // most for long-closed windows). Summarize instead; the raw session.json
+    // ships alongside report.md in the plasmazones-report.sh archive for
+    // anyone who needs the full state.
+    const QString path = ConfigDefaults::sessionFilePath();
+    QFile file(path);
+    if (!file.open(QIODevice::ReadOnly))
+        return QStringLiteral("*(session file — %1: %2)*\n").arg(redactHomePath(path), file.errorString());
+    if (file.size() > MaxFileSize)
+        return QStringLiteral("*(session file exceeds 1 MB limit)*\n");
+
+    QJsonParseError parseError{};
+    const QJsonDocument doc = QJsonDocument::fromJson(file.readAll(), &parseError);
+    if (parseError.error != QJsonParseError::NoError) {
+        // Unparseable state is itself a diagnostic — fall back to the raw dump.
+        return QStringLiteral("*(session file did not parse as JSON: %1 — raw content follows)*\n\n")
+                   .arg(parseError.errorString())
+            + readAndRedactFile(path, QStringLiteral("session file"));
+    }
+
+    const QJsonObject tracking = doc.object().value(QLatin1String("WindowTracking")).toObject();
+    const QJsonObject placements = tracking.value(QLatin1String("WindowPlacements")).toObject();
+
+    QString out;
+    out += QStringLiteral("**Active layout:** %1\n").arg(tracking.value(QLatin1String("ActiveLayoutId")).toString());
+    const QString lastZone = tracking.value(QLatin1String("LastUsedZoneId")).toString();
+    out += QStringLiteral("**Last used zone:** %1\n").arg(lastZone.isEmpty() ? QStringLiteral("(none)") : lastZone);
+    out += QStringLiteral("**User-snapped classes:** %1\n")
+               .arg(tracking.value(QLatin1String("UserSnappedClasses")).toArray().size());
+
+    int total = 0;
+    QVector<QJsonObject> entries;
+    QStringList classCounts;
+    for (auto it = placements.constBegin(); it != placements.constEnd(); ++it) {
+        const QJsonArray list = it.value().toArray();
+        total += list.size();
+        classCounts.append(QStringLiteral("%1 (%2)").arg(it.key()).arg(list.size()));
+        for (const QJsonValue& value : list)
+            entries.append(value.toObject());
+    }
+    out += QStringLiteral("**Tracked placements:** %1 entries across %2 window classes\n")
+               .arg(total)
+               .arg(placements.size());
+    if (!classCounts.isEmpty())
+        out += QStringLiteral("**Per class:** %1\n").arg(classCounts.join(QStringLiteral(", ")));
+
+    if (!entries.isEmpty()) {
+        std::sort(entries.begin(), entries.end(), [](const QJsonObject& a, const QJsonObject& b) {
+            return a.value(QLatin1String("seq")).toInt() > b.value(QLatin1String("seq")).toInt();
+        });
+        const int shown = qMin<int>(entries.size(), MaxRecentPlacements);
+        out += QStringLiteral("\n**Most recent placements (newest first, showing %1 of %2):**\n").arg(shown).arg(total);
+        for (int i = 0; i < shown; ++i)
+            out += placementLine(entries.at(i));
+    }
+
+    out += QStringLiteral(
+        "\n*Summary only. The full session.json is included in the report archive "
+        "when generated with plasmazones-report.sh.*\n");
+    return redactHomePath(out);
 }
 
 static QStringList journalctlArgs(const QString& identifier, int sinceMinutes, bool longForm = false,
@@ -333,18 +517,25 @@ QString SupportReport::sectionLogs(int sinceMinutes)
     return QStringLiteral("```\n%1\n```\n").arg(redactHomePath(capLogLines(output.split(QLatin1Char('\n')))));
 }
 
-QString SupportReport::sectionEffectLogs(int sinceMinutes)
+QString SupportReport::sectionEffectLogs(int sinceMinutes, bool bridgeRegistered)
 {
     // The KWin effect runs inside the kwin_wayland process, so its journal
     // entries are tagged "kwin_wayland", not "plasmazonesd" — sectionLogs()
     // never captures them. Without this section a non-registering effect is
     // invisible in the report.
+    //
+    // When the compositor bridge IS registered, an empty result just means the
+    // effect logged nothing in the window — saying "likely not loaded" there
+    // would contradict the Compositor Bridge section a few lines up.
+    const QString quietSuffix = bridgeRegistered
+        ? QStringLiteral("the effect is connected and simply logged nothing in this window")
+        : QStringLiteral("the KWin effect is likely not loaded");
+
     const QByteArray rawOutput = collectJournal(QStringLiteral("kwin_wayland"), sinceMinutes);
     if (rawOutput.isEmpty())
-        return QStringLiteral(
-                   "*(no kwin_wayland journal in the last %1 minutes, or journalctl unavailable — "
-                   "the KWin effect is likely not loaded)*\n")
-            .arg(sinceMinutes);
+        return QStringLiteral("*(no kwin_wayland journal in the last %1 minutes, or journalctl unavailable — %2)*\n")
+            .arg(sinceMinutes)
+            .arg(quietSuffix);
 
     // Keep only PlasmaZones effect lines — the rest of the kwin_wayland journal
     // is unrelated compositor noise. Every effect logging category begins with
@@ -358,10 +549,9 @@ QString SupportReport::sectionEffectLogs(int sinceMinutes)
     }
 
     if (kept.isEmpty()) {
-        return QStringLiteral(
-                   "*(no PlasmaZones effect log entries in the last %1 minutes — "
-                   "the KWin effect is likely not loaded)*\n")
-            .arg(sinceMinutes);
+        return QStringLiteral("*(no PlasmaZones effect log entries in the last %1 minutes — %2)*\n")
+            .arg(sinceMinutes)
+            .arg(quietSuffix);
     }
 
     return QStringLiteral("```\n%1\n```\n").arg(redactHomePath(capLogLines(kept)));
@@ -398,8 +588,8 @@ QString SupportReport::generateFromSnapshot(const Snapshot& snapshot, int sinceM
     report += sectionLayouts(snapshot);
     report += QLatin1Char('\n');
 
-    report += QStringLiteral("## Autotile\n");
-    report += sectionAutotile(snapshot);
+    report += QStringLiteral("## Placement Modes\n");
+    report += sectionPlacementModes(snapshot);
     report += QLatin1Char('\n');
 
     report += QStringLiteral("## Compositor Bridge\n");
@@ -415,7 +605,7 @@ QString SupportReport::generateFromSnapshot(const Snapshot& snapshot, int sinceM
     report += QLatin1Char('\n');
 
     report += QStringLiteral("## KWin Effect Logs (last %1 minutes)\n").arg(sinceMinutes);
-    report += sectionEffectLogs(sinceMinutes);
+    report += sectionEffectLogs(sinceMinutes, snapshot.hasBridgeInfo && snapshot.bridgeRegistered);
     report += QLatin1Char('\n');
 
     // Sanitize any literal </details> in section content that would prematurely
@@ -429,9 +619,11 @@ QString SupportReport::generateFromSnapshot(const Snapshot& snapshot, int sinceM
 
 QString SupportReport::generate(PhosphorScreens::ScreenManager* screenManager,
                                 PhosphorZones::LayoutRegistry* layoutManager,
-                                PhosphorEngine::IPlacementEngine* autotileEngine, int sinceMinutes)
+                                PhosphorEngine::IPlacementEngine* autotileEngine, int sinceMinutes,
+                                PhosphorEngine::IPlacementEngine* scrollEngine, const ScreenModeRouter* modeRouter)
 {
-    return generateFromSnapshot(collectSnapshot(screenManager, layoutManager, autotileEngine), sinceMinutes);
+    return generateFromSnapshot(collectSnapshot(screenManager, layoutManager, autotileEngine, scrollEngine, modeRouter),
+                                sinceMinutes);
 }
 
 } // namespace PlasmaZones

--- a/src/core/platform/supportreport.h
+++ b/src/core/platform/supportreport.h
@@ -28,8 +28,8 @@ class ScreenModeRouter;
 /**
  * @brief Generates a redacted support report for bug reports and discussions
  *
- * Collects config, screen topology, autotile state, layout info, and recent
- * journal logs into a Markdown-formatted report suitable for pasting into
+ * Collects config, screen topology, placement-mode state, layout info, and
+ * recent journal logs into a Markdown-formatted report suitable for pasting into
  * GitHub Discussions or Issues.
  *
  * Privacy:
@@ -131,6 +131,8 @@ public:
      * @param layoutManager PhosphorZones::LayoutRegistry instance (nullable)
      * @param autotileEngine AutotileEngine instance (nullable)
      * @param sinceMinutes How many minutes of journal logs to include (default 30, capped at 120)
+     * @param scrollEngine ScrollEngine instance (nullable)
+     * @param modeRouter ScreenModeRouter for the per-screen resolved mode (nullable)
      * @return Markdown-formatted support report
      */
     static QString generate(PhosphorScreens::ScreenManager* screenManager, PhosphorZones::LayoutRegistry* layoutManager,

--- a/src/core/platform/supportreport.h
+++ b/src/core/platform/supportreport.h
@@ -23,6 +23,8 @@ class IPlacementEngine;
 
 namespace PlasmaZones {
 
+class ScreenModeRouter;
+
 /**
  * @brief Generates a redacted support report for bug reports and discussions
  *
@@ -48,6 +50,9 @@ public:
         struct ScreenInfo
         {
             QString name;
+            /// Stable placement id ("Manuf:Model:Serial" form) used by the
+            /// engines and rules; falls back to the connector name.
+            QString id;
             QRect geometry;
             QRect available;
             qreal refreshRate = 0;
@@ -71,6 +76,20 @@ public:
         QStringList autotileScreens;
         bool hasAutotileEngine = false;
 
+        bool scrollingEnabled = false;
+        QStringList scrollingScreens;
+        bool hasScrollEngine = false;
+
+        /// Resolved placement mode per screen (ScreenModeRouter::modeFor),
+        /// keyed by the same stable id the engines use.
+        struct ScreenMode
+        {
+            QString screenId;
+            QString mode;
+        };
+        QVector<ScreenMode> screenModes;
+        bool hasModeRouter = false;
+
         // Compositor bridge (KWin effect) state. The bridge adaptor lives in
         // the dbus layer, which core/ must not depend on, so these fields are
         // populated by ControlAdaptor after collectSnapshot() returns rather
@@ -87,7 +106,9 @@ public:
      */
     static Snapshot collectSnapshot(PhosphorScreens::ScreenManager* screenManager,
                                     PhosphorZones::LayoutRegistry* layoutManager,
-                                    PhosphorEngine::IPlacementEngine* autotileEngine);
+                                    PhosphorEngine::IPlacementEngine* autotileEngine,
+                                    PhosphorEngine::IPlacementEngine* scrollEngine = nullptr,
+                                    const ScreenModeRouter* modeRouter = nullptr);
 
     /**
      * @brief Generate a report from a pre-collected snapshot (thread-safe)
@@ -113,7 +134,9 @@ public:
      * @return Markdown-formatted support report
      */
     static QString generate(PhosphorScreens::ScreenManager* screenManager, PhosphorZones::LayoutRegistry* layoutManager,
-                            PhosphorEngine::IPlacementEngine* autotileEngine, int sinceMinutes = 30);
+                            PhosphorEngine::IPlacementEngine* autotileEngine, int sinceMinutes = 30,
+                            PhosphorEngine::IPlacementEngine* scrollEngine = nullptr,
+                            const ScreenModeRouter* modeRouter = nullptr);
 
     /**
      * @brief Redact home directory paths from a string
@@ -141,11 +164,11 @@ private:
     static QString sectionConfig();
     static QString sectionRules();
     static QString sectionLayouts(const Snapshot& snapshot);
-    static QString sectionAutotile(const Snapshot& snapshot);
+    static QString sectionPlacementModes(const Snapshot& snapshot);
     static QString sectionCompositorBridge(const Snapshot& snapshot);
     static QString sectionSession();
     static QString sectionLogs(int sinceMinutes);
-    static QString sectionEffectLogs(int sinceMinutes);
+    static QString sectionEffectLogs(int sinceMinutes, bool bridgeRegistered);
 };
 
 } // namespace PlasmaZones

--- a/src/daemon/daemon/init_engines.cpp
+++ b/src/daemon/daemon/init_engines.cpp
@@ -1462,9 +1462,9 @@ void Daemon::initEnginesAndWiring()
     // Control adaptor - high-level convenience API for third-party integrations.
     // Held as a member so stop() can detach() it before the unique_ptr members
     // it borrows are destroyed.
-    m_controlAdaptor =
-        new ControlAdaptor(m_windowTrackingAdaptor, m_snapAdaptor, m_layoutAdaptor, m_layoutManager.get(),
-                           autotileEngine, m_screenManager.get(), m_compositorBridge, this);
+    m_controlAdaptor = new ControlAdaptor(m_windowTrackingAdaptor, m_snapAdaptor, m_layoutAdaptor,
+                                          m_layoutManager.get(), autotileEngine, m_screenManager.get(),
+                                          m_compositorBridge, m_scrollEngine.get(), m_screenModeRouter.get(), this);
 
     // Handle KCM assignment change resnap/OSD. This runs AFTER the KCM's batch
     // save completes (all setAssignmentEntry + notifyReload finished), so all

--- a/src/dbus/controladaptor.cpp
+++ b/src/dbus/controladaptor.cpp
@@ -31,6 +31,7 @@ ControlAdaptor::ControlAdaptor(WindowTrackingAdaptor* wta, SnapAdaptor* snapAdap
                                PhosphorZones::LayoutRegistry* layoutManager,
                                PhosphorEngine::IPlacementEngine* autotileEngine,
                                PhosphorScreens::ScreenManager* screenManager, CompositorBridgeAdaptor* compositorBridge,
+                               PhosphorEngine::IPlacementEngine* scrollEngine, const ScreenModeRouter* modeRouter,
                                QObject* parent)
     : QDBusAbstractAdaptor(parent)
     , m_wta(wta)
@@ -40,6 +41,8 @@ ControlAdaptor::ControlAdaptor(WindowTrackingAdaptor* wta, SnapAdaptor* snapAdap
     , m_autotileEngine(autotileEngine)
     , m_screenManager(screenManager)
     , m_compositorBridge(compositorBridge)
+    , m_scrollEngine(scrollEngine)
+    , m_modeRouter(modeRouter)
 {
 }
 
@@ -187,6 +190,8 @@ void ControlAdaptor::detach()
     m_autotileEngine = nullptr;
     m_screenManager = nullptr;
     m_compositorBridge = nullptr;
+    m_scrollEngine = nullptr;
+    m_modeRouter = nullptr;
 }
 
 QString ControlAdaptor::generateSupportReport(int sinceMinutes, const QDBusMessage& message)
@@ -217,7 +222,8 @@ QString ControlAdaptor::generateSupportReport(int sinceMinutes, const QDBusMessa
     message.setDelayedReply(true);
 
     // Snapshot QObject state on the main thread (these pointers are not thread-safe).
-    auto snapshot = SupportReport::collectSnapshot(m_screenManager, m_layoutManager, m_autotileEngine);
+    auto snapshot = SupportReport::collectSnapshot(m_screenManager, m_layoutManager, m_autotileEngine, m_scrollEngine,
+                                                   m_modeRouter);
 
     // Compositor bridge state lives in the dbus layer, so SupportReport (core/)
     // cannot read it directly — fold it into the snapshot here. Whether the

--- a/src/dbus/controladaptor.h
+++ b/src/dbus/controladaptor.h
@@ -23,6 +23,7 @@ class WindowTrackingAdaptor;
 class SnapAdaptor;
 class LayoutAdaptor;
 class CompositorBridgeAdaptor;
+class ScreenModeRouter;
 
 // PhosphorScreens::ScreenManager moved to libs/phosphor-screens (PhosphorScreens::ScreenManager).
 } // namespace PlasmaZones
@@ -53,7 +54,8 @@ public:
                             PhosphorZones::LayoutRegistry* layoutManager,
                             PhosphorEngine::IPlacementEngine* autotileEngine,
                             PhosphorScreens::ScreenManager* screenManager, CompositorBridgeAdaptor* compositorBridge,
-                            QObject* parent = nullptr);
+                            PhosphorEngine::IPlacementEngine* scrollEngine = nullptr,
+                            const ScreenModeRouter* modeRouter = nullptr, QObject* parent = nullptr);
     ~ControlAdaptor() override = default;
 
     /// Null every borrowed pointer. Called from Daemon::stop() before the
@@ -135,6 +137,8 @@ private:
     PhosphorEngine::IPlacementEngine* m_autotileEngine;
     PhosphorScreens::ScreenManager* m_screenManager;
     CompositorBridgeAdaptor* m_compositorBridge;
+    PhosphorEngine::IPlacementEngine* m_scrollEngine;
+    const ScreenModeRouter* m_modeRouter;
     QPointer<QFutureWatcher<QString>> m_reportWatcher;
 };
 

--- a/tests/unit/core/test_support_report.cpp
+++ b/tests/unit/core/test_support_report.cpp
@@ -184,6 +184,17 @@ private Q_SLOTS:
         QVERIFY(report.contains(QStringLiteral("**Scrolling active screens:** LG Display:eDP-1")));
     }
 
+    void testGenerate_placementModes_routerWithoutScreens()
+    {
+        // Router present but no screens collected: the section must not claim
+        // the daemon is down.
+        SupportReport::Snapshot snap;
+        snap.hasModeRouter = true;
+        const QString report = SupportReport::generateFromSnapshot(snap, 30);
+        QVERIFY(report.contains(QStringLiteral("nothing to resolve a mode for")));
+        QVERIFY(!report.contains(QStringLiteral("per-screen mode resolution unavailable")));
+    }
+
     void testGenerate_containsTimestamp()
     {
         const QString report = SupportReport::generate(nullptr, nullptr, nullptr, 30);

--- a/tests/unit/core/test_support_report.cpp
+++ b/tests/unit/core/test_support_report.cpp
@@ -80,7 +80,7 @@ private Q_SLOTS:
         QVERIFY(report.contains(QStringLiteral("## Screens")));
         QVERIFY(report.contains(QStringLiteral("## Config")));
         QVERIFY(report.contains(QStringLiteral("## Layouts")));
-        QVERIFY(report.contains(QStringLiteral("## Autotile")));
+        QVERIFY(report.contains(QStringLiteral("## Placement Modes")));
         QVERIFY(report.contains(QStringLiteral("## Compositor Bridge")));
         QVERIFY(report.contains(QStringLiteral("## Session State")));
         QVERIFY(report.contains(QStringLiteral("## Recent Logs")));
@@ -163,6 +163,31 @@ private Q_SLOTS:
     {
         const QString report = SupportReport::generate(nullptr, nullptr, nullptr, 30);
         QVERIFY(report.contains(QStringLiteral("autotile engine not available")));
+        QVERIFY(report.contains(QStringLiteral("scrolling engine not available")));
+        QVERIFY(report.contains(QStringLiteral("per-screen mode resolution unavailable")));
+    }
+
+    void testGenerate_placementModes_fromSnapshot()
+    {
+        SupportReport::Snapshot snap;
+        snap.hasModeRouter = true;
+        snap.screenModes.append({QStringLiteral("LG Display:eDP-1"), QStringLiteral("scrolling")});
+        snap.hasAutotileEngine = true;
+        snap.autotileEnabled = false;
+        snap.hasScrollEngine = true;
+        snap.scrollingEnabled = true;
+        snap.scrollingScreens = {QStringLiteral("LG Display:eDP-1")};
+        const QString report = SupportReport::generateFromSnapshot(snap, 30);
+        QVERIFY(report.contains(QStringLiteral("**LG Display:eDP-1**: scrolling")));
+        QVERIFY(report.contains(QStringLiteral("**Tiling engine enabled:** no")));
+        QVERIFY(report.contains(QStringLiteral("**Scrolling engine enabled:** yes")));
+        QVERIFY(report.contains(QStringLiteral("**Scrolling active screens:** LG Display:eDP-1")));
+    }
+
+    void testGenerate_containsTimestamp()
+    {
+        const QString report = SupportReport::generate(nullptr, nullptr, nullptr, 30);
+        QVERIFY(report.contains(QStringLiteral("**Generated:**")));
     }
 
     void testGenerate_containsVersionInfo()

--- a/tests/unit/dbus/test_compositor_bridge.cpp
+++ b/tests/unit/dbus/test_compositor_bridge.cpp
@@ -99,7 +99,7 @@ private Q_SLOTS:
 
         m_controlParent = new QObject(nullptr);
         m_controlAdaptor = new ControlAdaptor(m_wta, nullptr, nullptr, m_layoutManager, nullptr, nullptr,
-                                              m_bridgeAdaptor, m_controlParent);
+                                              m_bridgeAdaptor, nullptr, nullptr, m_controlParent);
     }
 
     void cleanup()


### PR DESCRIPTION
## Summary
The support report's Session State section dumped `session.json` verbatim. In practice that grew to thousands of lines of accumulated placement entries (a real-world report was 3587 lines, of which 3300 were the session dump) and drowned everything a triager actually needs. This PR reworks the report around summaries and adds the pieces that were missing for the scrolling era.

- **Session State is now a summary**: active layout, last used zone, user-snapped class count, total placements with per-class counts, and the 20 most recent entries by save sequence with their per-engine states. An unparseable file falls back to the raw dump. A footnote points to the full `session.json` in the archive.
- **New Placement Modes section** (replaces Autotile): resolved mode per screen via `ScreenModeRouter::modeFor`, plus enabled state and active screens for both the tiling and scrolling engines. The scrolling engine previously did not appear in the report at all, even on systems running it as the only mode.
- **Effect-log message no longer contradicts the bridge section**: with the compositor bridge registered, an empty effect log now says the effect is connected and logged nothing, instead of "likely not loaded".
- **Generation timestamp** next to the version, since report.md is often pasted standalone.
- **Config section** notes that persistence is sparse, so every key shown is a deviation from defaults.
- **Rules section** gains a one-line-per-rule summary (name or "(unnamed)", enabled state, priority) ahead of the JSON blob.
- **plasmazones-report.sh** appends an Archive Contents section to report.md listing the companion files it packs, which the daemon cannot know about.

`ControlAdaptor` gains defaulted `scrollEngine`/`modeRouter` constructor parameters (nulled in `detach()") and the daemon passes `m_scrollEngine`/`m_screenModeRouter` in `init_engines.cpp`.

## Testing
- Full ctest suite passes (414/414, one preexisting skip), warning-free build.
- New unit tests: Placement Modes rendering from a populated snapshot, generation timestamp, and updated section expectations.
- Live-verified in the nested kwin_wayland harness: generated a report over D-Bus, confirmed all new sections render, and seeded a real-world 147-entry `session.json` to confirm the summarizer collapses it to ~30 readable lines with correct per-class counts and newest-first ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BaBsgcdbxYkYnBTrQ52Gsq