### PR TITLE
chore(ci): bump all workflow actions off Node 20 to latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,14 +81,14 @@ jobs:
             xorg-server-xvfb mesa cava ffmpeg
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       # ccache: BIG win on PR rebuilds with unity-build + LTO; without it
       # every PR pays a 10-15 min cold compile.
       - name: ccache
-        # hendrikmuhs/ccache-action v1.2.18 — SHA-pin third-party actions
+        # hendrikmuhs/ccache-action v1.2.24 — SHA-pin third-party actions
         # so a hijacked tag can't run arbitrary code in our build matrix.
-        uses: hendrikmuhs/ccache-action@a1209f81afb8c005c13b4296c32e363431bffea5
+        uses: hendrikmuhs/ccache-action@f09c25b45002a07be2955cbe52e8cee55643f89d
         with:
           # Matrix is single-distro (arch only) so the ccache key is just
           # the kde toggle. Adding a second distro to the matrix above
@@ -184,10 +184,10 @@ jobs:
             libpipewire polkit-qt6 pam ddcutil
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@a1209f81afb8c005c13b4296c32e363431bffea5
+        uses: hendrikmuhs/ccache-action@f09c25b45002a07be2955cbe52e8cee55643f89d
         with:
           key: arch-shell
           max-size: 500M
@@ -274,7 +274,7 @@ jobs:
           clang-format --version
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           # Need the base commit to diff against. Shallow clone doesn't
           # have it; fetch the full history for the lint diff.
@@ -347,10 +347,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.x"
 
@@ -392,7 +392,7 @@ jobs:
           pacman -S --noconfirm --needed git cmake ninja gcc
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Build luau-analyze from vendored Luau
         run: |
@@ -469,10 +469,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Install Nix
-        uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72  # v31
+        uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24  # v31.11.1
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -572,7 +572,7 @@ jobs:
           echo "builder ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           # Full history so pkgver() can do `git rev-list --count HEAD`
           # and produce a sortable version.
@@ -837,9 +837,9 @@ jobs:
       - name: Post sticky PR comment with install instructions
         # Only for PR events — workflow_dispatch has no PR to comment on.
         if: github.event_name == 'pull_request'
-        # marocchino/sticky-pull-request-comment v3.0.4 — SHA-pinned for
+        # marocchino/sticky-pull-request-comment v3.0.5 — SHA-pinned for
         # the same supply-chain reason ccache-action is pinned above.
-        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88
         with:
           # `header` keys the sticky comment so re-runs update in place
           # instead of stacking new comments per build.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,7 +203,7 @@ jobs:
           apt_install_with_retry git ca-certificates dpkg-dev fakeroot
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ needs.version.outputs.ref }}
 
@@ -321,7 +321,7 @@ jobs:
         run: dnf install -y git rpm-build rpmdevtools
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ needs.version.outputs.ref }}
 
@@ -461,7 +461,7 @@ jobs:
           install_with_retry git rpm-build rpmdevtools
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ needs.version.outputs.ref }}
 
@@ -570,7 +570,7 @@ jobs:
           pacman -S --noconfirm git tar
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ needs.version.outputs.ref }}
 
@@ -660,7 +660,7 @@ jobs:
           echo "builder ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ needs.version.outputs.ref }}
 
@@ -766,13 +766,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ needs.version.outputs.ref }}
 
       - name: Install Nix
         # SHA-pinned to match ci.yml; bump together when verifying a new release.
-        uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72
+        uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -804,7 +804,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ needs.version.outputs.ref }}
           fetch-depth: 0
@@ -975,7 +975,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ needs.version.outputs.ref }}
 
@@ -1227,7 +1227,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ needs.version.outputs.ref }}
 

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -20,13 +20,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Install Nix
-        # cachix/install-nix-action v31 — pinned by SHA so a hijacked
+        # cachix/install-nix-action v31.11.1 — pinned by SHA so a hijacked
         # tag can't run arbitrary code in this workflow's write-scoped
         # context.
-        uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72
+        uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Why

A lot of jobs were reporting `Node.js 20 is deprecated`. Two actions were still on the node20 runtime and fired the warning on nearly every job:

- `hendrikmuhs/ccache-action` pinned to v1.2.18
- `actions/setup-python@v5`

## What changed

While auditing those, every action across all three workflows was checked against its latest release via the GitHub API and brought current.

| Action | Was | Now | Latest |
|---|---|---|---|
| actions/checkout | v6 | **v7** | v7.0.1 |
| actions/setup-python | v5 (node20) | **v7** | v7.0.0 |
| actions/upload-artifact | v7 | v7 | v7.0.1 |
| actions/download-artifact | v8 | v8 | v8.0.1 |
| hendrikmuhs/ccache-action | v1.2.18 (node20) | **v1.2.24** `f09c25b4` | v1.2.24 |
| cachix/install-nix-action | v30 `08dcb3a5` | **v31.11.1** `13d8dd58` | v31.11.1 |
| marocchino/sticky-pull-request-comment | v3.0.4 `0ea0beb6` | **v3.0.5** `5770ad5e` | v3.0.5 |
| DeterminateSystems/update-flake-lock | v28 `834c491b` | unchanged | v28 |

Third-party actions stay SHA-pinned, and each version comment was updated to match its new SHA. Major-tag pins on the first-party actions are left floating so patch releases self-update.

## Worth flagging

**The nix pin was mislabelled.** The comments in `ci.yml` and `update-flake-lock.yml` claimed v31, but `08dcb3a5` actually resolves to the **v30** tag. CI was therefore running a Nix predating two security advisories fixed in the v31 line: the Nix 2.29.1 privilege escalation, and the 2.30.1 fix for macOS builds running as root instead of the build users. The comments now match the SHA.

**`update-flake-lock` stays at v28**, which is the latest. It still calls five node20 actions internally (`ghaction-import-gpg`, `write-file-action`, `handlebars-action`, `read-file-action`, `create-pull-request`), so its deprecation warnings will persist. That is upstream's to fix and only affects the weekly cron.

## Verification

- All three workflow files parse as YAML.
- Every `using:` runtime was read from the pinned `action.yml` to confirm node24.
- Both v7 bumps are safe for our usage: the only breaking removal in setup-python v7 is the `pip-install` input, which we do not use. install-nix-action v30 to v31 keeps the `github_access_token` input we pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013p3sj9Vh7quM1hsjW3AEeS
