### PR TITLE
chore(i18n): refresh catalogs and translate the session-restore strings

### DIFF
--- a/translations/plasmazones_de.ts
+++ b/translations/plasmazones_de.ts
@@ -8880,19 +8880,19 @@
         <location filename="../src/settings/search/searchcatalog.cpp" line="374"/>
         <location filename=".qml-stubs/src/settings/qml/GeneralPage.qml.cpp" line="522"/>
         <source>Session restore</source>
-        <translation type="unfinished"></translation>
+        <translation>Sitzungswiederherstellung</translation>
     </message>
     <message>
         <location filename="../src/settings/search/searchcatalog.cpp" line="376"/>
         <location filename=".qml-stubs/src/settings/qml/GeneralPage.qml.cpp" line="530"/>
         <location filename=".qml-stubs/src/settings/qml/GeneralPage.qml.cpp" line="536"/>
         <source>Put windows back on their virtual desktop</source>
-        <translation type="unfinished"></translation>
+        <translation>Fenster auf ihrer virtuellen Arbeitsfläche wiederherstellen</translation>
     </message>
     <message>
         <location filename="../src/settings/search/searchcatalog.cpp" line="378"/>
         <source>logout</source>
-        <translation type="unfinished"></translation>
+        <translation>abmelden</translation>
     </message>
     <message>
         <location filename="../src/settings/search/searchcatalog.cpp" line="538"/>
@@ -13635,7 +13635,7 @@
     <message>
         <location filename=".qml-stubs/src/settings/qml/GeneralPage.qml.cpp" line="532"/>
         <source>After you log back in, each window returns to the desktop it was on. Without this, every window reopens on whichever desktop is showing when you log in.</source>
-        <translation type="unfinished"></translation>
+        <translation>Nach der erneuten Anmeldung kehrt jedes Fenster auf die Arbeitsfläche zurück, auf der es war. Ohne diese Einstellung öffnet sich jedes Fenster auf der Arbeitsfläche, die bei der Anmeldung angezeigt wird.</translation>
     </message>
     <message>
         <location filename=".qml-stubs/src/settings/qml/GeneralPage.qml.cpp" line="558"/>
@@ -21550,7 +21550,7 @@
         <translation>Der Reiter eines Fensters, das Aufmerksamkeit erbittet.</translation>
     </message>
     <message>
-        <location filename="../kwin-effect/tilinghandler/scrolltabs.cpp" line="672"/>
+        <location filename="../kwin-effect/tilinghandler/scrolltabs.cpp" line="696"/>
         <source>Untitled window</source>
         <translation>Unbenanntes Fenster</translation>
     </message>

--- a/translations/plasmazones_de.ts
+++ b/translations/plasmazones_de.ts
@@ -8887,7 +8887,7 @@
         <location filename=".qml-stubs/src/settings/qml/GeneralPage.qml.cpp" line="530"/>
         <location filename=".qml-stubs/src/settings/qml/GeneralPage.qml.cpp" line="536"/>
         <source>Put windows back on their virtual desktop</source>
-        <translation>Fenster auf ihrer virtuellen Arbeitsfläche wiederherstellen</translation>
+        <translation>Fenster auf ihre virtuelle Arbeitsfläche zurückbringen</translation>
     </message>
     <message>
         <location filename="../src/settings/search/searchcatalog.cpp" line="378"/>

--- a/translations/plasmazones_en.ts
+++ b/translations/plasmazones_en.ts
@@ -21550,7 +21550,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../kwin-effect/tilinghandler/scrolltabs.cpp" line="672"/>
+        <location filename="../kwin-effect/tilinghandler/scrolltabs.cpp" line="696"/>
         <source>Untitled window</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/plasmazones_ka.ts
+++ b/translations/plasmazones_ka.ts
@@ -7660,19 +7660,19 @@
         <location filename="../src/settings/search/searchcatalog.cpp" line="374"/>
         <location filename=".qml-stubs/src/settings/qml/GeneralPage.qml.cpp" line="522"/>
         <source>Session restore</source>
-        <translation type="unfinished"></translation>
+        <translation>სესიის აღდგენა</translation>
     </message>
     <message>
         <location filename="../src/settings/search/searchcatalog.cpp" line="376"/>
         <location filename=".qml-stubs/src/settings/qml/GeneralPage.qml.cpp" line="530"/>
         <location filename=".qml-stubs/src/settings/qml/GeneralPage.qml.cpp" line="536"/>
         <source>Put windows back on their virtual desktop</source>
-        <translation type="unfinished"></translation>
+        <translation>ფანჯრების დაბრუნება მათ ვირტუალურ სამუშაო მაგიდაზე</translation>
     </message>
     <message>
         <location filename="../src/settings/search/searchcatalog.cpp" line="378"/>
         <source>logout</source>
-        <translation type="unfinished"></translation>
+        <translation>სისტემიდან გასვლა</translation>
     </message>
     <message>
         <location filename="../src/settings/search/searchcatalog.cpp" line="524"/>
@@ -13635,7 +13635,7 @@
     <message>
         <location filename=".qml-stubs/src/settings/qml/GeneralPage.qml.cpp" line="532"/>
         <source>After you log back in, each window returns to the desktop it was on. Without this, every window reopens on whichever desktop is showing when you log in.</source>
-        <translation type="unfinished"></translation>
+        <translation>ხელახლა შესვლის შემდეგ თითოეული ფანჯარა ბრუნდება იმ სამუშაო მაგიდაზე, სადაც ის იყო. ამის გარეშე ყველა ფანჯარა იხსნება იმ სამუშაო მაგიდაზე, რომელიც შესვლისას ჩანს.</translation>
     </message>
     <message>
         <location filename=".qml-stubs/src/settings/qml/GeneralPage.qml.cpp" line="558"/>
@@ -21550,7 +21550,7 @@
         <translation>იმ ფანჯრის ჩანართი, რომელიც ყურადღებას ითხოვს.</translation>
     </message>
     <message>
-        <location filename="../kwin-effect/tilinghandler/scrolltabs.cpp" line="672"/>
+        <location filename="../kwin-effect/tilinghandler/scrolltabs.cpp" line="696"/>
         <source>Untitled window</source>
         <translation>უსახელო ფანჯარა</translation>
     </message>

--- a/translations/plasmazones_nl.ts
+++ b/translations/plasmazones_nl.ts
@@ -13635,7 +13635,7 @@
     <message>
         <location filename=".qml-stubs/src/settings/qml/GeneralPage.qml.cpp" line="532"/>
         <source>After you log back in, each window returns to the desktop it was on. Without this, every window reopens on whichever desktop is showing when you log in.</source>
-        <translation>Nadat u opnieuw hebt ingelogd, keert elk venster terug naar het bureaublad waarop het stond. Zonder dit wordt elk venster geopend op het bureaublad dat te zien is wanneer u inlogt.</translation>
+        <translation>Nadat u zich opnieuw hebt aangemeld, keert elk venster terug naar het bureaublad waarop het stond. Zonder dit wordt elk venster geopend op het bureaublad dat te zien is wanneer u zich aanmeldt.</translation>
     </message>
     <message>
         <location filename=".qml-stubs/src/settings/qml/GeneralPage.qml.cpp" line="558"/>

--- a/translations/plasmazones_nl.ts
+++ b/translations/plasmazones_nl.ts
@@ -7660,19 +7660,19 @@
         <location filename="../src/settings/search/searchcatalog.cpp" line="374"/>
         <location filename=".qml-stubs/src/settings/qml/GeneralPage.qml.cpp" line="522"/>
         <source>Session restore</source>
-        <translation type="unfinished"></translation>
+        <translation>Sessieherstel</translation>
     </message>
     <message>
         <location filename="../src/settings/search/searchcatalog.cpp" line="376"/>
         <location filename=".qml-stubs/src/settings/qml/GeneralPage.qml.cpp" line="530"/>
         <location filename=".qml-stubs/src/settings/qml/GeneralPage.qml.cpp" line="536"/>
         <source>Put windows back on their virtual desktop</source>
-        <translation type="unfinished"></translation>
+        <translation>Vensters terugzetten op hun virtuele bureaublad</translation>
     </message>
     <message>
         <location filename="../src/settings/search/searchcatalog.cpp" line="378"/>
         <source>logout</source>
-        <translation type="unfinished"></translation>
+        <translation>afmelden</translation>
     </message>
     <message>
         <location filename="../src/settings/search/searchcatalog.cpp" line="524"/>
@@ -13635,7 +13635,7 @@
     <message>
         <location filename=".qml-stubs/src/settings/qml/GeneralPage.qml.cpp" line="532"/>
         <source>After you log back in, each window returns to the desktop it was on. Without this, every window reopens on whichever desktop is showing when you log in.</source>
-        <translation type="unfinished"></translation>
+        <translation>Nadat u opnieuw hebt ingelogd, keert elk venster terug naar het bureaublad waarop het stond. Zonder dit wordt elk venster geopend op het bureaublad dat te zien is wanneer u inlogt.</translation>
     </message>
     <message>
         <location filename=".qml-stubs/src/settings/qml/GeneralPage.qml.cpp" line="558"/>
@@ -21550,7 +21550,7 @@
         <translation>Het tabblad van een venster dat om aandacht vraagt.</translation>
     </message>
     <message>
-        <location filename="../kwin-effect/tilinghandler/scrolltabs.cpp" line="672"/>
+        <location filename="../kwin-effect/tilinghandler/scrolltabs.cpp" line="696"/>
         <source>Untitled window</source>
         <translation>Naamloos venster</translation>
     </message>

--- a/translations/plasmazones_pl.ts
+++ b/translations/plasmazones_pl.ts
@@ -7669,19 +7669,19 @@
         <location filename="../src/settings/search/searchcatalog.cpp" line="374"/>
         <location filename=".qml-stubs/src/settings/qml/GeneralPage.qml.cpp" line="522"/>
         <source>Session restore</source>
-        <translation type="unfinished"></translation>
+        <translation>Przywracanie sesji</translation>
     </message>
     <message>
         <location filename="../src/settings/search/searchcatalog.cpp" line="376"/>
         <location filename=".qml-stubs/src/settings/qml/GeneralPage.qml.cpp" line="530"/>
         <location filename=".qml-stubs/src/settings/qml/GeneralPage.qml.cpp" line="536"/>
         <source>Put windows back on their virtual desktop</source>
-        <translation type="unfinished"></translation>
+        <translation>Przywracaj okna na ich wirtualny pulpit</translation>
     </message>
     <message>
         <location filename="../src/settings/search/searchcatalog.cpp" line="378"/>
         <source>logout</source>
-        <translation type="unfinished"></translation>
+        <translation>wylogowanie</translation>
     </message>
     <message>
         <location filename="../src/settings/search/searchcatalog.cpp" line="524"/>
@@ -13649,7 +13649,7 @@
     <message>
         <location filename=".qml-stubs/src/settings/qml/GeneralPage.qml.cpp" line="532"/>
         <source>After you log back in, each window returns to the desktop it was on. Without this, every window reopens on whichever desktop is showing when you log in.</source>
-        <translation type="unfinished"></translation>
+        <translation>Po ponownym zalogowaniu każde okno wraca na pulpit, na którym było. Bez tego każde okno otwiera się na pulpicie widocznym w chwili logowania.</translation>
     </message>
     <message>
         <location filename=".qml-stubs/src/settings/qml/GeneralPage.qml.cpp" line="558"/>
@@ -21601,7 +21601,7 @@
         <translation>Karta okna, które prosi o uwagę.</translation>
     </message>
     <message>
-        <location filename="../kwin-effect/tilinghandler/scrolltabs.cpp" line="672"/>
+        <location filename="../kwin-effect/tilinghandler/scrolltabs.cpp" line="696"/>
         <source>Untitled window</source>
         <translation>Okno bez tytułu</translation>
     </message>

--- a/translations/plasmazones_pt_BR.ts
+++ b/translations/plasmazones_pt_BR.ts
@@ -7667,7 +7667,7 @@
         <location filename=".qml-stubs/src/settings/qml/GeneralPage.qml.cpp" line="530"/>
         <location filename=".qml-stubs/src/settings/qml/GeneralPage.qml.cpp" line="536"/>
         <source>Put windows back on their virtual desktop</source>
-        <translation>Devolver as janelas à sua área de trabalho virtual</translation>
+        <translation>Devolver as janelas à área de trabalho virtual delas</translation>
     </message>
     <message>
         <location filename="../src/settings/search/searchcatalog.cpp" line="378"/>
@@ -13635,7 +13635,7 @@
     <message>
         <location filename=".qml-stubs/src/settings/qml/GeneralPage.qml.cpp" line="532"/>
         <source>After you log back in, each window returns to the desktop it was on. Without this, every window reopens on whichever desktop is showing when you log in.</source>
-        <translation>Depois que você entrar novamente, cada janela volta para a área de trabalho em que estava. Sem isso, todas as janelas reabrem na área de trabalho que estiver visível quando você entrar.</translation>
+        <translation>Depois que você entrar na sessão novamente, cada janela volta para a área de trabalho em que estava. Sem isso, todas as janelas reabrem na área de trabalho que estiver visível quando você entrar na sessão.</translation>
     </message>
     <message>
         <location filename=".qml-stubs/src/settings/qml/GeneralPage.qml.cpp" line="558"/>

--- a/translations/plasmazones_pt_BR.ts
+++ b/translations/plasmazones_pt_BR.ts
@@ -7660,19 +7660,19 @@
         <location filename="../src/settings/search/searchcatalog.cpp" line="374"/>
         <location filename=".qml-stubs/src/settings/qml/GeneralPage.qml.cpp" line="522"/>
         <source>Session restore</source>
-        <translation type="unfinished"></translation>
+        <translation>Restauração de sessão</translation>
     </message>
     <message>
         <location filename="../src/settings/search/searchcatalog.cpp" line="376"/>
         <location filename=".qml-stubs/src/settings/qml/GeneralPage.qml.cpp" line="530"/>
         <location filename=".qml-stubs/src/settings/qml/GeneralPage.qml.cpp" line="536"/>
         <source>Put windows back on their virtual desktop</source>
-        <translation type="unfinished"></translation>
+        <translation>Devolver as janelas à sua área de trabalho virtual</translation>
     </message>
     <message>
         <location filename="../src/settings/search/searchcatalog.cpp" line="378"/>
         <source>logout</source>
-        <translation type="unfinished"></translation>
+        <translation>encerrar sessão</translation>
     </message>
     <message>
         <location filename="../src/settings/search/searchcatalog.cpp" line="524"/>
@@ -13635,7 +13635,7 @@
     <message>
         <location filename=".qml-stubs/src/settings/qml/GeneralPage.qml.cpp" line="532"/>
         <source>After you log back in, each window returns to the desktop it was on. Without this, every window reopens on whichever desktop is showing when you log in.</source>
-        <translation type="unfinished"></translation>
+        <translation>Depois que você entrar novamente, cada janela volta para a área de trabalho em que estava. Sem isso, todas as janelas reabrem na área de trabalho que estiver visível quando você entrar.</translation>
     </message>
     <message>
         <location filename=".qml-stubs/src/settings/qml/GeneralPage.qml.cpp" line="558"/>
@@ -21550,7 +21550,7 @@
         <translation>A aba de uma janela que está pedindo atenção.</translation>
     </message>
     <message>
-        <location filename="../kwin-effect/tilinghandler/scrolltabs.cpp" line="672"/>
+        <location filename="../kwin-effect/tilinghandler/scrolltabs.cpp" line="696"/>
         <source>Untitled window</source>
         <translation>Janela sem título</translation>
     </message>

--- a/translations/plasmazones_ru.ts
+++ b/translations/plasmazones_ru.ts
@@ -7669,19 +7669,19 @@
         <location filename="../src/settings/search/searchcatalog.cpp" line="374"/>
         <location filename=".qml-stubs/src/settings/qml/GeneralPage.qml.cpp" line="522"/>
         <source>Session restore</source>
-        <translation type="unfinished"></translation>
+        <translation>Восстановление сеанса</translation>
     </message>
     <message>
         <location filename="../src/settings/search/searchcatalog.cpp" line="376"/>
         <location filename=".qml-stubs/src/settings/qml/GeneralPage.qml.cpp" line="530"/>
         <location filename=".qml-stubs/src/settings/qml/GeneralPage.qml.cpp" line="536"/>
         <source>Put windows back on their virtual desktop</source>
-        <translation type="unfinished"></translation>
+        <translation>Возвращать окна на их виртуальный рабочий стол</translation>
     </message>
     <message>
         <location filename="../src/settings/search/searchcatalog.cpp" line="378"/>
         <source>logout</source>
-        <translation type="unfinished"></translation>
+        <translation>выход из системы</translation>
     </message>
     <message>
         <location filename="../src/settings/search/searchcatalog.cpp" line="524"/>
@@ -13649,7 +13649,7 @@
     <message>
         <location filename=".qml-stubs/src/settings/qml/GeneralPage.qml.cpp" line="532"/>
         <source>After you log back in, each window returns to the desktop it was on. Without this, every window reopens on whichever desktop is showing when you log in.</source>
-        <translation type="unfinished"></translation>
+        <translation>После повторного входа каждое окно возвращается на тот рабочий стол, где оно было. Без этого все окна открываются на том рабочем столе, который показан при входе.</translation>
     </message>
     <message>
         <location filename=".qml-stubs/src/settings/qml/GeneralPage.qml.cpp" line="558"/>
@@ -21601,7 +21601,7 @@
         <translation>Вкладка окна, которое требует внимания.</translation>
     </message>
     <message>
-        <location filename="../kwin-effect/tilinghandler/scrolltabs.cpp" line="672"/>
+        <location filename="../kwin-effect/tilinghandler/scrolltabs.cpp" line="696"/>
         <source>Untitled window</source>
         <translation>Окно без заголовка</translation>
     </message>

--- a/translations/plasmazones_sv.ts
+++ b/translations/plasmazones_sv.ts
@@ -7660,19 +7660,19 @@
         <location filename="../src/settings/search/searchcatalog.cpp" line="374"/>
         <location filename=".qml-stubs/src/settings/qml/GeneralPage.qml.cpp" line="522"/>
         <source>Session restore</source>
-        <translation type="unfinished"></translation>
+        <translation>Sessionsåterställning</translation>
     </message>
     <message>
         <location filename="../src/settings/search/searchcatalog.cpp" line="376"/>
         <location filename=".qml-stubs/src/settings/qml/GeneralPage.qml.cpp" line="530"/>
         <location filename=".qml-stubs/src/settings/qml/GeneralPage.qml.cpp" line="536"/>
         <source>Put windows back on their virtual desktop</source>
-        <translation type="unfinished"></translation>
+        <translation>Placera tillbaka fönster på deras virtuella skrivbord</translation>
     </message>
     <message>
         <location filename="../src/settings/search/searchcatalog.cpp" line="378"/>
         <source>logout</source>
-        <translation type="unfinished"></translation>
+        <translation>logga ut</translation>
     </message>
     <message>
         <location filename="../src/settings/search/searchcatalog.cpp" line="524"/>
@@ -13635,7 +13635,7 @@
     <message>
         <location filename=".qml-stubs/src/settings/qml/GeneralPage.qml.cpp" line="532"/>
         <source>After you log back in, each window returns to the desktop it was on. Without this, every window reopens on whichever desktop is showing when you log in.</source>
-        <translation type="unfinished"></translation>
+        <translation>När du loggar in igen återgår varje fönster till det skrivbord det låg på. Utan detta öppnas alla fönster på det skrivbord som visas när du loggar in.</translation>
     </message>
     <message>
         <location filename=".qml-stubs/src/settings/qml/GeneralPage.qml.cpp" line="558"/>
@@ -21550,7 +21550,7 @@
         <translation>Fliken för ett fönster som ber om uppmärksamhet.</translation>
     </message>
     <message>
-        <location filename="../kwin-effect/tilinghandler/scrolltabs.cpp" line="672"/>
+        <location filename="../kwin-effect/tilinghandler/scrolltabs.cpp" line="696"/>
         <source>Untitled window</source>
         <translation>Namnlöst fönster</translation>
     </message>


### PR DESCRIPTION
Refreshes the Qt Linguist catalogs and fills in the last untranslated strings.

## Extraction

Re-ran the `update-ts` pipeline (stub generator plus `lupdate -no-obsolete`, with the same globs `cmake/PhosphorTranslations.cmake` uses). 2890 QML calls from 188 files, 0 unextractable. All eight catalogs report 4000 source texts, **0 new and 0 dropped**, so there is no scrape gap hiding in this diff. The only extraction change is a `<location>` line-number shift for `Untitled window` in `kwin-effect/tilinghandler/scrolltabs.cpp` (672 → 696).

## Translations

The same four session-restore strings were unfinished in every target language:

- `Session restore`
- `Put windows back on their virtual desktop`
- `logout` (search keyword)
- `After you log back in, each window returns to the desktop it was on. …`

Now translated for de, ka, nl, pl, pt_BR, ru and sv, reusing each catalog's existing term for "virtual desktop". `plasmazones_en.ts` is the source template and is untouched apart from the location shift.

## Verification

`lrelease` on all seven language catalogs: **4000 finished, 0 unfinished** each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B32PbbN7SRneoaNf413PQH
