### PR TITLE
fix(placement): #1028 follow-ups — mid-drag cancel resize and FFM leak on unassigned desktops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to PlasmaZones are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Letting go of the insert key mid-drag no longer resizes the window in your hand**: with drag set to float the window, tapping the insert key while dragging and then releasing it without dropping made the window jump to its old tile size while you were still holding it. Cancelling the insert preview now leaves the dragged window alone until you drop it. ([#1028](https://github.com/fuddlesworth/PlasmaZones/discussions/1028))
+- **Focus no longer follows the mouse on desktops without a placement mode**: switching from a tiled desktop to one with no mode assigned could leave focus-follows-mouse running there, so newly opened windows kept trading focus on hover. The switch could be announced to the compositor effect with a desktop it had already moved past, the announcement was rejected as stale, and no corrected one followed. One is now always sent after every desktop change, so the effect ends up with the right answer. ([#1028](https://github.com/fuddlesworth/PlasmaZones/discussions/1028))
+
 ## [3.4.9] - 2026-09-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2128,7 +2128,8 @@ Initial packaged release. Wayland-only (X11 support removed). Requires KDE Plasm
 - Session restoration and rotation after login ([#66])
 - Window tracking: snap/restore behavior, zone clearing, startup timing, rotation zone ID matching, floating window exclusion ([#67])
 
-[Unreleased]: https://github.com/fuddlesworth/PlasmaZones/compare/v3.4.8...HEAD
+[Unreleased]: https://github.com/fuddlesworth/PlasmaZones/compare/v3.4.9...HEAD
+[3.4.9]: https://github.com/fuddlesworth/PlasmaZones/compare/v3.4.8...v3.4.9
 [3.4.8]: https://github.com/fuddlesworth/PlasmaZones/compare/v3.4.6...v3.4.8
 [3.4.6]: https://github.com/fuddlesworth/PlasmaZones/compare/v3.4.5...v3.4.6
 [3.4.5]: https://github.com/fuddlesworth/PlasmaZones/compare/v3.4.4...v3.4.5

--- a/libs/phosphor-engine/include/PhosphorEngine/IPlacementEngine.h
+++ b/libs/phosphor-engine/include/PhosphorEngine/IPlacementEngine.h
@@ -582,8 +582,17 @@ public:
     virtual void commitDragInsertPreview()
     {
     }
-    virtual void cancelDragInsertPreview()
+    /// @p dragStillActive: the previewed window is still under an interactive
+    /// move when the cancel runs (mid-drag trigger release, or a screen /
+    /// desktop change during the drag). An engine that keeps the window
+    /// MANAGED while its preview is live (autotile) must then keep
+    /// suppressing geometry emission for it during the cancel's own retile —
+    /// applying the tile rect would resize the window in the user's hand
+    /// (discussion #1028: float-drag + tap the insert trigger = window grows).
+    /// The drop-time cancel passes false so the window snaps back as before.
+    virtual void cancelDragInsertPreview(bool dragStillActive = false)
     {
+        Q_UNUSED(dragStillActive)
     }
     virtual QString dragInsertPreviewScreenId() const
     {

--- a/libs/phosphor-engine/include/PhosphorEngine/IPlacementEngine.h
+++ b/libs/phosphor-engine/include/PhosphorEngine/IPlacementEngine.h
@@ -739,11 +739,13 @@ public:
     /// until drop, and fighting it yanks the window from the cursor (and a
     /// per-ack reconcile pins size intents to transient drag frames). The
     /// daemon sets it at beginDrag and clears it before the drop is
-    /// finalized, so commit/float paths apply normally. Today the daemon
-    /// calls this on the SCROLL engine only, and only ScrollEngine
-    /// overrides it: autotile also retiles mid-drag but exempts the dragged
-    /// window inside applyTiling's emit filter instead. Override this when
-    /// an engine has no such filter of its own.
+    /// finalized, so commit/float paths apply normally. The daemon calls
+    /// this on BOTH placement engines for every drag: ScrollEngine gates
+    /// applyLayout emission and ack reconciliation on it, AutotileEngine
+    /// gates applyTiling's geometry emission — its preview/cancel filters
+    /// cover only the preview's own lifecycle, and retiles from other
+    /// sources (a deferred geometry-retry, a neighbour opening or closing)
+    /// need this drag-long mark (discussion #1028).
     virtual void setInteractiveDragWindow(const QString& windowId)
     {
         Q_UNUSED(windowId)

--- a/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/ScrollEngine.h
+++ b/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/ScrollEngine.h
@@ -615,7 +615,7 @@ public:
     }
     bool beginDragInsertPreview(const QString& rawWindowId, const QString& screenId) override;
     void commitDragInsertPreview() override;
-    void cancelDragInsertPreview() override;
+    void cancelDragInsertPreview(bool dragStillActive = false) override;
     /// `primary` = column index; `newSlot` true opens a NEW column at
     /// `primary`; otherwise the window joins column `primary` as tile
     /// `secondary` (a MODEL-column tile index — minimized tiles count).

--- a/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/ScrollEngine.h
+++ b/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/ScrollEngine.h
@@ -615,6 +615,10 @@ public:
     }
     bool beginDragInsertPreview(const QString& rawWindowId, const QString& screenId) override;
     void commitDragInsertPreview() override;
+    /// @p dragStillActive carries the base-interface contract and is
+    /// deliberately unused here (see the definition): the DETACH-ONCE model
+    /// plus the interactive-drag mark already keep the dragged window's rect
+    /// from being emitted mid-drag.
     void cancelDragInsertPreview(bool dragStillActive = false) override;
     /// `primary` = column index; `newSlot` true opens a NEW column at
     /// `primary`; otherwise the window joins column `primary` as tile

--- a/libs/phosphor-scroll-engine/src/scrollengine/drag_preview.cpp
+++ b/libs/phosphor-scroll-engine/src/scrollengine/drag_preview.cpp
@@ -464,7 +464,13 @@ void ScrollEngine::commitDragInsertPreview()
     }
 }
 
-void ScrollEngine::cancelDragInsertPreview()
+// dragStillActive is accepted for interface parity and deliberately unused:
+// the scroll preview DETACHES the window from the strip for the whole hold,
+// so the cancel's re-insert is the only thing that can put it back, and the
+// strip relayout placing it is the intended niri-style behaviour even while
+// the pointer still holds it (the drag then re-begins a preview on whichever
+// screen the cursor is on).
+void ScrollEngine::cancelDragInsertPreview(bool /*dragStillActive*/)
 {
     if (!m_dragInsertPreview) {
         return;

--- a/libs/phosphor-scroll-engine/src/scrollengine/drag_preview.cpp
+++ b/libs/phosphor-scroll-engine/src/scrollengine/drag_preview.cpp
@@ -466,10 +466,12 @@ void ScrollEngine::commitDragInsertPreview()
 
 // dragStillActive is accepted for interface parity and deliberately unused:
 // the scroll preview DETACHES the window from the strip for the whole hold,
-// so the cancel's re-insert is the only thing that can put it back, and the
-// strip relayout placing it is the intended niri-style behaviour even while
-// the pointer still holds it (the drag then re-begins a preview on whichever
-// screen the cursor is on).
+// so the cancel's re-insert is the only thing that can put it back. The
+// re-insert plus neighbour reflow is the intended niri-style behaviour, and
+// the dragged window's own rect is never emitted mid-drag anyway — applyLayout
+// suppresses it through the daemon-set m_interactiveDragWindow mark, which is
+// exactly why ignoring the flag here is safe. (The drag then re-begins a
+// preview on whichever screen the cursor is on.)
 void ScrollEngine::cancelDragInsertPreview(bool /*dragStillActive*/)
 {
     if (!m_dragInsertPreview) {
@@ -616,13 +618,18 @@ void ScrollEngine::cancelDragInsertPreview(bool /*dragStillActive*/)
             m_parkedScrollEdge.remove(p.windowId);
             applyLayout(p.targetScreenId, false);
             Q_EMIT placementChanged(p.targetScreenId);
+            // Only for the arm that actually re-homed the window: the else
+            // arm below drops it from the engine entirely, and telling the
+            // daemon "not floating on targetScreen" for a window this engine
+            // no longer holds would clear a real float mark with no engine
+            // owning the window.
+            Q_EMIT windowFloatingStateSynced(p.windowId, false, p.targetScreenId);
         } else {
             // Target context refused too — the window would stay tracked
             // against a key holding it nowhere. Drop the reverse-map entry
             // instead of latching the detached-residue limbo.
             m_states.removeWindow(p.windowId);
         }
-        Q_EMIT windowFloatingStateSynced(p.windowId, false, p.targetScreenId);
         return;
     }
 

--- a/libs/phosphor-scroll-engine/tests/test_scrollengine_draginsert.cpp
+++ b/libs/phosphor-scroll-engine/tests/test_scrollengine_draginsert.cpp
@@ -72,6 +72,7 @@ private Q_SLOTS:
     void windowClosedDropsPreview();
     void screenSetChangeCancelsPreview();
     void interactiveDragMarkSuppressesEmitAndReconcile();
+    void midDragCancelReinsertsWithoutEmittingDraggedRect();
     void detachedResidueHealsInsteadOfLatching();
     void cancelRestoresADefensivelyDetachedWindow();
     void reentrantBeginRestoresPriorWindow();
@@ -1041,6 +1042,49 @@ void TestScrollEngineDragInsert::interactiveDragMarkSuppressesEmitAndReconcile()
         emittedA = emittedA || emission.first().toString().contains(QStringLiteral("\"a\""));
     }
     QVERIFY(emittedA);
+}
+
+void TestScrollEngineDragInsert::midDragCancelReinsertsWithoutEmittingDraggedRect()
+{
+    // The cancel's ignored dragStillActive parameter is safe BECAUSE of the
+    // interactive-drag mark: a mid-drag cancel (trigger released, pointer
+    // still holding the window) re-inserts the window into the strip MODEL
+    // and reflows the neighbours, while the dragged window's own rect is
+    // never emitted — the daemon holds the mark for the whole drag. This is
+    // the niri-style behaviour the definition-site comment describes.
+    QObject owner;
+    ScrollEngine* engine = makeProviderEngine(&owner, {QStringLiteral("S1")});
+    openWindows(engine, QStringLiteral("S1"), {QStringLiteral("a"), QStringLiteral("b"), QStringLiteral("c")});
+    ScrollState* state = stateFor(engine, QStringLiteral("S1"));
+    QVERIFY(state);
+
+    engine->setInteractiveDragWindow(QStringLiteral("b"));
+    QVERIFY(engine->beginDragInsertPreview(QStringLiteral("b"), QStringLiteral("S1")));
+    QVERIFY(!state->strip().containsWindow(QStringLiteral("b")));
+
+    QSignalSpy tiledSpy(engine, &ScrollEngine::windowsTiled);
+    engine->cancelDragInsertPreview(/*dragStillActive=*/true);
+
+    // Model re-insert happened even though the pointer still holds the frame.
+    QVERIFY(!engine->hasDragInsertPreview());
+    QVERIFY(state->strip().containsWindow(QStringLiteral("b")));
+    QVERIFY(engine->isWindowTiled(QStringLiteral("b")));
+
+    // The re-insert relayout reflows neighbours (their columns shrank back),
+    // and the non-empty-batch guard keeps the no-"b" scan from passing
+    // vacuously, mirroring beginDetachesFromStrip's idiom.
+    QVERIFY(tiledSpy.count() >= 1);
+    bool sawSurvivingWindow = false;
+    for (const auto& emission : tiledSpy) {
+        const QString payload = emission.first().toString();
+        if (payload.contains(QStringLiteral("\"a\"")) || payload.contains(QStringLiteral("\"c\""))) {
+            sawSurvivingWindow = true;
+        }
+        QVERIFY2(!payload.contains(QStringLiteral("\"b\"")),
+                 "mid-drag cancel emitted the dragged window's rect while KWin still owns the frame");
+    }
+    QVERIFY(sawSurvivingWindow);
+    engine->setInteractiveDragWindow(QString());
 }
 
 void TestScrollEngineDragInsert::detachedResidueHealsInsteadOfLatching()

--- a/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
+++ b/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
@@ -1218,7 +1218,7 @@ public:
     /**
      * @brief Cancel the active drag-insert preview, restoring the original order.
      */
-    void cancelDragInsertPreview() override;
+    void cancelDragInsertPreview(bool dragStillActive = false) override;
 
     /**
      * @brief Compute the insert index for a cursor position on an autotile screen.
@@ -1952,6 +1952,12 @@ private:
     // AutotileEngine::DragInsertPreview spelling valid for existing call sites.
     using DragInsertPreview = ::PhosphorTileEngine::DragInsertPreview;
     std::optional<DragInsertPreview> m_dragInsertPreview;
+
+    /// Set only for the duration of cancelDragInsertPreview(dragStillActive =
+    /// true)'s retiles: the window whose interactive move is still running and
+    /// must keep being skipped by applyTiling's geometry emission even though
+    /// m_dragInsertPreview has already been reset. Empty otherwise.
+    QString m_dragCancelFilterWindowId;
 
     /**
      * @brief Process all pending retiles (fires via QueuedConnection)

--- a/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
+++ b/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
@@ -1217,8 +1217,33 @@ public:
 
     /**
      * @brief Cancel the active drag-insert preview, restoring the original order.
+     *
+     * @p dragStillActive carries the base-interface contract (the previewed
+     * window is still under an interactive move, so the cancel's own retiles
+     * must keep skipping its geometry). Ignored when the daemon-set
+     * interactive-drag mark names a DIFFERENT window than the preview: the
+     * preview is then stale residue from an earlier drag, nobody is holding
+     * its window, and suppressing its snap-back would park it at the
+     * previewed rect until an unrelated retile.
      */
     void cancelDragInsertPreview(bool dragStillActive = false) override;
+
+    /**
+     * @brief Mark @p windowId as under a compositor interactive move
+     * (IPlacementEngine contract). Empty clears.
+     *
+     * While set, applyTiling never emits this window's geometry: autotile
+     * keeps a dragged window modeled as a tile, so any retile that runs
+     * during the drag — a deferred geometry-retry, a window opening or
+     * closing on the screen, a settings retile, an engine-internal preview
+     * self-cancel — would otherwise apply the tile rect to the window in the
+     * user's hand (discussion #1028). The preview filter and the cancel
+     * filter cover only the preview's own lifecycle; this covers the whole
+     * drag. Clearing does NOT retile — every drop path finalizes on its own
+     * (commit re-applies, ApplyFloat floats the window out, a cancelled move
+     * has KWin restore the frame).
+     */
+    void setInteractiveDragWindow(const QString& windowId) override;
 
     /**
      * @brief Compute the insert index for a cursor position on an autotile screen.
@@ -1958,6 +1983,13 @@ private:
     /// must keep being skipped by applyTiling's geometry emission even though
     /// m_dragInsertPreview has already been reset. Empty otherwise.
     QString m_dragCancelFilterWindowId;
+
+    /// The window under a compositor interactive move (canonical id), set by
+    /// the daemon at beginDrag and cleared on every drag exit. While set,
+    /// applyTiling skips its geometry emission entirely — the drag-long
+    /// counterpart to the scope-bound cancel filter above (see
+    /// setInteractiveDragWindow). Empty otherwise.
+    QString m_interactiveDragWindow;
 
     /**
      * @brief Process all pending retiles (fires via QueuedConnection)

--- a/libs/phosphor-tile-engine/src/autotileengine/drag_preview.cpp
+++ b/libs/phosphor-tile-engine/src/autotileengine/drag_preview.cpp
@@ -171,12 +171,24 @@ bool AutotileEngine::beginDragInsertPreview(const QString& rawWindowId, const QS
         // Roll back the prior-state capture so we don't leave the engine in a bad state.
         if (!preview.evictedWindowId.isEmpty()) {
             targetState->setFloating(preview.evictedWindowId, false);
+            // Paired with the markOverflow in the eviction block above, like
+            // the cancel path's restore: the victim is tiled again, so a
+            // standing mark would misclassify it everywhere the overflow
+            // KIND matters (capturePlacement, recoverIfRoom).
+            m_overflow.clearOverflow(preview.evictedWindowId);
         }
         if (preview.hadPriorState && preview.priorSameScreen) {
             // Same-screen: we only mutated the floating flag (if priorFloating).
             // Re-float to restore the original state.
             if (preview.priorFloating) {
                 targetState->setFloating(windowId, true);
+                // Restore the KIND of float too (the cancel path's idiom):
+                // the capture above cleared the overflow mark, and a
+                // floating-but-unmarked window reads as a user float that
+                // recoverIfRoom never auto-recovers.
+                if (preview.priorOverflow) {
+                    m_overflow.markOverflow(windowId, screenId);
+                }
             }
         } else if (preview.hadPriorState) {
             // Cross-screen: we removed from prior state and added to target.
@@ -304,6 +316,17 @@ void AutotileEngine::cancelDragInsertPreview(bool dragStillActive)
     // drag visibly grew to tile size the moment the trigger was released
     // (discussion #1028 follow-up). The drop-time cancel passes false and
     // keeps the snap-back behaviour.
+    //
+    // Identity gate: the adaptor derives dragStillActive from session
+    // liveness, so a stale preview swept at the START of a new drag arrives
+    // here with dragStillActive=true even though nobody holds ITS window —
+    // suppressing the snap-back would park that window at the previewed rect.
+    // When the daemon's interactive-drag mark is set and names a different
+    // window, trust the mark over the flag. An empty mark (engine driven
+    // without a daemon, as in the unit tests) keeps the flag's word.
+    if (dragStillActive && !m_interactiveDragWindow.isEmpty() && m_interactiveDragWindow != p.windowId) {
+        dragStillActive = false;
+    }
     if (dragStillActive) {
         m_dragCancelFilterWindowId = p.windowId;
     }
@@ -377,6 +400,16 @@ void AutotileEngine::cancelDragInsertPreview(bool dragStillActive)
     if (p.hadPriorState && !p.priorSameScreen) {
         retileAfterOperation(p.priorKey.screenId, /*operationSucceeded=*/true);
     }
+}
+
+void AutotileEngine::setInteractiveDragWindow(const QString& windowId)
+{
+    // Deliberately NO retile on clear, mirroring the scroll engine: every
+    // drop path finalizes on its own (commit retiles unfiltered, ApplyFloat
+    // floats the window out and that write retiles, a cancelled move has
+    // KWin restore the frame), and a defensive retile here would race the
+    // async float call.
+    m_interactiveDragWindow = canonicalizeForLookup(windowId);
 }
 
 int AutotileEngine::computeDragInsertIndexAtPoint(const QString& screenId, const QPoint& cursorPos) const

--- a/libs/phosphor-tile-engine/src/autotileengine/drag_preview.cpp
+++ b/libs/phosphor-tile-engine/src/autotileengine/drag_preview.cpp
@@ -288,13 +288,28 @@ void AutotileEngine::commitDragInsertPreview()
     }
 }
 
-void AutotileEngine::cancelDragInsertPreview()
+void AutotileEngine::cancelDragInsertPreview(bool dragStillActive)
 {
     if (!m_dragInsertPreview) {
         return;
     }
     const DragInsertPreview p = *m_dragInsertPreview;
     m_dragInsertPreview.reset();
+
+    // Mid-drag cancel (insert trigger released, or the screen/desktop changed
+    // under a live drag): the user is still holding the window, so the retiles
+    // below must keep skipping its geometry exactly as the preview filter did.
+    // Without this, resetting the preview first meant the cancel's own retile
+    // applied the tile rect to the window in the user's hand — a float-mode
+    // drag visibly grew to tile size the moment the trigger was released
+    // (discussion #1028 follow-up). The drop-time cancel passes false and
+    // keeps the snap-back behaviour.
+    if (dragStillActive) {
+        m_dragCancelFilterWindowId = p.windowId;
+    }
+    const auto clearCancelFilter = qScopeGuard([this] {
+        m_dragCancelFilterWindowId.clear();
+    });
 
     PhosphorTiles::TilingState* targetState = tilingStateForScreen(p.targetScreenId);
 

--- a/libs/phosphor-tile-engine/src/autotileengine/layout_apply.cpp
+++ b/libs/phosphor-tile-engine/src/autotileengine/layout_apply.cpp
@@ -356,8 +356,15 @@ void AutotileEngine::applyTiling(const QString& screenId)
     // Drag-insert preview: skip emitting geometry for the dragged window so
     // KWin's interactive move isn't fought. Other windows still animate to
     // their new tile positions, producing the OrderingPage-style shift.
-    const bool filterForPreview = m_dragInsertPreview && m_dragInsertPreview->targetScreenId == screenId;
-    const QString filteredWindowId = filterForPreview ? m_dragInsertPreview->windowId : QString();
+    // Two sources for the same skip: a live preview on this screen, or a
+    // cancel that is retiling while the interactive move is still running
+    // (m_dragCancelFilterWindowId, set only inside
+    // cancelDragInsertPreview(dragStillActive = true)). The cancel filter is
+    // not screen-scoped — the window is mid-drag on exactly one screen and
+    // its id cannot collide elsewhere.
+    const bool previewOnScreen = m_dragInsertPreview && m_dragInsertPreview->targetScreenId == screenId;
+    const QString filteredWindowId = previewOnScreen ? m_dragInsertPreview->windowId : m_dragCancelFilterWindowId;
+    const bool filterForPreview = !filteredWindowId.isEmpty();
 
     const QStringList windows = state->tiledWindows();
     const QVector<QRect> zones = state->calculatedZones();

--- a/libs/phosphor-tile-engine/src/autotileengine/layout_apply.cpp
+++ b/libs/phosphor-tile-engine/src/autotileengine/layout_apply.cpp
@@ -356,13 +356,17 @@ void AutotileEngine::applyTiling(const QString& screenId)
     // Drag-insert preview: skip emitting geometry for the dragged window so
     // KWin's interactive move isn't fought. Other windows still animate to
     // their new tile positions, producing the OrderingPage-style shift.
-    // Two sources for the same skip: a live preview on this screen, or a
+    // Three sources for the same skip: a live preview on this screen, a
     // cancel that is retiling while the interactive move is still running
     // (m_dragCancelFilterWindowId, set only inside
-    // cancelDragInsertPreview(dragStillActive = true)). The cancel filter is
-    // not screen-scoped — the window is mid-drag on exactly one screen and
-    // its id cannot collide elsewhere.
-    const bool previewOnScreen = m_dragInsertPreview && m_dragInsertPreview->targetScreenId == screenId;
+    // cancelDragInsertPreview(dragStillActive = true)), and the daemon-set
+    // interactive-drag mark (m_interactiveDragWindow), which covers every
+    // OTHER retile that lands during a drag — a deferred geometry-retry, a
+    // neighbour opening or closing, an engine-internal preview self-cancel.
+    // Neither the cancel filter nor the mark is screen-scoped — the window
+    // is mid-drag on exactly one screen and its id cannot collide elsewhere.
+    const bool previewOnScreen = m_dragInsertPreview
+        && PhosphorIdentity::VirtualScreenId::samePhysical(m_dragInsertPreview->targetScreenId, screenId);
     const QString filteredWindowId = previewOnScreen ? m_dragInsertPreview->windowId : m_dragCancelFilterWindowId;
     const bool filterForPreview = !filteredWindowId.isEmpty();
 
@@ -472,6 +476,14 @@ void AutotileEngine::applyTiling(const QString& screenId)
     QJsonArray arr;
     for (int i = 0; i < tileCount; ++i) {
         if (filterForPreview && windows[i] == filteredWindowId) {
+            continue;
+        }
+        if (!m_interactiveDragWindow.isEmpty() && windows[i] == m_interactiveDragWindow) {
+            // Under a compositor interactive move for the whole drag: KWin
+            // owns the frame until drop, so never fight it (see
+            // setInteractiveDragWindow). Skipped before the
+            // m_lastAppliedTileRect insert like the preview skip above — a
+            // rect never applied must not become the float-back comparand.
             continue;
         }
         // No inset: the KWin effect's border shader recolours each window's own

--- a/src/daemon/daemon/start.cpp
+++ b/src/daemon/daemon/start.cpp
@@ -397,6 +397,25 @@ void Daemon::connectDesktopActivity()
                 // [SEQ E] Per-desktop assignments may differ — recompute autotile
                 // screens, re-sync mode/filter, then refresh overlay geometry.
                 updateEngineScreens();
+                // [SEQ E½] Re-announce the managed set UNCONDITIONALLY for this
+                // report. The effect's staleness gate rejects any announce whose
+                // per-screen desktop stamps disagree with what it last reported,
+                // and its contract is "rejection converges: the daemon
+                // re-announces for the desktop the effect has since reported".
+                // updateEngineScreens only announces when the managed set
+                // CHANGES, so on a global switch (the effect fans out one report
+                // per output) the first report's announce carries the other
+                // outputs' not-yet-updated desktops, gets rejected, and the
+                // later reports change nothing — the promised follow-up never
+                // came and the effect kept the old desktop's managed set. That
+                // stale set is how focus-follows-mouse kept running on an
+                // unassigned desktop (discussion #1028 follow-up). The adaptor
+                // coalesces per event-loop turn and stamps desktops at emit
+                // time, so the burst's last announce carries a fully consistent
+                // map and is accepted.
+                if (m_tilingAdaptor) {
+                    m_tilingAdaptor->notifyEngineScreensChanged(/*isDesktopSwitch=*/true);
+                }
                 // A desktop whose assignment is snapping demotes the screen out
                 // of tiling in the recompute above; nothing further on this path
                 // consumes the preserved snap-ZONE half, so put the released

--- a/src/dbus/windowdragadaptor/drag.cpp
+++ b/src/dbus/windowdragadaptor/drag.cpp
@@ -630,7 +630,7 @@ void WindowDragAdaptor::dragMoved(const QString& windowId, int cursorX, int curs
                 && (previewEngine != insertEngine
                     || !PhosphorScreens::ScreenIdentity::screensMatch(previewEngine->dragInsertPreviewScreenId(),
                                                                       insertScreenId))) {
-                previewEngine->cancelDragInsertPreview();
+                previewEngine->cancelDragInsertPreview(/*dragStillActive=*/true);
                 // The departed screen's indicator goes with the preview it
                 // described. pushScrollDropIndicator would clear it anyway on
                 // the first tick that resolves a rect for the new screen, but
@@ -800,7 +800,7 @@ void WindowDragAdaptor::dragMoved(const QString& windowId, int cursorX, int curs
             // re-attaches the drag window, changing the strip's shape).
             const QString cancelledScreenId = previewEngine->dragInsertPreviewScreenId();
             const bool cancelledStripSelector = previewEngine->providesDragInsertSelector();
-            previewEngine->cancelDragInsertPreview();
+            previewEngine->cancelDragInsertPreview(/*dragStillActive=*/true);
             clearScrollDropIndicator();
             stopDragScrollTimer();
             if (cancelledStripSelector && m_overlayService && !cancelledScreenId.isEmpty()) {

--- a/src/dbus/windowdragadaptor/drag.cpp
+++ b/src/dbus/windowdragadaptor/drag.cpp
@@ -630,7 +630,20 @@ void WindowDragAdaptor::dragMoved(const QString& windowId, int cursorX, int curs
                 && (previewEngine != insertEngine
                     || !PhosphorScreens::ScreenIdentity::screensMatch(previewEngine->dragInsertPreviewScreenId(),
                                                                       insertScreenId))) {
+                // Captured before the cancel empties them, mirroring the
+                // trigger-release arm below: the departed screen's strip
+                // popup must re-snapshot at this boundary (the cancel
+                // re-attaches the drag window, changing that strip's shape),
+                // and nothing later on this tick reaches the departed screen
+                // — the per-tick selector check runs against the NEW screen
+                // only, so a stale popup would otherwise stay up for as long
+                // as the new screen's preview lives.
+                const QString departedScreenId = previewEngine->dragInsertPreviewScreenId();
+                const bool departedStripSelector = previewEngine->providesDragInsertSelector();
                 previewEngine->cancelDragInsertPreview(/*dragStillActive=*/true);
+                if (departedStripSelector && m_overlayService && !departedScreenId.isEmpty()) {
+                    m_overlayService->refreshStripSelector(departedScreenId);
+                }
                 // The departed screen's indicator goes with the preview it
                 // described. pushScrollDropIndicator would clear it anyway on
                 // the first tick that resolves a rect for the new screen, but

--- a/src/dbus/windowdragadaptor/drag_protocol.cpp
+++ b/src/dbus/windowdragadaptor/drag_protocol.cpp
@@ -251,12 +251,13 @@ PhosphorProtocol::DragPolicy WindowDragAdaptor::beginDrag(const QString& windowI
     // drag. The scroll engine keeps a dragged tile in its strip model (the
     // effect's immediate float is visual only), so without this mark any
     // mid-drag retile re-emits the slot rect against KWin's move and the
-    // per-ack reconcile pins size intents to transient drag frames. Cleared
-    // on every drag exit (endDrag before the drop settles, window close,
-    // and the clean-slate reset above for crash recovery).
-    if (m_scrollEngine) {
-        m_scrollEngine->setInteractiveDragWindow(windowId);
-    }
+    // per-ack reconcile pins size intents to transient drag frames. Autotile
+    // keeps its dragged window modeled as a tile too, so the same mark gates
+    // applyTiling's emission there (discussion #1028: a deferred retile
+    // resized the window in the user's hand). Cleared on every drag exit
+    // (endDrag before the drop settles, window close, and the clean-slate
+    // reset above for crash recovery).
+    setEngineInteractiveDragWindow(windowId);
 
     // Reset the drag-insert toggle latch on every drag start. This runs
     // before branching so it covers both the bypass path (drag starts on an
@@ -589,13 +590,15 @@ void WindowDragAdaptor::clearPendingSnapDragState()
     }
     // Any drag-insert preview left over from an incomplete previous drag
     // (daemon lost track, client disconnect, snapping-disabled flip, etc.)
-    // must be cleared too — its referenced window may no longer exist.
-    cancelDragInsertIfActive();
-    // Same staleness argument for the interactive-drag mark: a leftover
-    // mark would silently exempt a window from layout forever.
-    if (m_scrollEngine) {
-        m_scrollEngine->setInteractiveDragWindow(QString());
-    }
+    // must be cleared too — its referenced window may no longer exist, and
+    // nobody is holding it, so the snap-back must actually be emitted. The
+    // stale sweep clears the interactive-drag mark first (a leftover mark
+    // would suppress that snap-back, then silently exempt a window from
+    // layout forever) and cancels with an explicit false rather than the
+    // liveness derivation, which can read a dead session's ids as a live
+    // drag (a crashed drag's m_draggedWindowId is still set when beginDrag
+    // routes through here).
+    cancelStaleDragInsertPreviews();
 }
 
 PhosphorProtocol::DragOutcome WindowDragAdaptor::endDrag(const QString& windowId, int cursorX, int cursorY,
@@ -659,10 +662,11 @@ PhosphorProtocol::DragOutcome WindowDragAdaptor::endDrag(const QString& windowId
         if (m_draggedWindowId.isEmpty() && m_pendingSnapDragWindowId.isEmpty()) {
             m_currentDragPolicy = {};
             m_dragReorderActive = false;
-            cancelDragInsertIfActive();
-            if (m_scrollEngine) {
-                m_scrollEngine->setInteractiveDragWindow(QString());
-            }
+            // Stale-residue sweep: mark cleared first, cancels explicit
+            // false (see cancelStaleDragInsertPreviews) — with no live and
+            // no pending drag, whatever this finds belongs to a dead
+            // session and must snap back now.
+            cancelStaleDragInsertPreviews();
         }
         return outcome;
     }
@@ -675,9 +679,7 @@ PhosphorProtocol::DragOutcome WindowDragAdaptor::endDrag(const QString& windowId
     // The interactive move is over: release the window back to engine
     // authority BEFORE the drop settles, so a preview commit's finalizing
     // relayout emits the dragged window's rect unfiltered.
-    if (m_scrollEngine) {
-        m_scrollEngine->setInteractiveDragWindow(QString());
-    }
+    setEngineInteractiveDragWindow(QString());
 
     qCInfo(lcDbusWindow) << "endDrag:" << windowId << "cursor=" << cursorX << cursorY << "cancelled=" << cancelled
                          << "bypass=" << bypassReason;

--- a/src/dbus/windowdragadaptor/windowdragadaptor.cpp
+++ b/src/dbus/windowdragadaptor/windowdragadaptor.cpp
@@ -296,13 +296,17 @@ void WindowDragAdaptor::cancelDragInsertIfActive()
     // evaluated after its per-screen cancels have run, so do not
     // "harmonise" it to stop-first.
     stopDragScrollTimer();
+    // A preview can only belong to the live drag's window, so a still-active
+    // drag session means the cancel retile must keep suppressing that
+    // window's geometry (see IPlacementEngine::cancelDragInsertPreview).
+    const bool dragStillActive = isDragSessionActive();
     // At most one engine holds a preview, but sweep both — a stale second
     // preview would otherwise be unreachable by every cleanup path.
     if (m_autotileEngine && m_autotileEngine->hasDragInsertPreview()) {
-        m_autotileEngine->cancelDragInsertPreview();
+        m_autotileEngine->cancelDragInsertPreview(dragStillActive);
     }
     if (m_scrollEngine && m_scrollEngine->hasDragInsertPreview()) {
-        m_scrollEngine->cancelDragInsertPreview();
+        m_scrollEngine->cancelDragInsertPreview(dragStillActive);
     }
     clearScrollDropIndicator();
 }
@@ -331,11 +335,15 @@ void WindowDragAdaptor::cancelDragInsertPreviewsForScreen(const QString& screenI
         return PhosphorIdentity::VirtualScreenId::samePhysical(engine->dragInsertPreviewScreenId(), screenId)
             || PhosphorIdentity::VirtualScreenId::samePhysical(engine->dragInsertPreviewPriorScreenId(), screenId);
     };
+    // Same reasoning as cancelDragInsertIfActive: this runs from desktop
+    // switches and output removals that can land mid-drag, and the cancel
+    // retile must not resize the window still in the user's hand.
+    const bool dragStillActive = isDragSessionActive();
     if (affected(m_autotileEngine)) {
-        m_autotileEngine->cancelDragInsertPreview();
+        m_autotileEngine->cancelDragInsertPreview(dragStillActive);
     }
     if (affected(m_scrollEngine)) {
-        m_scrollEngine->cancelDragInsertPreview();
+        m_scrollEngine->cancelDragInsertPreview(dragStillActive);
     }
     // Clear the indicator on the departing output regardless of whether any
     // engine cancel ran above. The engine may have self-cancelled its own

--- a/src/dbus/windowdragadaptor/windowdragadaptor.cpp
+++ b/src/dbus/windowdragadaptor/windowdragadaptor.cpp
@@ -296,9 +296,15 @@ void WindowDragAdaptor::cancelDragInsertIfActive()
     // evaluated after its per-screen cancels have run, so do not
     // "harmonise" it to stop-first.
     stopDragScrollTimer();
-    // A preview can only belong to the live drag's window, so a still-active
+    // A preview normally belongs to the live drag's window, so a still-active
     // drag session means the cancel retile must keep suppressing that
     // window's geometry (see IPlacementEngine::cancelDragInsertPreview).
+    // STALE previews from a dead session must not reach this derivation —
+    // the dead-session paths (a fresh beginDrag, a compositor reconnect, a
+    // pending drag's exit) route through cancelStaleDragInsertPreviews
+    // instead, which cancels with an explicit false. As defense-in-depth,
+    // autotile additionally ignores a true flag when the interactive-drag
+    // mark names a different window than the preview.
     const bool dragStillActive = isDragSessionActive();
     // At most one engine holds a preview, but sweep both — a stale second
     // preview would otherwise be unreachable by every cleanup path.
@@ -314,6 +320,46 @@ void WindowDragAdaptor::cancelDragInsertIfActive()
 void WindowDragAdaptor::cancelDragInsertPreviews()
 {
     cancelDragInsertIfActive();
+}
+
+void WindowDragAdaptor::cancelStaleDragInsertPreviews()
+{
+    // Mark FIRST, cancels second — the cancels' snap-back retiles run
+    // synchronously inside cancelDragInsertPreview, and a mark still
+    // standing would suppress the very geometry this sweep exists to
+    // re-emit (applyTiling / applyLayout skip the marked window
+    // unconditionally, and clearing the mark deliberately does not retile).
+    setEngineInteractiveDragWindow(QString());
+    stopDragScrollTimer();
+    // Explicit false, never the session-liveness derivation: these paths run
+    // where the prior session is dead by construction (a fresh beginDrag —
+    // the compositor runs one interactive move at a time, so a new begin
+    // means the old move ended; a compositor reconnect; a pending drag's
+    // exit), but the dead session's ids can still be populated and would
+    // derive a phantom "still active".
+    if (m_autotileEngine && m_autotileEngine->hasDragInsertPreview()) {
+        m_autotileEngine->cancelDragInsertPreview(/*dragStillActive=*/false);
+    }
+    if (m_scrollEngine && m_scrollEngine->hasDragInsertPreview()) {
+        m_scrollEngine->cancelDragInsertPreview(/*dragStillActive=*/false);
+    }
+    clearScrollDropIndicator();
+}
+
+void WindowDragAdaptor::setEngineInteractiveDragWindow(const QString& windowId)
+{
+    // Both engines, always: each keeps the dragged window modeled as a tile
+    // in its own way (the scroll strip's DETACH-ONCE slot, autotile's tiled
+    // list), and each suppresses its own mid-drag geometry emission off this
+    // mark. The cursor's CURRENT screen is deliberately not consulted — a
+    // drag can cross engines, and the mark must already be in place on the
+    // engine the cursor arrives at.
+    if (m_autotileEngine) {
+        m_autotileEngine->setInteractiveDragWindow(windowId);
+    }
+    if (m_scrollEngine) {
+        m_scrollEngine->setInteractiveDragWindow(windowId);
+    }
 }
 
 void WindowDragAdaptor::cancelDragInsertPreviewsForScreen(const QString& screenId)
@@ -552,9 +598,7 @@ void WindowDragAdaptor::cancelSnap()
     if (m_draggedWindowId.isEmpty() && !m_pendingSnapDragWindowId.isEmpty()) {
         const QString pendingWindow = m_pendingSnapDragWindowId;
         clearPendingSnapDragState();
-        if (m_scrollEngine) {
-            m_scrollEngine->setInteractiveDragWindow(pendingWindow);
-        }
+        setEngineInteractiveDragWindow(pendingWindow);
     }
     m_currentZoneId.clear();
     m_currentZoneScreenId.clear();
@@ -597,9 +641,7 @@ void WindowDragAdaptor::handleWindowClosed(const QString& windowId)
     // If this window was being dragged, clean up drag state
     if (windowId == m_draggedWindowId) {
         cancelDragInsertIfActive();
-        if (m_scrollEngine) {
-            m_scrollEngine->setInteractiveDragWindow(QString());
-        }
+        setEngineInteractiveDragWindow(QString());
         // Drag-teardown: only drop the shared Escape grab if no picker / snap
         // assist still needs it. A layout picker can be open over an in-flight
         // drag, and it holds kCancelOverlayId — an unconditional release here
@@ -828,7 +870,16 @@ void WindowDragAdaptor::clearForCompositorReconnect()
     // preview whose window stays structurally detached. This is the call the
     // "every preview-end path" contract on cancelDragInsertIfActive's
     // declaration asks every new teardown to add.
-    cancelDragInsertIfActive();
+    //
+    // The STALE sweep, not cancelDragInsertIfActive: the compositor holding
+    // the interactive move is GONE, so no move survives this path — the
+    // liveness derivation would read the dead session's ids as a live drag,
+    // suppress the cancel retile's snap-back, and park the previously-
+    // dragged window at its mid-drag geometry until an unrelated retile.
+    // The helper also clears the interactive-drag mark BEFORE cancelling,
+    // for the same reason (the mark suppresses geometry independently of
+    // the flag).
+    cancelStaleDragInsertPreviews();
     // The zone selector popup and its stored selection belong to the dead
     // session too: resetDragState clears neither, and with the compositor
     // gone no drag-end ever will. A surviving shown-flag pair plus the

--- a/src/dbus/windowdragadaptor/windowdragadaptor.h
+++ b/src/dbus/windowdragadaptor/windowdragadaptor.h
@@ -857,6 +857,25 @@ private:
     // DRY helper: cancel any active drag-insert preview on either engine.
     void cancelDragInsertIfActive();
 
+    /// DRY helper: mark @p windowId as under a compositor interactive move on
+    /// BOTH placement engines (empty clears). Every set/clear site routes
+    /// through here — a site marking only one engine is exactly how the
+    /// autotile arm went missing (discussion #1028: any retile landing during
+    /// a drag resized the window in the user's hand).
+    void setEngineInteractiveDragWindow(const QString& windowId);
+
+    /// DRY helper for teardown paths where the prior session is DEAD by
+    /// construction (a fresh beginDrag, a compositor reconnect, a pending
+    /// drag's exit): clear the interactive-drag mark FIRST, then cancel any
+    /// leftover preview with an explicit dragStillActive=false so its
+    /// snap-back geometry is actually emitted. cancelDragInsertIfActive is
+    /// wrong on these paths twice over — its session-liveness derivation can
+    /// read a dead session's ids as a live drag, and a mark still standing
+    /// during the cancel suppresses the snap-back through applyTiling /
+    /// applyLayout even when the flag is false, parking the window at its
+    /// mid-drag geometry.
+    void cancelStaleDragInsertPreviews();
+
     /// Screen the drop indicator was last pushed to, empty when none is
     /// showing. Tracked rather than re-derived because the clear has to reach
     /// the screen the indicator is ON, which after a cross-screen drag is no

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -1326,6 +1326,19 @@ target_link_libraries(test_drag_policy PRIVATE Qt6::Test Qt6::Core Qt6::DBus pla
                                                PhosphorScrollEngine::PhosphorScrollEngine)
 add_test(NAME test_drag_policy COMMAND test_drag_policy)
 
+# Drag-insert cancel sweep seams + desktop-switch announce burst (the #1028
+# follow-up mechanisms): the live sweep's dragStillActive derivation, the
+# dead-session sweep's mark-first ordering, and TilingAdaptor's emit-time
+# desktop stamping under a per-output report burst.
+add_executable(test_windowdrag_cancel_sweeps dbus/test_windowdrag_cancel_sweeps.cpp
+               ${CMAKE_SOURCE_DIR}/libs/phosphor-screens/tests/FakeScreenProvider.cpp)
+target_include_directories(test_windowdrag_cancel_sweeps PRIVATE ${CMAKE_SOURCE_DIR}/libs/phosphor-screens/tests)
+# Constructs a real AutotileEngine — contractual link (see the
+# test_drag_policy rationale).
+target_link_libraries(test_windowdrag_cancel_sweeps PRIVATE Qt6::Test Qt6::Core Qt6::DBus plasmazones_core
+                                                            PhosphorTileEngine::PhosphorTileEngine)
+add_test(NAME test_windowdrag_cancel_sweeps COMMAND test_windowdrag_cancel_sweeps)
+
 # Truth-table guard for resolveActivationActive() - pins the per-tick
 # overlay-active decision (toggle latch + deactivation override + the
 # always-active gate that scopes deactivation to its UI surface, #249).

--- a/tests/unit/autotile/behavior/test_autotile_drag_insert.cpp
+++ b/tests/unit/autotile/behavior/test_autotile_drag_insert.cpp
@@ -3,6 +3,9 @@
 
 #include <QTest>
 #include <QCoreApplication>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
 #include <QSignalSpy>
 
 #include <PhosphorTileEngine/AutotileEngine.h>
@@ -169,6 +172,76 @@ private Q_SLOTS:
 
         QVERIFY(!engine.hasDragInsertPreview());
         QCOMPARE(engine.tilingStateForScreen(screen)->tiledWindows(), originalOrder);
+    }
+
+    /// Helper for the two cancel-geometry tests below: true when any
+    /// windowsTiled emission recorded by @p spy carries a GEOMETRY entry
+    /// (an "x" key — float-only sync entries have none) for @p windowId.
+    static bool spyHasGeometryEntryFor(const QSignalSpy& spy, const QString& windowId)
+    {
+        for (const QList<QVariant>& emission : spy) {
+            const QJsonArray arr = QJsonDocument::fromJson(emission.first().toString().toUtf8()).array();
+            for (const QJsonValue& v : arr) {
+                const QJsonObject obj = v.toObject();
+                if (obj.value(QLatin1String("windowId")).toString() == windowId && obj.contains(QLatin1String("x"))) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    // A mid-drag cancel (insert trigger released while the pointer still
+    // holds the window) must not emit tile geometry for the dragged window —
+    // doing so resized the window in the user's hand the moment they let go
+    // of the trigger (discussion #1028 follow-up: float-drag + tap ALT).
+    void testSameScreen_midDragCancelSkipsDraggedGeometry()
+    {
+        AutotileEngine engine(nullptr, nullptr, nullptr, PlasmaZones::TestHelpers::testRegistry());
+        const QString screen = QLatin1String(Screen1);
+        engine.setAutotileScreens({screen});
+        openWindows(engine, screen, {QStringLiteral("A"), QStringLiteral("B"), QStringLiteral("C")});
+
+        // Force zones — unit tests have no real screen geometry, and
+        // applyTiling reuses the last calculated zones when recalc bails.
+        PhosphorTiles::TilingState* state = engine.tilingStateForScreen(screen);
+        QVERIFY(state);
+        state->setCalculatedZones({QRect(0, 0, 900, 1000), QRect(900, 0, 500, 1000), QRect(1400, 0, 500, 1000)});
+
+        QVERIFY(engine.beginDragInsertPreview(QStringLiteral("A"), screen));
+        engine.updateDragInsertPreview(2);
+
+        QSignalSpy tiledSpy(&engine, &AutotileEngine::windowsTiled);
+        engine.cancelDragInsertPreview(/*dragStillActive=*/true);
+
+        QVERIFY(tiledSpy.count() >= 1);
+        QVERIFY2(spyHasGeometryEntryFor(tiledSpy, QStringLiteral("B")),
+                 "cancel retile emitted no neighbour geometry — the assertion below would be vacuous");
+        QVERIFY2(!spyHasGeometryEntryFor(tiledSpy, QStringLiteral("A")),
+                 "mid-drag cancel emitted tile geometry for the window still being dragged");
+    }
+
+    // Control: the drop-time cancel (default argument) keeps the snap-back —
+    // the dragged window's tile geometry IS applied.
+    void testSameScreen_dropTimeCancelAppliesDraggedGeometry()
+    {
+        AutotileEngine engine(nullptr, nullptr, nullptr, PlasmaZones::TestHelpers::testRegistry());
+        const QString screen = QLatin1String(Screen1);
+        engine.setAutotileScreens({screen});
+        openWindows(engine, screen, {QStringLiteral("A"), QStringLiteral("B"), QStringLiteral("C")});
+
+        PhosphorTiles::TilingState* state = engine.tilingStateForScreen(screen);
+        QVERIFY(state);
+        state->setCalculatedZones({QRect(0, 0, 900, 1000), QRect(900, 0, 500, 1000), QRect(1400, 0, 500, 1000)});
+
+        QVERIFY(engine.beginDragInsertPreview(QStringLiteral("A"), screen));
+        engine.updateDragInsertPreview(2);
+
+        QSignalSpy tiledSpy(&engine, &AutotileEngine::windowsTiled);
+        engine.cancelDragInsertPreview();
+
+        QVERIFY(tiledSpy.count() >= 1);
+        QVERIFY(spyHasGeometryEntryFor(tiledSpy, QStringLiteral("A")));
     }
 
     // =========================================================================

--- a/tests/unit/autotile/behavior/test_autotile_drag_insert.cpp
+++ b/tests/unit/autotile/behavior/test_autotile_drag_insert.cpp
@@ -219,6 +219,92 @@ private Q_SLOTS:
                  "cancel retile emitted no neighbour geometry — the assertion below would be vacuous");
         QVERIFY2(!spyHasGeometryEntryFor(tiledSpy, QStringLiteral("A")),
                  "mid-drag cancel emitted tile geometry for the window still being dragged");
+        // Any retile deferred past the cancel (the queued coalesced channel)
+        // must not re-emit A's rect after the scope-bound filter clears.
+        QCoreApplication::processEvents();
+        QVERIFY2(!spyHasGeometryEntryFor(tiledSpy, QStringLiteral("A")),
+                 "a deferred retile emitted the dragged window's geometry after the cancel returned");
+
+        // The filter is scope-bound to the cancel: a LATER retile on the same
+        // engine must emit A's geometry again. Deleting the qScopeGuard clear
+        // would otherwise skip this window on every future retile forever,
+        // with the suite green.
+        tiledSpy.clear();
+        state->setCalculatedZones(
+            {QRect(0, 0, 700, 1000), QRect(700, 0, 500, 1000), QRect(1200, 0, 400, 1000), QRect(1600, 0, 300, 1000)});
+        openWindows(engine, screen, {QStringLiteral("D")});
+        engine.retile(screen);
+        QVERIFY2(spyHasGeometryEntryFor(tiledSpy, QStringLiteral("A")),
+                 "the cancel filter outlived the cancel — geometry emission for the window never resumed");
+    }
+
+    // Cross-screen twin: a mid-drag cancel of a cross-screen adoption retiles
+    // BOTH screens (target, then the prior screen the window is restored to),
+    // and the non-screen-scoped filter must suppress the dragged window's
+    // geometry in each while neighbours still reflow.
+    void testCrossScreen_midDragCancelSkipsDraggedGeometryOnBothScreens()
+    {
+        AutotileEngine engine(nullptr, nullptr, nullptr, PlasmaZones::TestHelpers::testRegistry());
+        const QString s1 = QLatin1String(Screen1);
+        const QString s2 = QLatin1String(Screen2);
+        engine.setAutotileScreens({s1, s2});
+        openWindows(engine, s1, {QStringLiteral("A"), QStringLiteral("B")});
+        openWindows(engine, s2, {QStringLiteral("X"), QStringLiteral("Y")});
+
+        PhosphorTiles::TilingState* state1 = engine.tilingStateForScreen(s1);
+        PhosphorTiles::TilingState* state2 = engine.tilingStateForScreen(s2);
+        QVERIFY(state1);
+        QVERIFY(state2);
+
+        QVERIFY(engine.beginDragInsertPreview(QStringLiteral("A"), s2));
+
+        // Zones sized for the POST-CANCEL counts (cancel restores A to s1, so
+        // s1 tiles A+B and s2 tiles X+Y again). Set after begin — begin's own
+        // retiles bail harmlessly on the missing geometry, and applyTiling
+        // refuses a zone vector that outnumbers the tiled list, so begin-time
+        // counts must not constrain these.
+        state1->setCalculatedZones({QRect(0, 0, 900, 1000), QRect(900, 0, 900, 1000)});
+        state2->setCalculatedZones({QRect(0, 0, 600, 1000), QRect(600, 0, 600, 1000)});
+
+        QSignalSpy tiledSpy(&engine, &AutotileEngine::windowsTiled);
+        engine.cancelDragInsertPreview(/*dragStillActive=*/true);
+
+        QVERIFY(tiledSpy.count() >= 1);
+        QVERIFY2(spyHasGeometryEntryFor(tiledSpy, QStringLiteral("X")),
+                 "target-screen cancel retile emitted no neighbour geometry — the negative below would be vacuous");
+        QVERIFY2(spyHasGeometryEntryFor(tiledSpy, QStringLiteral("B")),
+                 "prior-screen cancel retile emitted no neighbour geometry — the negative below would be vacuous");
+        QVERIFY2(!spyHasGeometryEntryFor(tiledSpy, QStringLiteral("A")),
+                 "cross-screen mid-drag cancel emitted tile geometry for the window still being dragged");
+    }
+
+    // Eviction twin: the mid-drag cancel's unfloat-the-victim retile must
+    // still skip the dragged window while re-tiling the restored neighbour.
+    void testEviction_midDragCancelSkipsDraggedGeometry()
+    {
+        AutotileEngine engine(nullptr, nullptr, nullptr, PlasmaZones::TestHelpers::testRegistry());
+        const QString screen = QLatin1String(Screen1);
+        engine.setAutotileScreens({screen});
+        engine.config()->maxWindows = 3;
+        openWindows(engine, screen, {QStringLiteral("A"), QStringLiteral("B"), QStringLiteral("C")});
+
+        PhosphorTiles::TilingState* state = engine.tilingStateForScreen(screen);
+        QVERIFY(state);
+        state->setCalculatedZones({QRect(0, 0, 700, 1000), QRect(700, 0, 600, 1000), QRect(1300, 0, 600, 1000)});
+
+        // Fresh adoption over the cap evicts C (last tiled neighbour).
+        QVERIFY(engine.beginDragInsertPreview(QStringLiteral("newcomer"), screen));
+        QVERIFY(!engine.tilingStateForScreen(screen)->tiledWindows().contains(QStringLiteral("C")));
+
+        QSignalSpy tiledSpy(&engine, &AutotileEngine::windowsTiled);
+        engine.cancelDragInsertPreview(/*dragStillActive=*/true);
+
+        QVERIFY(tiledSpy.count() >= 1);
+        // The victim is back in the tiled list and gets geometry again.
+        QVERIFY2(spyHasGeometryEntryFor(tiledSpy, QStringLiteral("C")),
+                 "cancel retile emitted no geometry for the restored eviction victim");
+        QVERIFY2(!spyHasGeometryEntryFor(tiledSpy, QStringLiteral("newcomer")),
+                 "eviction-arm mid-drag cancel emitted tile geometry for the window still being dragged");
     }
 
     // Control: the drop-time cancel (default argument) keeps the snap-back —
@@ -241,7 +327,81 @@ private Q_SLOTS:
         engine.cancelDragInsertPreview();
 
         QVERIFY(tiledSpy.count() >= 1);
+        // Neighbour guard first, mirroring the mid-drag twin: an emission
+        // with no geometry entries at all would satisfy neither assertion
+        // meaningfully, and the helper answers false for a payload whose
+        // shape changed, which the positive alone would misread as regression.
+        QVERIFY2(spyHasGeometryEntryFor(tiledSpy, QStringLiteral("B")),
+                 "drop-time cancel retile emitted no neighbour geometry — payload shape changed?");
         QVERIFY(spyHasGeometryEntryFor(tiledSpy, QStringLiteral("A")));
+    }
+
+    // =========================================================================
+    // Interactive-drag mark (setInteractiveDragWindow)
+    // =========================================================================
+
+    // While the daemon-set mark names a window, NO retile may emit its
+    // geometry — this is what protects the window in the user's hand from
+    // retiles the preview/cancel filters never see (a deferred geometry
+    // retry, a neighbour opening or closing, discussion #1028).
+    void testInteractiveDragMark_suppressesGeometryUntilCleared()
+    {
+        AutotileEngine engine(nullptr, nullptr, nullptr, PlasmaZones::TestHelpers::testRegistry());
+        const QString screen = QLatin1String(Screen1);
+        engine.setAutotileScreens({screen});
+        openWindows(engine, screen, {QStringLiteral("A"), QStringLiteral("B"), QStringLiteral("C")});
+
+        PhosphorTiles::TilingState* state = engine.tilingStateForScreen(screen);
+        QVERIFY(state);
+        state->setCalculatedZones({QRect(0, 0, 900, 1000), QRect(900, 0, 500, 1000), QRect(1400, 0, 500, 1000)});
+
+        engine.setInteractiveDragWindow(QStringLiteral("A"));
+        QSignalSpy tiledSpy(&engine, &AutotileEngine::windowsTiled);
+        engine.retile(screen);
+        QVERIFY(tiledSpy.count() >= 1);
+        QVERIFY2(spyHasGeometryEntryFor(tiledSpy, QStringLiteral("B")),
+                 "marked retile emitted no neighbour geometry — the negative below would be vacuous");
+        QVERIFY2(!spyHasGeometryEntryFor(tiledSpy, QStringLiteral("A")),
+                 "a retile emitted geometry for the window under a compositor interactive move");
+
+        // Clearing the mark restores normal emission (the drop finalizes
+        // through its own paths; here we just prove the mark is not sticky).
+        engine.setInteractiveDragWindow(QString());
+        tiledSpy.clear();
+        engine.retile(screen);
+        QVERIFY2(spyHasGeometryEntryFor(tiledSpy, QStringLiteral("A")), "the interactive-drag mark outlived its clear");
+    }
+
+    // The stale-preview identity gate: a cancel(dragStillActive=true) whose
+    // preview names a DIFFERENT window than the interactive-drag mark is
+    // residue from a prior drag — nobody holds that window, so its snap-back
+    // geometry must be emitted, not suppressed.
+    void testInteractiveDragMark_stalePreviewCancelStillSnapsBack()
+    {
+        AutotileEngine engine(nullptr, nullptr, nullptr, PlasmaZones::TestHelpers::testRegistry());
+        const QString screen = QLatin1String(Screen1);
+        engine.setAutotileScreens({screen});
+        openWindows(engine, screen, {QStringLiteral("A"), QStringLiteral("B"), QStringLiteral("C")});
+
+        PhosphorTiles::TilingState* state = engine.tilingStateForScreen(screen);
+        QVERIFY(state);
+        state->setCalculatedZones({QRect(0, 0, 900, 1000), QRect(900, 0, 500, 1000), QRect(1400, 0, 500, 1000)});
+
+        // A's preview is left over from a prior drag; the NEW drag holds C.
+        QVERIFY(engine.beginDragInsertPreview(QStringLiteral("A"), screen));
+        engine.updateDragInsertPreview(2);
+        engine.setInteractiveDragWindow(QStringLiteral("C"));
+
+        QSignalSpy tiledSpy(&engine, &AutotileEngine::windowsTiled);
+        engine.cancelDragInsertPreview(/*dragStillActive=*/true);
+
+        QVERIFY(tiledSpy.count() >= 1);
+        QVERIFY2(spyHasGeometryEntryFor(tiledSpy, QStringLiteral("A")),
+                 "stale preview's snap-back was suppressed — the window stays parked at the previewed rect");
+        // The genuinely-held window stays protected throughout.
+        QVERIFY2(!spyHasGeometryEntryFor(tiledSpy, QStringLiteral("C")),
+                 "cancel retile emitted geometry for the window the NEW drag is holding");
+        engine.setInteractiveDragWindow(QString());
     }
 
     // =========================================================================

--- a/tests/unit/dbus/test_windowdrag_cancel_sweeps.cpp
+++ b/tests/unit/dbus/test_windowdrag_cancel_sweeps.cpp
@@ -1,0 +1,246 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_windowdrag_cancel_sweeps.cpp
+ * @brief Adaptor-level pins for the drag-insert cancel sweeps and the
+ * desktop-switch announce burst (discussion #1028 follow-ups).
+ *
+ * Three seams that previously had no test:
+ *
+ *  1. WindowDragAdaptor's LIVE sweep derives dragStillActive from
+ *     isDragSessionActive() — replacing the derivation with a constant false
+ *     used to leave the whole suite green while the mid-drag cancel resized
+ *     the window in the user's hand.
+ *
+ *  2. The DEAD-SESSION sweep (clearForCompositorReconnect and friends) must
+ *     clear the interactive-drag mark BEFORE cancelling with an explicit
+ *     false, or the snap-back it exists to emit is suppressed by the mark
+ *     (or by a phantom liveness derivation from the dead session's ids).
+ *
+ *  3. TilingAdaptor's coalesced managed-screens announce stamps per-screen
+ *     desktops at EMIT time. The daemon's screenDesktopChanged handler leans
+ *     on that: a global switch fans out one report per output, each calling
+ *     notifyEngineScreensChanged(true), and only emit-time stamping makes
+ *     the burst's single emission carry a fully consistent desktop map (the
+ *     focus-follows-mouse leak fixed by [SEQ E½] in start.cpp).
+ */
+
+#include <QCoreApplication>
+#include <QDir>
+#include <QSignalSpy>
+#include <QTest>
+
+#include <PhosphorRules/RuleStore.h>
+#include "FakeScreenProvider.h"
+#include <PhosphorScreens/Manager.h>
+#include <PhosphorTileEngine/AutotileEngine.h>
+#include <PhosphorTiles/TilingState.h>
+#include <PhosphorWorkspaces/VirtualDesktopManager.h>
+#include <PhosphorZones/LayoutRegistry.h>
+
+#include "config/configdefaults.h"
+#include "config/configkeys.h"
+#include "dbus/tilingadaptor/tilingadaptor.h"
+#include "dbus/windowdragadaptor/windowdragadaptor.h"
+#include "dbus/windowtrackingadaptor/windowtrackingadaptor.h"
+
+#include "helpers/AutotileTestHelpers.h"
+#include "helpers/IsolatedConfigGuard.h"
+#include "helpers/StubOverlayService.h"
+#include "helpers/StubSettings.h"
+#include "helpers/StubZoneDetector.h"
+
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+
+using namespace PlasmaZones;
+using namespace PhosphorTileEngine;
+using PlasmaZones::StubSettings;
+using PlasmaZones::StubZoneDetector;
+using PlasmaZones::TestHelpers::IsolatedConfigGuard;
+using PlasmaZones::TestHelpers::StubOverlayService;
+
+namespace {
+
+/// True when any windowsTiled emission carries a GEOMETRY entry (an "x" key —
+/// float-only entries have none) for @p windowId. Same discriminator as the
+/// engine-level suite (test_autotile_drag_insert.cpp).
+bool spyHasGeometryEntryFor(const QSignalSpy& spy, const QString& windowId)
+{
+    for (const QList<QVariant>& emission : spy) {
+        const QJsonArray arr = QJsonDocument::fromJson(emission.first().toString().toUtf8()).array();
+        for (const QJsonValue& v : arr) {
+            const QJsonObject obj = v.toObject();
+            if (obj.value(QLatin1String("windowId")).toString() == windowId && obj.contains(QLatin1String("x"))) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+} // namespace
+
+class TestWindowDragCancelSweeps : public QObject
+{
+    Q_OBJECT
+
+private:
+    static constexpr auto Screen = "eDP-1";
+
+    /// The full dependency set WindowDragAdaptor's ctor qFatals without,
+    /// plus an autotile engine seeded with three windows and forced zones.
+    struct Fixture
+    {
+        Fixture()
+            : store(std::make_unique<PhosphorRules::RuleStore>(ConfigDefaults::rulesFilePath()))
+            , registry(std::make_unique<PhosphorZones::LayoutRegistry>(store.get(), ConfigKeys::layoutsSubdir()))
+        {
+            const QString layoutDir = guard.dataPath() + QLatin1Char('/') + ConfigKeys::layoutsSubdir();
+            QDir().mkpath(layoutDir);
+            registry->setLayoutDirectory(layoutDir);
+
+            wta = new WindowTrackingAdaptor(registry.get(), &detector, nullptr, &settings, nullptr, nullptr, &parent);
+            adaptor = new WindowDragAdaptor(&overlay, &detector, registry.get(), nullptr, &settings, wta, &parent);
+
+            engine =
+                std::make_unique<AutotileEngine>(nullptr, nullptr, nullptr, PlasmaZones::TestHelpers::testRegistry());
+            const QString screen = QLatin1String(Screen);
+            engine->setAutotileScreens({screen});
+            for (const auto* id : {"A", "B", "C"}) {
+                engine->windowOpened(QLatin1String(id), screen);
+            }
+            QCoreApplication::processEvents();
+            PhosphorTiles::TilingState* state = engine->tilingStateForScreen(screen);
+            if (state) {
+                state->setCalculatedZones(
+                    {QRect(0, 0, 900, 1000), QRect(900, 0, 500, 1000), QRect(1400, 0, 500, 1000)});
+            }
+            adaptor->setAutotileEngine(engine.get());
+        }
+
+        IsolatedConfigGuard guard;
+        QObject parent;
+        StubOverlayService overlay;
+        StubZoneDetector detector;
+        StubSettings settings;
+        std::unique_ptr<PhosphorRules::RuleStore> store;
+        std::unique_ptr<PhosphorZones::LayoutRegistry> registry;
+        WindowTrackingAdaptor* wta = nullptr; // parent-owned
+        WindowDragAdaptor* adaptor = nullptr; // parent-owned
+        std::unique_ptr<AutotileEngine> engine;
+    };
+
+private Q_SLOTS:
+
+    // Seam 1: with a live drag session, the shared sweep derives
+    // dragStillActive=true and the cancel's retile must keep skipping the
+    // dragged window's geometry. Hardcoding the derivation to false fails
+    // this on the "A" negative.
+    void liveSweepDerivesStillActiveAndSuppressesDraggedGeometry()
+    {
+        Fixture f;
+        f.settings.setSnappingEnabled(true);
+        f.adaptor->beginDrag(QStringLiteral("A"), 0, 0, 400, 300, QLatin1String(Screen), 0);
+        // Drop the interactive-drag mark beginDrag installed: this slot pins
+        // the SWEEP's liveness derivation, and with the mark standing the
+        // geometry suppression would hold through the engine's mark skip
+        // even if the derivation were hardcoded false — masking exactly the
+        // mutation this test exists to catch.
+        f.engine->setInteractiveDragWindow(QString());
+        QVERIFY(f.engine->beginDragInsertPreview(QStringLiteral("A"), QLatin1String(Screen)));
+
+        QSignalSpy tiledSpy(f.engine.get(), &AutotileEngine::windowsTiled);
+        f.adaptor->cancelDragInsertPreviews();
+
+        QVERIFY(!f.engine->hasDragInsertPreview());
+        QVERIFY(tiledSpy.count() >= 1);
+        QVERIFY2(spyHasGeometryEntryFor(tiledSpy, QStringLiteral("B")),
+                 "cancel retile emitted no neighbour geometry — the negative below would be vacuous");
+        QVERIFY2(!spyHasGeometryEntryFor(tiledSpy, QStringLiteral("A")),
+                 "live-session sweep did not suppress the dragged window's geometry (derivation broken?)");
+    }
+
+    // Seam 2: the compositor-reconnect sweep runs with the dead session's
+    // ids still populated AND the interactive-drag mark still set. It must
+    // clear the mark first and cancel with an explicit false so the
+    // previously-dragged window's snap-back is actually emitted. Either
+    // regression — deriving liveness, or cancelling before the mark clear —
+    // fails this on the "A" positive.
+    void reconnectSweepClearsMarkFirstAndEmitsSnapBack()
+    {
+        Fixture f;
+        f.settings.setSnappingEnabled(true);
+        // beginDrag installs the interactive-drag mark for "A" on both
+        // engines — the exact state a compositor loss mid-drag leaves behind.
+        f.adaptor->beginDrag(QStringLiteral("A"), 0, 0, 400, 300, QLatin1String(Screen), 0);
+        QVERIFY(f.engine->beginDragInsertPreview(QStringLiteral("A"), QLatin1String(Screen)));
+
+        QSignalSpy tiledSpy(f.engine.get(), &AutotileEngine::windowsTiled);
+        f.adaptor->clearForCompositorReconnect();
+
+        QVERIFY(!f.engine->hasDragInsertPreview());
+        QVERIFY(tiledSpy.count() >= 1);
+        QVERIFY2(spyHasGeometryEntryFor(tiledSpy, QStringLiteral("A")),
+                 "reconnect sweep suppressed the snap-back — the window stays parked at mid-drag geometry");
+    }
+
+    // Seam 3: the FFM fix's convergence mechanism. A global desktop switch
+    // fans out one per-output report per screen; each calls
+    // notifyEngineScreensChanged(true) with the OTHER screen's desktop not
+    // yet updated. Emit-time stamping means the burst's single coalesced
+    // emission carries the FINAL desktop for every screen — stamping at
+    // queue time instead would freeze the first report's stale map and
+    // recreate the rejected-announce leak ([SEQ E½] in start.cpp).
+    void announceBurstStampsDesktopsAtEmitTime()
+    {
+        IsolatedConfigGuard guard;
+        QObject parent;
+        StubZoneDetector detector;
+        StubSettings settings;
+        auto store = std::make_unique<PhosphorRules::RuleStore>(ConfigDefaults::rulesFilePath());
+        auto registry = std::make_unique<PhosphorZones::LayoutRegistry>(store.get(), ConfigKeys::layoutsSubdir());
+
+        PhosphorScreens::FakeScreenProvider fake;
+        fake.addScreen(QStringLiteral("DP-1"), QRect(0, 0, 1920, 1080), QStringLiteral("DP-1"));
+        fake.addScreen(QStringLiteral("DP-2"), QRect(1920, 0, 1920, 1080), QStringLiteral("DP-2"));
+        PhosphorScreens::ScreenManager screenMgr(
+            PhosphorScreens::ScreenManagerConfig{.screenProvider = &fake, .useGeometrySensors = false});
+        screenMgr.start();
+
+        PhosphorWorkspaces::VirtualDesktopManager vdm;
+        vdm.updateScreenDesktop(QStringLiteral("DP-1"), 1);
+        vdm.updateScreenDesktop(QStringLiteral("DP-2"), 1);
+
+        auto* wta = new WindowTrackingAdaptor(registry.get(), &detector, &screenMgr, &settings, &vdm, nullptr, &parent);
+        AutotileEngine engine(nullptr, nullptr, nullptr, PlasmaZones::TestHelpers::testRegistry());
+        engine.setAutotileScreens({QStringLiteral("DP-1"), QStringLiteral("DP-2")});
+        TilingAdaptor adaptor(&screenMgr, &parent);
+        adaptor.setWindowTrackingAdaptor(wta);
+        adaptor.setLifecycleEngines({&engine});
+
+        QSignalSpy spy(&adaptor, &TilingAdaptor::managedScreensChanged);
+
+        // The burst: each per-output report updates ITS screen's desktop and
+        // re-announces unconditionally, exactly as the daemon handler does.
+        vdm.updateScreenDesktop(QStringLiteral("DP-1"), 2);
+        adaptor.notifyEngineScreensChanged(/*isDesktopSwitch=*/true);
+        vdm.updateScreenDesktop(QStringLiteral("DP-2"), 2);
+        adaptor.notifyEngineScreensChanged(/*isDesktopSwitch=*/true);
+        QCoreApplication::processEvents();
+
+        QCOMPARE(spy.count(), 1);
+        QCOMPARE(spy.first().at(1).toBool(), true);
+        const QVariantMap stamps = spy.first().at(2).toMap();
+        // Both screens stamped, both with the FINAL desktop: the first
+        // report queued the announce while DP-2 still sat on desktop 1, so
+        // any capture-at-queue-time regression shows up as a stale stamp.
+        QCOMPARE(stamps.value(QStringLiteral("DP-1")).toInt(), 2);
+        QCOMPARE(stamps.value(QStringLiteral("DP-2")).toInt(), 2);
+    }
+};
+
+QTEST_MAIN(TestWindowDragCancelSweeps)
+#include "test_windowdrag_cancel_sweeps.moc"

--- a/tests/unit/helpers/StubOverlayService.h
+++ b/tests/unit/helpers/StubOverlayService.h
@@ -1,0 +1,179 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+/**
+ * @brief No-op IOverlayService for unit tests that need a constructible
+ * WindowDragAdaptor (whose ctor qFatals on a null overlay). Every method is
+ * inert; the few queries answer the neutral value ("nothing visible, nothing
+ * selected") so drag-adaptor teardown paths walk their default branches.
+ */
+
+#include "core/interfaces/ioverlayservice.h"
+
+namespace PlasmaZones::TestHelpers {
+
+class StubOverlayService : public IOverlayService
+{
+    // Q_OBJECT intentionally omitted: IOverlayService already carries the
+    // meta-object; this stub adds no signals or slots of its own (the
+    // StubZoneDetector helper documents the same idiom).
+public:
+    explicit StubOverlayService(QObject* parent = nullptr)
+        : IOverlayService(parent)
+    {
+    }
+
+    bool isVisible() const override
+    {
+        return false;
+    }
+    void show() override
+    {
+    }
+    void showAtPosition(int, int) override
+    {
+    }
+    void hide() override
+    {
+    }
+    void toggle() override
+    {
+    }
+    void updateLayout(PhosphorZones::Layout*) override
+    {
+    }
+    void updateSettings(ISettings*) override
+    {
+    }
+    void updateGeometries() override
+    {
+    }
+    void highlightZone(const QString&) override
+    {
+    }
+    void highlightZones(const QStringList&) override
+    {
+    }
+    void clearHighlight() override
+    {
+    }
+    void setIdleForDragPause() override
+    {
+    }
+    void forgetCurrentScreen() override
+    {
+    }
+    void refreshFromIdle() override
+    {
+    }
+    void updateScrollDropIndicator(const QString&, const QRect&, bool) override
+    {
+    }
+    void setScrollDropIndicatorWindowOverrides(const QVariantMap&) override
+    {
+    }
+    bool isZoneSelectorVisible() const override
+    {
+        return false;
+    }
+    void showZoneSelector(const QString&) override
+    {
+    }
+    void hideZoneSelector() override
+    {
+    }
+    void updateSelectorPosition(int, int) override
+    {
+    }
+    void scrollZoneSelector(int) override
+    {
+    }
+    void updateMousePosition(int, int) override
+    {
+    }
+    int visibleLayoutCount(const QString&) const override
+    {
+        return 0;
+    }
+    bool screenResolvesToTemplates(const QString&) const override
+    {
+        return false;
+    }
+    int selectorCardCount(const QString&) const override
+    {
+        return 0;
+    }
+    QList<qreal> selectorStripFractions(const QString&) const override
+    {
+        return {};
+    }
+    bool hasSelectedZone() const override
+    {
+        return false;
+    }
+    QString selectedLayoutId() const override
+    {
+        return {};
+    }
+    int selectedZoneIndex() const override
+    {
+        return -1;
+    }
+    QRect getSelectedZoneGeometry(QScreen*) const override
+    {
+        return {};
+    }
+    QRect getSelectedZoneGeometry(const QString&) const override
+    {
+        return {};
+    }
+    void clearSelectedZone() override
+    {
+    }
+    void showShaderPreview(int, int, int, int, const QString&, const QString&, const QString&, const QString&) override
+    {
+    }
+    void updateShaderPreview(int, int, int, int, const QString&, const QString&) override
+    {
+    }
+    void hideShaderPreview() override
+    {
+    }
+    void showSnapAssist(const QString&, const PhosphorProtocol::EmptyZoneList&,
+                        const PhosphorProtocol::SnapAssistCandidateList&) override
+    {
+    }
+    void hideSnapAssist() override
+    {
+    }
+    bool isSnapAssistVisible() const override
+    {
+        return false;
+    }
+    bool setSnapAssistThumbnail(const QString&, int, int, const QByteArray&) override
+    {
+        return false;
+    }
+    bool setWindowThumbnailDmabuf(const QString&, const DmabufThumbnailDesc&) override
+    {
+        return false;
+    }
+    void hideLayoutPicker() override
+    {
+    }
+    bool isLayoutPickerVisible() const override
+    {
+        return false;
+    }
+    void hideCheatsheet() override
+    {
+    }
+    bool isCheatsheetVisible() const override
+    {
+        return false;
+    }
+};
+
+} // namespace PlasmaZones::TestHelpers


### PR DESCRIPTION
Fixes the two follow-ups from https://github.com/fuddlesworth/PlasmaZones/discussions/1028#discussioncomment-18259818.

**1. Releasing the drag-insert trigger mid-drag resized the window (video 1)**
`AutotileEngine::cancelDragInsertPreview()` reset the preview before its retile, so `applyTiling` stopped filtering the dragged window and emitted its tile rect while KWin's interactive move was still running. With drag-to-float the engine still considers the window tiled until drop, so the float-sized window in the user's hand jumped to tile size the moment ALT was released. `cancelDragInsertPreview` now takes `dragStillActive`; the mid-drag cancel arms (trigger release, cross-screen crossing, desktop switch / output removal during a live drag) keep the dragged window filtered out of the cancel retile, and drop-time cancels keep the snap-back. Regression tests added and mutation-checked (the mid-drag test fails with the guard neutralized).

**2. Focus-follows-mouse leaked onto desktops with no assigned mode (video 2)**
Confirmed in the support report's effect log: on a global desktop switch the effect fans out one desktop report per output; the daemon's first managed-screens announce is stamped with the other outputs' not-yet-updated desktops, the effect's staleness gate rejects it (`dropping a desktop-switch announce`), and the later reports don't change the already-empty managed set, so the gate's promised converging re-announce never came — the effect kept the tiled desktop's managed set and FFM stayed live on the unassigned desktop. (The "only fresh windows, minimize/restore stops it" symptom is the float bail: floats are click-to-focus.) The daemon now calls `notifyEngineScreensChanged(true)` unconditionally after every per-screen desktop report; the announce is coalesced per event-loop turn and stamped at emit time, so the burst's last announce carries a consistent map and is accepted.

Full ctest suite green under `dbus-run-session`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CR1cULQVwzMDSRGL6TGSD3