### PR TITLE
fix(snap): stop the move-cancel revert from unsnapping a fresh drop

### DIFF
--- a/kwin-effect/plasmazoneseffect/drag_end.cpp
+++ b/kwin-effect/plasmazoneseffect/drag_end.cpp
@@ -23,6 +23,7 @@
 #include <QDBusPendingReply>
 #include <QLoggingCategory>
 #include <QPointer>
+#include <QScopeGuard>
 #include <QTimer>
 
 #include <memory>
@@ -332,10 +333,46 @@ void PlasmaZonesEffect::callEndDrag(KWin::EffectWindow* window, const QString& w
                     // defers (100ms retry) until ALL buttons are released —
                     // noticeable delay when using a mouse button (RMB) for
                     // zone activation.
-                    if (KWin::Window* kw = rescuableMove()) {
-                        kw->cancelInteractiveMoveResize();
+                    //
+                    // Both the cancel and the apply run under the
+                    // self-caused-frame-change guard, and the cancel is why
+                    // the bracket has to open BEFORE it rather than inside
+                    // applyWindowGeometry: cancelInteractiveMoveResize()
+                    // reverts the window to its DRAG-START rect, which on a
+                    // cross-screen drop is the source monitor. KWin fires
+                    // outputChanged synchronously from that revert, in the gap
+                    // before the zone geometry lands. By then the drag tracker
+                    // has already stopped (this is the async endDrag reply), so
+                    // the outputChanged handler's mid-drag gate no longer
+                    // holds it back and it reported a cross-screen move to the
+                    // SOURCE screen — moments after the daemon stored the
+                    // TARGET screen in commitSnap. The daemon read the
+                    // mismatch as the user moving the window off its zone and
+                    // unsnapped the snap it had just committed, leaving the
+                    // window at the zone rect the apply below writes but with
+                    // no snap state behind it.
+                    //
+                    // Pre-seed the tracked screen from the daemon's
+                    // authoritative answer first, exactly as the batch apply
+                    // does and for the same reason: the bracket covers the
+                    // synchronous frame changes, the seed covers any async
+                    // follow-up (X11 size constraints, client round-trip)
+                    // that lands after it closes.
+                    if (!outcome.targetScreenId.isEmpty()) {
+                        m_trackedScreenPerWindow[safeWindow] = outcome.targetScreenId;
                     }
-                    applyWindowGeometry(safeWindow, snapGeometry);
+                    // Save/restore, not set/clear (nesting-safe).
+                    const bool prevInApply = m_daemonGate.inGeometryApply;
+                    m_daemonGate.inGeometryApply = true;
+                    {
+                        const auto applyGuard = qScopeGuard([this, prevInApply] {
+                            m_daemonGate.inGeometryApply = prevInApply;
+                        });
+                        if (KWin::Window* kw = rescuableMove()) {
+                            kw->cancelInteractiveMoveResize();
+                        }
+                        applyWindowGeometry(safeWindow, snapGeometry);
+                    }
                     // Drag-drop snap committed — record in snapping's border set,
                     // but only for a resolved snap-mode screen. An empty
                     // (unresolved) or autotile-managed screen is owned by
@@ -400,6 +437,22 @@ void PlasmaZonesEffect::callEndDrag(KWin::EffectWindow* window, const QString& w
                         // sub-pixel residue in frameGeometry() (same convention as
                         // the toRect() sites).
                         const QRect geo(qRound(frame.x()), qRound(frame.y()), outcome.width, outcome.height);
+                        // Same self-caused-frame-change bracket as ApplySnap,
+                        // for the same reason: the cancel reverts to the
+                        // drag-start rect, and on a cross-screen drag-out that
+                        // revert lands on the SOURCE monitor and fires a
+                        // synchronous outputChanged the post-drag handler would
+                        // forward to the daemon as a user move. `geo` above was
+                        // captured from the pre-cancel frame, so the apply puts
+                        // the window back where the user dropped it and the
+                        // tracked screen (still the drop screen, because the
+                        // guard suppresses the revert's stamp) stays correct.
+                        // Save/restore, not set/clear (nesting-safe).
+                        const bool prevInApply = m_daemonGate.inGeometryApply;
+                        m_daemonGate.inGeometryApply = true;
+                        const auto applyGuard = qScopeGuard([this, prevInApply] {
+                            m_daemonGate.inGeometryApply = prevInApply;
+                        });
                         if (KWin::Window* kw = rescuableMove()) {
                             kw->cancelInteractiveMoveResize();
                         }

--- a/kwin-effect/plasmazoneseffect/drag_end.cpp
+++ b/kwin-effect/plasmazoneseffect/drag_end.cpp
@@ -58,8 +58,9 @@ void PlasmaZonesEffect::callEndDrag(KWin::EffectWindow* window, const QString& w
     const bool startedFloating = m_dragActivation.startedFloating;
 
     // Identity of the interactive move/resize this drag belongs to, captured
-    // synchronously at dispatch. The three rescue sites in the reply lambda
-    // below (ApplyFloat's end, ApplySnap's and RestoreSize's cancel) all read
+    // synchronously at dispatch. The four rescue sites in the reply lambda
+    // below (ApplyFloat's end, ApplySnap's cancel, and RestoreSize's cancel
+    // when the resize is still owed / end when it is not) all read
     // isUserMove() at reply time, up to EndDragTimeoutMs later. By then the
     // user may have released the remaining button and begun a NEW gesture on
     // the same window (a Meta+RMB resize, say) — the predicate cannot tell the
@@ -432,6 +433,19 @@ void PlasmaZonesEffect::callEndDrag(KWin::EffectWindow* window, const QString& w
                         qAbs(frame.width() - outcome.width) <= 1 && qAbs(frame.height() - outcome.height) <= 1;
                     if (sizeAlreadyRestored) {
                         qCDebug(lcEffect) << "endDrag RestoreSize: already at correct size, skipping the resize";
+                        // The resize is owed no longer, but the rescue still is.
+                        // Skipping it here left KWin's interactive move alive on
+                        // the COMMON drag-out path (slotRestoreSizeDuringDrag
+                        // lands mid-drag, so this branch is the usual one), and a
+                        // live move makes the window follow every desktop switch
+                        // until the last button comes up somewhere KWin's filter
+                        // can see. END rather than cancel, for ApplyFloat's
+                        // reason: no apply follows to undo a revert, so
+                        // cancelInteractiveMoveResize would throw the window back
+                        // to the drag-start rect and undo the drag-out itself.
+                        if (KWin::Window* kw = rescuableMove()) {
+                            kw->endInteractiveMoveResize();
+                        }
                     } else {
                         // qRound, not truncation: fractional-scale outputs leave
                         // sub-pixel residue in frameGeometry() (same convention as

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -1172,6 +1172,20 @@ target_include_directories(test_wta_capture_guards PRIVATE ${CMAKE_SOURCE_DIR}/l
 target_link_libraries(test_wta_capture_guards PRIVATE Qt6::Test Qt6::Core Qt6::DBus plasmazones_core)
 add_test(NAME test_wta_capture_guards COMMAND test_wta_capture_guards)
 
+# WindowTrackingAdaptor windowScreenChanged tests — the stored-screen
+# comparison that keeps or drops a snap when the compositor reports a window
+# on a new output. Split out rather than folded into test_wta_convenience,
+# which is already at the file-size ceiling. Same shared fixture, so the same
+# FakeScreenProvider compile-in and engine link set.
+add_executable(test_wta_screen_changed dbus/test_wta_screen_changed.cpp
+               ${CMAKE_SOURCE_DIR}/libs/phosphor-screens/tests/FakeScreenProvider.cpp)
+target_include_directories(test_wta_screen_changed PRIVATE ${CMAKE_SOURCE_DIR}/libs/phosphor-screens/tests)
+target_link_libraries(test_wta_screen_changed PRIVATE Qt6::Test Qt6::Core Qt6::DBus plasmazones_core
+                      PhosphorSnapEngine::PhosphorSnapEngine PhosphorRules::PhosphorRules
+                      PhosphorEngine::PhosphorEngine PhosphorZones::PhosphorZones
+                      PhosphorWorkspaces::PhosphorWorkspaces)
+add_test(NAME test_wta_screen_changed COMMAND test_wta_screen_changed)
+
 add_executable(test_wta_reactive_metadata dbus/test_wta_reactive_metadata.cpp)
 target_link_libraries(test_wta_reactive_metadata PRIVATE Qt6::Test Qt6::Core Qt6::DBus plasmazones_core)
 add_test(NAME test_wta_reactive_metadata COMMAND test_wta_reactive_metadata)

--- a/tests/unit/dbus/test_wta_screen_changed.cpp
+++ b/tests/unit/dbus/test_wta_screen_changed.cpp
@@ -1,0 +1,156 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_wta_screen_changed.cpp
+ * @brief WindowTrackingAdaptor::windowScreenChanged coverage for SNAPPED
+ *        windows: the stored-screen comparison that decides between keeping
+ *        the snap and unsnapping, the empty-screen bail, and the
+ *        "screen_changed" windowStateChanged emission.
+ *
+ * Why this surface earns a suite of its own: it is the arm a compositor-side
+ * defect fires straight into. The effect's endDrag ApplySnap branch calls
+ * cancelInteractiveMoveResize() to end KWin's interactive move before writing
+ * the zone rect, and that cancel REVERTS the window to its drag-start rect —
+ * the source monitor on a cross-screen drop. KWin emits outputChanged
+ * synchronously from the revert, and with the drag already stopped (the
+ * endDrag reply is async) nothing in the effect held it back, so the daemon
+ * received windowScreenChanged naming the SOURCE screen moments after
+ * commitSnap had stored the TARGET. This adaptor then did exactly what the
+ * contract below says it should — read the mismatch as the user moving the
+ * window off its zone and unsnap — which surfaced to users as a drop that
+ * lands at the zone rect with no snap state behind it (reported 2026-08-31,
+ * PZ 3.4.3, dual-head).
+ *
+ * The daemon behaviour was never wrong; the input was. These cases pin the
+ * contract from both sides so the compositor-side guard has something
+ * explicit to be correct against: a report naming the ASSIGNED screen must
+ * leave the snap intact, and only a genuine divergence may unsnap.
+ */
+
+#include "wta_convenience_fixture.h"
+
+class TestWtaScreenChanged : public QObject, protected WtaConvenienceFixture
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void init()
+    {
+        initFixture();
+    }
+    void cleanup()
+    {
+        cleanupFixture();
+    }
+
+    // ── The keep-snap arm ────────────────────────────────────────────────
+    //
+    // The commit stores the target screen; a screen report naming that same
+    // screen is the daemon's own placement being observed back, not a user
+    // move. This is the arm the effect's ApplySnap guard exists to land on:
+    // whatever KWin says mid-apply, what reaches here must either be
+    // suppressed outright or name the screen the window was snapped to.
+    void testWindowScreenChanged_reportForAssignedScreenKeepsTheSnap()
+    {
+        const QString windowId = QStringLiteral("brave-browser|screen-keep");
+        const QString target = QStringLiteral("HDMI-1");
+
+        m_snapEngine->commitSnap(windowId, m_zoneIds[0], target);
+        QCOMPARE(m_wta->service()->screenForWindow(windowId), target);
+
+        m_wta->windowScreenChanged(windowId, target);
+
+        QCOMPARE(m_wta->service()->zoneForWindow(windowId), m_zoneIds[0]);
+        QCOMPARE(m_wta->service()->screenForWindow(windowId), target);
+    }
+
+    // ── The unsnap arm ───────────────────────────────────────────────────
+    //
+    // The genuine user gesture this arm is FOR ("Move to Screen" on a snapped
+    // window): the window leaves the monitor holding its zone, so the zone
+    // assignment must not follow it.
+    void testWindowScreenChanged_reportForADifferentScreenUnsnaps()
+    {
+        const QString windowId = QStringLiteral("brave-browser|screen-move");
+        const QString assigned = QStringLiteral("HDMI-1");
+        const QString elsewhere = QStringLiteral("DP-1");
+
+        m_snapEngine->commitSnap(windowId, m_zoneIds[0], assigned);
+        QVERIFY(!m_wta->service()->zoneForWindow(windowId).isEmpty());
+
+        m_wta->windowScreenChanged(windowId, elsewhere);
+
+        QVERIFY2(m_wta->service()->zoneForWindow(windowId).isEmpty(),
+                 "a report naming a screen other than the assigned one must drop the zone assignment");
+    }
+
+    // The unsnap arm's wire half: subscribers are told the window is no
+    // longer snapped, tagged "screen_changed", and carrying the screen the
+    // decision was actually made against rather than the stored one.
+    void testWindowScreenChanged_unsnapEmitsScreenChangedWithTheResolvedScreen()
+    {
+        const QString windowId = QStringLiteral("brave-browser|screen-emit");
+        const QString elsewhere = QStringLiteral("DP-1");
+
+        m_snapEngine->commitSnap(windowId, m_zoneIds[0], QStringLiteral("HDMI-1"));
+
+        QSignalSpy spy(m_wta, &WindowTrackingAdaptor::windowStateChanged);
+        m_wta->windowScreenChanged(windowId, elsewhere);
+
+        bool found = false;
+        for (int i = 0; i < spy.count(); ++i) {
+            const auto state = spy.at(i).at(1).value<PhosphorProtocol::WindowStateEntry>();
+            if (state.changeType != QLatin1String("screen_changed")) {
+                continue;
+            }
+            QCOMPARE(spy.at(i).at(0).toString(), windowId);
+            QCOMPARE(state.screenId, elsewhere);
+            QCOMPARE(state.zoneId, QString());
+            QVERIFY(!state.isFloating);
+            found = true;
+            break;
+        }
+        QVERIFY2(found, "the screen-change unsnap must publish a screen_changed entry");
+    }
+
+    // ── The empty-screen bail ────────────────────────────────────────────
+    //
+    // An empty id is "no tracking", not a screen. Letting it through would
+    // store an empty screen downstream, and the live screen arrives on the
+    // next callback anyway — so a snapped window must be left alone.
+    void testWindowScreenChanged_emptyScreenIsIgnored()
+    {
+        const QString windowId = QStringLiteral("brave-browser|screen-empty");
+        const QString assigned = QStringLiteral("HDMI-1");
+
+        m_snapEngine->commitSnap(windowId, m_zoneIds[0], assigned);
+
+        m_wta->windowScreenChanged(windowId, QString());
+
+        QCOMPARE(m_wta->service()->zoneForWindow(windowId), m_zoneIds[0]);
+        QCOMPARE(m_wta->service()->screenForWindow(windowId), assigned);
+    }
+
+    // Repeated reports for the assigned screen stay inert. The effect can
+    // legitimately emit more than one per apply (the synchronous frame change
+    // and an async follow-up from an X11 size constraint), so idempotence
+    // here is what keeps a second one from undoing the first's no-op.
+    void testWindowScreenChanged_repeatedAssignedScreenReportsStayInert()
+    {
+        const QString windowId = QStringLiteral("brave-browser|screen-repeat");
+        const QString target = QStringLiteral("HDMI-1");
+
+        m_snapEngine->commitSnap(windowId, m_zoneIds[0], target);
+
+        for (int i = 0; i < 3; ++i) {
+            m_wta->windowScreenChanged(windowId, target);
+            QVERIFY2(!m_wta->service()->zoneForWindow(windowId).isEmpty(),
+                     "no repeat of an assigned-screen report may drop the snap");
+        }
+        QCOMPARE(m_wta->service()->screenForWindow(windowId), target);
+    }
+};
+
+QTEST_MAIN(TestWtaScreenChanged)
+#include "test_wta_screen_changed.moc"

--- a/tests/unit/dbus/test_wta_screen_changed.cpp
+++ b/tests/unit/dbus/test_wta_screen_changed.cpp
@@ -132,6 +132,45 @@ private Q_SLOTS:
         QCOMPARE(m_wta->service()->screenForWindow(windowId), assigned);
     }
 
+    // ── The virtual-screen arm ───────────────────────────────────────────
+    //
+    // KWin reports PHYSICAL output names, so on a subdivided monitor the
+    // assigned screen ("HDMI-1/vs:0") never equals the reported one
+    // ("HDMI-1") and a naive compare unsnaps every window on every report.
+    // The physical-parent check is what stops that, and it is the arm the
+    // cross-screen drop lands on for any user running virtual screens — the
+    // same configuration the effect-side guard was written for.
+    void testWindowScreenChanged_physicalReportForAVirtualAssignedScreenKeepsTheSnap()
+    {
+        const QString windowId = QStringLiteral("brave-browser|screen-virtual");
+        const QString assigned = QStringLiteral("HDMI-1/vs:0");
+
+        m_snapEngine->commitSnap(windowId, m_zoneIds[0], assigned);
+        QCOMPARE(m_wta->service()->screenForWindow(windowId), assigned);
+
+        m_wta->windowScreenChanged(windowId, QStringLiteral("HDMI-1"));
+
+        QCOMPARE(m_wta->service()->zoneForWindow(windowId), m_zoneIds[0]);
+        QCOMPARE(m_wta->service()->screenForWindow(windowId), assigned);
+    }
+
+    // The other half of that arm: a physical report naming a DIFFERENT
+    // monitor than the virtual screen's parent is a genuine move and must
+    // still unsnap, so the check above cannot be read as "virtual assignments
+    // never unsnap".
+    void testWindowScreenChanged_physicalReportForAnotherMonitorUnsnapsAVirtualAssignment()
+    {
+        const QString windowId = QStringLiteral("brave-browser|screen-virtual-move");
+
+        m_snapEngine->commitSnap(windowId, m_zoneIds[0], QStringLiteral("HDMI-1/vs:0"));
+        QVERIFY(!m_wta->service()->zoneForWindow(windowId).isEmpty());
+
+        m_wta->windowScreenChanged(windowId, QStringLiteral("DP-1"));
+
+        QVERIFY2(m_wta->service()->zoneForWindow(windowId).isEmpty(),
+                 "a report from a different physical monitor must drop a virtual-screen assignment");
+    }
+
     // Repeated reports for the assigned screen stay inert. The effect can
     // legitimately emit more than one per apply (the synchronous frame change
     // and an async follow-up from an X11 size constraint), so idempotence

--- a/tests/unit/dbus/wta_convenience_fixture.h
+++ b/tests/unit/dbus/wta_convenience_fixture.h
@@ -7,8 +7,10 @@
  * @file wta_convenience_fixture.h
  * @brief Shared fixture for the WindowTrackingAdaptor convenience-surface
  *        tests, split across test_wta_convenience.cpp (window-state and
- *        float-restore surface) and test_wta_routing.cpp (open routing and
- *        cross-mode handoff) to stay under the file-size ceiling. Plain
+ *        float-restore surface), test_wta_routing.cpp (open routing and
+ *        cross-mode handoff), test_wta_screen_changed.cpp (the screen-report
+ *        keep/unsnap arm) and test_compositor_bridge.cpp to stay under the
+ *        file-size ceiling. Plain
  *        (non-QObject) base so each test class keeps QObject first; the
  *        derived class forwards its init()/cleanup() slots here.
  */


### PR DESCRIPTION
## The bug

A cross-screen drop into a zone commits the snap and then immediately loses it. The window ends up sitting at the zone rect with no snap state behind it.

Reported against 3.4.3 on a dual-head setup. The daemon journal shows the pair back to back in the same event turn, 14 times across the session, with no user action between them:

```
21:48:55 endDrag: brave-browser-nightly cursor= 2655 334 cancelled= false
21:48:55 commitSnap: ... zones=({7d60770c...}) screen= "Samsung..." intent= user
21:48:55 windowScreenChanged: ... moved from "Samsung..." to "Acer..." - unsnapping
```

The zone rect is `1920,0 1551x1048`, entirely on the Samsung, so the window never legitimately moved to the Acer.

## Cause

The `endDrag` `ApplySnap` branch calls `cancelInteractiveMoveResize()` to end KWin's interactive move before writing the zone rect. That cancel **reverts the window to its drag-start rect**, which on a cross-screen drop is the source monitor, and KWin emits `outputChanged` synchronously from the revert, in the gap before the zone geometry lands.

By that point the drag tracker has already stopped (the `endDrag` reply is async), so the `outputChanged` handler's mid-drag gate no longer holds it back, and `m_daemonGate.inGeometryApply` is not yet set — `applyWindowGeometry` does not bracket itself; only the batch path (`daemon_apply.cpp:463`) and the deferred replay (`drag_snap.cpp:444`) do. The handler sailed through both gates and reported a cross-screen move naming the **source** screen, moments after `commitSnap` had stored the **target**. The daemon read the mismatch as the user moving the window off its zone and dropped the assignment it had just made.

The daemon was never wrong here. The input was.

## What users saw

- a drop that "maximizes to the whole monitor" — the unsnap restores the recorded free geometry, which is full-screen for a window that had been maximized (`Drag-out unsnap: restoring size 1920 x 1048`)
- a window whose decoration disagrees with its size (un-maximize icon on a zone-sized window)
- with restore-on-unsnap enabled, a window straddling both monitors

## The change

`kwin-effect/plasmazoneseffect/drag_end.cpp`, two sites:

- **`ApplySnap`** — pre-seeds `m_trackedScreenPerWindow` from `outcome.targetScreenId`, then opens the `inGeometryApply` bracket around `cancelInteractiveMoveResize()` + `applyWindowGeometry()`.
- **`RestoreSize`** — same bracket around its own cancel + apply pair.

The bracket has to open *before* the cancel rather than inside `applyWindowGeometry`, because the cancel is the thing that emits the bogus event. Both use the nesting-safe save/restore `qScopeGuard` shape already established in `daemon_apply.cpp` and `drag_snap.cpp`.

The pre-seed is **not** belt-and-braces, which is how an earlier draft of this description had it. Measurement (below) shows the zone apply changes the window's *size*, so KWin defers the output flip until the client commits its new buffer, and that `outputChanged` lands after the bracket has already closed. The bracket cannot cover it. The two halves divide the work: the **bracket** suppresses the harmful source-named report the cancel emits synchronously, and the **pre-seed** absorbs the later target-named report from the resize round-trip. Without the pre-seed that late report still names the target, so the daemon keeps the snap and the result is noise rather than a bug, but it should not be removed as redundant.

`ApplyFloat` is deliberately untouched — it calls `endInteractiveMoveResize()`, which does not revert geometry, so it never emits the event.

One further fix, found auditing the above. `RestoreSize`'s "already at correct size" branch skipped the interactive-move rescue along with the resize, so on the *common* drag-out path — the mid-drag `slotRestoreSizeDuringDrag` resize lands first, which is what that branch exists for — KWin's move stayed live and the window followed every desktop switch until the last button came up. `315daae62` scoped that skip to the geometry and its message lists `RestoreSize` among the three rescue sites, but the rescue itself stayed inside the geometry `else`. It now ends the move rather than cancelling it: nothing writes geometry on that branch to undo a revert, so `cancelInteractiveMoveResize()` would throw the window back to the drag-start rect and undo the drag-out. Same reasoning `ApplyFloat` already documents.

## Tests

New `tests/unit/dbus/test_wta_screen_changed.cpp` (7 cases) on the shared `WtaConvenienceFixture`. `windowScreenChanged` had **zero** coverage before this.

**Scope, stated plainly:** it pins the *daemon* half of the contract the effect now has to be correct against — a report naming the assigned screen keeps the snap, only a genuine divergence unsnaps, an empty screen id is ignored, repeats stay inert. **It does not cover the effect change itself**, which has no harness in this repo.

Two of the seven cover the virtual-screen arm, which had no coverage and is the one every user on a subdivided monitor hits: KWin reports physical output names, so a `HDMI-1/vs:0` assignment never equals a `HDMI-1` report, and the physical-parent check is the only thing standing between that and an unsnap on every report. Both halves are pinned, so the check cannot be read as "virtual assignments never unsnap".

Each case was mutation-checked rather than trusted for being green:

| mutation to `lifecycle.cpp` | caught by |
| --- | --- |
| `screensMatch(...)` -> `false &&` (never keep) | the 2 keep-snap cases |
| `screensMatch(...)` -> `true \|\|` (never unsnap) | the 2 unsnap cases |
| delete the empty-`newScreenId` early return | the empty-screen case |
| physical-parent `screensMatch(...)` -> `false` | the virtual keep case only |
| physical-parent `screensMatch(...)` -> `true` | the virtual unsnap case only |

Full suite 417/417, build clean.

## Verified in the nested harness

Measured in `scripts/nested-kwin` on two virtual outputs, with the effect and daemon both loaded from the build tree. A KWin script brackets each geometry write with printed markers, so the ordering in the compositor's single stderr stream is the evidence.

**The premise this PR rested on is confirmed.** A cross-output `moveResize` emits `outputChanged` **synchronously** — the event lands between the markers, and the window's output has already flipped by the closing one. The leg that matters is the revert to the drag-start rect, which is exactly what `cancelInteractiveMoveResize()` does:

```
PZN3|MARK|C-before|REVERT-to-Virtual-0
PZN3|EVENT|outputChanged|Virtual-0@640,286     <- synchronous, names the SOURCE
PZN3|MARK|C-after|Virtual-0@640,286
```

Ungated, that report reaches the daemon: every script-driven cross-output move produced a matching `windowScreenChanged` in the daemon log, the revert leg included. The bogus input is real and reproducible with no drag at all.

**The remedy pattern works end to end.** `Snap.snapToZoneByNumber(1, "Virtual-1")` on a window sitting on Virtual-0 is a genuine cross-output daemon-driven snap through the same bracket-and-pre-seed shape this PR copies into `ApplySnap`:

```
commitSnap: "org.kde.kwrite|..." zones=({f8c77e53-...}) screen= "Virtual-1" intent= user
windowScreenChanged: "org.kde.kwrite|..." moved to assigned screen, keeping snap
```

No unsnap. Note the report still arrives rather than being suppressed outright: it is the async one from the resize round-trip, and it names the assigned screen, which is why the daemon keeps the snap. That is the arm the two keep-snap unit tests pin.

**What is still not covered.** The drag-specific `ApplySnap` path end to end, because entering it needs a genuine pointer drag and this machine has no input-injection route — no `org_kde_kwin_fake_input` global on either compositor, no wlr virtual pointer, no `xdotool`/`ydotool`/`wtype`. `workspace.slotWindowMove()` starts a real interactive move but never moves the cursor, so zone resolution reads the wrong point, and a keyboard move ends as cancelled and routes to `CancelSnap` rather than `ApplySnap`.

So the premise and the remedy are both measured, but the user gesture itself is not. The check still worth doing by hand before merge: drag a window from one monitor into a zone on another and confirm `commitSnap` is no longer followed by `windowScreenChanged ... - unsnapping` in `journalctl --user -u plasmazonesd`.

## Out of scope

The same report showed the primary monitor resolving no layout (`snapToEmptyZone: no layout for screen "Acer..."`). That is a rule setting `"layoutId": "none"`, the explicit opt-out sentinel, and the reporter confirmed it was intentional. Working as designed, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UTm2sqR8BSVatoCx95HFj4

