### PR TITLE
fix(scrolling): stop a live window move spending a session-restore credit

### DIFF
--- a/libs/phosphor-engine/include/PhosphorEngine/WindowPlacementStore.h
+++ b/libs/phosphor-engine/include/PhosphorEngine/WindowPlacementStore.h
@@ -9,6 +9,7 @@
 #include <QHash>
 #include <QJsonObject>
 #include <QList>
+#include <QSet>
 #include <QString>
 
 #include <functional>
@@ -221,6 +222,33 @@ public:
     /// next save.
     bool markInstanceClosed(const QString& windowId, bool graceEligible = true);
 
+    /// The window was RELEASED WHILE LIVE (a move, not a close): its next
+    /// takeForReopen is a move return, not a session-restore open, so it must
+    /// consume its record WITHOUT spending a reclaim credit.
+    ///
+    /// WHY THIS EXISTS. The daemon's live-release funnel
+    /// (Tiling.releaseWindowTracking) untracks the window in its engine, so
+    /// the re-announce that follows arrives as a FIRST OBSERVATION — the
+    /// engine no longer holds it, and nothing downstream can tell that
+    /// announce apart from a genuine open. Verified live: a desktop move of a
+    /// floating scrolling window reached takeForReopen and retired a credit
+    /// belonging to a sibling that had not reopened yet, which is exactly the
+    /// window the credit exists to bring home.
+    ///
+    /// ONE-SHOT, consumed by the next takeForReopen for the instance, so a
+    /// window moved twice is excused twice and a move never disarms the
+    /// window's later genuine opens. Keyed by INSTANCE id, so a mid-session
+    /// class rename cannot lose it. Cleared when the instance closes
+    /// (markInstanceClosed / clear) and by deserialize's whole-store replace.
+    ///
+    /// Sibling of TilingAdaptor::m_moveReleasedInstances, armed from the same
+    /// line for the same reason. They are deliberately NOT one flag: that one
+    /// is consumed by the adaptor BEFORE engine dispatch (to suppress the
+    /// cross-screen reclaim), this one during the engine's open path (to
+    /// suppress the burn), so a single flag consumed at the first moment
+    /// would already be gone by the second.
+    void markInstanceMovedLive(const QString& windowId);
+
     /// Retire ONE reclaim credit in @p appId's bucket: the newest
     /// reclaim-eligible record not bound to a live window and not
     /// @p windowId's own instance. This is takeForReopen's per-open burn,
@@ -429,6 +457,12 @@ private:
     /// every record is worse than the disagreement the claim exists to fix.
     QHash<QString, QString> m_openPairing;
     QHash<QString, QString> m_claimedBy;
+
+    /// Instance ids released while LIVE, each excusing exactly one
+    /// takeForReopen from the reclaim-credit burn — see
+    /// markInstanceMovedLive. TRANSIENT and never serialized: it describes
+    /// moves in flight and means nothing across a restart.
+    QSet<QString> m_movedLiveInstances;
 };
 
 } // namespace PhosphorEngine

--- a/libs/phosphor-engine/include/PhosphorEngine/WindowPlacementStore.h
+++ b/libs/phosphor-engine/include/PhosphorEngine/WindowPlacementStore.h
@@ -235,11 +235,23 @@ public:
     /// belonging to a sibling that had not reopened yet, which is exactly the
     /// window the credit exists to bring home.
     ///
-    /// ONE-SHOT, consumed by the next takeForReopen for the instance, so a
-    /// window moved twice is excused twice and a move never disarms the
-    /// window's later genuine opens. Keyed by INSTANCE id, so a mid-session
-    /// class rename cannot lose it. Cleared when the instance closes
-    /// (markInstanceClosed / clear) and by deserialize's whole-store replace.
+    /// ONE-SHOT, consumed by the next reclaim-credit BURN for the instance —
+    /// burnReclaimCredit, which is where both open channels converge
+    /// (takeForReopen for tiling-screen arrivals, the snap adaptor's
+    /// open-path resolve for snap-mode ones). Consuming it inside
+    /// takeForReopen instead would leave the snap channel burning a sibling's
+    /// credit on a move return AND leave the excuse armed for some later
+    /// genuine open. A window moved twice is excused twice, and a move never
+    /// disarms the window's later genuine opens. Keyed by INSTANCE id, so a
+    /// mid-session class rename cannot lose it. Cleared when the instance
+    /// closes (markInstanceClosed / clear) and by deserialize's whole-store
+    /// replace.
+    ///
+    /// An announce that reaches NEITHER burn channel (an arrival on a screen
+    /// no engine claims, dropped by the tiling dispatch) leaves the excuse
+    /// standing, deliberately: that window is still live, still released, and
+    /// still unplaced, so the announce that eventually does land is the same
+    /// move's continuation.
     ///
     /// Sibling of TilingAdaptor::m_moveReleasedInstances, armed from the same
     /// line for the same reason. They are deliberately NOT one flag: that one

--- a/libs/phosphor-engine/src/WindowPlacementStore.cpp
+++ b/libs/phosphor-engine/src/WindowPlacementStore.cpp
@@ -647,25 +647,34 @@ std::optional<WindowPlacement> WindowPlacementStore::takeForReopen(const QString
     }
     // Per-open reclaim-credit burn — see the header contract. Hit or miss,
     // and AFTER any consumption/re-record above (the bucket may have been
-    // erased and re-created by it, so the helper re-finds it).
-    //
-    // Excused for a MOVE RETURN: the daemon's live-release funnel untracked
-    // this window in its engine, so this announce reaches us looking exactly
-    // like a first observation while actually being the second half of a
-    // user's move. Spending a session-restore credit on it takes the credit
-    // from a sibling that has not reopened yet. One-shot, so the window's
-    // later genuine opens still burn (markInstanceMovedLive).
-    if (m_movedLiveInstances.remove(PhosphorIdentity::WindowId::extractInstanceId(windowId)) > 0) {
-        qCDebug(lcPlacementStore) << "takeForReopen:" << engineId << "move return for" << windowId
-                                  << "— reclaim-credit burn excused";
-    } else {
-        burnReclaimCredit(windowId, appId);
-    }
+    // erased and re-created by it, so the helper re-finds it). The move-return
+    // excuse lives inside the helper rather than here, so BOTH burn channels
+    // honour it — see markInstanceMovedLive.
+    burnReclaimCredit(windowId, appId);
     return rec;
 }
 
 bool WindowPlacementStore::burnReclaimCredit(const QString& windowId, const QString& appId)
 {
+    // MOVE RETURN excuse, consumed here rather than at either call site
+    // because there are TWO per-open burn channels and both must honour it:
+    // takeForReopen for tiling-screen arrivals, and the snap adaptor's
+    // open-path resolve for snap-mode ones (see the header). The daemon's
+    // live-release funnel untracked this window in its engine, so the
+    // announce that follows reaches whichever channel it lands in looking
+    // exactly like a first observation while actually being the second half
+    // of a user's move; spending a session-restore credit on it takes the
+    // credit from a sibling that has not reopened yet. One-shot, so the
+    // window's later genuine opens still burn (markInstanceMovedLive).
+    //
+    // AHEAD of the appId guard below: the one-shot answers "was this announce
+    // a move return", which is true whether or not the window has a bucket to
+    // burn from, and leaving it armed past a bucket-less announce would hand
+    // the excuse to some later genuine open instead.
+    if (m_movedLiveInstances.remove(PhosphorIdentity::WindowId::extractInstanceId(windowId)) > 0) {
+        qCDebug(lcPlacementStore) << "burnReclaimCredit: move return for" << windowId << "— burn excused";
+        return false;
+    }
     if (appId.isEmpty()) {
         return false;
     }
@@ -713,8 +722,12 @@ bool WindowPlacementStore::markInstanceClosed(const QString& windowId, bool grac
     }
     // A window that closed is not coming back to spend its move excuse, and
     // the instance id is unique so the entry could never fire again — but the
-    // set must not accumulate corpses (the sibling one-shot in TilingAdaptor
-    // is reaped on the same events for the same reason).
+    // set must not accumulate corpses. This and clear() are the store's only
+    // reap points, and between them they cover both of the daemon's close
+    // funnels: the observed close and the alive-set prune backstop, which
+    // calls this with graceEligible=false. (The TilingAdaptor sibling reaps on
+    // its own four events instead — it is armed from the same line, but the
+    // two sets live in different objects and see different signals.)
     m_movedLiveInstances.remove(PhosphorIdentity::WindowId::extractInstanceId(windowId));
     // An OBSERVED close is authoritative and stamps the time. An unobserved one
     // contributes no time at all and must not overwrite a stamp an earlier

--- a/libs/phosphor-engine/src/WindowPlacementStore.cpp
+++ b/libs/phosphor-engine/src/WindowPlacementStore.cpp
@@ -648,7 +648,19 @@ std::optional<WindowPlacement> WindowPlacementStore::takeForReopen(const QString
     // Per-open reclaim-credit burn — see the header contract. Hit or miss,
     // and AFTER any consumption/re-record above (the bucket may have been
     // erased and re-created by it, so the helper re-finds it).
-    burnReclaimCredit(windowId, appId);
+    //
+    // Excused for a MOVE RETURN: the daemon's live-release funnel untracked
+    // this window in its engine, so this announce reaches us looking exactly
+    // like a first observation while actually being the second half of a
+    // user's move. Spending a session-restore credit on it takes the credit
+    // from a sibling that has not reopened yet. One-shot, so the window's
+    // later genuine opens still burn (markInstanceMovedLive).
+    if (m_movedLiveInstances.remove(PhosphorIdentity::WindowId::extractInstanceId(windowId)) > 0) {
+        qCDebug(lcPlacementStore) << "takeForReopen:" << engineId << "move return for" << windowId
+                                  << "— reclaim-credit burn excused";
+    } else {
+        burnReclaimCredit(windowId, appId);
+    }
     return rec;
 }
 
@@ -686,11 +698,24 @@ bool WindowPlacementStore::burnReclaimCredit(const QString& windowId, const QStr
     return true;
 }
 
+void WindowPlacementStore::markInstanceMovedLive(const QString& windowId)
+{
+    if (windowId.isEmpty()) {
+        return;
+    }
+    m_movedLiveInstances.insert(PhosphorIdentity::WindowId::extractInstanceId(windowId));
+}
+
 bool WindowPlacementStore::markInstanceClosed(const QString& windowId, bool graceEligible)
 {
     if (windowId.isEmpty()) {
         return false;
     }
+    // A window that closed is not coming back to spend its move excuse, and
+    // the instance id is unique so the entry could never fire again — but the
+    // set must not accumulate corpses (the sibling one-shot in TilingAdaptor
+    // is reaped on the same events for the same reason).
+    m_movedLiveInstances.remove(PhosphorIdentity::WindowId::extractInstanceId(windowId));
     // An OBSERVED close is authoritative and stamps the time. An unobserved one
     // contributes no time at all and must not overwrite a stamp an earlier
     // observed close already wrote: logout tears windows down and can push an
@@ -862,6 +887,9 @@ bool WindowPlacementStore::clear(const QString& windowId)
     if (windowId.isEmpty()) {
         return false;
     }
+    // The move excuse names a record that is going away — same reaping
+    // rationale as markInstanceClosed's.
+    m_movedLiveInstances.remove(PhosphorIdentity::WindowId::extractInstanceId(windowId));
     bool removed = false;
     for (auto it = m_byApp.begin(); it != m_byApp.end();) {
         QList<WindowPlacement>& bucket = it.value();
@@ -1023,6 +1051,9 @@ void WindowPlacementStore::deserialize(const QJsonObject& obj)
     // Every claim named a record in the store being replaced.
     m_openPairing.clear();
     m_claimedBy.clear();
+    // Likewise the in-flight move excuses: they describe this session's moves,
+    // and both deserialize callers are startup-time (see the note above).
+    m_movedLiveInstances.clear();
     QList<WindowPlacement> loaded;
     // Persisted ARRAY positions, keyed per (bucket, instance) — NOT a global
     // index into the flattened list: a renamed duplicate persisted under an

--- a/src/dbus/tilingadaptor/tilingadaptor.cpp
+++ b/src/dbus/tilingadaptor/tilingadaptor.cpp
@@ -1117,11 +1117,21 @@ void TilingAdaptor::releaseWindowTracking(const QString& windowId)
     }
     removeUnclaimedOpen(windowId);
     removePendingOpen(windowId);
-    // Arm the move-release one-shot BEFORE the pipeline gate, mirroring the
+    // Arm the move-release one-shots BEFORE the pipeline gate, mirroring the
     // bookkeeping above: the window is live and being moved, and its next
     // announce must not be mistaken for a session restore (see
     // m_moveReleasedInstances).
+    //
+    // TWO of them, armed together because the same announce is misread in two
+    // independent places and each excuse is consumed at a different moment:
+    // this one by the dispatch below (suppressing the cross-screen reclaim),
+    // the store's by the engine's takeForReopen (suppressing the
+    // reclaim-credit burn). A single flag consumed at the first moment would
+    // already be gone by the second — see markInstanceMovedLive.
     m_moveReleasedInstances.insert(PhosphorIdentity::WindowId::extractInstanceId(windowId));
+    if (m_windowTrackingAdaptor && m_windowTrackingAdaptor->service()) {
+        m_windowTrackingAdaptor->service()->placementStore().markInstanceMovedLive(windowId);
+    }
     if (!ensurePipeline("releaseWindowTracking")) {
         return;
     }

--- a/tests/unit/core/windowtracking/test_window_placement_store.cpp
+++ b/tests/unit/core/windowtracking/test_window_placement_store.cpp
@@ -1680,6 +1680,39 @@ private Q_SLOTS:
         QVERIFY2(!holdsCredit(store, QStringLiteral("firefox|ghostA")), "the second open retires the second credit");
     }
 
+    void testMarkInstanceMovedLive_excusesTheSnapChannelsDirectBurn()
+    {
+        // There are TWO per-open burn channels, not one: takeForReopen for
+        // tiling-screen arrivals, and the snap adaptor's open-path resolve
+        // (SnapRestore) which calls burnReclaimCredit DIRECTLY and never
+        // reaches takeForReopen. A move return whose re-announce lands on a
+        // snap-mode screen goes through the second, so an excuse consumed
+        // inside takeForReopen alone would leave that channel spending a
+        // sibling's session-restore credit — the very bug — while leaving the
+        // one-shot armed to excuse a later genuine open.
+        //
+        // MUTATION NOTE: this fails with the excuse moved back into
+        // takeForReopen, which is the whole point; the sibling test above
+        // passes either way because it only ever drives the tiling channel.
+        WindowPlacementStore store;
+        store.record(makePlacement(QStringLiteral("firefox|ghost"), QStringLiteral("firefox"),
+                                   WindowPlacement::stateTiled(), WindowPlacement::snapEngineId(),
+                                   QStringLiteral("DP-2")));
+        store.record(makePlacement(QStringLiteral("firefox|live"), QStringLiteral("firefox"),
+                                   WindowPlacement::stateFloating(), WindowPlacement::snapEngineId(),
+                                   QStringLiteral("DP-1")));
+
+        store.markInstanceMovedLive(QStringLiteral("firefox|live"));
+        QVERIFY2(!store.burnReclaimCredit(QStringLiteral("firefox|live"), QStringLiteral("firefox")),
+                 "the snap channel's burn must report nothing retired for a move return");
+        QVERIFY2(holdsCredit(store, QStringLiteral("firefox|ghost")),
+                 "a move return must not spend a credit through the snap channel either");
+
+        // ONE shot here too: the window's next genuine snap-screen open burns.
+        QVERIFY(store.burnReclaimCredit(QStringLiteral("firefox|live"), QStringLiteral("firefox")));
+        QVERIFY(!holdsCredit(store, QStringLiteral("firefox|ghost")));
+    }
+
     void testMarkInstanceMovedLive_excuseDiesWithTheInstance()
     {
         // A window released for a move that then CLOSES instead of

--- a/tests/unit/core/windowtracking/test_window_placement_store.cpp
+++ b/tests/unit/core/windowtracking/test_window_placement_store.cpp
@@ -21,6 +21,23 @@ class TestWindowPlacementStore : public QObject
 {
     Q_OBJECT
 
+    /// Whether the record for @p windowId still holds its cross-screen reclaim
+    /// credit. Read straight off the record rather than inferred from
+    /// peekForReclaim: that lookup also excludes live siblings and prefers the
+    /// newest, so using it as a credit proxy makes an assertion depend on the
+    /// probe and on which record happens to be newest — which is how an
+    /// earlier version of the move-excuse tests below ended up asserting
+    /// something other than what it claimed.
+    static bool holdsCredit(const WindowPlacementStore& store, const QString& windowId)
+    {
+        for (const WindowPlacement& p : store.records()) {
+            if (p.windowId == windowId) {
+                return p.reclaimEligible;
+            }
+        }
+        return false;
+    }
+
 private Q_SLOTS:
     void testRecordAndTake_exact()
     {
@@ -1607,6 +1624,92 @@ private Q_SLOTS:
         // hand-back rather than a permanent exemption.
         QVERIFY(store.markInstanceClosed(QStringLiteral("app|new")));
         QVERIFY(!store.peekForReclaim(QStringLiteral("app|third"), QStringLiteral("app")).has_value());
+    }
+
+    void testMarkInstanceMovedLive_excusesExactlyOneBurn()
+    {
+        // A live release (a move) untracks the window in its engine, so the
+        // re-announce that follows reaches takeForReopen looking exactly like
+        // a first observation. Burning there spends a session-restore credit
+        // belonging to a sibling that has not reopened yet — verified live in
+        // the nested harness, where a desktop move retired a ghost's credit.
+        //
+        // Assertions read each sibling's credit off its record (holdsCredit)
+        // rather than through peekForReclaim, so they say exactly which credit
+        // was spent instead of depending on the probe and record recency.
+        WindowPlacementStore store;
+        // Two credit-bearing siblings that have not reopened, so two burns are
+        // distinguishable from one. The burn takes the NEWEST first, so ghostB
+        // goes before ghostA.
+        store.record(makePlacement(QStringLiteral("firefox|ghostA"), QStringLiteral("firefox"),
+                                   WindowPlacement::stateTiled(), WindowPlacement::scrollingEngineId(),
+                                   QStringLiteral("DP-2")));
+        store.record(makePlacement(QStringLiteral("firefox|ghostB"), QStringLiteral("firefox"),
+                                   WindowPlacement::stateTiled(), WindowPlacement::scrollingEngineId(),
+                                   QStringLiteral("DP-2")));
+        // The moving window: a floating slot on the screen it re-announces on,
+        // so the accept passes and the call REACHES the burn rather than
+        // stopping at the exact-final return.
+        store.record(makePlacement(QStringLiteral("firefox|live"), QStringLiteral("firefox"),
+                                   WindowPlacement::stateFloating(), WindowPlacement::scrollingEngineId(),
+                                   QStringLiteral("DP-1")));
+
+        const auto reopen = [&]() {
+            return store
+                .takeForReopen(WindowPlacement::scrollingEngineId(), QStringLiteral("firefox|live"),
+                               QStringLiteral("firefox"), QStringLiteral("DP-1"))
+                .has_value();
+        };
+        QVERIFY(holdsCredit(store, QStringLiteral("firefox|ghostA")));
+        QVERIFY(holdsCredit(store, QStringLiteral("firefox|ghostB")));
+
+        // The move return: the record is still consumed, but no credit spent.
+        store.markInstanceMovedLive(QStringLiteral("firefox|live"));
+        QVERIFY(reopen());
+        QVERIFY2(holdsCredit(store, QStringLiteral("firefox|ghostB")),
+                 "a move return must not spend a session-restore credit");
+        QVERIFY(holdsCredit(store, QStringLiteral("firefox|ghostA")));
+
+        // ONE shot. The window's next genuine open burns normally, or a single
+        // move would excuse that window's opens for the rest of the session.
+        QVERIFY(reopen());
+        QVERIFY2(!holdsCredit(store, QStringLiteral("firefox|ghostB")), "a genuine open must retire a credit");
+        QVERIFY2(holdsCredit(store, QStringLiteral("firefox|ghostA")), "and only ONE credit");
+
+        QVERIFY(reopen());
+        QVERIFY2(!holdsCredit(store, QStringLiteral("firefox|ghostA")), "the second open retires the second credit");
+    }
+
+    void testMarkInstanceMovedLive_excuseDiesWithTheInstance()
+    {
+        // A window released for a move that then CLOSES instead of
+        // re-announcing must not leave its excuse behind.
+        //
+        // CONTRACT PIN, not a reachable scenario: instance ids are unique to a
+        // window, so a closed instance can never re-announce and a leaked
+        // excuse could never actually fire — the reap is leak hygiene. That
+        // makes it unobservable except by re-announcing the SAME instance,
+        // which is what this drives. An earlier version of this test closed
+        // one instance and opened a DIFFERENT one; it passed with the reap
+        // deleted, because the excuse was never consulted either way.
+        WindowPlacementStore store;
+        store.record(makePlacement(QStringLiteral("kate|ghost"), QStringLiteral("kate"), WindowPlacement::stateTiled(),
+                                   WindowPlacement::scrollingEngineId(), QStringLiteral("DP-2")));
+        store.record(makePlacement(QStringLiteral("kate|gone"), QStringLiteral("kate"),
+                                   WindowPlacement::stateFloating(), WindowPlacement::scrollingEngineId(),
+                                   QStringLiteral("DP-1")));
+
+        store.markInstanceMovedLive(QStringLiteral("kate|gone"));
+        store.markInstanceClosed(QStringLiteral("kate|gone"));
+
+        // The excuse went with the close, so this take burns like any other.
+        QVERIFY(holdsCredit(store, QStringLiteral("kate|ghost")));
+        QVERIFY(store
+                    .takeForReopen(WindowPlacement::scrollingEngineId(), QStringLiteral("kate|gone"),
+                                   QStringLiteral("kate"), QStringLiteral("DP-1"))
+                    .has_value());
+        QVERIFY2(!holdsCredit(store, QStringLiteral("kate|ghost")),
+                 "a closed instance's move excuse must not survive its close");
     }
 
     void testMarkInstanceClosed_unobservedCloseEarnsNoShutdownGrace()


### PR DESCRIPTION
Follow-up to #1020, which introduced the reclaim-credit machinery this builds on. That has merged, so this targets `main` directly and is a single commit on top of it.

## The bug

A live release/re-announce — a desktop move, a drag-bypass revert, a float cleanup, a cross-screen transfer — reaches `WindowPlacementStore::takeForReopen` looking exactly like a **first observation**, because the daemon's release funnel (`Tiling.releaseWindowTracking`) calls `engine->windowClosed()` and untracks the window before the re-announce arrives.

So the announce burned a cross-screen reclaim credit belonging to a sibling that had **not reopened yet** — precisely the window that credit exists to bring home at login. Moving your windows around during a session quietly spent other windows' restore budget.

This was found by live-instrumenting the nested harness while auditing #1020, not by reading. An earlier attempt to fix it by guarding `ScrollEngine`'s `oldState` migration branch was **inert** — the effect releases first, so that branch is never reached on a desktop change — and was reverted in `f1c9f1a71`.

## The fix

`WindowPlacementStore` gains a one-shot, `markInstanceMovedLive`, armed by `Tiling.releaseWindowTracking` and consumed by the next `takeForReopen` for that instance. Only the **burn** is suppressed; consumption, re-binding and re-recording are untouched.

Two flags rather than one, deliberately: the adaptor's existing `m_moveReleasedInstances` is consumed *before* engine dispatch (to suppress the cross-screen reclaim), this one *during* the engine's open path (to suppress the burn). A single flag consumed at the first moment would already be gone at the second. Both are armed from the same line and documented as siblings.

Keyed by instance id so a mid-session class rename cannot lose it; reaped on close / `clear` / `deserialize`.

**No interface change.** The store already owns credit accounting, and the release funnel reaches it exactly as `dispatchWindowOpened` reaches `claimForOpen` — so nothing needed plumbing through `IPlacementEngine`.

## Verification

Live, in the nested harness, with a control to rule out a false pass:

| drive | `takeForReopen` | result |
|---|---|---|
| announce alone (**control**) | consumed, slot `floating` | `burnReclaimCredit: retired credit of ghost-bbbb` |
| release + announce (**under test**) | consumed, slot `floating` | `move return — reclaim-credit burn excused` |

Both drives reach `takeForReopen` and consume the record identically; only the burn differs. The control is what makes the zero meaningful — an earlier probe reported "0 burns" simply because `applyPersistedDesktopRestore` early-returned before engine dispatch and the path was never exercised at all.

Two unit tests, both mutation-verified (each fails with its guard removed). The second is labelled a **contract pin**: a closed instance can never re-announce, so the reap is unobservable except by driving that unreachable path — an earlier version of it closed one instance and opened a different one, and passed with the reap deleted.

Build clean, no new warnings, 416/416 tests pass.
