### PR TITLE
fix(kwin-effect): wobbly-move jitter and KWin feel parity

### DIFF
--- a/data/animations/wobble/metadata.json
+++ b/data/animations/wobble/metadata.json
@@ -26,16 +26,16 @@
             "id": "sheetStiffness",
             "name": "Sheet stiffness",
             "type": "float",
-            "default": 0.018,
+            "default": 0.15,
             "min": 0.005,
-            "max": 0.08,
+            "max": 0.3,
             "description": "How rigidly the body holds its shape, where lower values drape more like loose cloth"
         },
         {
             "id": "gripStiffness",
             "name": "Grip strength",
             "type": "float",
-            "default": 0.16,
+            "default": 0.15,
             "min": 0.03,
             "max": 0.5,
             "description": "How tightly the grabbed point tracks the cursor, where higher values keep it pinned under the pointer"
@@ -44,7 +44,7 @@
             "id": "springiness",
             "name": "Springiness",
             "type": "float",
-            "default": 0.82,
+            "default": 0.8,
             "min": 0.6,
             "max": 0.97,
             "description": "How much the sheet oscillates before settling, where lower values drift to rest and higher values bounce like jelly"
@@ -53,7 +53,7 @@
             "id": "moveFactor",
             "name": "Responsiveness",
             "type": "float",
-            "default": 0.16,
+            "default": 0.1,
             "min": 0.05,
             "max": 0.4,
             "description": "How quickly the sheet reacts to the drag, where lower values feel heavier"

--- a/kwin-effect/plasmazoneseffect/mesh_sim.cpp
+++ b/kwin-effect/plasmazoneseffect/mesh_sim.cpp
@@ -253,7 +253,6 @@ void initMeshSim(MeshSim& sim, const QRectF& frame, const QPointF& cursor, const
     // trailing drape falls out of the soft neighbour springs + the tight
     // grip alone.
     sim.lastFrameTopLeft = frame.topLeft();
-    sim.accumMs = 0.0;
     sim.settled = false;
     sim.initialized = true;
 }
@@ -264,14 +263,20 @@ void stepMeshSim(MeshSim& sim, const QRectF& frame, qreal deltaMs)
         return;
     }
     updateOrigins(sim, frame);
-    sim.accumMs += qBound(0.0, deltaMs, 200.0);
+    // Drain the WHOLE frame delta, KWin-style: full 10 ms chunks then a
+    // partial final step, leaving no remainder. Carrying a remainder in an
+    // accumulator (the previous scheme) makes some frames advance the
+    // lattice zero times at refresh rates whose frame time is not a
+    // multiple of the step (6.9 ms at 144 Hz), while the window itself
+    // moves every frame — visible jitter.
+    qreal remaining = qBound(0.0, deltaMs, 200.0);
     qreal accSum = 0.0;
     qreal velSum = 0.0;
-    bool stepped = false;
-    while (sim.accumMs >= kIntegrationStepMs) {
-        sim.accumMs -= kIntegrationStepMs;
-        integrateOne(sim, frame, kIntegrationStepMs);
-        stepped = true;
+    const bool stepped = remaining > 0.0;
+    while (remaining > 0.0) {
+        const qreal dt = qMin(remaining, kIntegrationStepMs);
+        remaining -= dt;
+        integrateOne(sim, frame, dt);
     }
     if (stepped) {
         for (int i = 0; i < MeshSim::kCount; ++i) {

--- a/kwin-effect/plasmazoneseffect/mesh_sim.cpp
+++ b/kwin-effect/plasmazoneseffect/mesh_sim.cpp
@@ -6,8 +6,9 @@
 // below are a direct transcription of KWin's wobblywindows effect
 // (updateWindowWobblyDatas / heightRingLinearMean), with Qt's QPointF
 // standing in for KWin's Pair and the resize-only edge-lock logic dropped
-// (this path is move-driven). Constants and the 10 ms fixed step match
-// KWin so the feel is the same.
+// (this path is move-driven). Constants and the 10 ms integration step
+// (full chunks plus a partial final step) match KWin so the feel is the
+// same.
 
 #include "mesh_sim.h"
 
@@ -88,9 +89,9 @@ qreal absSum(const QPointF& p)
     return std::fabs(p.x()) + std::fabs(p.y());
 }
 
-// One 10 ms physics tick. Neighbour-spring accelerations per KWin's
+// One <=10 ms physics tick. Neighbour-spring accelerations per KWin's
 // per-node cases, ring-smoothed, then Verlet-style velocity/position
-// update. Returns acc_sum + vel_sum so the caller can detect settle.
+// update. Leaves accel/velocity in the sim for the caller's settle check.
 void integrateOne(MeshSim& sim, const QRectF& rect, qreal time)
 {
     constexpr int W = MeshSim::kW;
@@ -103,11 +104,11 @@ void integrateOne(MeshSim& sim, const QRectF& rect, qreal time)
     QPointF* pos = sim.position;
     QPointF* acc = sim.accel;
 
-    // Constrained (grip) nodes spring to their origin with the STRONGER
-    // gripStiffness so the grabbed point tracks the window tightly; free
-    // nodes use the soft sheet stiffness `k` for their neighbour springs,
-    // so the body drapes. This split is what makes it read as fabric held
-    // at one point rather than a uniformly wobbling solid.
+    // Constrained (grip) nodes spring to their origin with the separate
+    // gripStiffness so the grabbed point tracks the window; free nodes use
+    // the sheet stiffness `k` for their neighbour springs. The knobs are
+    // split so a pack can stiffen the grip above the sheet for a draped,
+    // held-at-one-point read; the KWin-parity defaults keep them equal.
     const qreal gk = sim.params.gripStiffness;
     auto constrainAccel = [&](int idx) {
         const QPointF move = sim.origin[idx] - pos[idx];
@@ -252,7 +253,6 @@ void initMeshSim(MeshSim& sim, const QRectF& frame, const QPointF& cursor, const
     // NO throb impulse (a symmetric squeeze = the pudding character). The
     // trailing drape falls out of the soft neighbour springs + the tight
     // grip alone.
-    sim.lastFrameTopLeft = frame.topLeft();
     sim.settled = false;
     sim.initialized = true;
 }

--- a/kwin-effect/plasmazoneseffect/mesh_sim.h
+++ b/kwin-effect/plasmazoneseffect/mesh_sim.h
@@ -34,16 +34,16 @@ namespace PlasmaZones {
 /// and a loose flag can share this one solver.
 struct MeshSimParams
 {
-    // Sheet stiffness: LOW so the body drapes and trails like fabric rather
-    // than snapping back. Grip stiffness is separate and HIGH so the grabbed
-    // point stays under the cursor while the rest hangs off it — a dragged
-    // cloth, not a jiggling blob. `drag` is KWin's velocity-RETENTION factor
-    // (higher = more oscillation, counter-intuitively); kept modest so the
-    // sheet settles by drifting, not by ringing (the "pudding" bounce).
-    qreal stiffness = 0.018;
-    qreal gripStiffness = 0.16;
-    qreal drag = 0.82;
-    qreal moveFactor = 0.16;
+    // Defaults are KWin wobblywindows' default preset (pset[0]: stiffness
+    // 0.15, drag 0.80, move_factor 0.10) so the out-of-the-box feel matches
+    // the native effect. KWin uses ONE stiffness for grip and sheet alike;
+    // gripStiffness stays a separate knob so a pack can still split them,
+    // but defaults equal. `drag` is KWin's velocity-RETENTION factor
+    // (higher = more oscillation, counter-intuitively).
+    qreal stiffness = 0.15;
+    qreal gripStiffness = 0.15;
+    qreal drag = 0.80;
+    qreal moveFactor = 0.10;
 };
 
 struct MeshSim
@@ -61,7 +61,6 @@ struct MeshSim
 
     MeshSimParams params;
     QPointF lastFrameTopLeft;
-    qreal accumMs = 0.0;
     bool initialized = false;
     /// False once the lattice has energy; the caller keeps the transition
     /// alive (and repainting) until this reads true again after release.

--- a/kwin-effect/plasmazoneseffect/mesh_sim.h
+++ b/kwin-effect/plasmazoneseffect/mesh_sim.h
@@ -18,8 +18,9 @@
 // node (interior and edge alike) is free, coupled only to its NEIGHBOURS at
 // ideal spacing, so a drag propagates node to node as a wave. No interior
 // pinning — a rigid centre with wiggling edges read as a jiggling blob.
-// Integrated in fixed <=10 ms
-// substeps with KWin's ring-mean smoothing; a generic caller need only
+// Integrated in <=10 ms
+// substeps (full 10 ms chunks plus a partial final step, KWin's scheme)
+// with KWin's ring-mean smoothing; a generic caller need only
 // init, feed the live rect each frame, and read displacements.
 
 #pragma once
@@ -29,8 +30,8 @@
 
 namespace PlasmaZones {
 
-/// Tunable spring constants. Defaults mirror KWin's middle "wobbliness"
-/// preset (set_2); a pack may override via its metadata so a stiff jello
+/// Tunable spring constants. Defaults mirror KWin's default "wobbliness"
+/// preset (pset[0]); a pack may override via its metadata so a stiff jello
 /// and a loose flag can share this one solver.
 struct MeshSimParams
 {
@@ -60,7 +61,6 @@ struct MeshSim
     bool constraint[kCount] = {};
 
     MeshSimParams params;
-    QPointF lastFrameTopLeft;
     bool initialized = false;
     /// False once the lattice has energy; the caller keeps the transition
     /// alive (and repainting) until this reads true again after release.

--- a/kwin-effect/plasmazoneseffect/shader_transitions.cpp
+++ b/kwin-effect/plasmazoneseffect/shader_transitions.cpp
@@ -514,8 +514,10 @@ bool PlasmaZonesEffect::beginShaderTransition(KWin::EffectWindow* window,
         // directly (single DOF), while the free-sheet neighbour springs can
         // reach ~2x sheetStiffness at the highest lattice mode, so take
         // max(gripStiffness, 2*sheetStiffness). Cap moveFactor to 80% of the
-        // bound for margin; the shipped KWin preset (k=0.018, gk=0.16,
-        // mf=0.16, drag=0.82) sits at ~70% and is left untouched.
+        // bound for margin; the shipped KWin default preset (k=0.15,
+        // gk=0.15, drag=0.80, mf=0.10) computes a limit of 0.096, so the
+        // clamp trims its moveFactor by ~4% — imperceptible, and the margin
+        // is worth more than exact preset parity.
         constexpr qreal kMeshSubstepMs = 10.0; // matches mesh_sim.cpp integrator step
         const qreal effectiveK = qMax(transition.meshParams.gripStiffness, 2.0 * transition.meshParams.stiffness);
         if (effectiveK > 0.0) {


### PR DESCRIPTION
## Summary
- The wobble lattice integrator kept a remainder in a 10 ms-step accumulator, so at refresh rates whose frame time is not a multiple of the step (144 Hz = 6.9 ms) some paints advanced the simulation zero times while the window kept moving. This was visible jitter during drags. The integrator now drains the entire frame delta each paint with a partial final step, matching KWin wobblywindows exactly.
- The default parameters diverged from KWin: sheet stiffness 0.018 sat near KWin's loosest preset, and the grip used a separate stronger constant KWin does not have. Defaults now match KWin's default preset (stiffness 0.15 for sheet and grip, drag 0.80, moveFactor 0.10) in both `MeshSimParams` and the wobble pack metadata.
- The pack's sheet-stiffness slider topped out at 0.08, so KWin's 0.15 was unreachable from the settings UI; the range is widened to 0.3.

## Testing
- Full ctest suite passes (one pre-existing skip: test_surface_decoration_orientation); build is warning-free.
- Verified against KWin's wobblywindows source (invent.kde.org) for the preset table, the delta-draining loop, and the constrained-point handling.

## Notes
- Saved user overrides for the pack's sliders will mask the new defaults; reset the pack's parameters to defaults to get the KWin feel.
- The separate "laggy with decorations on" report (decoration/backdrop fold cost riding inside every held-drag frame) is not addressed here and remains open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01326q5TqqhuxQQNmfF2gCW1