### PR TITLE
feat(shell): nested-compositor test harness (visible or headless, AI-drivable)

### DIFF
--- a/scripts/nested-kwin/run-nested.sh
+++ b/scripts/nested-kwin/run-nested.sh
@@ -122,12 +122,11 @@ HOME_N="$NEST/home"
 
 # Refuse to wipe a LIVE session's state out from under it. Existence of the
 # socket inode is not liveness (a crashed compositor leaves it behind), so
-# probe for a process holding it and quietly unlink a stale one — otherwise
-# a crash would lock the harness out until a manual rm. Without fuser the
-# probe cannot answer, so the guard fails CLOSED (refuses) rather than
-# unlinking what might be a live session's socket. PZ_NESTED_FORCE=1 skips
-# the check either way and unlinks; note that a compositor still holding
-# the old socket keeps running orphaned and must be killed by hand.
+# probe /proc/net/unix for a bound listener on the path and quietly unlink
+# a stale one — otherwise a crash would lock the harness out until a manual
+# rm. PZ_NESTED_FORCE=1 skips the check and unlinks; note that a compositor
+# still holding the old socket keeps running orphaned and must be killed by
+# hand.
 # Socket name, so two worktrees can each run a nested session at once (kwin
 # takes a lockfile named after it, and a second session on the same name dies
 # with "could not add wayland socket"). Pair a distinct PZ_NESTED_SOCKET with
@@ -152,13 +151,15 @@ if [ -e "$SOCK" ] && [ ! -S "$SOCK" ]; then
     exit 1
 fi
 if [ -S "$SOCK" ] && [ -z "${PZ_NESTED_FORCE:-}" ]; then
-    if ! command -v fuser >/dev/null 2>&1; then
-        echo "$SOCK exists and fuser is unavailable to tell live from stale;" >&2
-        echo "install psmisc, remove the socket by hand, or re-run with PZ_NESTED_FORCE=1" >&2
-        exit 1
-    fi
-    if fuser -s "$SOCK" 2>/dev/null; then
-        echo "a nested session is live (a process holds $SOCK);" >&2
+    # Liveness probe via /proc/net/unix, which lists every bound unix
+    # socket by the path given at bind time. fuser is the wrong tool here
+    # and was observed false-negating on a live compositor: a bound
+    # listening socket shows up in the holder's fd table as
+    # socket:[inode], not as the filesystem path, so a path-keyed fuser
+    # finds nothing and the guard waves a second run through to wipe the
+    # live session's state.
+    if awk -v p="$SOCK" '$NF == p { found = 1 } END { exit !found }' /proc/net/unix; then
+        echo "a nested session is live (a process has $SOCK bound);" >&2
         echo "kill it first, or re-run with PZ_NESTED_FORCE=1" >&2
         exit 1
     fi
@@ -172,7 +173,12 @@ rm -f "$SOCK"
 # previous env.sh names a bus whose socket is still there, a session is live
 # in THIS tree.
 if [ -f "$NEST/env.sh" ] && [ -z "${PZ_NESTED_FORCE:-}" ]; then
-    OLDBUS=$(sed -n 's/^export DBUS_SESSION_BUS_ADDRESS=.*unix:path=\([^;'"'"'"]*\).*/\1/p' "$NEST/env.sh" 2>/dev/null | head -n1)
+    # The exclusion class MUST stop at ',' too: dbus-run-session addresses
+    # look like unix:path=/tmp/dbus-XXX,guid=..., and letting the capture
+    # run through the comma yields a path with ',guid=...' glued on, whose
+    # -S test always fails — the guard then never fires and a second run
+    # wipes a LIVE session's state (observed exactly that way).
+    OLDBUS=$(sed -n 's/^export DBUS_SESSION_BUS_ADDRESS=.*unix:path=\([^;,'"'"'"]*\).*/\1/p' "$NEST/env.sh" 2>/dev/null | head -n1)
     if [ -n "$OLDBUS" ] && [ -S "$OLDBUS" ]; then
         echo "a nested session is live in $NEST (its bus socket $OLDBUS still exists);" >&2
         echo "point PZ_NESTED_DIR somewhere else, kill that session, or re-run with PZ_NESTED_FORCE=1" >&2

--- a/scripts/nested-kwin/run-nested.sh
+++ b/scripts/nested-kwin/run-nested.sh
@@ -19,6 +19,14 @@
 # session (X11 test clients; see the flag site below for how to point a
 # client at the nested display).
 #
+# Set PZ_NESTED_VISIBLE to any value to run the nested compositor as a
+# WINDOW on the host desktop instead of headless --virtual: same isolated
+# session, but you can watch it and interact with pointer/keyboard.
+# Requires a live host WAYLAND_DISPLAY. Defaults to 1600x900 when no
+# width/height are given (the headless default of the host's mode size
+# makes an unwieldy window). Everything else — bus, homes, env.sh,
+# screenshots — behaves identically in both modes.
+#
 # State (isolated XDG home and env.sh) lives in $PZ_NESTED_DIR (default
 # $XDG_RUNTIME_DIR/pz-nested, private to the user). The daemon's log is
 # the only log file (daemon.sh writes it); the compositor's output stays
@@ -320,6 +328,25 @@ EXTRA_FLAGS=""
 # silently test the wrong compositor).
 [ -n "${PZ_NESTED_XWAYLAND:-}" ] && EXTRA_FLAGS="$EXTRA_FLAGS --xwayland"
 
+# Backend selection: headless virtual outputs by default; a visible nested
+# window when PZ_NESTED_VISIBLE is set. The visible backend needs the host
+# compositor, so fail early with the reason instead of letting kwin die
+# with a bare backend error.
+BACKEND_FLAGS="--virtual --output-count $OUTPUTS"
+if [ -n "${PZ_NESTED_VISIBLE:-}" ]; then
+    if [ -z "${WAYLAND_DISPLAY:-}" ]; then
+        echo "PZ_NESTED_VISIBLE needs a live host Wayland session (WAYLAND_DISPLAY is unset)" >&2
+        exit 1
+    fi
+    BACKEND_FLAGS="--output-count $OUTPUTS"
+    # A visible window with no requested size inherits the host output's
+    # full mode, which is unwieldy; pick a sane default when the caller
+    # gave none.
+    if [ -z "$WIDTH" ]; then
+        EXTRA_FLAGS="$EXTRA_FLAGS --width 1600 --height 900"
+    fi
+fi
+
 exec dbus-run-session -- sh -c "
   # set -e inside the child: the outer set -eu does NOT cross an sh -c, so
   # without this a failed env.sh write (full disk, read-only or unwritable
@@ -347,5 +374,7 @@ exec dbus-run-session -- sh -c "
   mv '$NEST/env.sh.tmp' '$NEST/env.sh'
   # \$EXTRA_FLAGS stays unquoted on purpose: it is a flag LIST and needs word
   # splitting. Everything else is quoted.
-  exec kwin_wayland --virtual --output-count '$OUTPUTS'$EXTRA_FLAGS --socket '$PZ_NESTED_SOCKET' --no-lockscreen --no-global-shortcuts --no-kactivities
+  # \$BACKEND_FLAGS is a flag list like \$EXTRA_FLAGS and needs the same
+  # word splitting.
+  exec kwin_wayland $BACKEND_FLAGS$EXTRA_FLAGS --socket '$PZ_NESTED_SOCKET' --no-lockscreen --no-global-shortcuts --no-kactivities
 "

--- a/scripts/nested-shell/capture.sh
+++ b/scripts/nested-shell/capture.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 fuddlesworth
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Screenshot one nested output as a PNG — the harness's eyes for
+# headless / AI-driven runs.
+#
+#   scripts/nested-shell/capture.sh [OutputName] <out.png>
+#
+# OutputName defaults to Virtual-0 (kwin's first --virtual output; in
+# PZ_NESTED_VISIBLE mode list the real names with
+# `qdbus6 org.kde.KWin /KWin org.kde.KWin.supportInformation | grep -A2 Screens`
+# after sourcing env.sh). Delegates to nested-kwin's capture-output.py
+# with the session env loaded.
+#
+# Unlike the PlasmaZones EFFECT (whose painting ScreenShot2 bypasses,
+# hence the geometry-only caveat in the sibling harness), the shell is an
+# ordinary layer-shell client on the normal composite path: bars, popouts
+# and toasts DO appear in these captures, so they are genuine rendering
+# evidence here.
+set -eu
+
+REPO="$(cd "$(dirname "$0")/../.." && pwd)"
+RUNTIME_DIR="${XDG_RUNTIME_DIR:-/tmp/pz-nested-$(id -u)}"
+NEST="${PZ_NESTED_DIR:-$RUNTIME_DIR/pz-nested}"
+
+case $# in
+    1) OUTPUT="Virtual-0"; OUT="$1" ;;
+    2) OUTPUT="$1"; OUT="$2" ;;
+    *) echo "usage: capture.sh [OutputName] <out.png>" >&2; exit 1 ;;
+esac
+
+if [ ! -f "$NEST/env.sh" ]; then
+    echo "no nested session in $NEST (run scripts/nested-shell/run-shell.sh first)" >&2
+    exit 1
+fi
+# shellcheck disable=SC1091
+. "$NEST/env.sh"
+
+exec python3 "$REPO/scripts/nested-kwin/capture-output.py" "$OUTPUT" "$OUT"

--- a/scripts/nested-shell/ctl.sh
+++ b/scripts/nested-shell/ctl.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 fuddlesworth
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Build-tree phosphorctl aimed at the NESTED shell's socket. The pinned
+# --socket is the point: a bare phosphorctl resolves the host session's
+# $XDG_RUNTIME_DIR/phosphor.sock, silently driving the wrong shell.
+#
+#   scripts/nested-shell/ctl.sh call power.toggle
+#   scripts/nested-shell/ctl.sh list
+set -eu
+
+REPO="$(cd "$(dirname "$0")/../.." && pwd)"
+RUNTIME_DIR="${XDG_RUNTIME_DIR:-/tmp/pz-nested-$(id -u)}"
+NEST="${PZ_NESTED_DIR:-$RUNTIME_DIR/pz-nested}"
+
+if [ ! -f "$NEST/env.sh" ]; then
+    echo "no nested session in $NEST (run scripts/nested-shell/run-shell.sh first)" >&2
+    exit 1
+fi
+# shellcheck disable=SC1091
+. "$NEST/env.sh"
+BUILD="${PZ_NESTED_BUILD:-build}"
+
+if [ ! -S "$NEST/phosphor.sock" ]; then
+    echo "the nested shell's socket $NEST/phosphor.sock is not bound (start it with scripts/nested-shell/shell.sh)" >&2
+    exit 1
+fi
+exec "$REPO/$BUILD/bin/phosphorctl" --socket "$NEST/phosphor.sock" "$@"

--- a/scripts/nested-shell/run-shell.sh
+++ b/scripts/nested-shell/run-shell.sh
@@ -61,31 +61,51 @@ if [ ! -x "$REPO/$BUILD/bin/phosphor-shell" ]; then
     exit 1
 fi
 
-# The launcher execs the compositor in the foreground; background it and
-# keep its log where the sibling scripts document it. Its own guards
-# handle a stale or live session in this NEST.
-"$REPO/scripts/nested-kwin/run-nested.sh" "$@" > "$RUNTIME_DIR/pz-shell-launch.log" 2>&1 &
+# A stale env.sh from a crashed previous session must not satisfy the wait
+# below — the launcher deletes and rewrites it, and breaking on the stale
+# one races the launcher's home wipe (which would eat the seed) and can key
+# the socket wait on a dead inode. Record the pre-launch file's identity
+# (inode + mtime; the launcher always mv's a fresh tmp file into place, so
+# the fresh one never matches) and wait for a DIFFERENT env.sh.
+mkdir -p "$NEST"
+PRE_ENV_ID=$(stat -c '%i %Y' "$NEST/env.sh" 2>/dev/null || echo none)
+
+# The launcher execs the compositor in the foreground; background it with
+# its output on a per-NEST temp name, renamed to the documented
+# compositor.log once the session is confirmed up. Per-NEST (not a shared
+# name in $RUNTIME_DIR) so concurrent per-worktree sessions cannot clobber
+# each other's launch output; a temp name (not compositor.log itself) so
+# this invocation cannot truncate a LIVE session's log before the
+# launcher's guard refuses; and a same-directory rename so the
+# compositor's open log fd stays on the very inode the final path names.
+# The launcher's own guards handle a stale or live session in this NEST.
+"$REPO/scripts/nested-kwin/run-nested.sh" "$@" > "$NEST/compositor.log.launch" 2>&1 &
 LAUNCHER_PID=$!
 
-# env.sh is written just before kwin execs, so its appearance is the
+# env.sh is written just before kwin execs, so a FRESH env.sh is the
 # up-signal. The launcher exiting first means its guards refused — surface
 # its log instead of spinning the full timeout.
+env_fresh() {
+    [ "$(stat -c '%i %Y' "$NEST/env.sh" 2>/dev/null || echo none)" != "$PRE_ENV_ID" ] \
+        && [ -f "$NEST/env.sh" ]
+}
 for _ in $(seq 1 100); do
-    [ -f "$NEST/env.sh" ] && break
+    env_fresh && break
     if ! kill -0 "$LAUNCHER_PID" 2>/dev/null; then
         echo "nested launcher exited before the session came up; its output:" >&2
-        cat "$RUNTIME_DIR/pz-shell-launch.log" >&2
+        cat "$NEST/compositor.log.launch" >&2
         exit 1
     fi
     sleep 0.1
 done
-if [ ! -f "$NEST/env.sh" ]; then
-    echo "timed out waiting for $NEST/env.sh; launcher output:" >&2
-    cat "$RUNTIME_DIR/pz-shell-launch.log" >&2
+if ! env_fresh; then
+    echo "timed out waiting for a fresh $NEST/env.sh; launcher output:" >&2
+    cat "$NEST/compositor.log.launch" >&2
     exit 1
 fi
-# The compositor's own log lives with the session state from here on.
-mv "$RUNTIME_DIR/pz-shell-launch.log" "$NEST/compositor.log"
+# Session confirmed up: give the log its documented name. Same-directory
+# rename, so the compositor's open fd and the path stay one inode.
+mv "$NEST/compositor.log.launch" "$NEST/compositor.log"
 
 # Give the compositor a moment to bind its wayland socket — env.sh lands
 # a hair before the exec.

--- a/scripts/nested-shell/run-shell.sh
+++ b/scripts/nested-shell/run-shell.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 fuddlesworth
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# One-command phosphor-shell harness: a nested kwin_wayland session with
+# the BUILD-TREE shell running inside it, drivable over the shell's own
+# IPC socket and screenshot-able for eyes-free (AI) test loops. No
+# install, no logout, and nothing touches the live session — the power
+# menu's logind actions act on the NESTED session's scope, so clicking
+# Suspend in here does not suspend the machine you are sitting at.
+#
+# Usage:
+#   scripts/nested-shell/run-shell.sh [output-count] [width height] [scale]
+#
+# Headless by default (kwin --virtual; drive it with ctl.sh and read it
+# with capture.sh). Set PZ_NESTED_VISIBLE=1 to get the nested compositor
+# as a window on the host desktop instead, same session semantics, with
+# pointer and keyboard.
+#
+# What it does, in order:
+#   1. launches scripts/nested-kwin/run-nested.sh in the background
+#      (compositor log: $PZ_NESTED_DIR/compositor.log) and waits for the
+#      session's env.sh;
+#   2. seeds the example shell tree into the nested config home
+#      ($NEST/home/config/phosphor-shell/), so shell.qml edits there
+#      hot-reload without rebuilds — seeding must happen AFTER the
+#      launcher, whose home wipe would otherwise eat the seed;
+#   3. starts the build-tree phosphor-shell inside the session via
+#      shell.sh (shell log: $NEST/shell.log, IPC socket:
+#      $NEST/phosphor.sock).
+#
+# Follow-ups (each sources env.sh itself):
+#   scripts/nested-shell/ctl.sh call power.toggle     # drive the shell
+#   scripts/nested-shell/capture.sh Virtual-1 out.png # look at it
+#   scripts/nested-shell/shell.sh                     # restart after a rebuild
+#
+# Screenshot note, and why the nested-kwin caveat does NOT apply here:
+# ScreenShot2 bypasses the PlasmaZones EFFECT chain, which is why the
+# sibling harness treats captures as geometry-only evidence. The shell is
+# an ordinary layer-shell CLIENT, composited on the normal path, so its
+# bars, popouts and toasts DO appear in captures — screenshots are real
+# rendering evidence for this harness.
+#
+# Environment knobs (all inherited by the sibling scripts through env.sh):
+#   PZ_NESTED_DIR / PZ_NESTED_SOCKET  — per-worktree isolation, as for
+#                                       nested-kwin (defaults pz-nested/
+#                                       pznested).
+#   PZ_NESTED_BUILD                   — configure dir other than build/.
+#   PZ_NESTED_VISIBLE                 — windowed nested compositor.
+#   PZ_SHELL_NO_SEED                  — keep the qrc-baked example instead
+#                                       of seeding an editable copy.
+set -eu
+
+REPO="$(cd "$(dirname "$0")/../.." && pwd)"
+RUNTIME_DIR="${XDG_RUNTIME_DIR:-/tmp/pz-nested-$(id -u)}"
+NEST="${PZ_NESTED_DIR:-$RUNTIME_DIR/pz-nested}"
+BUILD="${PZ_NESTED_BUILD:-build}"
+
+if [ ! -x "$REPO/$BUILD/bin/phosphor-shell" ]; then
+    echo "no $BUILD/bin/phosphor-shell — configure with -DBUILD_PHOSPHOR_SHELL=ON and build first" >&2
+    exit 1
+fi
+
+# The launcher execs the compositor in the foreground; background it and
+# keep its log where the sibling scripts document it. Its own guards
+# handle a stale or live session in this NEST.
+"$REPO/scripts/nested-kwin/run-nested.sh" "$@" > "$RUNTIME_DIR/pz-shell-launch.log" 2>&1 &
+LAUNCHER_PID=$!
+
+# env.sh is written just before kwin execs, so its appearance is the
+# up-signal. The launcher exiting first means its guards refused — surface
+# its log instead of spinning the full timeout.
+for _ in $(seq 1 100); do
+    [ -f "$NEST/env.sh" ] && break
+    if ! kill -0 "$LAUNCHER_PID" 2>/dev/null; then
+        echo "nested launcher exited before the session came up; its output:" >&2
+        cat "$RUNTIME_DIR/pz-shell-launch.log" >&2
+        exit 1
+    fi
+    sleep 0.1
+done
+if [ ! -f "$NEST/env.sh" ]; then
+    echo "timed out waiting for $NEST/env.sh; launcher output:" >&2
+    cat "$RUNTIME_DIR/pz-shell-launch.log" >&2
+    exit 1
+fi
+# The compositor's own log lives with the session state from here on.
+mv "$RUNTIME_DIR/pz-shell-launch.log" "$NEST/compositor.log"
+
+# Give the compositor a moment to bind its wayland socket — env.sh lands
+# a hair before the exec.
+SOCK_PATH="$RUNTIME_DIR/$(. "$NEST/env.sh" && printf %s "$WAYLAND_DISPLAY")"
+for _ in $(seq 1 50); do
+    [ -S "$SOCK_PATH" ] && break
+    sleep 0.1
+done
+if [ ! -S "$SOCK_PATH" ]; then
+    echo "compositor did not bind $SOCK_PATH; see $NEST/compositor.log" >&2
+    exit 1
+fi
+
+# Seed an EDITABLE copy of the example shell. Without this the binary
+# falls back to its qrc-baked copy, which works but cannot be edited, so
+# the hot-reload loop — the point of the harness — has nothing to watch.
+if [ -z "${PZ_SHELL_NO_SEED:-}" ]; then
+    SHELL_CFG="$NEST/home/config/phosphor-shell"
+    mkdir -p "$SHELL_CFG"
+    cp -r "$REPO/examples/phosphor-shell/." "$SHELL_CFG/"
+    echo "seeded editable shell: $SHELL_CFG/shell.qml"
+fi
+
+exec "$REPO/scripts/nested-shell/shell.sh"

--- a/scripts/nested-shell/shell.sh
+++ b/scripts/nested-shell/shell.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 fuddlesworth
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# (Re)start the build-tree phosphor-shell inside the nested session.
+# QML edits in the seeded config hot-reload on their own; this exists for
+# the C++ side — rebuild, run shell.sh, and the new binary is live in
+# seconds. Evicts a previous harness shell by recorded pid first, so
+# there is exactly one shell with a known pid and log per session.
+#
+#   log:    $PZ_NESTED_DIR/shell.log   (QT_FORCE_STDERR_LOGGING is already
+#           in env.sh, so category output lands here, not in journald)
+#   socket: $PZ_NESTED_DIR/phosphor.sock  (via $PHOSPHOR_SOCKET — a
+#           per-session path, so a shell on the HOST session keeps its own
+#           $XDG_RUNTIME_DIR/phosphor.sock undisturbed)
+#   pid:    $PZ_NESTED_DIR/shell.pid
+set -eu
+
+REPO="$(cd "$(dirname "$0")/../.." && pwd)"
+RUNTIME_DIR="${XDG_RUNTIME_DIR:-/tmp/pz-nested-$(id -u)}"
+NEST="${PZ_NESTED_DIR:-$RUNTIME_DIR/pz-nested}"
+
+if [ ! -f "$NEST/env.sh" ]; then
+    echo "no nested session in $NEST (run scripts/nested-shell/run-shell.sh first)" >&2
+    exit 1
+fi
+# shellcheck disable=SC1091
+. "$NEST/env.sh"
+BUILD="${PZ_NESTED_BUILD:-build}"
+
+# Evict by RECORDED pid, never by name: a pkill pattern would also hit a
+# shell running against the host session in another terminal.
+if [ -f "$NEST/shell.pid" ]; then
+    OLD=$(cat "$NEST/shell.pid")
+    case "$OLD" in
+        *[!0-9]*|'') ;;
+        *)
+            if kill -0 "$OLD" 2>/dev/null; then
+                kill "$OLD" 2>/dev/null || true
+                # Bounded wait so a wedged shell cannot hang the restart.
+                for _ in $(seq 1 30); do
+                    kill -0 "$OLD" 2>/dev/null || break
+                    sleep 0.1
+                done
+                kill -9 "$OLD" 2>/dev/null || true
+            fi
+            ;;
+    esac
+    rm -f "$NEST/shell.pid"
+fi
+
+export PHOSPHOR_SOCKET="$NEST/phosphor.sock"
+nohup "$REPO/$BUILD/bin/phosphor-shell" > "$NEST/shell.log" 2>&1 &
+echo $! > "$NEST/shell.pid"
+
+# Up means the IPC socket is bound: the shell binds it early in main, so
+# it doubles as the liveness probe, and it is the thing every ctl.sh
+# caller is about to need anyway.
+for _ in $(seq 1 50); do
+    [ -S "$PHOSPHOR_SOCKET" ] && break
+    if ! kill -0 "$(cat "$NEST/shell.pid")" 2>/dev/null; then
+        echo "phosphor-shell exited at startup; its log:" >&2
+        cat "$NEST/shell.log" >&2
+        exit 1
+    fi
+    sleep 0.1
+done
+if [ ! -S "$PHOSPHOR_SOCKET" ]; then
+    echo "shell is running but never bound $PHOSPHOR_SOCKET; see $NEST/shell.log" >&2
+    exit 1
+fi
+echo "phosphor-shell up (pid $(cat "$NEST/shell.pid"), log $NEST/shell.log, socket $PHOSPHOR_SOCKET)"

--- a/src/shell/main.cpp
+++ b/src/shell/main.cpp
@@ -216,7 +216,24 @@ int main(int argc, char* argv[])
     // Declared before the engine for the same reverse-destruction reason as
     // the others: targets unregister themselves on destruction and must find
     // a live router when they do.
+    //
+    // start() binds the Unix socket; without it every target registers
+    // against a router nobody can reach and `phosphorctl call` resolves
+    // nothing. $PHOSPHOR_SOCKET mirrors phosphorctl's own resolution
+    // (--socket > $PHOSPHOR_SOCKET > $XDG_RUNTIME_DIR/phosphor.sock), which
+    // is what lets a nested test session bind a private socket instead of
+    // colliding with a shell on the host session. Non-fatal on failure: a
+    // shell without its control socket still draws bars and popouts, so warn
+    // and continue rather than refusing to start.
     PhosphorIpc::IpcRouter ipcRouter;
+    const QString socketOverride = qEnvironmentVariable("PHOSPHOR_SOCKET");
+    if (!ipcRouter.start(socketOverride)) {
+        qCWarning(lcShell) << "IPC router failed to bind"
+                           << (socketOverride.isEmpty() ? QStringLiteral("the default socket") : socketOverride)
+                           << "— phosphorctl will not reach this shell";
+    } else {
+        qCInfo(lcShell) << "IPC socket:" << ipcRouter.socketPath();
+    }
 
     // Popout infrastructure, declared BEFORE the engine for the same
     // reverse-destruction reason as barController: the engine must die (and


### PR DESCRIPTION
## Summary
- `scripts/nested-shell/`: a one-command harness that runs the build-tree phosphor-shell inside a nested kwin_wayland session — headless by default for eyes-free/AI test loops, or as a visible window on the host desktop with `PZ_NESTED_VISIBLE=1`. No install, no logout, and the power menu's logind actions stay scoped to the nested session.
  - `run-shell.sh` launches the session (via the existing nested-kwin harness), seeds an editable copy of the example shell into the nested config home (QML hot-reload with no rebuild), and starts the shell with a per-session IPC socket
  - `shell.sh` restarts the shell after a C++ rebuild (evicts by recorded pid)
  - `ctl.sh` drives the shell over its own socket (`ctl.sh call power.toggle`)
  - `capture.sh` screenshots a nested output; the shell renders on the normal composite path, so captures are genuine rendering evidence (unlike the KWin-effect harness's geometry-only caveat)
- `scripts/nested-kwin/run-nested.sh` gains `PZ_NESTED_VISIBLE` (windowed nested compositor instead of `--virtual`)
- Fix: `src/shell/main.cpp` now actually starts the IPC router — it was constructed but never bound, so `phosphorctl` could not reach the shell at all. Honors `$PHOSPHOR_SOCKET`, mirroring phosphorctl's own resolution order.

## Test plan
- Verified end to end headless: `run-shell.sh 1 1600 900` brings up the session, the bar renders (clock, metrics, status icons, buttons), `ctl.sh call power.toggle` opens the power menu, and `capture.sh` shows it in the PNG
- Full build clean; smoke session teardown leaves no orphaned processes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3oHjaMv4FHriYzB8ft1te