### PR TITLE
fix(effect): forward focus reports unconditionally so cross-desktop activations center the strip

### DIFF
--- a/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
+++ b/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
@@ -848,12 +848,22 @@ bool PlasmaZonesEffect::notifyWindowActivated(KWin::EffectWindow* w)
     PhosphorProtocol::ClientHelpers::fireAndForget(this, PhosphorProtocol::Service::Interface::WindowTracking,
                                                    QStringLiteral("windowActivated"), {windowId, screenId});
 
-    // Notify autotile engine of focus change so m_windowToScreen is updated
-    if (m_tilingHandler->isManagedScreen(screenId)) {
-        PhosphorProtocol::ClientHelpers::fireAndForget(this, PhosphorProtocol::Service::Interface::Tiling,
-                                                       QStringLiteral("notifyWindowFocused"), {windowId, screenId},
-                                                       QStringLiteral("notifyWindowFocused"));
-    }
+    // Notify the placement engines of the focus change so m_windowToScreen is
+    // updated. NOT gated on isManagedScreen: the managed set tracks the
+    // CURRENT desktop and is rebuilt only by the daemon's asynchronous
+    // announce, while a cross-desktop activation (taskbar click, alt-tab into
+    // another desktop) fires before either the desktopChanged signal or that
+    // announce lands — so when the desktop being LEFT runs no placement mode
+    // the gate read an empty set and dropped the one report that centers the
+    // destination strip on the clicked window. The daemon routes safely on
+    // its own: reportScreenDesktop above already switched its context to the
+    // destination desktop on the same ordered connection, engineOwningScreen
+    // falls back for exactly this desktop-switch window, and every engine's
+    // windowFocused self-guards on window tracking, so an activation on a
+    // genuinely unmanaged screen is a routed no-op rather than a lost report.
+    PhosphorProtocol::ClientHelpers::fireAndForget(this, PhosphorProtocol::Service::Interface::Tiling,
+                                                   QStringLiteral("notifyWindowFocused"), {windowId, screenId},
+                                                   QStringLiteral("notifyWindowFocused"));
     return true;
 }
 


### PR DESCRIPTION
## Summary
Fixes the surviving half of the cross-desktop click-to-focus bug (reported on 3.4.8, which already contains #1021): on a non-main desktop, clicking a taskbar entry for a main-desktop window did not scroll the strip to that window.

## Root cause
KWin activates the cross-desktop target **before** the effect processes the desktop switch. `m_managedScreens` tracks the current desktop and is rebuilt only by the daemon's asynchronous announce, so when the desktop being left runs no placement mode the `isManagedScreen` gate in `window_lifecycle.cpp` read an empty set and dropped the one `notifyWindowFocused` that centers the destination strip. All of #1021's daemon-side centering machinery never received the event. Journal signature in the support report: desktop return runs the context switch and its forced emit, but `reanchorAfterFocusChange` shows `prevIdx == active` unchanged.

## Fix
Forward `notifyWindowFocused` unconditionally. Safe because:
- `reportScreenDesktop` just above shares the same ordered D-Bus connection and has already switched the daemon's context to the destination desktop
- `TilingAdaptor::engineOwningScreen`'s primary fallback is documented as the normal desktop-switch delivery route
- every engine's `windowFocused` self-guards on window tracking (snap's `noteFocused` no-ops for untracked windows, autotile checks tracking + `isKnownScreen`, scroll's `stateForWindow` bails)

## Testing
- Clean build, no warnings
- 418/418 ctest pass (1 skipped, pre-existing)
- Needs a live repro check after install (KWin effect, requires relogin): from a non-main desktop, click a main-desktop app that isn't centered; the strip should scroll it into view

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D7hazfM5fKyCpa4AH1nQBM