### PR TITLE
fix(effect): X11 resize animation edge smear and stale expandedGeometry canvases

### DIFF
--- a/kwin-effect/plasmazoneseffect/lifecycle_wiring.cpp
+++ b/kwin-effect/plasmazoneseffect/lifecycle_wiring.cpp
@@ -762,6 +762,10 @@ void PlasmaZonesEffect::connectWindowAndScreenSignals()
         // erase here to keep it bounded across long sessions.
         m_shaderManager.m_lastFullyMaximized.remove(w);
         m_lastPushedCaption.remove(w);
+        // Same raw-pointer-keyed rationale, and address reuse matters here too:
+        // a new window inheriting a dead one's shadow margins would build its
+        // canvas at the wrong size until its first expanded-geometry change.
+        m_surfaceShadowMargins.remove(w);
         // Sibling raw-pointer-keyed hashes — the maximize morph's departure
         // rect and the deferred-install entry. Same bounded-across-long-
         // sessions rationale as above, plus address-reuse safety for the

--- a/kwin-effect/plasmazoneseffect/paint_capture.cpp
+++ b/kwin-effect/plasmazoneseffect/paint_capture.cpp
@@ -31,6 +31,7 @@
 
 #include <chrono>
 #include <type_traits>
+#include <epoxy/gl.h>
 
 #include "compositor/windowanimator.h"
 
@@ -48,6 +49,33 @@ struct SnapshotExtent
     qreal scale = 1.0;
     QSize textureSize;
 };
+
+// Wrap mode for the old-content snapshot textures. CLAMP_TO_BORDER (default
+// border colour: transparent black), NOT CLAMP_TO_EDGE.
+//
+// A surface-extent morph samples the pad ring OUTSIDE the card, and oldColor()
+// addresses the snapshot there at t outside [0,1]. For a Wayland client the
+// snapshot spans the expanded rect, so those samples land in its transparent
+// shadow band and fade out. An X11 client with no shadow (Steam) has
+// expanded == frame: the snapshot has NO margin at all, and CLAMP_TO_EDGE
+// smeared the outermost row of window pixels across the whole ring — streaked
+// edges on every animated resize, on exactly the client class whose ring has
+// no shadow to hide under. A transparent border reproduces the Wayland
+// behaviour for free. Cost: GL_LINEAR blends the card's outermost half-texel
+// against transparent for a margin-less snapshot, which is strictly better
+// than the smear it replaces.
+//
+// Desktop GL has border clamp in core; on GLES it needs 3.2 or the
+// EXT_texture_border_clamp extension (same enum value), so fall back to the
+// old smear rather than an INVALID_ENUM where neither is present.
+GLenum snapshotWrapMode()
+{
+    static const GLenum mode =
+        (epoxy_is_desktop_gl() || epoxy_gl_version() >= 32 || epoxy_has_gl_extension("GL_EXT_texture_border_clamp"))
+        ? GL_CLAMP_TO_BORDER
+        : GL_CLAMP_TO_EDGE;
+    return mode;
+}
 
 SnapshotExtent snapshotExtentFor(const QRectF& logicalGeometry, const KWin::LogicalOutput* screen)
 {
@@ -132,7 +160,16 @@ void PlasmaZonesEffect::captureOldWindowSnapshot(ShaderTransition& transition, K
     // (For the ordinary case src IS window, so this expression covers both —
     // an earlier ternary here had identical arms and only implied a
     // distinction that does not exist.)
-    const QRectF logicalGeometry = src->expandedGeometry();
+    // surfaceWindowRect, NOT raw expandedGeometry(): this capture runs on the
+    // FIRST paint frame after a geometry change, which is inside the window
+    // where an X11 client's expandedGeometry() still answers for the OLD frame
+    // rect (measured: 1908x2052 against a settled 678-tall frame, 8 ms after
+    // the resize). The draw side maps this snapshot with the SETTLED rect on
+    // every later frame, so a capture spanning the stale rect is sampled as if
+    // it spanned the true one — the old content lands shrunk and misplaced for
+    // the whole cross-fade. Capturing over the reconstructed rect keeps the
+    // capture and the draw in the same geometry by construction.
+    const QRectF logicalGeometry = surfaceWindowRect(src);
     const auto [scale, textureSize] = snapshotExtentFor(logicalGeometry, screen);
     if (textureSize.isEmpty()) {
         if (foreignSrc) {
@@ -156,7 +193,7 @@ void PlasmaZonesEffect::captureOldWindowSnapshot(ShaderTransition& transition, K
         return;
     }
     tex->setFilter(GL_LINEAR);
-    tex->setWrapMode(GL_CLAMP_TO_EDGE);
+    tex->setWrapMode(snapshotWrapMode());
 
     KWin::GLFramebuffer fbo(tex.get());
     if (!fbo.valid()) {
@@ -450,7 +487,7 @@ void PlasmaZonesEffect::seedTabSwapSnapshot(ShaderTransition& transition, KWin::
         return;
     }
     tex->setFilter(GL_LINEAR);
-    tex->setWrapMode(GL_CLAMP_TO_EDGE);
+    tex->setWrapMode(snapshotWrapMode());
     KWin::GLFramebuffer fbo(tex.get());
     KWin::GLFramebuffer srcFbo(comp);
     if (!fbo.valid() || !srcFbo.valid()) {
@@ -579,10 +616,11 @@ void PlasmaZonesEffect::apply(KWin::EffectWindow* window, int mask, KWin::Window
         // spelling of the invariant, not two.
         const auto bit = m_windowDecorations.find(frozenWindowId);
         if (bit != m_windowDecorations.end() && bit->shaderApplied) {
-            QRectF textureGeo = window->expandedGeometry();
-            if (textureGeo.isEmpty()) {
-                textureGeo = window->frameGeometry();
-            }
+            // Through surfaceWindowRect for the same reason the fold and the
+            // backdrop do: this anchors the present against the rect the canvas
+            // was BUILT from, and a raw expandedGeometry() read here would
+            // re-anchor a correctly-built canvas on a stale rect.
+            const QRectF textureGeo = surfaceWindowRect(window);
             if (textureGeo.isEmpty()) {
                 return;
             }

--- a/kwin-effect/plasmazoneseffect/paint_capture.cpp
+++ b/kwin-effect/plasmazoneseffect/paint_capture.cpp
@@ -425,8 +425,8 @@ void PlasmaZonesEffect::seedTabSwapSnapshot(ShaderTransition& transition, KWin::
     // committed the arriving window to it (moveResize updates frameGeometry
     // synchronously; the no-op-skip bail in applyWindowGeometry relies on the
     // same fact), and the composite was folded at that same rect. The capture
-    // spans the ARRIVING window's expanded rect so the snapshot lives in the
-    // coordinate system iAnchorRectInTexture describes; the clip against the
+    // spans the ARRIVING window's reconstructed surface rect so the snapshot
+    // lives in the coordinate system iAnchorRectInTexture describes; the clip against the
     // source's canvas trims the sliver where the two clients' shadow padding
     // disagrees, which stays cleared like every out-of-canvas band.
     //
@@ -470,7 +470,14 @@ void PlasmaZonesEffect::seedTabSwapSnapshot(ShaderTransition& transition, KWin::
         armFallback();
         return;
     }
-    const QRectF logicalGeometry = window->expandedGeometry();
+    // surfaceWindowRect, NOT raw expandedGeometry(), for the same reason the
+    // lazy capture reads it: this seed runs right after the moveResize that
+    // committed the arriving tab, which is exactly the window where an X11
+    // client's expandedGeometry() can still answer for the PREVIOUS (park)
+    // rect. The seed is one-shot, so a stale rect would misregister the old
+    // side for the whole leg; the reconstructed rect is the settled rect
+    // iAnchorRectInTexture converges on, by construction.
+    const QRectF logicalGeometry = surfaceWindowRect(window);
     const auto [scale, textureSize] = snapshotExtentFor(logicalGeometry, window->screen());
     if (textureSize.isEmpty()) {
         armFallback();
@@ -532,12 +539,12 @@ void PlasmaZonesEffect::seedTabSwapSnapshot(ShaderTransition& transition, KWin::
     fbo.blitFromFramebuffer(KWin::Rect(srcPx.x(), srcPx.y(), srcPx.width(), srcPx.height()),
                             KWin::Rect(dstPx.x(), dstPx.y(), dstPx.width(), dstPx.height()), GL_LINEAR);
     KWin::GLFramebuffer::popFramebuffer();
-    // expandedGeometry in the trace: the map above assumes it still holds the
-    // pre-park column rect when the seed runs. If a Wayland commit ever lands
-    // the park BEFORE this install, the mismatch is visible only here — the
-    // blit itself would quietly seed a sliver (srcClipped stays non-empty for
-    // most park positions).
-    qCDebug(lcEffect) << "tabSwap seed OK from pre-park composite, canvas" << mp.canvasGeo << "src expanded"
+    // The dest rect in the trace: the map above assumes the SOURCE's canvas
+    // still holds the pre-park column rect when the seed runs. If a Wayland
+    // commit ever lands the park BEFORE this install, the mismatch is visible
+    // only here — the blit itself would quietly seed a sliver (srcClipped
+    // stays non-empty for most park positions).
+    qCDebug(lcEffect) << "tabSwap seed OK from pre-park composite, canvas" << mp.canvasGeo << "dest rect"
                       << logicalGeometry << "src px" << srcPx << "dst px" << dstPx;
     transition.oldSnapshot = std::move(tex);
     transition.needsSnapshot = false;

--- a/kwin-effect/plasmazoneseffect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect/plasmazoneseffect.h
@@ -64,6 +64,7 @@
 #include <QVarLengthArray>
 #include <QTimer>
 #include <QHash>
+#include <QMargins> // QMarginsF, m_surfaceShadowMargins' value type
 #include <QFont> // scrollTabIndicatorFont's return type
 #include <QPointer>
 #include <QRect>
@@ -1427,6 +1428,34 @@ private:
     /// Raw-pointer-keyed; erased in the windowDeleted cleanup with its
     /// siblings.
     QHash<KWin::EffectWindow*, QString> m_lastPushedCaption;
+    /// Last CONSISTENT shadow margins (expandedGeometry - frameGeometry) per
+    /// window, the input surfaceWindowRect() reconstructs the canvas base from.
+    /// Seeded when the window's connections are made and refreshed on every
+    /// windowExpandedGeometryChanged, which is the one moment KWin guarantees
+    /// the two rects agree. Raw-pointer-keyed; erased in the windowDeleted
+    /// cleanup with its siblings.
+    QHash<KWin::EffectWindow*, QMarginsF> m_surfaceShadowMargins;
+    /// The rect every surface canvas is built from: the frame grown by the last
+    /// consistent shadow margins, NEVER expandedGeometry() read raw.
+    ///
+    /// expandedGeometry() can transiently answer for the window's PREVIOUS frame
+    /// rect. Measured on KWin 6.7.4 with an X11 client (Steam): a shrink from
+    /// 1908x2052 to 1908x678 left expandedGeometry() reporting the old 2052
+    /// height for 25 ms while frameGeometry(), bufferGeometry() and
+    /// clientGeometry() had all already moved. Steam carries no shadow at all,
+    /// so that value was not a stale shadow — it was a stale copy of the old
+    /// frame rect. The canvas built from it ran 1374 px past the window, and the
+    /// chain painted its border and backdrop pane across the overhang: a band of
+    /// blurred wallpaper below the window, framed as if the window were still
+    /// there. A Wayland client (ghastty) driven through the SAME four-step
+    /// resize never diverged, KWin applying frame, shadow and item tree together
+    /// at the client's commit.
+    ///
+    /// Reconstructing rather than reading raw is what makes this ordering-proof:
+    /// the margins are a property of the window's decoration, not of its size,
+    /// so carrying them across a resize is correct by construction and needs no
+    /// assumption about whether the frame or the expanded signal lands first.
+    QRectF surfaceWindowRect(KWin::EffectWindow* w) const;
     QTimer* m_frameGeometryFlushTimer = nullptr;
     void flushPendingFrameGeometry();
 

--- a/kwin-effect/plasmazoneseffect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect/plasmazoneseffect.h
@@ -1456,6 +1456,14 @@ private:
     /// so carrying them across a resize is correct by construction and needs no
     /// assumption about whether the frame or the expanded signal lands first.
     QRectF surfaceWindowRect(KWin::EffectWindow* w) const;
+    /// The margin cache's ONE refresh path: recompute @p window's shadow
+    /// margins from the live frame/expanded pair and store them when
+    /// plausible. Called at connect time (setupWindowConnections seeds it)
+    /// and on every windowExpandedGeometryChanged; defined in
+    /// surfacelayers.cpp beside surfaceWindowRect, which consumes it. The
+    /// write-side invariants (why it must never run from a paint-time
+    /// sample, and the implausible-margin refusal) live on the definition.
+    void refreshSurfaceShadowMargins(KWin::EffectWindow* window);
     QTimer* m_frameGeometryFlushTimer = nullptr;
     void flushPendingFrameGeometry();
 

--- a/kwin-effect/plasmazoneseffect/surface_backdrop.cpp
+++ b/kwin-effect/plasmazoneseffect/surface_backdrop.cpp
@@ -42,10 +42,11 @@ void PlasmaZonesEffect::captureWindowBackdrop(const KWin::RenderTarget& renderTa
     // texScale note below); alignment is a property of the rects, not of
     // the densities.
     const qreal pad = wb.outerPadding;
-    QRectF windowRect = w->expandedGeometry();
-    if (windowRect.isEmpty()) {
-        windowRect = w->frameGeometry();
-    }
+    // The same rect the fold builds from, through the same accessor — a second
+    // reading of expandedGeometry() here would reintroduce the stale-rect case
+    // on the backdrop alone and silently misalign it against the composite,
+    // which is exactly the drift the shared surfaceCanvasFor exists to prevent.
+    const QRectF windowRect = surfaceWindowRect(w);
     // The SAME canvas the fold builds, from the same helper — not a second derivation that
     // happens to agree. Texel alignment between the backdrop and the composite is what lets
     // a pack sample both with one uv, and a drift between two copies of this arithmetic

--- a/kwin-effect/plasmazoneseffect/surfacelayers.cpp
+++ b/kwin-effect/plasmazoneseffect/surfacelayers.cpp
@@ -145,6 +145,56 @@ QRectF PlasmaZonesEffect::surfaceWindowRect(KWin::EffectWindow* w) const
     return frame.marginsAdded(*it);
 }
 
+// Shadow-margin cache refresh for surfaceWindowRect() above. Seeded at
+// connect time (setupWindowConnections — nothing is resizing then, so the
+// pair agrees) and re-run on every windowExpandedGeometryChanged, which is
+// the one moment KWin has just recomputed the expanded rect against the live
+// frame.
+//
+// A resize is exactly the interval where those two disagree (see
+// surfaceWindowRect's declaration for the measured X11 case), so the cache
+// must never be refreshed from an arbitrary paint-time sample: doing that
+// would launder the stale value into the very cache that exists to reject
+// it. This function, driven by that signal and the connect-time seed, is the
+// only writer.
+void PlasmaZonesEffect::refreshSurfaceShadowMargins(KWin::EffectWindow* window)
+{
+    if (!window) {
+        return;
+    }
+    const QRectF frame = window->frameGeometry();
+    const QRectF expanded = window->expandedGeometry();
+    if (frame.isEmpty() || expanded.isEmpty()) {
+        return;
+    }
+    // Shadows only ever grow the frame. A negative margin would mean the
+    // expanded rect does not contain the frame, which is not a shadow and
+    // must not be baked in — clamp at zero rather than shrinking the canvas
+    // below the window on some future KWin quirk.
+    const QMarginsF margins(qMax(0.0, frame.left() - expanded.left()), qMax(0.0, frame.top() - expanded.top()),
+                            qMax(0.0, expanded.right() - frame.right()), qMax(0.0, expanded.bottom() - frame.bottom()));
+    // Sanity cap, and it is load-bearing rather than defensive. Reading the
+    // expanded rect is now safe, but this WRITE still samples both rects at
+    // once: if the signal ever arrives while the frame is settled and the
+    // expanded rect is not (the reverse of the measured ordering, where the
+    // frame leads and the expanded rect lags ~25 ms), the stale value would
+    // be cached as a margin and every later frame would rebuild the canvas
+    // from it — turning a 25 ms glitch into a permanent one.
+    //
+    // A shadow wider or taller than the window it surrounds is not a
+    // shadow. The measured stale sample would have cached a 1374 px bottom
+    // margin on a 678 px window; the real margins are 65/53/65/77 against
+    // frames from 628 to 2052 px, three orders of magnitude clear of this
+    // bound. Reject the update and keep the last good margins.
+    if (margins.left() > frame.width() || margins.right() > frame.width() || margins.top() > frame.height()
+        || margins.bottom() > frame.height()) {
+        qCWarning(lcEffect) << "Refusing implausible shadow margins" << margins << "for" << window->windowClass()
+                            << "frame" << frame << "expanded" << expanded;
+        return;
+    }
+    m_surfaceShadowMargins.insert(window, margins);
+}
+
 KWin::GLTexture* PlasmaZonesEffect::renderSurfaceChainComposite(KWin::EffectWindow* w, qreal scale,
                                                                 KWin::GLShader* captureRestoreShader)
 {

--- a/kwin-effect/plasmazoneseffect/surfacelayers.cpp
+++ b/kwin-effect/plasmazoneseffect/surfacelayers.cpp
@@ -121,6 +121,30 @@ KWin::GLTexture* PlasmaZonesEffect::renderSurfaceChain(ShaderTransition& transit
 //   decoration_render.cpp  — surfacePresentShader, alongside the two paths that
 //                            consume the program it compiles
 
+QRectF PlasmaZonesEffect::surfaceWindowRect(KWin::EffectWindow* w) const
+{
+    if (!w) {
+        return {};
+    }
+    const QRectF frame = w->frameGeometry();
+    // No margins recorded yet (a window whose connections have not been made,
+    // or one that has never emitted windowExpandedGeometryChanged): fall back to
+    // the raw pair, preserving the previous behaviour for anything this cache
+    // does not cover. The isEmpty guard is the one the three call sites used to
+    // carry individually.
+    const auto it = m_surfaceShadowMargins.constFind(w);
+    if (it == m_surfaceShadowMargins.constEnd()) {
+        const QRectF expanded = w->expandedGeometry();
+        return expanded.isEmpty() ? frame : expanded;
+    }
+    if (frame.isEmpty()) {
+        return frame;
+    }
+    // The frame grown by the last CONSISTENT margins. See the declaration for
+    // why this is reconstructed rather than read from expandedGeometry().
+    return frame.marginsAdded(*it);
+}
+
 KWin::GLTexture* PlasmaZonesEffect::renderSurfaceChainComposite(KWin::EffectWindow* w, qreal scale,
                                                                 KWin::GLShader* captureRestoreShader)
 {
@@ -205,10 +229,9 @@ KWin::GLTexture* PlasmaZonesEffect::renderSurfaceChainComposite(KWin::EffectWind
     // decoration-shadow margin of its own (borderless windows). apply()
     // presents the composite on a matching padded quad.
     const qreal pad = bit->outerPadding;
-    QRectF windowRect = w->expandedGeometry();
-    if (windowRect.isEmpty()) {
-        windowRect = w->frameGeometry();
-    }
+    // NOT expandedGeometry() raw — see surfaceWindowRect's declaration for the
+    // stale-rect case this exists to reject.
+    const QRectF windowRect = surfaceWindowRect(w);
     const SurfaceCanvas canvas = surfaceCanvasFor(windowRect, pad, scale);
     const QRectF logicalGeometry = canvas.logicalGeometry;
     const qreal captureScale = canvas.captureScale;

--- a/kwin-effect/plasmazoneseffect/window_connections.cpp
+++ b/kwin-effect/plasmazoneseffect/window_connections.cpp
@@ -826,54 +826,13 @@ void PlasmaZonesEffect::setupWindowConnections(KWin::EffectWindow* w)
     }
 
     // Shadow-margin cache for surfaceWindowRect(). Seed from the window's
-    // current rects — nothing is resizing at connect time, so the pair agrees —
-    // then refresh on every windowExpandedGeometryChanged, which is the one
-    // moment KWin has just recomputed the expanded rect against the live frame.
-    //
-    // A resize is exactly the interval where those two disagree (see
-    // surfaceWindowRect's declaration for the measured X11 case), so the cache
-    // must never be refreshed from an arbitrary paint-time sample: doing that
-    // would launder the stale value into the very cache that exists to reject
-    // it. This signal, and the connect-time seed, are the only two writers.
-    const auto refreshShadowMargins = [this](KWin::EffectWindow* window) {
-        if (!window) {
-            return;
-        }
-        const QRectF frame = window->frameGeometry();
-        const QRectF expanded = window->expandedGeometry();
-        if (frame.isEmpty() || expanded.isEmpty()) {
-            return;
-        }
-        // Shadows only ever grow the frame. A negative margin would mean the
-        // expanded rect does not contain the frame, which is not a shadow and
-        // must not be baked in — clamp at zero rather than shrinking the canvas
-        // below the window on some future KWin quirk.
-        const QMarginsF margins(qMax(0.0, frame.left() - expanded.left()), qMax(0.0, frame.top() - expanded.top()),
-                                qMax(0.0, expanded.right() - frame.right()),
-                                qMax(0.0, expanded.bottom() - frame.bottom()));
-        // Sanity cap, and it is load-bearing rather than defensive. Reading the
-        // expanded rect is now safe, but this WRITE still samples both rects at
-        // once: if the signal ever arrives while the frame is settled and the
-        // expanded rect is not (the reverse of the measured ordering, where the
-        // frame leads and the expanded rect lags ~25 ms), the stale value would
-        // be cached as a margin and every later frame would rebuild the canvas
-        // from it — turning a 25 ms glitch into a permanent one.
-        //
-        // A shadow wider or taller than the window it surrounds is not a
-        // shadow. The measured stale sample would have cached a 1374 px bottom
-        // margin on a 678 px window; the real margins are 65/53/65/77 against
-        // frames from 628 to 2052 px, three orders of magnitude clear of this
-        // bound. Reject the update and keep the last good margins.
-        if (margins.left() > frame.width() || margins.right() > frame.width() || margins.top() > frame.height()
-            || margins.bottom() > frame.height()) {
-            qCWarning(lcEffect) << "Refusing implausible shadow margins" << margins << "for" << window->windowClass()
-                                << "frame" << frame << "expanded" << expanded;
-            return;
-        }
-        m_surfaceShadowMargins.insert(window, margins);
-    };
-    refreshShadowMargins(w);
-    connect(w, &KWin::EffectWindow::windowExpandedGeometryChanged, this, refreshShadowMargins);
+    // current rects (nothing is resizing at connect time, so the pair agrees),
+    // then refresh on every windowExpandedGeometryChanged. The body — and the
+    // write-side invariants: never refresh from a paint-time sample, refuse
+    // implausible margins — lives beside surfaceWindowRect in surfacelayers.cpp.
+    refreshSurfaceShadowMargins(w);
+    connect(w, &KWin::EffectWindow::windowExpandedGeometryChanged, this,
+            &PlasmaZonesEffect::refreshSurfaceShadowMargins);
     connect(w, &KWin::EffectWindow::windowMaximizedStateChanged, this,
             [this](KWin::EffectWindow* window, bool horizontal, bool vertical) {
                 if (!window) {

--- a/kwin-effect/plasmazoneseffect/window_connections.cpp
+++ b/kwin-effect/plasmazoneseffect/window_connections.cpp
@@ -824,6 +824,56 @@ void PlasmaZonesEffect::setupWindowConnections(KWin::EffectWindow* w)
     if (KWin::Window* kwSeed = w->window()) {
         m_shaderManager.m_lastFullyMaximized.insert(w, kwSeed->maximizeMode() == KWin::MaximizeFull);
     }
+
+    // Shadow-margin cache for surfaceWindowRect(). Seed from the window's
+    // current rects — nothing is resizing at connect time, so the pair agrees —
+    // then refresh on every windowExpandedGeometryChanged, which is the one
+    // moment KWin has just recomputed the expanded rect against the live frame.
+    //
+    // A resize is exactly the interval where those two disagree (see
+    // surfaceWindowRect's declaration for the measured X11 case), so the cache
+    // must never be refreshed from an arbitrary paint-time sample: doing that
+    // would launder the stale value into the very cache that exists to reject
+    // it. This signal, and the connect-time seed, are the only two writers.
+    const auto refreshShadowMargins = [this](KWin::EffectWindow* window) {
+        if (!window) {
+            return;
+        }
+        const QRectF frame = window->frameGeometry();
+        const QRectF expanded = window->expandedGeometry();
+        if (frame.isEmpty() || expanded.isEmpty()) {
+            return;
+        }
+        // Shadows only ever grow the frame. A negative margin would mean the
+        // expanded rect does not contain the frame, which is not a shadow and
+        // must not be baked in — clamp at zero rather than shrinking the canvas
+        // below the window on some future KWin quirk.
+        const QMarginsF margins(qMax(0.0, frame.left() - expanded.left()), qMax(0.0, frame.top() - expanded.top()),
+                                qMax(0.0, expanded.right() - frame.right()),
+                                qMax(0.0, expanded.bottom() - frame.bottom()));
+        // Sanity cap, and it is load-bearing rather than defensive. Reading the
+        // expanded rect is now safe, but this WRITE still samples both rects at
+        // once: if the signal ever arrives while the frame is settled and the
+        // expanded rect is not (the reverse of the measured ordering, where the
+        // frame leads and the expanded rect lags ~25 ms), the stale value would
+        // be cached as a margin and every later frame would rebuild the canvas
+        // from it — turning a 25 ms glitch into a permanent one.
+        //
+        // A shadow wider or taller than the window it surrounds is not a
+        // shadow. The measured stale sample would have cached a 1374 px bottom
+        // margin on a 678 px window; the real margins are 65/53/65/77 against
+        // frames from 628 to 2052 px, three orders of magnitude clear of this
+        // bound. Reject the update and keep the last good margins.
+        if (margins.left() > frame.width() || margins.right() > frame.width() || margins.top() > frame.height()
+            || margins.bottom() > frame.height()) {
+            qCWarning(lcEffect) << "Refusing implausible shadow margins" << margins << "for" << window->windowClass()
+                                << "frame" << frame << "expanded" << expanded;
+            return;
+        }
+        m_surfaceShadowMargins.insert(window, margins);
+    };
+    refreshShadowMargins(w);
+    connect(w, &KWin::EffectWindow::windowExpandedGeometryChanged, this, refreshShadowMargins);
     connect(w, &KWin::EffectWindow::windowMaximizedStateChanged, this,
             [this](KWin::EffectWindow* window, bool horizontal, bool vertical) {
                 if (!window) {


### PR DESCRIPTION
## Summary

Two defects behind the Steam resize-animation artifacts, sharing one root asymmetry: a shadowless X11 client (Steam reports `expandedGeometry == frameGeometry` exactly) has no shadow ring for mistakes to hide in, while every Wayland client's shadow (measured 65/53/65/77) exceeds the decoration pad (56), masking both bugs there.

**1. Edge smear on every animated resize (the visible bug).** A surface-extent morph paints the pad ring outside the card, and `oldColor()` addresses the old-content snapshot there at uv outside [0,1]. A Wayland snapshot spans the expanded rect, so ring samples land in its transparent shadow band; a shadowless X11 snapshot has no margin, and `GL_CLAMP_TO_EDGE` smeared its outermost pixel row across the whole 56 px ring. Snapshot textures now use `GL_CLAMP_TO_BORDER` (transparent default border) with a GLES capability fallback.

**2. Transiently stale `expandedGeometry()` (caught live three times).** On an X11 resize, `frameGeometry`/`bufferGeometry`/`clientGeometry` update immediately but `expandedGeometry()` can answer for the previous frame rect for ~25 ms (measured: 1908x2052 against a settled 678-tall frame — a 1374 px overhang). The morph snapshot is captured on the first paint frame after the change, inside exactly that window, poisoning the whole leg; a canvas built then overhangs the same way. The canvas derivations (fold, backdrop, present anchor) and the snapshot capture now go through `surfaceWindowRect()`, which rebuilds the rect as frame + last consistent shadow margins. The margin cache is written only at connect time and on `windowExpandedGeometryChanged`, and refuses a margin larger than the window itself — that refusal also fired live on a Wayland session-restore edge, where caching the mismatch would have made the overhang permanent.

A Wayland client driven through the identical four-step resize never diverged (KWin applies frame, shadow and item tree atomically at the client's commit), which is why both bugs presented as X11-only.

## Test plan

- Full build clean (zero warnings), ctest 418/418 pass.
- Verified live on KWin 6.7.4: Steam resize animations clean after the fix; ghastty as Wayland control unchanged through the identical resize sequence; the stale-rect event and the implausible-margin refusal both observed firing in the journal before/while validating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AvhwFeGC6r1esHJStKL4Xh