### PR TITLE
fix(daemon): learn the current desktop before adopting the window set

### DIFF
--- a/src/daemon/daemon/start.cpp
+++ b/src/daemon/daemon/start.cpp
@@ -318,12 +318,23 @@ void Daemon::connectScreenSignals()
 
 void Daemon::connectDesktopActivity()
 {
-    // start() BEFORE init(): init()'s initial refresh takes the BLOCKING
-    // session-bus path (up to 1 s on this thread) while m_running is still
-    // false. With start() first the refresh issues asynchronously, the
-    // order Workspaces::sharedManager documents for the same reason.
-    m_virtualDesktopManager->start();
+    // init() BEFORE start(), DELIBERATELY the opposite of the order
+    // Workspaces::sharedManager uses. init()'s first refresh takes the
+    // BLOCKING session-bus path only while m_running is still false, and the
+    // daemon needs the current desktop to be known SYNCHRONOUSLY by the time
+    // this function returns: the compositor announces its whole window set
+    // (windowsOpenedBatch) as soon as the bridge comes up, and every engine
+    // keys the context it adopts those windows into on
+    // currentDesktopForScreen(). With start() first the refresh is issued
+    // asynchronously, the batch wins the race, and the daemon adopts the
+    // session onto desktop 1 — then the effect's per-output report flips the
+    // context to the real desktop and the user is looking at an empty strip
+    // ("No windows on the strip yet") until something forces a re-announce.
+    // The shell orders these the other way because a 1 s stall there is on the
+    // GUI thread; here it is on the daemon's start path, before any window has
+    // been placed, and correctness outranks it.
     m_virtualDesktopManager->init();
+    m_virtualDesktopManager->start();
 
     // Virtual desktop changes are handled on TWO distinct paths (#648):
     //


### PR DESCRIPTION
Every daemon restart came up with an empty scrolling strip, and the scroll shortcuts answered "No windows on the strip yet". Verified live, and the journal shows the whole session adopted onto desktop 1 before the context flips to the real desktop:

```
strip context: "LG…115107|1|"          <- 5 windows adopted here
Switching autotile context for screen … desktop 1 -> 2
strip context: "LG…115107|2|"
Showing scrolling-mode strip preview OSD: tiles= 0 zones= 0 empty= true
```

## Cause

The effect announces its whole window set (`windowsOpenedBatch`) as soon as the bridge comes up, before it re-pushes each output's virtual desktop, so the daemon has to know the desktop from its own KWin query by then. It used to: `VirtualDesktopManager::refreshFromKWin()` reads KWin's `current` synchronously only while `m_running` is false, which is what `init()` gave it.

575cd8cad flipped the two calls so `init()`'s refresh would not block, which turned the startup read asynchronous. The batch then wins the race, every engine keys the context it adopts those windows into on `currentDesktopForScreen()`, and the later per-output report moves the context to a strip nothing was ever put in. Nothing re-seeds it, so the strip stayed empty until a mode toggle forced a re-announce.

## Fix

Restore `init()` before `start()`. The daemon deliberately orders these the opposite way from `Workspaces::sharedManager`: the shell avoids the blocking read because a stall there is on the GUI thread, while here it is on the daemon's start path before any window has been placed.

Build clean, ctest green, and confirmed on a live restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMpjJ7sJwLmdHyE8kFAg6U
