### PR TITLE
fix(scrolling): make a strip tile's own fullscreen cover its output

### DIFF
--- a/kwin-effect/tilinghandler/signals.cpp
+++ b/kwin-effect/tilinghandler/signals.cpp
@@ -495,6 +495,10 @@ void TilingHandler::slotWindowFullScreenChanged(KWin::EffectWindow* w)
         m_effect->updateAllDecorations();
         return;
     }
+    // Captured BEFORE the clear below drops it: the fullscreen-area assert at
+    // the tail of this branch needs to know this window was a strip tile, and
+    // clearWindowTiledAllScreens is exactly what stops it being one.
+    const QString stripScreenBeforeClear = scrollTrackedScreenFor(windowId);
     // Clear border tracking so borders are not drawn over fullscreen content
     // (title-bar restores flow through the rule path).
     clearWindowTiledAllScreens(windowId);
@@ -538,6 +542,48 @@ void TilingHandler::slotWindowFullScreenChanged(KWin::EffectWindow* w)
     m_effect->m_scrollOfferedColumn.remove(windowId);
     if (m_effect->m_scrollVisualDelta.remove(windowId) > 0 && KWin::effects) {
         KWin::effects->addRepaintFull();
+    }
+    // A strip tile entering its OWN fullscreen (a client F11, a video going
+    // fullscreen — NOT the windowed-fullscreen feature, whose members returned
+    // above) must actually COVER its output.
+    //
+    // Measured, in the nested harness and live: such a window commits at the
+    // output SIZE with the COLUMN's origin — (8,286 1920x1080) for a
+    // (8,286 948x508) tile, and (1924,54 3840x2160) live on a 3840-wide output.
+    // The presentation then runs off the screen with only the part inside the
+    // output visible, which for letterboxed video is a black band where the
+    // column was. Unloading this effect and repeating the identical cycle on the
+    // identical window gives the correct origin, so the strip placement is what
+    // KWin's fullscreen geometry ends up anchored on.
+    //
+    // Nothing downstream repairs it: every later batch takes
+    // applyWindowGeometry's fullscreen bail ("window is fullscreen, skipping"),
+    // so the wrong rect stands for the whole hold while the engine goes on
+    // scrolling and PARKING that column — the model/reality split that produces
+    // the off-screen desktop and the empty slots.
+    //
+    // FullScreenArea is the rect KWin itself uses for a fullscreen window, so
+    // asserting it can only agree with what KWin was trying to do. Change-gated,
+    // so a window already covering its output takes no commit. Bracketed with
+    // inGeometryApply like every sibling direct moveResize in this file: the call
+    // emits frameGeometryChanged synchronously on X11 and must not re-enter the
+    // VS-crossing detector for a move the effect itself just made, and the
+    // tracker re-seed pairs with the outputChanged the bracket swallows.
+    if (KWin::effects && !stripScreenBeforeClear.isEmpty() && isScrollingScreen(stripScreenBeforeClear)) {
+        if (KWin::Window* kwFull = w->window()) {
+            const QRect fsArea = KWin::effects->clientArea(KWin::FullScreenArea, w).toRect();
+            if (fsArea.isValid() && w->frameGeometry().toRect() != fsArea) {
+                qCInfo(lcEffect) << "Asserting fullscreen area for strip tile" << windowId << "from"
+                                 << w->frameGeometry() << "to" << fsArea;
+                const bool prevInApply = m_effect->m_daemonGate.inGeometryApply;
+                m_effect->m_daemonGate.inGeometryApply = true;
+                const auto fsGuard = qScopeGuard([this, prevInApply] {
+                    m_effect->m_daemonGate.inGeometryApply = prevInApply;
+                });
+                kwFull->moveResize(QRectF(fsArea));
+                m_effect->m_trackedScreenPerWindow[w] = m_effect->getWindowScreenId(w);
+            }
+        }
     }
     m_effect->removeWindowDecoration(windowId);
 }

--- a/kwin-effect/tilinghandler/state.cpp
+++ b/kwin-effect/tilinghandler/state.cpp
@@ -41,10 +41,12 @@
 #include <QList>
 #include <QLoggingCategory>
 #include <QMetaType>
+#include <QScopeGuard>
 #include <QVariant>
 
 #include <cmath>
 #include <optional>
+#include <utility> // std::as_const over the collected sets and lists
 
 namespace PlasmaZones {
 
@@ -1029,11 +1031,30 @@ bool TilingHandler::handleWheelChord(qreal delta, qint32 deltaV120, Qt::Orientat
     // never pass through here, so a keyboard scroll still leaves the hold in
     // place. Closing that needs the engine to mark a batch as user-driven,
     // which is a wire change and is deliberately not folded in here.
+    //
+    // SELECTED first, ACTED on second, and never with m_notifiedWindows under
+    // an open iterator. setFullScreen emits windowFrameGeometryChanged and
+    // outputChanged SYNCHRONOUSLY on XWayland, and the exit restores the
+    // window's pre-fullscreen rect — for a strip column that is routinely a
+    // park rect on the neighbouring output, so outputChanged genuinely fires.
+    // Its handler reaches handleWindowOutputChanged and, on a cross-mode arm,
+    // cleanupAutotileTracking, which removes from the very set a range-for
+    // would be walking. The collect/act split is the same one this file
+    // already takes for maximizeClaimsLeavingScrolling, and for the same
+    // stated reason.
+    //
+    // Floating tracked windows are excluded outright: a float holds no column,
+    // so the engine is not parking one out from under it and there is nothing
+    // for a scroll to reconcile.
+    QStringList fullscreenTilesToExit;
     for (const QString& tiledId : m_notifiedWindows) {
         if (m_notifiedWindowScreens.value(tiledId) != screenId) {
             continue;
         }
         if (m_effect->m_windowedFullscreenWindows.contains(tiledId)) {
+            continue;
+        }
+        if (m_effect->isWindowFloating(tiledId)) {
             continue;
         }
         KWin::EffectWindow* fsWin = m_effect->findWindowByIdExact(tiledId);
@@ -1044,13 +1065,72 @@ bool TilingHandler::handleWheelChord(qreal delta, qint32 deltaV120, Qt::Orientat
         if (!kwFs || !kwFs->isRequestedFullScreen()) {
             continue;
         }
+        fullscreenTilesToExit.append(tiledId);
+    }
+    for (const QString& tiledId : std::as_const(fullscreenTilesToExit)) {
+        // Re-resolved per entry rather than carried as a pointer: an earlier
+        // entry's synchronous exit can have destroyed a later one, and
+        // isDeleted() on a dangling EffectWindow* is undefined rather than a
+        // guard (the QPointer note on maximizeClaimsLeavingScrolling above).
+        KWin::EffectWindow* fsWin = m_effect->findWindowByIdExact(tiledId);
+        if (!fsWin || fsWin->isDeleted()) {
+            continue;
+        }
+        KWin::Window* kwFs = fsWin->window();
+        if (!kwFs) {
+            continue;
+        }
         qCInfo(lcEffect) << "Wheel scroll on a strip holding a fullscreen tile — leaving fullscreen for" << tiledId;
-        // Suppressed, so our own slotWindowFullScreenChanged does not read the
-        // effect's write as a user toggle. setFullScreen flips the REQUESTED
-        // state synchronously while the committed isFullScreen() lags a client
-        // round-trip, so the bail in applyWindowGeometry — which reads that same
-        // pair — already resolves false for the batch this scroll produces.
-        applyFullScreenSuppressed(kwFs, false);
+        {
+            // Own inGeometryApply bracket, exactly as releaseWindowedFullscreenState
+            // takes one around the same call: none of the handlers that answer
+            // the synchronous frame/output change is suppressed by the
+            // fullscreen-changed counter, and ungated they re-enter the
+            // cross-screen migration paths for a move the effect itself made.
+            // Save/restore rather than set/clear, so a caller already inside an
+            // apply is handed its own state back.
+            const bool prevInApply = m_effect->m_daemonGate.inGeometryApply;
+            m_effect->m_daemonGate.inGeometryApply = true;
+            const auto geomGuard = qScopeGuard([this, prevInApply] {
+                m_effect->m_daemonGate.inGeometryApply = prevInApply;
+            });
+            // Suppressed, so our own slotWindowFullScreenChanged does not read the
+            // effect's write as a user toggle. setFullScreen flips the REQUESTED
+            // state synchronously while the committed isFullScreen() lags a client
+            // round-trip, so the bail in applyWindowGeometry — which reads that same
+            // pair — already resolves false for the batch this scroll produces.
+            applyFullScreenSuppressed(kwFs, false);
+        }
+        // The suppression above bought re-entrancy safety at the cost of the
+        // exit branch's own repair, so deliver that repair here. The ENTER
+        // branch shed this window's tiled tracking (clearWindowTiledAllScreens)
+        // and its decoration, and neither comes back on its own: the verb below
+        // only produces a batch when the engine's rects actually move, and a
+        // focusColumn or scrollView at the end of the strip moves nothing. The
+        // window would then sit at whatever rect KWin restored — for a column
+        // that was parked during the hold, off the union entirely — untiled and
+        // undecorated for the rest of the session.
+        markWindowTiled(screenId, tiledId);
+        // Re-seed the tracker the bracket's swallowed outputChanged would have
+        // written, the pairing rule every bracketed apply follows. AFTER the
+        // re-mark, so getWindowScreenId answers from the engine-authoritative
+        // override rather than resolving a still-parked frame positionally.
+        m_effect->m_trackedScreenPerWindow[fsWin] = m_effect->getWindowScreenId(fsWin);
+        // Same dispatch the fullscreen-exit branch makes, for the same reason:
+        // KWin re-applies the PRE-fullscreen rect a client round-trip later and
+        // the engine's emit-on-change gate stays silent because its own rects
+        // never moved, so nothing else corrects the stray frame. Both of its
+        // gates are already established here — wheelTargetScreen resolved this
+        // screen through isScrollingScreen and refuses a closed daemon gate.
+        PhosphorProtocol::ClientHelpers::fireAndForget(this, PhosphorProtocol::Service::Interface::Scrolling,
+                                                       QStringLiteral("reapplyWindowGeometry"), {tiledId},
+                                                       QStringLiteral("reapplyWindowGeometry"));
+    }
+    if (!fullscreenTilesToExit.isEmpty()) {
+        // shouldDecorateWindow's fullscreen reject has lifted for these
+        // windows, and the enter branch's removeWindowDecoration is what left
+        // them bare. Once per scroll, not once per window.
+        m_effect->updateAllDecorations();
     }
     // One verb per notch. The engine owns the step SIZE, so a two-notch event
     // is two single steps rather than one double-sized one, which keeps the

--- a/kwin-effect/tilinghandler/state.cpp
+++ b/kwin-effect/tilinghandler/state.cpp
@@ -32,6 +32,9 @@
 #include <PhosphorProtocol/ServiceConstants.h>
 
 #include <effect/effectwindow.h>
+// KWin::Window is only forward-declared through the effect header; the wheel
+// dispatch below needs isRequestedFullScreen on the complete type.
+#include <window.h>
 
 #include <QDBusVariant>
 #include <QHash>
@@ -998,6 +1001,57 @@ bool TilingHandler::handleWheelChord(qreal delta, qint32 deltaV120, Qt::Orientat
     }
     const QLatin1String verb = focusMatch ? QLatin1String("focusColumn") : QLatin1String("scrollView");
     qCDebug(lcEffect) << "Wheel chord:" << verb << "step" << step << "x" << steps << "on" << screenId;
+    // Scrolling a strip that holds a natively-fullscreen tile LEAVES that
+    // fullscreen first.
+    //
+    // A window in its OWN fullscreen (a client F11, a video going fullscreen —
+    // not the windowed-fullscreen feature, whose members are committed at their
+    // column rect on purpose) refuses every geometry commit through
+    // applyWindowGeometry's fullscreen bail. The engine does not know that, so
+    // it goes on scrolling and PARKING that column while the screen still shows
+    // the fullscreen window: the model says "parked off-strip", the user sees a
+    // video, and the two owners stay split for the whole hold. Measured live,
+    // one wheel notch at a time, the same window's target walked (8,54) ->
+    // (1924,54) -> the park (1932,2176), each answered "fullscreen, skipping".
+    //
+    // Done HERE, at the wheel dispatch, rather than in the batch apply: a batch
+    // cannot tell a user scroll from an insert-driven reflow, and gating the
+    // exit on the batch's own strip-motion fields (viewDelta / scrollEdge /
+    // hasVisualPos) dropped the fullscreen whenever an unrelated window merely
+    // OPENED and slid the strip — measured. This site is the scroll itself, so
+    // it carries no such ambiguity.
+    //
+    // Exits before the verb goes out, so the engine's own relayout for this
+    // notch already places a window the compositor will accept, rather than the
+    // exit racing a batch that was built against the fullscreen.
+    //
+    // KNOWN GAP: the keyboard navigation verbs reach the engine in-process and
+    // never pass through here, so a keyboard scroll still leaves the hold in
+    // place. Closing that needs the engine to mark a batch as user-driven,
+    // which is a wire change and is deliberately not folded in here.
+    for (const QString& tiledId : m_notifiedWindows) {
+        if (m_notifiedWindowScreens.value(tiledId) != screenId) {
+            continue;
+        }
+        if (m_effect->m_windowedFullscreenWindows.contains(tiledId)) {
+            continue;
+        }
+        KWin::EffectWindow* fsWin = m_effect->findWindowByIdExact(tiledId);
+        if (!fsWin || fsWin->isDeleted() || !fsWin->isFullScreen()) {
+            continue;
+        }
+        KWin::Window* kwFs = fsWin->window();
+        if (!kwFs || !kwFs->isRequestedFullScreen()) {
+            continue;
+        }
+        qCInfo(lcEffect) << "Wheel scroll on a strip holding a fullscreen tile — leaving fullscreen for" << tiledId;
+        // Suppressed, so our own slotWindowFullScreenChanged does not read the
+        // effect's write as a user toggle. setFullScreen flips the REQUESTED
+        // state synchronously while the committed isFullScreen() lags a client
+        // round-trip, so the bail in applyWindowGeometry — which reads that same
+        // pair — already resolves false for the batch this scroll produces.
+        applyFullScreenSuppressed(kwFs, false);
+    }
     // One verb per notch. The engine owns the step SIZE, so a two-notch event
     // is two single steps rather than one double-sized one, which keeps the
     // strip's own animation identical to scrolling those notches separately.


### PR DESCRIPTION
## The bug

Fullscreening a video in a scroll-managed window (reported with vesktop) left the presentation as a black half-screen that slid around with the strip, alongside an off-screen desktop and empty column slots.

A window taking its **own** fullscreen on a strip — a client F11, a video going fullscreen, *not* the windowed-fullscreen feature — committed at the output **size** with its **column's** origin:

| | committed | correct |
|---|---|---|
| harness, `948x508` tile at `8,286` | `8,286 1920x1080` | `0,0 1920x1080` |
| live, 3840-wide output | `1924,54 3840x2160` | `0,0 3840x2160` |

So the surface ran off the screen and only the part inside the output was visible. For letterboxed video that is a black band where the column used to be.

Unloading the effect and repeating the identical cycle on the identical window gives the correct origin, so the strip placement is what KWin's fullscreen geometry ends up anchored on.

Nothing downstream repaired it. Every later batch takes `applyWindowGeometry`'s fullscreen bail, so the wrong rect stood for the whole hold while the engine went on scrolling and **parking** that column. Measured one wheel notch at a time, the same window's target walked `(8,54)` → `(1924,54)` → the park `(1932,2176)`, each answered `"window is fullscreen, skipping"`. That model/reality split is what produced the off-screen desktop and the empty slots.

## The fix

**`slotWindowFullScreenChanged`, enter branch** — assert `clientArea(FullScreenArea)` for a scroll-tracked non-member, so the presentation actually covers its output. The tracked screen is captured *before* `clearWindowTiledAllScreens`, which is what drops the membership the guard reads. Change-gated, and bracketed with `inGeometryApply` like every sibling direct `moveResize`.

**The wheel dispatch** — leave that fullscreen before the `focusColumn` / `scrollView` verb goes out, so a scroll never leaves the two owners split.

Putting the second half in the batch apply does **not** work, and was measured failing: a batch cannot tell a user scroll from an insert-driven reflow, so gating on the batch's own strip-motion fields (`viewDelta` / `scrollEdge` / `hasVisualPos`) dropped the fullscreen whenever an unrelated window merely *opened* and slid the strip. The wheel dispatch carries no such ambiguity.

## Verification

Nested harness (`scripts/nested-kwin/`), scrolling mode, with the reporter's own config:

| case | result |
|---|---|
| fullscreen enter | `0,0 1920x1080` |
| enter from an already-**parked** column | `0,0 1920x1080` |
| exit fullscreen | returns to its strip column |
| unrelated window opens while fullscreen | no exit, fullscreen holds |

Confirmed working in a live session by the reporter. 417/417 tests pass.

## Known gap

The keyboard navigation verbs reach the engine in-process and never pass through the wheel dispatch, so a keyboard scroll still leaves the hold in place. Closing that needs the engine to mark a batch as user-driven, which is a wire change and deliberately not folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015yAfQ8rNUMDyViem1gNkvm
