### PR TITLE
chore(i18n): regenerate catalogs and translate the placeIn/placeOut strings

### DIFF
--- a/translations/plasmazones_de.ts
+++ b/translations/plasmazones_de.ts
@@ -6931,7 +6931,7 @@
     <message>
         <location filename="../src/settings/search/searchcatalog.cpp" line="193"/>
         <source>place</source>
-        <translation type="unfinished"></translation>
+        <translation>Platzieren</translation>
     </message>
     <message>
         <location filename="../src/settings/search/searchcatalog.cpp" line="219"/>
@@ -9380,13 +9380,13 @@
         <location filename="../src/settings/search/searchcatalog_animations.cpp" line="30"/>
         <location filename=".qml-stubs/src/settings/qml/pages/animations/AnimationsWindowMotionPage.qml.cpp" line="36"/>
         <source>Placed</source>
-        <translation type="unfinished"></translation>
+        <translation>Platziert</translation>
     </message>
     <message>
         <location filename="../src/settings/search/searchcatalog_animations.cpp" line="32"/>
         <location filename=".qml-stubs/src/settings/qml/pages/animations/AnimationsWindowMotionPage.qml.cpp" line="41"/>
         <source>Released</source>
-        <translation type="unfinished"></translation>
+        <translation>Freigegeben</translation>
     </message>
     <message>
         <location filename="../src/settings/search/searchcatalog_animations.cpp" line="66"/>
@@ -15193,7 +15193,7 @@
     <message>
         <location filename=".qml-stubs/src/settings/qml/pages/animations/AnimationsWindowMotionPage.qml.cpp" line="27"/>
         <source>Animations for windows being placed, released and rearranged, including maximizing. “All Windows” is the default. Each event can override it.</source>
-        <translation type="unfinished"></translation>
+        <translation>Animationen für Fenster, die platziert, freigegeben und neu angeordnet werden, einschließlich Maximieren. „Alle Fenster“ ist die Voreinstellung. Jedes Ereignis kann sie überschreiben.</translation>
     </message>
     <message>
         <location filename=".qml-stubs/src/settings/qml/pages/animations/AnimationsWindowMotionPage.qml.cpp" line="31"/>
@@ -15558,8 +15558,7 @@
     <message>
         <location filename=".qml-stubs/src/settings/qml/pages/animations/StockAnimationConflictChip.qml.cpp" line="59"/>
         <source>A rule cannot turn off the KDE maximize animation for matched windows. If it is enabled in System Settings → Desktop Effects, both animations will play together when such a window maximizes or restores.</source>
-        <oldsource>A rule cannot turn off the KDE maximize animation for matched windows. If it is enabled in System Settings → Desktop Effects, both animations will play together.</oldsource>
-        <translation type="unfinished">Eine Regel kann die KDE-Maximieren-Animation für zutreffende Fenster nicht abschalten. Ist sie in Systemeinstellungen → Arbeitsflächen-Effekte aktiviert, laufen beide Animationen gemeinsam ab.</translation>
+        <translation>Eine Regel kann die KDE-Maximieren-Animation für zutreffende Fenster nicht abschalten. Ist sie in Systemeinstellungen → Arbeitsflächen-Effekte aktiviert, laufen beide Animationen gemeinsam ab, wenn ein solches Fenster maximiert oder wiederhergestellt wird.</translation>
     </message>
     <message>
         <location filename=".qml-stubs/src/settings/qml/pages/animations/StockAnimationConflictChip.qml.cpp" line="59"/>
@@ -18903,7 +18902,7 @@
         <translation>Neuer Reiter</translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="644"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="627"/>
         <location filename=".qml-stubs/src/settings/qml/pages/shaders/DecorationPreviewPane.qml.cpp" line="139"/>
         <location filename=".qml-stubs/src/shared/ShaderPreviewPlaceholder.qml.cpp" line="52"/>
         <source>Preview unavailable</source>
@@ -18911,50 +18910,50 @@
         <translation>Vorschau nicht verfügbar</translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="644"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="627"/>
         <location filename=".qml-stubs/src/settings/qml/pages/shaders/DecorationPreviewPane.qml.cpp" line="139"/>
         <source>This pack&apos;s shader did not compile.</source>
         <comment>@info:placeholder shader preview</comment>
         <translation>Der Shader dieses Pakets konnte nicht kompiliert werden.</translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="658"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="641"/>
         <source>Previewing a desktop switch, there and back, on stand-in desktops.</source>
         <comment>@info animation preview caption</comment>
         <translation>Vorschau eines Arbeitsflächenwechsels hin und zurück auf Platzhalter-Arbeitsflächen.</translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="660"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="643"/>
         <source>Previewing a window move on a sample window.</source>
         <comment>@info animation preview caption</comment>
         <translation>Vorschau einer Fensterbewegung an einem Beispielfenster.</translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="662"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="645"/>
         <source>Previewing a window being dragged back and forth.</source>
         <comment>@info animation preview caption</comment>
         <translation>Vorschau eines Fensters, das hin und her gezogen wird.</translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="664"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="647"/>
         <source>Previewing a tab switch between two sample windows.</source>
         <comment>@info animation preview caption</comment>
         <translation>Vorschau eines Reiterwechsels zwischen zwei Beispielfenstern.</translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="666"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="649"/>
         <source>Previewing a scroll settling on a stand-in strip.</source>
         <comment>@info animation preview caption</comment>
         <translation>Vorschau eines Bildlaufs, der auf einem Platzhalter-Streifen zur Ruhe kommt.</translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="668"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="651"/>
         <source>Previewing open, minimize, restore and close on a sample window.</source>
         <comment>@info animation preview caption</comment>
         <translation>Vorschau von Öffnen, Minimieren, Wiederherstellen und Schließen an einem Beispielfenster.</translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="682"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="665"/>
         <location filename=".qml-stubs/src/settings/qml/pages/shaders/DecorationPreviewPane.qml.cpp" line="187"/>
         <source>This pack reacts to audio. Turn on Audio spectrum in General settings to see it move.</source>
         <comment>@info shader preview limitation</comment>
@@ -23043,13 +23042,13 @@
         <location filename="../src/settings/pages/animationspagecontroller_paths.cpp" line="196"/>
         <source>Placed</source>
         <comment>animation event or section</comment>
-        <translation type="unfinished"></translation>
+        <translation>Platziert</translation>
     </message>
     <message>
         <location filename="../src/settings/pages/animationspagecontroller_paths.cpp" line="199"/>
         <source>Released</source>
         <comment>animation event or section</comment>
-        <translation type="unfinished"></translation>
+        <translation>Freigegeben</translation>
     </message>
     <message>
         <location filename="../src/settings/pages/animationspagecontroller_paths.cpp" line="202"/>

--- a/translations/plasmazones_en.ts
+++ b/translations/plasmazones_en.ts
@@ -18903,7 +18903,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="644"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="627"/>
         <location filename=".qml-stubs/src/settings/qml/pages/shaders/DecorationPreviewPane.qml.cpp" line="139"/>
         <location filename=".qml-stubs/src/shared/ShaderPreviewPlaceholder.qml.cpp" line="52"/>
         <source>Preview unavailable</source>
@@ -18911,50 +18911,50 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="644"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="627"/>
         <location filename=".qml-stubs/src/settings/qml/pages/shaders/DecorationPreviewPane.qml.cpp" line="139"/>
         <source>This pack&apos;s shader did not compile.</source>
         <comment>@info:placeholder shader preview</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="658"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="641"/>
         <source>Previewing a desktop switch, there and back, on stand-in desktops.</source>
         <comment>@info animation preview caption</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="660"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="643"/>
         <source>Previewing a window move on a sample window.</source>
         <comment>@info animation preview caption</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="662"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="645"/>
         <source>Previewing a window being dragged back and forth.</source>
         <comment>@info animation preview caption</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="664"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="647"/>
         <source>Previewing a tab switch between two sample windows.</source>
         <comment>@info animation preview caption</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="666"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="649"/>
         <source>Previewing a scroll settling on a stand-in strip.</source>
         <comment>@info animation preview caption</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="668"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="651"/>
         <source>Previewing open, minimize, restore and close on a sample window.</source>
         <comment>@info animation preview caption</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="682"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="665"/>
         <location filename=".qml-stubs/src/settings/qml/pages/shaders/DecorationPreviewPane.qml.cpp" line="187"/>
         <source>This pack reacts to audio. Turn on Audio spectrum in General settings to see it move.</source>
         <comment>@info shader preview limitation</comment>

--- a/translations/plasmazones_ka.ts
+++ b/translations/plasmazones_ka.ts
@@ -7111,7 +7111,7 @@
     <message>
         <location filename="../src/settings/search/searchcatalog.cpp" line="193"/>
         <source>place</source>
-        <translation type="unfinished"></translation>
+        <translation>განთავსება</translation>
     </message>
     <message>
         <location filename="../src/settings/search/searchcatalog.cpp" line="219"/>
@@ -9683,13 +9683,13 @@
         <location filename="../src/settings/search/searchcatalog_animations.cpp" line="30"/>
         <location filename=".qml-stubs/src/settings/qml/pages/animations/AnimationsWindowMotionPage.qml.cpp" line="36"/>
         <source>Placed</source>
-        <translation type="unfinished"></translation>
+        <translation>განთავსებული</translation>
     </message>
     <message>
         <location filename="../src/settings/search/searchcatalog_animations.cpp" line="32"/>
         <location filename=".qml-stubs/src/settings/qml/pages/animations/AnimationsWindowMotionPage.qml.cpp" line="41"/>
         <source>Released</source>
-        <translation type="unfinished"></translation>
+        <translation>გათავისუფლებული</translation>
     </message>
     <message>
         <location filename="../src/settings/search/searchcatalog_animations.cpp" line="98"/>
@@ -15193,7 +15193,7 @@
     <message>
         <location filename=".qml-stubs/src/settings/qml/pages/animations/AnimationsWindowMotionPage.qml.cpp" line="27"/>
         <source>Animations for windows being placed, released and rearranged, including maximizing. “All Windows” is the default. Each event can override it.</source>
-        <translation type="unfinished"></translation>
+        <translation>ანიმაციები ფანჯრებისთვის, რომლებიც თავსდება, თავისუფლდება და გადალაგდება, გადიდების ჩათვლით. ნაგულისხმევია „ყველა ფანჯარა“. თითოეულ მოვლენას შეუძლია მისი გადაფარვა.</translation>
     </message>
     <message>
         <location filename=".qml-stubs/src/settings/qml/pages/animations/AnimationsWindowMotionPage.qml.cpp" line="31"/>
@@ -15558,8 +15558,7 @@
     <message>
         <location filename=".qml-stubs/src/settings/qml/pages/animations/StockAnimationConflictChip.qml.cpp" line="59"/>
         <source>A rule cannot turn off the KDE maximize animation for matched windows. If it is enabled in System Settings → Desktop Effects, both animations will play together when such a window maximizes or restores.</source>
-        <oldsource>A rule cannot turn off the KDE maximize animation for matched windows. If it is enabled in System Settings → Desktop Effects, both animations will play together.</oldsource>
-        <translation type="unfinished">წესს არ შეუძლია, გათიშოს KDE-ის გადიდების ანიმაცია შესატყვის ფანჯრებზე. თუ ის ჩართულია სისტემის პარამეტრები → სამუშაო მაგიდის ეფექტებში, ორივე ანიმაცია ერთად დაიკვრება.</translation>
+        <translation>წესს არ შეუძლია, გათიშოს KDE-ის გადიდების ანიმაცია შესატყვის ფანჯრებზე. თუ ის ჩართულია სისტემის პარამეტრები → სამუშაო მაგიდის ეფექტებში, ორივე ანიმაცია ერთად დაიკვრება, როცა ასეთი ფანჯარა გადიდდება ან აღდგება.</translation>
     </message>
     <message>
         <location filename=".qml-stubs/src/settings/qml/pages/animations/StockAnimationConflictChip.qml.cpp" line="59"/>
@@ -18903,7 +18902,7 @@
         <translation>ახალი ჩანართი</translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="644"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="627"/>
         <location filename=".qml-stubs/src/settings/qml/pages/shaders/DecorationPreviewPane.qml.cpp" line="139"/>
         <location filename=".qml-stubs/src/shared/ShaderPreviewPlaceholder.qml.cpp" line="52"/>
         <source>Preview unavailable</source>
@@ -18911,50 +18910,50 @@
         <translation>გადახედვა ხელმისაწვდომი არაა</translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="644"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="627"/>
         <location filename=".qml-stubs/src/settings/qml/pages/shaders/DecorationPreviewPane.qml.cpp" line="139"/>
         <source>This pack&apos;s shader did not compile.</source>
         <comment>@info:placeholder shader preview</comment>
         <translation>ამ პაკეტის შეიდერი ვერ დაკომპილირდა.</translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="658"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="641"/>
         <source>Previewing a desktop switch, there and back, on stand-in desktops.</source>
         <comment>@info animation preview caption</comment>
         <translation>სამუშაო მაგიდის გადართვის გადახედვა, იქით და უკან, დროებით სამუშაო მაგიდებზე.</translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="660"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="643"/>
         <source>Previewing a window move on a sample window.</source>
         <comment>@info animation preview caption</comment>
         <translation>ფანჯრის გადატანის გადახედვა სანიმუშო ფანჯარაზე.</translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="662"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="645"/>
         <source>Previewing a window being dragged back and forth.</source>
         <comment>@info animation preview caption</comment>
         <translation>ფანჯრის წინ და უკან გადათრევის გადახედვა.</translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="664"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="647"/>
         <source>Previewing a tab switch between two sample windows.</source>
         <comment>@info animation preview caption</comment>
         <translation>ჩანართის გადართვის გადახედვა ორ სანიმუშო ფანჯარას შორის.</translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="666"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="649"/>
         <source>Previewing a scroll settling on a stand-in strip.</source>
         <comment>@info animation preview caption</comment>
         <translation>გადახვევის დამშვიდების გადახედვა დროებით ზოლზე.</translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="668"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="651"/>
         <source>Previewing open, minimize, restore and close on a sample window.</source>
         <comment>@info animation preview caption</comment>
         <translation>გახსნის, ჩაკეცვის, აღდგენისა და დახურვის გადახედვა სანიმუშო ფანჯარაზე.</translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="682"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="665"/>
         <location filename=".qml-stubs/src/settings/qml/pages/shaders/DecorationPreviewPane.qml.cpp" line="187"/>
         <source>This pack reacts to audio. Turn on Audio spectrum in General settings to see it move.</source>
         <comment>@info shader preview limitation</comment>
@@ -23043,13 +23042,13 @@
         <location filename="../src/settings/pages/animationspagecontroller_paths.cpp" line="196"/>
         <source>Placed</source>
         <comment>animation event or section</comment>
-        <translation type="unfinished"></translation>
+        <translation>განთავსებული</translation>
     </message>
     <message>
         <location filename="../src/settings/pages/animationspagecontroller_paths.cpp" line="199"/>
         <source>Released</source>
         <comment>animation event or section</comment>
-        <translation type="unfinished"></translation>
+        <translation>გათავისუფლებული</translation>
     </message>
     <message>
         <location filename="../src/settings/pages/animationspagecontroller_paths.cpp" line="202"/>

--- a/translations/plasmazones_nl.ts
+++ b/translations/plasmazones_nl.ts
@@ -7111,7 +7111,7 @@
     <message>
         <location filename="../src/settings/search/searchcatalog.cpp" line="193"/>
         <source>place</source>
-        <translation type="unfinished"></translation>
+        <translation>plaatsen</translation>
     </message>
     <message>
         <location filename="../src/settings/search/searchcatalog.cpp" line="219"/>
@@ -9683,13 +9683,13 @@
         <location filename="../src/settings/search/searchcatalog_animations.cpp" line="30"/>
         <location filename=".qml-stubs/src/settings/qml/pages/animations/AnimationsWindowMotionPage.qml.cpp" line="36"/>
         <source>Placed</source>
-        <translation type="unfinished"></translation>
+        <translation>Geplaatst</translation>
     </message>
     <message>
         <location filename="../src/settings/search/searchcatalog_animations.cpp" line="32"/>
         <location filename=".qml-stubs/src/settings/qml/pages/animations/AnimationsWindowMotionPage.qml.cpp" line="41"/>
         <source>Released</source>
-        <translation type="unfinished"></translation>
+        <translation>Losgelaten</translation>
     </message>
     <message>
         <location filename="../src/settings/search/searchcatalog_animations.cpp" line="98"/>
@@ -15193,7 +15193,7 @@
     <message>
         <location filename=".qml-stubs/src/settings/qml/pages/animations/AnimationsWindowMotionPage.qml.cpp" line="27"/>
         <source>Animations for windows being placed, released and rearranged, including maximizing. “All Windows” is the default. Each event can override it.</source>
-        <translation type="unfinished"></translation>
+        <translation>Animaties voor vensters die worden geplaatst, losgelaten en herschikt, inclusief maximaliseren. “Alle vensters” is de standaard. Elke gebeurtenis kan die overschrijven.</translation>
     </message>
     <message>
         <location filename=".qml-stubs/src/settings/qml/pages/animations/AnimationsWindowMotionPage.qml.cpp" line="31"/>
@@ -15558,8 +15558,7 @@
     <message>
         <location filename=".qml-stubs/src/settings/qml/pages/animations/StockAnimationConflictChip.qml.cpp" line="59"/>
         <source>A rule cannot turn off the KDE maximize animation for matched windows. If it is enabled in System Settings → Desktop Effects, both animations will play together when such a window maximizes or restores.</source>
-        <oldsource>A rule cannot turn off the KDE maximize animation for matched windows. If it is enabled in System Settings → Desktop Effects, both animations will play together.</oldsource>
-        <translation type="unfinished">Een regel kan de KDE-maximaliseeranimatie voor overeenkomende vensters niet uitschakelen. Als deze is ingeschakeld in Systeeminstellingen → Bureaubladeffecten, spelen beide animaties samen af.</translation>
+        <translation>Een regel kan de KDE-maximaliseeranimatie voor overeenkomende vensters niet uitschakelen. Als deze is ingeschakeld in Systeeminstellingen → Bureaubladeffecten, spelen beide animaties samen af wanneer zo&apos;n venster maximaliseert of herstelt.</translation>
     </message>
     <message>
         <location filename=".qml-stubs/src/settings/qml/pages/animations/StockAnimationConflictChip.qml.cpp" line="59"/>
@@ -18903,7 +18902,7 @@
         <translation>Nieuw tabblad</translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="644"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="627"/>
         <location filename=".qml-stubs/src/settings/qml/pages/shaders/DecorationPreviewPane.qml.cpp" line="139"/>
         <location filename=".qml-stubs/src/shared/ShaderPreviewPlaceholder.qml.cpp" line="52"/>
         <source>Preview unavailable</source>
@@ -18911,50 +18910,50 @@
         <translation>Voorbeeld niet beschikbaar</translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="644"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="627"/>
         <location filename=".qml-stubs/src/settings/qml/pages/shaders/DecorationPreviewPane.qml.cpp" line="139"/>
         <source>This pack&apos;s shader did not compile.</source>
         <comment>@info:placeholder shader preview</comment>
         <translation>De shader van dit pakket kon niet worden gecompileerd.</translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="658"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="641"/>
         <source>Previewing a desktop switch, there and back, on stand-in desktops.</source>
         <comment>@info animation preview caption</comment>
         <translation>Voorbeeld van een bureaubladwissel, heen en terug, op vervangende bureaubladen.</translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="660"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="643"/>
         <source>Previewing a window move on a sample window.</source>
         <comment>@info animation preview caption</comment>
         <translation>Voorbeeld van een vensterverplaatsing op een voorbeeldvenster.</translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="662"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="645"/>
         <source>Previewing a window being dragged back and forth.</source>
         <comment>@info animation preview caption</comment>
         <translation>Voorbeeld van een venster dat heen en weer wordt gesleept.</translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="664"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="647"/>
         <source>Previewing a tab switch between two sample windows.</source>
         <comment>@info animation preview caption</comment>
         <translation>Voorbeeld van een tabbladwissel tussen twee voorbeeldvensters.</translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="666"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="649"/>
         <source>Previewing a scroll settling on a stand-in strip.</source>
         <comment>@info animation preview caption</comment>
         <translation>Voorbeeld van scrollen dat tot rust komt op een vervangende strook.</translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="668"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="651"/>
         <source>Previewing open, minimize, restore and close on a sample window.</source>
         <comment>@info animation preview caption</comment>
         <translation>Voorbeeld van openen, minimaliseren, herstellen en sluiten op een voorbeeldvenster.</translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="682"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="665"/>
         <location filename=".qml-stubs/src/settings/qml/pages/shaders/DecorationPreviewPane.qml.cpp" line="187"/>
         <source>This pack reacts to audio. Turn on Audio spectrum in General settings to see it move.</source>
         <comment>@info shader preview limitation</comment>
@@ -23043,13 +23042,13 @@
         <location filename="../src/settings/pages/animationspagecontroller_paths.cpp" line="196"/>
         <source>Placed</source>
         <comment>animation event or section</comment>
-        <translation type="unfinished"></translation>
+        <translation>Geplaatst</translation>
     </message>
     <message>
         <location filename="../src/settings/pages/animationspagecontroller_paths.cpp" line="199"/>
         <source>Released</source>
         <comment>animation event or section</comment>
-        <translation type="unfinished"></translation>
+        <translation>Losgelaten</translation>
     </message>
     <message>
         <location filename="../src/settings/pages/animationspagecontroller_paths.cpp" line="202"/>

--- a/translations/plasmazones_pl.ts
+++ b/translations/plasmazones_pl.ts
@@ -7120,7 +7120,7 @@
     <message>
         <location filename="../src/settings/search/searchcatalog.cpp" line="193"/>
         <source>place</source>
-        <translation type="unfinished"></translation>
+        <translation>umieszczanie</translation>
     </message>
     <message>
         <location filename="../src/settings/search/searchcatalog.cpp" line="219"/>
@@ -9692,13 +9692,13 @@
         <location filename="../src/settings/search/searchcatalog_animations.cpp" line="30"/>
         <location filename=".qml-stubs/src/settings/qml/pages/animations/AnimationsWindowMotionPage.qml.cpp" line="36"/>
         <source>Placed</source>
-        <translation type="unfinished"></translation>
+        <translation>Umieszczone</translation>
     </message>
     <message>
         <location filename="../src/settings/search/searchcatalog_animations.cpp" line="32"/>
         <location filename=".qml-stubs/src/settings/qml/pages/animations/AnimationsWindowMotionPage.qml.cpp" line="41"/>
         <source>Released</source>
-        <translation type="unfinished"></translation>
+        <translation>Zwolnione</translation>
     </message>
     <message>
         <location filename="../src/settings/search/searchcatalog_animations.cpp" line="98"/>
@@ -15213,7 +15213,7 @@
     <message>
         <location filename=".qml-stubs/src/settings/qml/pages/animations/AnimationsWindowMotionPage.qml.cpp" line="27"/>
         <source>Animations for windows being placed, released and rearranged, including maximizing. “All Windows” is the default. Each event can override it.</source>
-        <translation type="unfinished"></translation>
+        <translation>Animacje dla okien umieszczanych, zwalnianych i przestawianych, w tym maksymalizowanych. Domyślnie obowiązuje „Wszystkie okna”. Każde zdarzenie może to nadpisać.</translation>
     </message>
     <message>
         <location filename=".qml-stubs/src/settings/qml/pages/animations/AnimationsWindowMotionPage.qml.cpp" line="31"/>
@@ -15578,8 +15578,7 @@
     <message>
         <location filename=".qml-stubs/src/settings/qml/pages/animations/StockAnimationConflictChip.qml.cpp" line="59"/>
         <source>A rule cannot turn off the KDE maximize animation for matched windows. If it is enabled in System Settings → Desktop Effects, both animations will play together when such a window maximizes or restores.</source>
-        <oldsource>A rule cannot turn off the KDE maximize animation for matched windows. If it is enabled in System Settings → Desktop Effects, both animations will play together.</oldsource>
-        <translation type="unfinished">Reguła nie może wyłączyć animacji maksymalizacji KDE dla pasujących okien. Jeśli jest włączona w Ustawieniach systemowych → Efekty pulpitu, obie animacje odtworzą się razem.</translation>
+        <translation>Reguła nie może wyłączyć animacji maksymalizacji KDE dla pasujących okien. Jeśli jest włączona w Ustawieniach systemowych → Efekty pulpitu, obie animacje odtworzą się razem, gdy takie okno zostanie zmaksymalizowane lub przywrócone.</translation>
     </message>
     <message>
         <location filename=".qml-stubs/src/settings/qml/pages/animations/StockAnimationConflictChip.qml.cpp" line="59"/>
@@ -18946,7 +18945,7 @@
         <translation>Nowa karta</translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="644"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="627"/>
         <location filename=".qml-stubs/src/settings/qml/pages/shaders/DecorationPreviewPane.qml.cpp" line="139"/>
         <location filename=".qml-stubs/src/shared/ShaderPreviewPlaceholder.qml.cpp" line="52"/>
         <source>Preview unavailable</source>
@@ -18954,50 +18953,50 @@
         <translation>Podgląd niedostępny</translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="644"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="627"/>
         <location filename=".qml-stubs/src/settings/qml/pages/shaders/DecorationPreviewPane.qml.cpp" line="139"/>
         <source>This pack&apos;s shader did not compile.</source>
         <comment>@info:placeholder shader preview</comment>
         <translation>Nie udało się skompilować shadera tej paczki.</translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="658"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="641"/>
         <source>Previewing a desktop switch, there and back, on stand-in desktops.</source>
         <comment>@info animation preview caption</comment>
         <translation>Podgląd przełączenia pulpitu tam i z powrotem na zastępczych pulpitach.</translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="660"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="643"/>
         <source>Previewing a window move on a sample window.</source>
         <comment>@info animation preview caption</comment>
         <translation>Podgląd przeniesienia okna na przykładowym oknie.</translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="662"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="645"/>
         <source>Previewing a window being dragged back and forth.</source>
         <comment>@info animation preview caption</comment>
         <translation>Podgląd okna przeciąganego w tę i z powrotem.</translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="664"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="647"/>
         <source>Previewing a tab switch between two sample windows.</source>
         <comment>@info animation preview caption</comment>
         <translation>Podgląd przełączenia karty między dwoma przykładowymi oknami.</translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="666"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="649"/>
         <source>Previewing a scroll settling on a stand-in strip.</source>
         <comment>@info animation preview caption</comment>
         <translation>Podgląd przewijania zatrzymującego się na zastępczym pasie.</translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="668"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="651"/>
         <source>Previewing open, minimize, restore and close on a sample window.</source>
         <comment>@info animation preview caption</comment>
         <translation>Podgląd otwarcia, minimalizacji, przywrócenia i zamknięcia na przykładowym oknie.</translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="682"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="665"/>
         <location filename=".qml-stubs/src/settings/qml/pages/shaders/DecorationPreviewPane.qml.cpp" line="187"/>
         <source>This pack reacts to audio. Turn on Audio spectrum in General settings to see it move.</source>
         <comment>@info shader preview limitation</comment>
@@ -23097,13 +23096,13 @@
         <location filename="../src/settings/pages/animationspagecontroller_paths.cpp" line="196"/>
         <source>Placed</source>
         <comment>animation event or section</comment>
-        <translation type="unfinished"></translation>
+        <translation>Umieszczone</translation>
     </message>
     <message>
         <location filename="../src/settings/pages/animationspagecontroller_paths.cpp" line="199"/>
         <source>Released</source>
         <comment>animation event or section</comment>
-        <translation type="unfinished"></translation>
+        <translation>Zwolnione</translation>
     </message>
     <message>
         <location filename="../src/settings/pages/animationspagecontroller_paths.cpp" line="202"/>

--- a/translations/plasmazones_pt_BR.ts
+++ b/translations/plasmazones_pt_BR.ts
@@ -7111,7 +7111,7 @@
     <message>
         <location filename="../src/settings/search/searchcatalog.cpp" line="193"/>
         <source>place</source>
-        <translation type="unfinished"></translation>
+        <translation>posicionar</translation>
     </message>
     <message>
         <location filename="../src/settings/search/searchcatalog.cpp" line="219"/>
@@ -9683,13 +9683,13 @@
         <location filename="../src/settings/search/searchcatalog_animations.cpp" line="30"/>
         <location filename=".qml-stubs/src/settings/qml/pages/animations/AnimationsWindowMotionPage.qml.cpp" line="36"/>
         <source>Placed</source>
-        <translation type="unfinished"></translation>
+        <translation>Posicionada</translation>
     </message>
     <message>
         <location filename="../src/settings/search/searchcatalog_animations.cpp" line="32"/>
         <location filename=".qml-stubs/src/settings/qml/pages/animations/AnimationsWindowMotionPage.qml.cpp" line="41"/>
         <source>Released</source>
-        <translation type="unfinished"></translation>
+        <translation>Liberada</translation>
     </message>
     <message>
         <location filename="../src/settings/search/searchcatalog_animations.cpp" line="98"/>
@@ -15193,7 +15193,7 @@
     <message>
         <location filename=".qml-stubs/src/settings/qml/pages/animations/AnimationsWindowMotionPage.qml.cpp" line="27"/>
         <source>Animations for windows being placed, released and rearranged, including maximizing. “All Windows” is the default. Each event can override it.</source>
-        <translation type="unfinished"></translation>
+        <translation>Animações para janelas sendo posicionadas, liberadas e reorganizadas, incluindo maximizar. “Todas as janelas” é o padrão. Cada evento pode substituí-lo.</translation>
     </message>
     <message>
         <location filename=".qml-stubs/src/settings/qml/pages/animations/AnimationsWindowMotionPage.qml.cpp" line="31"/>
@@ -15558,8 +15558,7 @@
     <message>
         <location filename=".qml-stubs/src/settings/qml/pages/animations/StockAnimationConflictChip.qml.cpp" line="59"/>
         <source>A rule cannot turn off the KDE maximize animation for matched windows. If it is enabled in System Settings → Desktop Effects, both animations will play together when such a window maximizes or restores.</source>
-        <oldsource>A rule cannot turn off the KDE maximize animation for matched windows. If it is enabled in System Settings → Desktop Effects, both animations will play together.</oldsource>
-        <translation type="unfinished">Uma regra não consegue desligar a animação de maximizar do KDE nas janelas correspondentes. Se ela estiver ativada em Configurações do sistema → Efeitos da área de trabalho, as duas animações vão rodar juntas.</translation>
+        <translation>Uma regra não consegue desligar a animação de maximizar do KDE nas janelas correspondentes. Se ela estiver ativada em Configurações do sistema → Efeitos da área de trabalho, as duas animações vão rodar juntas quando uma dessas janelas for maximizada ou restaurada.</translation>
     </message>
     <message>
         <location filename=".qml-stubs/src/settings/qml/pages/animations/StockAnimationConflictChip.qml.cpp" line="59"/>
@@ -18903,7 +18902,7 @@
         <translation>Nova aba</translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="644"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="627"/>
         <location filename=".qml-stubs/src/settings/qml/pages/shaders/DecorationPreviewPane.qml.cpp" line="139"/>
         <location filename=".qml-stubs/src/shared/ShaderPreviewPlaceholder.qml.cpp" line="52"/>
         <source>Preview unavailable</source>
@@ -18911,50 +18910,50 @@
         <translation>Visualização indisponível</translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="644"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="627"/>
         <location filename=".qml-stubs/src/settings/qml/pages/shaders/DecorationPreviewPane.qml.cpp" line="139"/>
         <source>This pack&apos;s shader did not compile.</source>
         <comment>@info:placeholder shader preview</comment>
         <translation>O shader deste pacote não compilou.</translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="658"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="641"/>
         <source>Previewing a desktop switch, there and back, on stand-in desktops.</source>
         <comment>@info animation preview caption</comment>
         <translation>Visualização de uma troca de área de trabalho, ida e volta, em áreas de trabalho provisórias.</translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="660"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="643"/>
         <source>Previewing a window move on a sample window.</source>
         <comment>@info animation preview caption</comment>
         <translation>Visualização de uma janela sendo movida em uma janela de exemplo.</translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="662"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="645"/>
         <source>Previewing a window being dragged back and forth.</source>
         <comment>@info animation preview caption</comment>
         <translation>Visualização de uma janela sendo arrastada para lá e para cá.</translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="664"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="647"/>
         <source>Previewing a tab switch between two sample windows.</source>
         <comment>@info animation preview caption</comment>
         <translation>Visualização de uma troca de abas entre duas janelas de exemplo.</translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="666"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="649"/>
         <source>Previewing a scroll settling on a stand-in strip.</source>
         <comment>@info animation preview caption</comment>
         <translation>Visualização de uma rolagem se acomodando em uma faixa provisória.</translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="668"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="651"/>
         <source>Previewing open, minimize, restore and close on a sample window.</source>
         <comment>@info animation preview caption</comment>
         <translation>Visualização de abrir, minimizar, restaurar e fechar em uma janela de exemplo.</translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="682"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="665"/>
         <location filename=".qml-stubs/src/settings/qml/pages/shaders/DecorationPreviewPane.qml.cpp" line="187"/>
         <source>This pack reacts to audio. Turn on Audio spectrum in General settings to see it move.</source>
         <comment>@info shader preview limitation</comment>
@@ -23043,13 +23042,13 @@
         <location filename="../src/settings/pages/animationspagecontroller_paths.cpp" line="196"/>
         <source>Placed</source>
         <comment>animation event or section</comment>
-        <translation type="unfinished"></translation>
+        <translation>Posicionada</translation>
     </message>
     <message>
         <location filename="../src/settings/pages/animationspagecontroller_paths.cpp" line="199"/>
         <source>Released</source>
         <comment>animation event or section</comment>
-        <translation type="unfinished"></translation>
+        <translation>Liberada</translation>
     </message>
     <message>
         <location filename="../src/settings/pages/animationspagecontroller_paths.cpp" line="202"/>

--- a/translations/plasmazones_ru.ts
+++ b/translations/plasmazones_ru.ts
@@ -7120,7 +7120,7 @@
     <message>
         <location filename="../src/settings/search/searchcatalog.cpp" line="193"/>
         <source>place</source>
-        <translation type="unfinished"></translation>
+        <translation>размещение</translation>
     </message>
     <message>
         <location filename="../src/settings/search/searchcatalog.cpp" line="219"/>
@@ -9692,13 +9692,13 @@
         <location filename="../src/settings/search/searchcatalog_animations.cpp" line="30"/>
         <location filename=".qml-stubs/src/settings/qml/pages/animations/AnimationsWindowMotionPage.qml.cpp" line="36"/>
         <source>Placed</source>
-        <translation type="unfinished"></translation>
+        <translation>Размещено</translation>
     </message>
     <message>
         <location filename="../src/settings/search/searchcatalog_animations.cpp" line="32"/>
         <location filename=".qml-stubs/src/settings/qml/pages/animations/AnimationsWindowMotionPage.qml.cpp" line="41"/>
         <source>Released</source>
-        <translation type="unfinished"></translation>
+        <translation>Освобождено</translation>
     </message>
     <message>
         <location filename="../src/settings/search/searchcatalog_animations.cpp" line="98"/>
@@ -15213,7 +15213,7 @@
     <message>
         <location filename=".qml-stubs/src/settings/qml/pages/animations/AnimationsWindowMotionPage.qml.cpp" line="27"/>
         <source>Animations for windows being placed, released and rearranged, including maximizing. “All Windows” is the default. Each event can override it.</source>
-        <translation type="unfinished"></translation>
+        <translation>Анимации для окон, которые размещаются, освобождаются и переставляются, включая разворачивание. По умолчанию действует «Все окна». Каждое событие может это переопределить.</translation>
     </message>
     <message>
         <location filename=".qml-stubs/src/settings/qml/pages/animations/AnimationsWindowMotionPage.qml.cpp" line="31"/>
@@ -15578,8 +15578,7 @@
     <message>
         <location filename=".qml-stubs/src/settings/qml/pages/animations/StockAnimationConflictChip.qml.cpp" line="59"/>
         <source>A rule cannot turn off the KDE maximize animation for matched windows. If it is enabled in System Settings → Desktop Effects, both animations will play together when such a window maximizes or restores.</source>
-        <oldsource>A rule cannot turn off the KDE maximize animation for matched windows. If it is enabled in System Settings → Desktop Effects, both animations will play together.</oldsource>
-        <translation type="unfinished">Правило не может отключить анимацию KDE при разворачивании для подходящих окон. Если она включена в разделе «Параметры системы → Эффекты рабочего стола», обе анимации будут проигрываться вместе.</translation>
+        <translation>Правило не может отключить анимацию KDE при разворачивании для подходящих окон. Если она включена в разделе «Параметры системы → Эффекты рабочего стола», обе анимации будут проигрываться вместе, когда такое окно разворачивается или восстанавливается.</translation>
     </message>
     <message>
         <location filename=".qml-stubs/src/settings/qml/pages/animations/StockAnimationConflictChip.qml.cpp" line="59"/>
@@ -18946,7 +18945,7 @@
         <translation>Новая вкладка</translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="644"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="627"/>
         <location filename=".qml-stubs/src/settings/qml/pages/shaders/DecorationPreviewPane.qml.cpp" line="139"/>
         <location filename=".qml-stubs/src/shared/ShaderPreviewPlaceholder.qml.cpp" line="52"/>
         <source>Preview unavailable</source>
@@ -18954,50 +18953,50 @@
         <translation>Предпросмотр недоступен</translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="644"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="627"/>
         <location filename=".qml-stubs/src/settings/qml/pages/shaders/DecorationPreviewPane.qml.cpp" line="139"/>
         <source>This pack&apos;s shader did not compile.</source>
         <comment>@info:placeholder shader preview</comment>
         <translation>Не удалось скомпилировать шейдер этого пакета.</translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="658"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="641"/>
         <source>Previewing a desktop switch, there and back, on stand-in desktops.</source>
         <comment>@info animation preview caption</comment>
         <translation>Предпросмотр переключения рабочих столов туда и обратно на условных рабочих столах.</translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="660"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="643"/>
         <source>Previewing a window move on a sample window.</source>
         <comment>@info animation preview caption</comment>
         <translation>Предпросмотр перемещения на образце окна.</translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="662"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="645"/>
         <source>Previewing a window being dragged back and forth.</source>
         <comment>@info animation preview caption</comment>
         <translation>Предпросмотр окна, которое перетаскивают туда-сюда.</translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="664"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="647"/>
         <source>Previewing a tab switch between two sample windows.</source>
         <comment>@info animation preview caption</comment>
         <translation>Предпросмотр переключения вкладок между двумя образцами окон.</translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="666"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="649"/>
         <source>Previewing a scroll settling on a stand-in strip.</source>
         <comment>@info animation preview caption</comment>
         <translation>Предпросмотр прокрутки, останавливающейся на условной ленте.</translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="668"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="651"/>
         <source>Previewing open, minimize, restore and close on a sample window.</source>
         <comment>@info animation preview caption</comment>
         <translation>Предпросмотр открытия, сворачивания, восстановления и закрытия на образце окна.</translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="682"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="665"/>
         <location filename=".qml-stubs/src/settings/qml/pages/shaders/DecorationPreviewPane.qml.cpp" line="187"/>
         <source>This pack reacts to audio. Turn on Audio spectrum in General settings to see it move.</source>
         <comment>@info shader preview limitation</comment>
@@ -23097,13 +23096,13 @@
         <location filename="../src/settings/pages/animationspagecontroller_paths.cpp" line="196"/>
         <source>Placed</source>
         <comment>animation event or section</comment>
-        <translation type="unfinished"></translation>
+        <translation>Размещено</translation>
     </message>
     <message>
         <location filename="../src/settings/pages/animationspagecontroller_paths.cpp" line="199"/>
         <source>Released</source>
         <comment>animation event or section</comment>
-        <translation type="unfinished"></translation>
+        <translation>Освобождено</translation>
     </message>
     <message>
         <location filename="../src/settings/pages/animationspagecontroller_paths.cpp" line="202"/>

--- a/translations/plasmazones_sv.ts
+++ b/translations/plasmazones_sv.ts
@@ -7111,7 +7111,7 @@
     <message>
         <location filename="../src/settings/search/searchcatalog.cpp" line="193"/>
         <source>place</source>
-        <translation type="unfinished"></translation>
+        <translation>placera</translation>
     </message>
     <message>
         <location filename="../src/settings/search/searchcatalog.cpp" line="219"/>
@@ -9683,13 +9683,13 @@
         <location filename="../src/settings/search/searchcatalog_animations.cpp" line="30"/>
         <location filename=".qml-stubs/src/settings/qml/pages/animations/AnimationsWindowMotionPage.qml.cpp" line="36"/>
         <source>Placed</source>
-        <translation type="unfinished"></translation>
+        <translation>Placerat</translation>
     </message>
     <message>
         <location filename="../src/settings/search/searchcatalog_animations.cpp" line="32"/>
         <location filename=".qml-stubs/src/settings/qml/pages/animations/AnimationsWindowMotionPage.qml.cpp" line="41"/>
         <source>Released</source>
-        <translation type="unfinished"></translation>
+        <translation>Släppt</translation>
     </message>
     <message>
         <location filename="../src/settings/search/searchcatalog_animations.cpp" line="98"/>
@@ -15193,7 +15193,7 @@
     <message>
         <location filename=".qml-stubs/src/settings/qml/pages/animations/AnimationsWindowMotionPage.qml.cpp" line="27"/>
         <source>Animations for windows being placed, released and rearranged, including maximizing. “All Windows” is the default. Each event can override it.</source>
-        <translation type="unfinished"></translation>
+        <translation>Animeringar för fönster som placeras, släpps och ordnas om, inklusive maximering. ”Alla fönster” är standard. Varje händelse kan åsidosätta det.</translation>
     </message>
     <message>
         <location filename=".qml-stubs/src/settings/qml/pages/animations/AnimationsWindowMotionPage.qml.cpp" line="31"/>
@@ -15558,8 +15558,7 @@
     <message>
         <location filename=".qml-stubs/src/settings/qml/pages/animations/StockAnimationConflictChip.qml.cpp" line="59"/>
         <source>A rule cannot turn off the KDE maximize animation for matched windows. If it is enabled in System Settings → Desktop Effects, both animations will play together when such a window maximizes or restores.</source>
-        <oldsource>A rule cannot turn off the KDE maximize animation for matched windows. If it is enabled in System Settings → Desktop Effects, both animations will play together.</oldsource>
-        <translation type="unfinished">En regel kan inte stänga av KDE:s maximeringsanimering för matchande fönster. Om den är aktiverad i Systeminställningar → Skrivbordseffekter spelas båda animeringarna tillsammans.</translation>
+        <translation>En regel kan inte stänga av KDE:s maximeringsanimering för matchande fönster. Om den är aktiverad i Systeminställningar → Skrivbordseffekter spelas båda animeringarna tillsammans när ett sådant fönster maximeras eller återställs.</translation>
     </message>
     <message>
         <location filename=".qml-stubs/src/settings/qml/pages/animations/StockAnimationConflictChip.qml.cpp" line="59"/>
@@ -18903,7 +18902,7 @@
         <translation>Ny flik</translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="644"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="627"/>
         <location filename=".qml-stubs/src/settings/qml/pages/shaders/DecorationPreviewPane.qml.cpp" line="139"/>
         <location filename=".qml-stubs/src/shared/ShaderPreviewPlaceholder.qml.cpp" line="52"/>
         <source>Preview unavailable</source>
@@ -18911,50 +18910,50 @@
         <translation>Förhandsgranskning ej tillgänglig</translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="644"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="627"/>
         <location filename=".qml-stubs/src/settings/qml/pages/shaders/DecorationPreviewPane.qml.cpp" line="139"/>
         <source>This pack&apos;s shader did not compile.</source>
         <comment>@info:placeholder shader preview</comment>
         <translation>Paketets shader kunde inte kompileras.</translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="658"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="641"/>
         <source>Previewing a desktop switch, there and back, on stand-in desktops.</source>
         <comment>@info animation preview caption</comment>
         <translation>Förhandsgranskar ett skrivbordsbyte, dit och tillbaka, på exempelskrivbord.</translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="660"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="643"/>
         <source>Previewing a window move on a sample window.</source>
         <comment>@info animation preview caption</comment>
         <translation>Förhandsgranskar en fönsterflytt på ett exempelfönster.</translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="662"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="645"/>
         <source>Previewing a window being dragged back and forth.</source>
         <comment>@info animation preview caption</comment>
         <translation>Förhandsgranskar ett fönster som dras fram och tillbaka.</translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="664"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="647"/>
         <source>Previewing a tab switch between two sample windows.</source>
         <comment>@info animation preview caption</comment>
         <translation>Förhandsgranskar ett flikbyte mellan två exempelfönster.</translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="666"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="649"/>
         <source>Previewing a scroll settling on a stand-in strip.</source>
         <comment>@info animation preview caption</comment>
         <translation>Förhandsgranskar en rullning som stannar på en exempelremsa.</translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="668"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="651"/>
         <source>Previewing open, minimize, restore and close on a sample window.</source>
         <comment>@info animation preview caption</comment>
         <translation>Förhandsgranskar öppning, minimering, återställning och stängning på ett exempelfönster.</translation>
     </message>
     <message>
-        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="682"/>
+        <location filename=".qml-stubs/src/settings/qml/pages/shaders/AnimationPreviewPane.qml.cpp" line="665"/>
         <location filename=".qml-stubs/src/settings/qml/pages/shaders/DecorationPreviewPane.qml.cpp" line="187"/>
         <source>This pack reacts to audio. Turn on Audio spectrum in General settings to see it move.</source>
         <comment>@info shader preview limitation</comment>
@@ -23043,13 +23042,13 @@
         <location filename="../src/settings/pages/animationspagecontroller_paths.cpp" line="196"/>
         <source>Placed</source>
         <comment>animation event or section</comment>
-        <translation type="unfinished"></translation>
+        <translation>Placerat</translation>
     </message>
     <message>
         <location filename="../src/settings/pages/animationspagecontroller_paths.cpp" line="199"/>
         <source>Released</source>
         <comment>animation event or section</comment>
-        <translation type="unfinished"></translation>
+        <translation>Släppt</translation>
     </message>
     <message>
         <location filename="../src/settings/pages/animationspagecontroller_paths.cpp" line="202"/>


### PR DESCRIPTION
## Summary

Follow-up to #1052. Runs `update-ts` and fills the translations the placeIn/placeOut rename left unfinished.

- lupdate extracted the same 4009 strings as before. The only regeneration churn is shifted stub line numbers in AnimationPreviewPane.
- Each of the seven language catalogs (de, ka, nl, pl, pt_BR, ru, sv) had seven unfinished entries:
  - the `place` search keyword for the Window Motion animations page
  - the `Placed` and `Released` event labels, in both the plain search-catalog form and the "animation event or section" form
  - the Window Motion page description that names "All Windows" as the default
  - the KDE maximize conflict chip text, whose source gained the clause "when such a window maximizes or restores". Each existing translation was extended to match and the stale `oldsource` marker dropped.
- Wording follows the existing catalog conventions, such as the feminine past participles in pt_BR and the neuter ones in sv that "Dragged" already uses.

## Verification

- A second `update-ts` pass produced no further changes.
- `release_translations` compiles all seven catalogs with 4009 finished and 0 unfinished messages each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JKPqSBqbxZc2ZmS54u2PaA