### PR TITLE
fix(settings): drop the painted taskbar stand-in from animation previews

### DIFF
--- a/src/settings/qml/pages/shaders/AnimationPreviewPane.qml
+++ b/src/settings/qml/pages/shaders/AnimationPreviewPane.qml
@@ -293,23 +293,6 @@ Item {
                         }
                     }
 
-                    // The stand-in taskbar entry the minimize collapses
-                    // into. Drawn as real pixels (not just fed to the
-                    // shader) so the funnel visibly lands ON something; a
-                    // faint slot when the card is up, tinted while
-                    // swallowed.
-                    Rectangle {
-                        visible: field.iconPhase && root._class === "appearance"
-                        x: field.iconRect.x
-                        y: field.iconRect.y
-                        width: field.iconRect.width
-                        height: field.iconRect.height
-                        radius: Kirigami.Units.smallSpacing
-                        color: Qt.alpha(Kirigami.Theme.highlightColor, 0.35)
-                        border.width: 1
-                        border.color: Kirigami.Theme.highlightColor
-                    }
-
                     // Live capture of the card for uTexture0 — the same
                     // separate-pass FBO a real leg builds. Parked off-screen
                     // (a ShaderEffectSource is itself renderable and


### PR DESCRIPTION
The appearance preview (open / minimize / restore / close) drew a highlighted slot at the bottom-centre of the field so the minimize funnel had something visible to land on. In practice it just reads as a stray rectangle floating over the wallpaper, so it's gone.

`field.iconRect` is unchanged and still handed to the shader through `driveTransitionState`, so minimize still funnels to the bottom-centre and restore still flies back out of it. The target is simply no longer painted.

Verified with qmlformat; QML-only deletion, no build/test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015TfR5e9pV241hBPmz92ZAd