### PR TITLE
feat(cheatsheet): search the shortcut sheet, and keep each category whole

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- **The shortcut cheatsheet can be searched, and reads more clearly**: the sheet listed around ninety shortcuts across three dense columns with no way to look one up, so finding a key meant scanning the whole card. There is now a filter field at the top, focused as soon as the sheet opens, matching on action names, category names and the keys themselves, so typing "column width" or "meta alt" narrows the card as you go. The columns no longer cut a category in half and reprint its heading as "(continued)", which had left most headings pointing at the middle of a section. Each category is now kept whole with a heading that reads as one, the leading modifiers on each row are drawn lighter than the key they lead to so a row can be read by its last cap, and a category's unassigned actions collapse into a single line you can open. The sheet also says which placement mode it is filtered for, since it has always been filtered by the mode of the screen it opens on and never mentioned it, and it now says that Escape closes it.
+- **The shortcut cheatsheet can be filtered, and its categories are no longer split across columns**: the sheet listed every shortcut the current mode offers with no way to look one up, so finding a key meant reading the whole card. A filter field now sits at the top and takes focus as soon as the sheet opens. It matches on the action and category names as well as on the key sequences themselves, so typing "column width" or "meta alt" leaves the rows that answer at full contrast and dims the rest. The card keeps its size and its layout while you type, and a counter beside the field says how many rows answered out of the total. The columns no longer cut a category in half and reprint its heading as "(continued)", which had left most headings pointing at the middle of a section. Each category is now kept whole under one heading. The leading modifiers on a row are drawn lighter than the key they end on, so a row can be read by its last cap, and a category's unassigned actions collapse into one line you can open. The sheet also says which placement mode it is filtered for, since it has always been filtered by the mode of the screen it opens on and never mentioned it, and it now says that Escape closes it. ([#1059](https://github.com/fuddlesworth/PlasmaZones/pull/1059))
 
 ### Fixed
 
@@ -2162,7 +2162,8 @@ Initial packaged release. Wayland-only (X11 support removed). Requires KDE Plasm
 - Session restoration and rotation after login ([#66])
 - Window tracking: snap/restore behavior, zone clearing, startup timing, rotation zone ID matching, floating window exclusion ([#67])
 
-[Unreleased]: https://github.com/fuddlesworth/PlasmaZones/compare/v3.4.9...HEAD
+[Unreleased]: https://github.com/fuddlesworth/PlasmaZones/compare/v3.4.10...HEAD
+[3.4.10]: https://github.com/fuddlesworth/PlasmaZones/compare/v3.4.9...v3.4.10
 [3.4.9]: https://github.com/fuddlesworth/PlasmaZones/compare/v3.4.8...v3.4.9
 [3.4.8]: https://github.com/fuddlesworth/PlasmaZones/compare/v3.4.6...v3.4.8
 [3.4.6]: https://github.com/fuddlesworth/PlasmaZones/compare/v3.4.5...v3.4.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- **The shortcut cheatsheet can be searched, and reads more clearly**: the sheet listed around ninety shortcuts across three dense columns with no way to look one up, so finding a key meant scanning the whole card. There is now a filter field at the top, focused as soon as the sheet opens, matching on action names, category names and the keys themselves, so typing "column width" or "meta alt" narrows the card as you go. The columns no longer cut a category in half and reprint its heading as "(continued)", which had left most headings pointing at the middle of a section. Each category is now kept whole with a heading that reads as one, the leading modifiers on each row are drawn lighter than the key they lead to so a row can be read by its last cap, and a category's unassigned actions collapse into a single line you can open. The sheet also says which placement mode it is filtered for, since it has always been filtered by the mode of the screen it opens on and never mentioned it, and it now says that Escape closes it.
+
 ### Fixed
 
 - **Restoring a maximized window on a scrolling screen now plays the Released animation**: with a pack assigned to Released under Settings → Animations → Window Motion, clicking the restore button on a maximized window in scrolling mode played the Placed animation instead. The maximize button on a scrolling screen is answered by the scrolling engine rather than by KDE, and every placement that came back from it was treated as an arrival. A window handing its maximize state back is now treated as a release, so it animates on Released. A tiling algorithm such as monocle giving the screen back does the same. ([#1058](https://github.com/fuddlesworth/PlasmaZones/pull/1058))

--- a/libs/phosphor-overlay/README.md
+++ b/libs/phosphor-overlay/README.md
@@ -55,7 +55,7 @@ host.setPreDestroyCallback([&](const QString& sid) {
 // Lifecycle:
 host.registerConfigForRole(MyOsdRole, buildOsdConfig());
 host.ensureShell(screenId, physScreen);
-host.syncSurfaceState(screenId, /*anyVisible=*/true, /*anyInputGrabbing=*/false);
+host.syncSurfaceState(screenId, {.visible = true, .inputGrabbing = false, .keyboardGrabbing = false});
 host.hideSlot(screenId, QStringLiteral("osd"), [&]{ /* on hide-leg settle */ });
 host.destroyShell(screenId);
 ```
@@ -85,9 +85,15 @@ host.destroyShell(screenId);
   `SurfaceAnimator::beginHide` without the caller re-specifying the
   role at every dismiss / cancel call site.
 - **`syncSurfaceState` is mechanism-only.** Consumers compute
-  `anyVisible` and `anyInputGrabbing` from their content slot
+  `visible` and `inputGrabbing` from their content slot
   visibility (e.g. modal vs non-modal classification), and the library
   decides surface mapping + `Qt::WindowTransparentForInput` toggling.
+  A third field, `keyboardGrabbing`, drives the layer surface's keyboard
+  interactivity between Exclusive and None at runtime — only content that
+  has to read typed characters should ask for it, since while it is held
+  the focused toplevel receives no keys. It is per-screen with no
+  cross-screen arbitration, so a consumer moving such content between
+  screens must sync the screen it left as well as the one it entered.
 - **Sticky per-screen creation failure.** When the surface factory
   returns nullptr for a screen, the host flags it. Subsequent
   `ensureShell` calls short-circuit until `clearFailure(screenId)` is

--- a/libs/phosphor-overlay/include/PhosphorOverlay/ShellHost.h
+++ b/libs/phosphor-overlay/include/PhosphorOverlay/ShellHost.h
@@ -63,6 +63,15 @@ class PHOSPHOROVERLAY_EXPORT ShellHost : public QObject
     Q_OBJECT
 
 public:
+    /// What the consumer's live content wants from the shell surface on one
+    /// screen. See @ref syncSurfaceState for what each field drives.
+    struct SurfaceStateWants
+    {
+        bool visible = false;
+        bool inputGrabbing = false;
+        bool keyboardGrabbing = false;
+    };
+
     /// Consumer-provided factory for the per-screen layer-shell surface.
     /// The library does not know which Role / qmlSource / SurfaceManager
     /// the consumer wires through - the factory encapsulates all of
@@ -109,6 +118,12 @@ public:
     /// own a single instance and thread it through every consumer.
     void setSurfaceAnimator(PhosphorAnimationLayer::SurfaceAnimator* animator);
 
+    /// All methods on this class must be called on the GUI thread. It writes
+    /// QQuickWindow flags and masks and issues Wayland protocol requests
+    /// through the surface's transport, none of which is safe off-thread.
+    /// The constraint is an obligation on the consumer, not something the
+    /// class enforces or detects.
+    ///
     /// Idempotent: bring up (or return) the per-screen shell for
     /// @p screenId on @p physScreen. Returns a pointer to the ShellState
     /// on success. Returns nullptr when:
@@ -126,7 +141,16 @@ public:
     /// On the cached-live path (state exists and @c shellSurface() is
     /// non-null), the state's @c physScreen() is refreshed to the
     /// argument so callers that read it always see the most recent
-    /// @c ensureShell call's value.
+    /// @c ensureShell call's value, and @c shellWindow() is re-read from
+    /// @c Surface::window() alongside it.
+    ///
+    /// The PostCreateCallback runs with the state's mechanism fields already
+    /// populated, and its return value is the pointer this function hands
+    /// back. It may call @ref destroyShell for the same screen — the daemon
+    /// does exactly that to tear down a half-wired shell — in which case the
+    /// returned state is non-null with @c shellSurface() == nullptr. It must
+    /// NOT call @ref removeState or @ref rekey for that screen, since both
+    /// delete the object the caller is about to receive.
     ShellState* ensureShell(const QString& screenId, QScreen* physScreen);
 
     /// Tear down the shell for @p screenId. Fires the pre-destroy
@@ -139,7 +163,7 @@ public:
     /// Reconcile the shell's mapped state + pointer-input region with
     /// the consumer's view of what's live on this screen.
     ///
-    /// @p anyVisible - true when at least one slot wants the surface
+    /// @c wants.visible - true when at least one slot wants the surface
     /// mapped (driven by the consumer's slot-visibility check). Drives
     /// the Surface state machine in both directions: show() on
     /// false→true, hide() on true→false. The behavior of hide() is
@@ -152,23 +176,23 @@ public:
     /// to no-ops and do not interfere with per-slot animator state
     /// (which lives on different keys).
     ///
-    /// @p anyInputGrabbing - true when at least one modal slot
-    /// (consumer-defined; Phosphor today: snap-assist + layout picker) wants
-    /// pointer input. When false, OR when @p anyVisible is false, the shell's
+    /// @c wants.inputGrabbing - true when at least one modal slot
+    /// (consumer-defined; Phosphor today: snap-assist, layout picker and the
+    /// cheatsheet) wants pointer input. When false, OR when @p anyVisible is false, the shell's
     /// QQuickWindow is flagged Qt::WindowTransparentForInput so background
     /// windows stay interactable beneath non-modal slots (OSDs, main overlay,
-    /// zone selector during drag). The @p anyVisible term means this does not
+    /// zone selector during drag). The @c wants.visible term means this does not
     /// rest on the caller guaranteeing that a grabbing slot is a visible one:
     /// a grab with nothing visible would otherwise hand an unseen surface
     /// every click on the screen.
     ///
     /// Input is all-or-nothing for the whole shell surface: a visible modal
     /// grab takes every click the surface covers, and anything else leaves it
-    /// click-through. Every kbd-None slot shares one screen-sized surface, so
+    /// click-through. Every passive slot shares one screen-sized surface, so
     /// a slot wanting clicks only where it draws would need a sub-surface
     /// input region, which nothing asks for today.
     ///
-    /// @p anyKeyboardGrabbing - true when at least one slot needs to TYPE
+    /// @c wants.keyboardGrabbing - true when at least one slot needs to TYPE
     /// (consumer-defined; Phosphor today: the cheatsheet's search field).
     /// Drives the layer surface's keyboard interactivity between Exclusive
     /// and None at runtime, which wlr-layer-shell permits after the initial
@@ -185,11 +209,26 @@ public:
     /// drop the flag on the FIRST edge of dismissal rather than waiting for a
     /// hide animation to finish.
     ///
-    /// Gated on @p anyVisible for the same reason the input flag is: an
+    /// Gated on @c wants.visible for the same reason the input flag is: an
     /// invisible surface must never hold the session's keyboard.
     ///
-    /// No-op when the shell surface or window is not yet up.
-    void syncSurfaceState(const QString& screenId, bool anyVisible, bool anyInputGrabbing, bool anyKeyboardGrabbing);
+    /// Per-screen, with no cross-screen arbitration: this call reads and
+    /// writes one screen's state and nothing else. When the keyboard-grabbing
+    /// slot MOVES between screens, the consumer must call this for the screen
+    /// being LEFT as well as the one being entered. Syncing the new screen
+    /// does not release the old one, and two surfaces asking for an exclusive
+    /// keyboard at once is resolved by the compositor, not here.
+    ///
+    /// No-op when the shell surface or window is not yet up, and the keyboard
+    /// write is additionally skipped when the surface has not attached yet
+    /// (null transport handle) — harmless, since the role attaches kbd-None.
+    ///
+    /// Taken as a struct rather than three bools in a row: the three are
+    /// independent, same-typed, and a transposition would compile silently
+    /// while producing exactly the failure this doc block warns about (a
+    /// pointer-modal slot taking the keyboard from the focused window).
+    /// Designated initialisers at the call site name each one.
+    void syncSurfaceState(const QString& screenId, const SurfaceStateWants& wants);
 
     /// Move the ShellState entry from @p oldKey to @p newKey, preserving
     /// the underlying heap-allocated state object (the borrowed pointer
@@ -198,6 +237,17 @@ public:
     ///   - oldKey has no live shell (no entry or shellSurface is nullptr)
     ///   - newKey already has a LIVE entry (refuses to clobber); a stale
     ///     zeroed entry under newKey is dropped to make room.
+    ///
+    /// That drop DELETES the stale state object, so this is a third delete
+    /// site alongside the destructor and @ref removeState, and any borrowed
+    /// pointer to the newKey entry dies with it. No PreDestroyCallback fires
+    /// for it — the dropped entry is non-live by construction, and the
+    /// callback is gated on a live shell surface, so @ref removeState would
+    /// not fire one for the same entry either.
+    ///
+    /// On success the sticky creation-failure flag at newKey is cleared, since
+    /// a live shell now backs that key. oldKey's flag is deliberately left
+    /// alone.
     ///
     /// Same-key (`oldKey == newKey`) is idempotent success: returns true
     /// iff a live entry exists under that key. The entry is at newKey
@@ -232,9 +282,18 @@ public:
     ///     (clear loader mode, release content state, restore siblings)
     ///     runs in either case.
     ///
-    /// Completion is dropped only when the call is a programmer-setup
-    /// error: animator not injected, empty @p screenId, or empty
-    /// @p slotKey - none have a recovery path the consumer could take.
+    /// Completion is dropped when the call is a programmer-setup error:
+    /// animator not injected, empty @p screenId, or empty @p slotKey - none
+    /// have a recovery path the consumer could take.
+    ///
+    /// It is ALSO dropped when the hide leg is cancelled before it settles,
+    /// which the animator does per its own cancellation contract. Hiding the
+    /// shell surface cancels every leg on that surface, and so does destroying
+    /// it, so a @ref syncSurfaceState that unmaps the surface or a
+    /// @ref destroyShell landing while a slot hide is in flight will strand
+    /// whatever that completion was going to clean up. Consumers must not rely
+    /// on this completion as the only path that clears parallel per-screen
+    /// state across a teardown.
     void hideSlot(const QString& screenId, const QString& slotKey, std::function<void()> completion = {});
 
     /// Read-write accessor. Returns the existing ShellState for
@@ -285,8 +344,12 @@ private:
     /// stay valid across QHash rehashes (QHash holds @c ShellState* by
     /// value, but the pointed-to objects are stable). Consumers cache
     /// these pointers on parallel per-screen state and need them stable.
-    /// The host's destructor and @ref removeState delete the pointed-to
-    /// objects.
+    /// The host's destructor, @ref removeState, and @ref rekey (which drops a
+    /// stale entry standing at its target key) delete the pointed-to objects.
+    /// Those three are the whole list, and a consumer holding a borrowed
+    /// pointer must drop it at each of them; the host publishes no destroyed
+    /// signal, so the PreDestroyCallback and the consumer's own call site are
+    /// the only notifications.
     ///
     /// @c std::unique_ptr cannot live in @c QHash (Qt 6's hash requires
     /// copy-constructible values), and @c std::shared_ptr would add

--- a/libs/phosphor-overlay/include/PhosphorOverlay/ShellHost.h
+++ b/libs/phosphor-overlay/include/PhosphorOverlay/ShellHost.h
@@ -168,8 +168,28 @@ public:
     /// a slot wanting clicks only where it draws would need a sub-surface
     /// input region, which nothing asks for today.
     ///
+    /// @p anyKeyboardGrabbing - true when at least one slot needs to TYPE
+    /// (consumer-defined; Phosphor today: the cheatsheet's search field).
+    /// Drives the layer surface's keyboard interactivity between Exclusive
+    /// and None at runtime, which wlr-layer-shell permits after the initial
+    /// configure. Separate from @p anyInputGrabbing because the two are
+    /// genuinely different asks: snap-assist and the layout picker are modal
+    /// for the pointer but must NOT take the keyboard away from the focused
+    /// toplevel, since they are driven entirely by global shortcuts the
+    /// compositor routes before any surface sees them.
+    ///
+    /// Exclusive rather than OnDemand: a slot that wants the keyboard was
+    /// opened by an explicit user gesture and expects to receive the next
+    /// keystroke, not to be clicked into first. The cost is that the focused
+    /// window stops receiving keys for the slot's lifetime, so consumers must
+    /// drop the flag on the FIRST edge of dismissal rather than waiting for a
+    /// hide animation to finish.
+    ///
+    /// Gated on @p anyVisible for the same reason the input flag is: an
+    /// invisible surface must never hold the session's keyboard.
+    ///
     /// No-op when the shell surface or window is not yet up.
-    void syncSurfaceState(const QString& screenId, bool anyVisible, bool anyInputGrabbing);
+    void syncSurfaceState(const QString& screenId, bool anyVisible, bool anyInputGrabbing, bool anyKeyboardGrabbing);
 
     /// Move the ShellState entry from @p oldKey to @p newKey, preserving
     /// the underlying heap-allocated state object (the borrowed pointer

--- a/libs/phosphor-overlay/include/PhosphorOverlay/ShellHost.h
+++ b/libs/phosphor-overlay/include/PhosphorOverlay/ShellHost.h
@@ -178,7 +178,7 @@ public:
     ///
     /// @c wants.inputGrabbing - true when at least one modal slot
     /// (consumer-defined; Phosphor today: snap-assist, layout picker and the
-    /// cheatsheet) wants pointer input. When false, OR when @p anyVisible is false, the shell's
+    /// cheatsheet) wants pointer input. When false, OR when @c wants.visible is false, the shell's
     /// QQuickWindow is flagged Qt::WindowTransparentForInput so background
     /// windows stay interactable beneath non-modal slots (OSDs, main overlay,
     /// zone selector during drag). The @c wants.visible term means this does not
@@ -196,7 +196,7 @@ public:
     /// (consumer-defined; Phosphor today: the cheatsheet's search field).
     /// Drives the layer surface's keyboard interactivity between Exclusive
     /// and None at runtime, which wlr-layer-shell permits after the initial
-    /// configure. Separate from @p anyInputGrabbing because the two are
+    /// configure. Separate from @c wants.inputGrabbing because the two are
     /// genuinely different asks: snap-assist and the layout picker are modal
     /// for the pointer but must NOT take the keyboard away from the focused
     /// toplevel, since they are driven entirely by global shortcuts the

--- a/libs/phosphor-overlay/include/PhosphorOverlay/ShellState.h
+++ b/libs/phosphor-overlay/include/PhosphorOverlay/ShellState.h
@@ -64,9 +64,11 @@ public:
         return m_shellSurface;
     }
 
-    /// The QQuickWindow hosting the shell's QML scene tree. Cached at
-    /// create-time to avoid repeated `shellSurface->window()` calls in
-    /// the hot per-show path.
+    /// The QQuickWindow hosting the shell's QML scene tree. Cached to avoid
+    /// repeated `shellSurface->window()` calls in the hot per-show path. Set
+    /// at create-time and re-read from the surface on every cached-live
+    /// `ShellHost::ensureShell`, so a future Surface that swapped its window
+    /// across a transport reattach would not strand a stale one here.
     QQuickWindow* shellWindow() const
     {
         return m_shellWindow;
@@ -93,6 +95,11 @@ public:
 
 private:
     friend class ShellHost;
+    /// Raw, not QPointer, and the host nulls them explicitly in
+    /// `ShellHost::destroyShell`. That is the whole ownership story, so the
+    /// consumer owes the host one rule: a Surface handed to the SurfaceFactory
+    /// must not be destroyed behind the host's back. Route every teardown
+    /// through destroyShell / removeState, and the fields can never be stale.
     PhosphorLayer::Surface* m_shellSurface = nullptr;
     QQuickWindow* m_shellWindow = nullptr;
     QScreen* m_physScreen = nullptr;

--- a/libs/phosphor-overlay/src/shellhost.cpp
+++ b/libs/phosphor-overlay/src/shellhost.cpp
@@ -4,6 +4,7 @@
 #include <PhosphorOverlay/ShellHost.h>
 
 #include <PhosphorAnimation/SurfaceAnimator.h>
+#include <PhosphorLayer/ILayerShellTransport.h>
 #include <PhosphorLayer/Surface.h>
 
 #include <QChar>
@@ -164,7 +165,8 @@ void ShellHost::destroyShell(const QString& screenId)
     state->slots.clear();
 }
 
-void ShellHost::syncSurfaceState(const QString& screenId, bool anyVisible, bool anyInputGrabbing)
+void ShellHost::syncSurfaceState(const QString& screenId, bool anyVisible, bool anyInputGrabbing,
+                                 bool anyKeyboardGrabbing)
 {
     auto it = m_states.find(screenId);
     if (it == m_states.end() || !it.value()->m_shellSurface || !it.value()->m_shellWindow) {
@@ -238,6 +240,25 @@ void ShellHost::syncSurfaceState(const QString& screenId, bool anyVisible, bool 
     // place with the flag. Every caller is on a structural edge (slot show,
     // hide completion, screen add/remove), never a paint path.
     s.m_shellWindow->setMask(QRegion());
+
+    // Keyboard interactivity is a separate axis from the pointer flag above:
+    // the picker and snap assist are pointer-modal but deliberately leave the
+    // keyboard with the focused toplevel, because every key they answer to is
+    // a global shortcut the compositor routes before any surface sees it. Only
+    // a slot that has to TYPE asks for this, and while it holds it the user's
+    // focused window receives nothing.
+    //
+    // Runtime set_keyboard_interactivity is legal on wlr-layer-shell after the
+    // initial configure (unlike the scope, which is immutable), so this rides
+    // the same structural edges as the input flag rather than needing a
+    // surface rebuild. The transport handle is null until the surface has
+    // attached; a pre-attach call would be dropped, and the role's own
+    // KeyboardInteractivity::None is the correct value to attach with anyway.
+    if (auto* handle = s.m_shellSurface->transport()) {
+        const auto wantKeyboard = (anyVisible && anyKeyboardGrabbing) ? PhosphorLayer::KeyboardInteractivity::Exclusive
+                                                                      : PhosphorLayer::KeyboardInteractivity::None;
+        handle->setKeyboardInteractivity(wantKeyboard);
+    }
 }
 
 bool ShellHost::rekey(const QString& oldKey, const QString& newKey)

--- a/libs/phosphor-overlay/src/shellhost.cpp
+++ b/libs/phosphor-overlay/src/shellhost.cpp
@@ -119,7 +119,14 @@ ShellState* ShellHost::ensureShell(const QString& screenId, QScreen* physScreen)
     PhosphorLayer::Surface* surface = m_surfaceFactory(screenId, physScreen);
     if (!surface) {
         m_creationFailed.insert(screenId);
-        return nullptr;
+        // Same answer as the sticky short-circuit above: hand back the
+        // existing zeroed state when there is one, so a caller that already
+        // holds the pointer does not see it vanish for exactly one call and
+        // reappear on the next. Re-find rather than reusing the iterator from
+        // the top of the function - the factory ran in between, and anything
+        // it re-enters could have rehashed m_states.
+        const auto after = m_states.find(screenId);
+        return (after == m_states.end()) ? nullptr : after.value();
     }
 
     auto* state = ensureEntry(m_states, screenId);
@@ -157,6 +164,16 @@ void ShellHost::destroyShell(const QString& screenId)
     }
 
     if (state->m_shellSurface) {
+        // Hand the keyboard back before the teardown rather than relying on
+        // the surface's destruction to do it. deleteLater defers the actual
+        // destroy to the next event-loop pass, and until then the compositor
+        // still has an exclusive grab pointed at a surface that is on its way
+        // out. Ordering the release here makes the hand-back deterministic
+        // instead of a side effect of when the loop next turns. Null handle
+        // means the surface never attached, so there is nothing to release.
+        if (auto* handle = state->m_shellSurface->transport()) {
+            handle->setKeyboardInteractivity(PhosphorLayer::KeyboardInteractivity::None);
+        }
         state->m_shellSurface->deleteLater();
     }
     state->m_shellSurface = nullptr;
@@ -165,8 +182,7 @@ void ShellHost::destroyShell(const QString& screenId)
     state->slots.clear();
 }
 
-void ShellHost::syncSurfaceState(const QString& screenId, bool anyVisible, bool anyInputGrabbing,
-                                 bool anyKeyboardGrabbing)
+void ShellHost::syncSurfaceState(const QString& screenId, const SurfaceStateWants& wants)
 {
     auto it = m_states.find(screenId);
     if (it == m_states.end() || !it.value()->m_shellSurface || !it.value()->m_shellWindow) {
@@ -175,7 +191,7 @@ void ShellHost::syncSurfaceState(const QString& screenId, bool anyVisible, bool 
     auto& s = *it.value();
 
     // Show/hide are driven through the Surface state machine on every
-    // anyVisible transition. The behavior in each direction depends on
+    // wants.visible transition. The behavior in each direction depends on
     // the SurfaceConfig the consumer registered:
     //
     //   show()  - maps the wl_surface, warms the RHI, fires the
@@ -201,9 +217,9 @@ void ShellHost::syncSurfaceState(const QString& screenId, bool anyVisible, bool 
     // (modal slot in / out) - this keeps non-modal slot dismissals
     // from re-entering the surface state machine for a pure
     // click-through change.
-    if (anyVisible && !s.m_shellSurface->isLogicallyShown()) {
+    if (wants.visible && !s.m_shellSurface->isLogicallyShown()) {
         s.m_shellSurface->show();
-    } else if (!anyVisible && s.m_shellSurface->isLogicallyShown()) {
+    } else if (!wants.visible && s.m_shellSurface->isLogicallyShown()) {
         s.m_shellSurface->hide();
     }
 
@@ -219,12 +235,12 @@ void ShellHost::syncSurfaceState(const QString& screenId, bool anyVisible, bool 
     //   visible modal up -> whole surface takes input (no mask).
     //   anything else    -> click-through.
     //
-    // The grab term is spelled `anyVisible && anyInputGrabbing` rather than
-    // bare `anyInputGrabbing` so the derivation does not rest on callers
+    // The grab term is spelled `wants.visible && wants.inputGrabbing` rather
+    // than bare `wants.inputGrabbing` so the derivation does not rest on callers
     // guaranteeing that a grabbing slot is also a visible one. Nothing in this
     // library enforces that, and if it were ever false the bare form would hand
     // an invisible surface the whole screen's clicks.
-    const bool wantTransparent = !(anyVisible && anyInputGrabbing);
+    const bool wantTransparent = !(wants.visible && wants.inputGrabbing);
     if (s.m_shellWindow->flags().testFlag(Qt::WindowTransparentForInput) != wantTransparent) {
         s.m_shellWindow->setFlag(Qt::WindowTransparentForInput, wantTransparent);
     }
@@ -241,12 +257,12 @@ void ShellHost::syncSurfaceState(const QString& screenId, bool anyVisible, bool 
     // hide completion, screen add/remove), never a paint path.
     s.m_shellWindow->setMask(QRegion());
 
-    // Keyboard interactivity is a separate axis from the pointer flag above:
-    // the picker and snap assist are pointer-modal but deliberately leave the
-    // keyboard with the focused toplevel, because every key they answer to is
-    // a global shortcut the compositor routes before any surface sees it. Only
-    // a slot that has to TYPE asks for this, and while it holds it the user's
-    // focused window receives nothing.
+    // Keyboard interactivity is a separate axis from the pointer flag above.
+    // All three modal slots are pointer-modal, but the picker and snap assist
+    // deliberately leave the keyboard with the focused toplevel, because every
+    // key they answer to is a global shortcut the compositor routes before any
+    // surface sees it. Only a slot that has to TYPE asks for this, and while
+    // it holds it the user's focused window receives nothing.
     //
     // Runtime set_keyboard_interactivity is legal on wlr-layer-shell after the
     // initial configure (unlike the scope, which is immutable), so this rides
@@ -255,8 +271,9 @@ void ShellHost::syncSurfaceState(const QString& screenId, bool anyVisible, bool 
     // attached; a pre-attach call would be dropped, and the role's own
     // KeyboardInteractivity::None is the correct value to attach with anyway.
     if (auto* handle = s.m_shellSurface->transport()) {
-        const auto wantKeyboard = (anyVisible && anyKeyboardGrabbing) ? PhosphorLayer::KeyboardInteractivity::Exclusive
-                                                                      : PhosphorLayer::KeyboardInteractivity::None;
+        const auto wantKeyboard = (wants.visible && wants.keyboardGrabbing)
+            ? PhosphorLayer::KeyboardInteractivity::Exclusive
+            : PhosphorLayer::KeyboardInteractivity::None;
         handle->setKeyboardInteractivity(wantKeyboard);
     }
 }
@@ -400,6 +417,13 @@ void ShellHost::removeState(const QString& screenId)
     }
     delete it.value();
     m_states.erase(it);
+    // The sticky failure flag exists to stop ensureShell retrying while a
+    // state object stands for that screen. With the entry gone there is
+    // nothing left for it to guard, and a leftover flag would short-circuit
+    // the next ensureShell for a key that has no state at all. Consumers
+    // sweeping by their own id grammar (clearFailure) still work; this just
+    // means removeState no longer depends on them doing it.
+    m_creationFailed.remove(screenId);
 }
 
 QStringList ShellHost::screenIds() const

--- a/libs/phosphor-overlay/src/shellhost.cpp
+++ b/libs/phosphor-overlay/src/shellhost.cpp
@@ -97,6 +97,13 @@ ShellState* ShellHost::ensureShell(const QString& screenId, QScreen* physScreen)
         // holds today, but re-reading is cheap insurance against
         // future Surface internals that could swap the window across
         // a transport reattach.
+        //
+        // Note this refreshes what the state REPORTS, not where the surface
+        // actually sits: the layer surface's output and its baked anchors were
+        // fixed at attach time. A consumer reading physScreen() to decide
+        // which monitor a shell belongs to is reading the most recent claim,
+        // which is only the truth because every path that genuinely moves a
+        // shell between monitors destroys and recreates it.
         it.value()->m_physScreen = physScreen;
         it.value()->m_shellWindow = it.value()->m_shellSurface->window();
         return it.value();
@@ -267,9 +274,11 @@ void ShellHost::syncSurfaceState(const QString& screenId, const SurfaceStateWant
     // Runtime set_keyboard_interactivity is legal on wlr-layer-shell after the
     // initial configure (unlike the scope, which is immutable), so this rides
     // the same structural edges as the input flag rather than needing a
-    // surface rebuild. The transport handle is null until the surface has
-    // attached; a pre-attach call would be dropped, and the role's own
-    // KeyboardInteractivity::None is the correct value to attach with anyway.
+    // surface rebuild. The transport handle is null in two cases, and the
+    // no-op is right for both: before the surface has attached, where the
+    // role's own KeyboardInteractivity::None is the correct value to attach
+    // with anyway, and after it has detached, where there is no compositor-
+    // side grab left to release.
     if (auto* handle = s.m_shellSurface->transport()) {
         const auto wantKeyboard = (wants.visible && wants.keyboardGrabbing)
             ? PhosphorLayer::KeyboardInteractivity::Exclusive

--- a/libs/phosphor-overlay/tests/CMakeLists.txt
+++ b/libs/phosphor-overlay/tests/CMakeLists.txt
@@ -12,6 +12,13 @@ add_executable(test_overlay_smoke
     test_overlay_smoke.cpp
 )
 
+# Reuse the in-tree phosphor-layer test mocks, so the syncSurfaceState cases
+# can drive a real PhosphorLayer::Surface over a recording transport instead
+# of needing a live Wayland connection.
+target_include_directories(test_overlay_smoke
+    PRIVATE ${CMAKE_SOURCE_DIR}/libs/phosphor-layer/tests
+)
+
 target_link_libraries(test_overlay_smoke
     PRIVATE
         PhosphorOverlay::PhosphorOverlay

--- a/libs/phosphor-overlay/tests/test_overlay_smoke.cpp
+++ b/libs/phosphor-overlay/tests/test_overlay_smoke.cpp
@@ -13,19 +13,27 @@
 //   - rekey happy path migrates the entry across keys, preserving the
 //     heap-allocated ShellState* so borrowed pointers stay valid.
 //
-// Tests that need a live shellSurface are deferred - the lib's
-// SurfaceFactory contract requires a real PhosphorLayer::Surface, which
-// in turn needs a Wayland transport. These tests focus on the lib-side
-// state-machine paths that don't depend on a live surface.
+// Most cases here need no live shellSurface and cover the lib-side
+// state-machine paths that do not depend on one. The syncSurfaceState
+// keyboard cases DO need a live surface, and get one from phosphor-layer's
+// in-tree MockTransport rather than a real Wayland connection.
 
 #include <PhosphorOverlay/PhosphorOverlay.h>
 
 #include <PhosphorAnimation/PhosphorProfileRegistry.h>
 #include <PhosphorAnimation/SurfaceAnimator.h>
 #include <PhosphorLayer/Role.h>
+#include <PhosphorLayer/Surface.h>
+#include <PhosphorLayer/SurfaceConfig.h>
+#include <PhosphorLayer/SurfaceFactory.h>
 #include <PhosphorShellPatterns/Patterns.h>
 
+#include "mocks/mockscreenprovider.h"
+#include "mocks/mocktransport.h"
+#include "mocks/testroles.h"
+
 #include <QObject>
+#include <QQuickItem>
 #include <QString>
 #include <QStringLiteral>
 #include <QtTest/QtTest>
@@ -64,6 +72,9 @@ private Q_SLOTS:
 
     void makePerInstanceRoleAppendsScreenAndGenerationToScope();
     void registerConfigForRoleIsNoOpWithoutAnimator();
+
+    // syncSurfaceState keyboard axis, over a mock-transport-backed surface
+    void syncSurfaceStateDrivesKeyboardInteractivity();
 };
 
 void TestOverlaySmoke::shellHostConstructsAndDestructs()
@@ -301,6 +312,85 @@ void TestOverlaySmoke::registerConfigForRoleIsNoOpWithoutAnimator()
     // without injection get nothing rather than a crash.
     const auto role = PhosphorShellPatterns::Hud().withScopePrefix(QStringLiteral("phosphor-overlay-test"));
     host.registerConfigForRole(role, {});
+}
+
+// The keyboard axis fails SILENTLY in production in both directions: a grab
+// that never lands means the content simply never receives a keystroke, and
+// one that never releases means the user's focused window stops receiving
+// them. Neither raises an error or a log line, so nothing but a test notices.
+//
+// Two traps are load-bearing in how this is written:
+//
+//  - The factory MUST hand back a warmed surface. Surface::window() is null in
+//    State::Constructed, and syncSurfaceState early-returns on a null window,
+//    so a freshly-created surface would exercise nothing while every
+//    assertion below still passed.
+//  - MockTransportHandle::m_keyboard starts at None and attach() never seeds
+//    it, so an "expect None" assertion passes vacuously against a ShellHost
+//    whose keyboard block was deleted outright. Every None case here is
+//    therefore preceded by a transition to Exclusive, and asserts the change.
+void TestOverlaySmoke::syncSurfaceStateDrivesKeyboardInteractivity()
+{
+    using namespace PhosphorLayer;
+
+    // Declared before the host so the host is destroyed first: ~ShellHost runs
+    // destroyShell over every key, which touches the surface and its transport.
+    Testing::MockTransport transport;
+    Testing::MockScreenProvider screens;
+    SurfaceFactory factory(Testing::makeDeps(&transport, &screens));
+
+    PhosphorOverlay::ShellHost host;
+    const QString screenId = QStringLiteral("screen-0");
+
+    host.setSurfaceFactory([&](const QString&, QScreen* physScreen) -> Surface* {
+        SurfaceConfig cfg;
+        // Hud rather than Modal: it attaches kbd-None, matching the passive
+        // shell role this axis exists to flip at runtime.
+        cfg.role = Testing::makeHudRole();
+        // Inline content settles the state machine synchronously in one drive
+        // pass, so nothing here needs an event loop or a QTRY_.
+        cfg.contentItem = std::make_unique<QQuickItem>();
+        cfg.screen = physScreen;
+        cfg.debugName = QStringLiteral("kbd-axis");
+        auto* surface = factory.create(std::move(cfg));
+        // The attach is what gives the surface a window and a transport
+        // handle, and syncSurfaceState needs both.
+        surface->warmUp();
+        return surface;
+    });
+
+    auto* state = host.ensureShell(screenId, screens.primary());
+    QVERIFY(state != nullptr);
+    // Guard the trap rather than trusting it: without these, every assertion
+    // below would pass against a surface that never reached the write.
+    QVERIFY(state->shellWindow() != nullptr);
+    QVERIFY(state->shellSurface() != nullptr);
+    auto* handle = state->shellSurface()->transport();
+    QVERIFY(handle != nullptr);
+
+    // Visible and asking to type: the one combination that takes the keyboard.
+    host.syncSurfaceState(screenId, {.visible = true, .inputGrabbing = false, .keyboardGrabbing = true});
+    QCOMPARE(transport.m_lastHandle->m_keyboard, KeyboardInteractivity::Exclusive);
+
+    // The release edge the daemon depends on. The slot stays visible for its
+    // whole fade-out, so the flag dropping - not the slot hiding - is what has
+    // to hand the keyboard back.
+    host.syncSurfaceState(screenId, {.visible = true, .inputGrabbing = false, .keyboardGrabbing = false});
+    QCOMPARE(transport.m_lastHandle->m_keyboard, KeyboardInteractivity::None);
+
+    // Asking to type while nothing is visible must not hold the session's
+    // keyboard on an unseen surface.
+    host.syncSurfaceState(screenId, {.visible = true, .inputGrabbing = false, .keyboardGrabbing = true});
+    QCOMPARE(transport.m_lastHandle->m_keyboard, KeyboardInteractivity::Exclusive);
+    host.syncSurfaceState(screenId, {.visible = false, .inputGrabbing = false, .keyboardGrabbing = true});
+    QCOMPARE(transport.m_lastHandle->m_keyboard, KeyboardInteractivity::None);
+
+    // Teardown hands the keyboard back before the surface goes, rather than
+    // leaving the grab live until the event loop next turns.
+    host.syncSurfaceState(screenId, {.visible = true, .inputGrabbing = false, .keyboardGrabbing = true});
+    QCOMPARE(transport.m_lastHandle->m_keyboard, KeyboardInteractivity::Exclusive);
+    host.destroyShell(screenId);
+    QCOMPARE(transport.m_lastHandle->m_keyboard, KeyboardInteractivity::None);
 }
 
 QTEST_MAIN(TestOverlaySmoke)

--- a/src/daemon/overlayservice.h
+++ b/src/daemon/overlayservice.h
@@ -1422,8 +1422,17 @@ private:
     /// Hidden after first show, and the input region eats every click
     /// for the daemon's lifetime.
     ///
-    /// Called after every slot setVisible toggle. Idempotent:
-    /// isLogicallyShown() guards re-show; the all-slots-hidden
+    /// It also drives the surface's layer-shell keyboard interactivity, and
+    /// that third predicate is NOT derived from slot visibility. It reads
+    /// m_cheatsheetVisible and m_cheatsheetScreenId, because the grab has to
+    /// be released on the first edge of dismissal while the slot itself stays
+    /// visible for the whole fade-out. Any caller that changes whether the
+    /// cheatsheet is up must therefore set those two members BEFORE calling
+    /// this, or the sync computes the pre-change answer.
+    ///
+    /// Called after every slot setVisible toggle, and additionally on the
+    /// dismissal edge described above, which is not a setVisible toggle.
+    /// Idempotent: isLogicallyShown() guards re-show; the all-slots-hidden
     /// predicate guards the hide.
     void syncPassiveShellSurfaceState(const QString& effectiveId);
 

--- a/src/daemon/overlayservice/animation_config.cpp
+++ b/src/daemon/overlayservice/animation_config.cpp
@@ -368,6 +368,14 @@ void OverlayService::setupSurfaceAnimator(PhosphorAnimation::PhosphorProfileRegi
     //     animation-profile taxonomy defines no domain for it, so the library
     //     default is the intended motion for both legs, and the role doc
     //     points back at this list.
+    // Drop the host's borrowed pointer before the assignment below destroys
+    // the animator it points at. Assigning through the unique_ptr would leave
+    // ShellHost::m_surfaceAnimator dangling for the span between the two
+    // statements. Nothing calls into the host there today, and this runs once
+    // from the ctor, but the window costs nothing to close.
+    if (m_shellHost) {
+        m_shellHost->setSurfaceAnimator(nullptr);
+    }
     m_surfaceAnimator = std::make_unique<PAL::SurfaceAnimator>(profileRegistry, buildDefaultConfig());
     if (m_animShaderRegistry) {
         m_surfaceAnimator->setAnimationShaderRegistry(m_animShaderRegistry);

--- a/src/daemon/overlayservice/cheatsheet.cpp
+++ b/src/daemon/overlayservice/cheatsheet.cpp
@@ -252,6 +252,14 @@ void OverlayService::onCheatsheetSlotHideCompleted(const QString& effectiveId)
     // applyDecoration again, which rewrites it.
     writeQmlProperty(it->cheatsheetSlot(), QStringLiteral("backdropTexture"), QVariant());
     syncPassiveShellSurfaceState(effectiveId);
+    // Symmetric with every other modal's hide completion (snap assist, the
+    // picker, the OSD): the zone selector suppresses its restore while an
+    // input-grabbing modal owns the screen, so whichever modal was owning it
+    // has to hand the screen back on its way out. The sheet cannot currently
+    // be up during a drag, so this restores nothing today; leaving it out
+    // would make the selector's guard depend on that suppression holding
+    // forever, in a different file.
+    restoreZoneSelectorAfterHide(effectiveId);
 }
 
 void OverlayService::onCheatsheetDismissRequested()

--- a/src/daemon/overlayservice/cheatsheet.cpp
+++ b/src/daemon/overlayservice/cheatsheet.cpp
@@ -1,13 +1,14 @@
 // SPDX-FileCopyrightText: 2026 fuddlesworth
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-// Shortcut cheatsheet overlay — a display-only reference card listing the
-// user's global shortcuts, grouped by category and filtered by the tiling
-// mode of the screen it opens on. Structural twin of the layout picker
-// (singleton passive-shell slot, animator-driven show/hide, dedicated
-// Escape ad-hoc grab wired daemon-side); diverges only in being
-// non-interactive and in taking its content pushed in by the daemon
-// (catalog + mode) rather than resolving it here.
+// Shortcut cheatsheet overlay — a reference card listing the user's global
+// shortcuts, grouped by category and filtered by the tiling mode of the screen
+// it opens on, with a filter field for looking one up. Structural twin of the
+// layout picker (singleton passive-shell slot, animator-driven show/hide,
+// dedicated Escape ad-hoc grab wired daemon-side). It diverges in taking its
+// content pushed in by the daemon (catalog + mode) rather than resolving it
+// here, and in being the one slot that asks the shared passive shell for the
+// keyboard, so its search field can receive typed characters.
 
 #include "internal.h"
 #include "daemon/overlayservice.h"
@@ -40,9 +41,15 @@ void OverlayService::showCheatsheet(const QString& screenId, const QVariantList&
 
     // Same-screen re-request while visible is a no-op (the daemon's toggle
     // handler flips to hideCheatsheet before calling us, so this only
-    // triggers for redundant programmatic calls); a DIFFERENT screen
-    // migrates the sheet there, mirroring the picker's cross-screen
-    // singleton handling.
+    // triggers for redundant programmatic calls). A DIFFERENT screen migrates
+    // the sheet there, mirroring the picker's cross-screen singleton handling.
+    //
+    // The migration arm is defensive rather than live: the sheet's only entry
+    // point is the toggle, which hides and returns when the sheet is already
+    // up, and showCheatsheet is on neither IOverlayService nor D-Bus. So
+    // m_cheatsheetVisible is false here today. It is kept correct, rather than
+    // dropped, because the singleton invariant is the picker's too and a
+    // second caller would arrive without it.
     if (m_cheatsheetVisible && m_cheatsheetScreenId == resolvedId) {
         return;
     }
@@ -63,12 +70,27 @@ void OverlayService::showCheatsheet(const QString& screenId, const QVariantList&
         return;
     }
 
+    // Latch the singleton state here, ahead of both the previous-screen hide
+    // and the content pushes, exactly as showLayoutPicker does. Two reasons,
+    // and neither is about this function's own reads. The lib's hideSlot runs
+    // its completion inline on every benign-no-op branch, so the handler can
+    // re-enter while we are still mid-show; and OverlayService is a QML context
+    // property, so a binding evaluated during a push can reach back in. Both
+    // must observe the sheet as visible-on-the-new-screen, or their hide takes
+    // the idempotent branch and the sheet ends up shown with nothing recording
+    // it. The keyboard predicate reads these two members too (see
+    // shellhost_bridge.cpp) — it has to, because releasing on the first edge of
+    // dismissal means it cannot key on a slot that stays visible for the whole
+    // fade-out — so they are also set before the sync at the end.
+    const QString prevScreenId = m_cheatsheetVisible ? m_cheatsheetScreenId : QString();
+    m_cheatsheetScreenId = resolvedId;
+    m_cheatsheetVisible = true;
+
     // Singleton across screens: with the new target validated, dismiss on
     // the previous screen before showing here. Animator-driven hideSlot
     // keys only the cheatsheet track, so sibling slots on the previous
     // shell keep animating cleanly.
-    if (m_cheatsheetVisible && !m_cheatsheetScreenId.isEmpty() && m_cheatsheetScreenId != resolvedId) {
-        const QString prevScreenId = m_cheatsheetScreenId;
+    if (!prevScreenId.isEmpty() && prevScreenId != resolvedId) {
         auto prevIt = m_screenStates.find(prevScreenId);
         if (prevIt != m_screenStates.end() && prevIt->shell && prevIt->shell->shellSurface()
             && prevIt->cheatsheetSlot()) {
@@ -76,6 +98,15 @@ void OverlayService::showCheatsheet(const QString& screenId, const QVariantList&
                 onCheatsheetSlotHideCompleted(prevScreenId);
             });
         }
+        // Drop the previous surface's keyboard grab on this edge rather than
+        // waiting for its fade to finish. The slot stays visible for the whole
+        // hide animation, so deferring to the completion would leave two layer
+        // surfaces asking for an exclusive keyboard at once, which is the
+        // arrangement the release-on-first-edge rule exists to prevent. Safe
+        // to run after the latch: the predicate compares the cheatsheet's
+        // screen id against the id being synced, and that is now the new
+        // screen, so the previous one correctly computes kbd-None.
+        syncPassiveShellSurfaceState(prevScreenId);
     }
 
     auto* slot = state->cheatsheetSlot();
@@ -113,17 +144,9 @@ void OverlayService::showCheatsheet(const QString& screenId, const QVariantList&
     slot->setVisible(true);
     m_surfaceAnimator->beginShow(shellSurface, slot, PhosphorRoles::Cheatsheet, []() { });
 
-    // Set BEFORE the sync, not after. The pointer-input predicate reads the
-    // slot's own visibility, which is already true above, but the keyboard
-    // predicate reads these two members (see shellhost_bridge.cpp) — it has to,
-    // because releasing on the first edge of dismissal means it cannot key on a
-    // slot that stays visible for the whole fade-out. Syncing first would
-    // compute kbd-None and the search field would never receive a keystroke.
-    m_cheatsheetScreenId = resolvedId;
-    m_cheatsheetVisible = true;
-
     // Modal — needs input for the backdrop click-to-dismiss, and the keyboard
-    // for the search field.
+    // for the search field. The singleton state was latched above, before the
+    // pushes, so the keyboard predicate reads the new screen here.
     syncPassiveShellSurfaceStateForSurface(shellSurface);
 
     qCInfo(lcOverlay) << "showCheatsheet: screen=" << resolvedId << "rows=" << model.size() << "mode=" << currentMode;

--- a/src/daemon/overlayservice/cheatsheet.cpp
+++ b/src/daemon/overlayservice/cheatsheet.cpp
@@ -112,11 +112,19 @@ void OverlayService::showCheatsheet(const QString& screenId, const QVariantList&
     }
     slot->setVisible(true);
     m_surfaceAnimator->beginShow(shellSurface, slot, PhosphorRoles::Cheatsheet, []() { });
-    // Modal — needs input for the backdrop click-to-dismiss.
-    syncPassiveShellSurfaceStateForSurface(shellSurface);
 
+    // Set BEFORE the sync, not after. The pointer-input predicate reads the
+    // slot's own visibility, which is already true above, but the keyboard
+    // predicate reads these two members (see shellhost_bridge.cpp) — it has to,
+    // because releasing on the first edge of dismissal means it cannot key on a
+    // slot that stays visible for the whole fade-out. Syncing first would
+    // compute kbd-None and the search field would never receive a keystroke.
     m_cheatsheetScreenId = resolvedId;
     m_cheatsheetVisible = true;
+
+    // Modal — needs input for the backdrop click-to-dismiss, and the keyboard
+    // for the search field.
+    syncPassiveShellSurfaceStateForSurface(shellSurface);
 
     qCInfo(lcOverlay) << "showCheatsheet: screen=" << resolvedId << "rows=" << model.size() << "mode=" << currentMode;
 }
@@ -139,6 +147,15 @@ void OverlayService::hideCheatsheet()
     // completion" regardless of whether the completion runs synchronously
     // or asynchronously — same ordering contract as the picker.
     Q_EMIT cheatsheetDismissed();
+
+    // Hand the keyboard back now, not when the fade finishes. The sheet is the
+    // one overlay that takes keyboard focus for its search field (see the
+    // anyKeyboardGrabbing derivation in shellhost_bridge.cpp), and the slot
+    // stays visible for the whole hide animation — releasing on completion
+    // would eat every keystroke aimed at the window the user just came back
+    // to. m_cheatsheetVisible is already false above, so this recomputes to
+    // kbd-None while leaving the mapped/input-region state untouched.
+    syncPassiveShellSurfaceState(screenId);
 
     auto stateIt = m_screenStates.find(screenId);
     if (stateIt != m_screenStates.end() && stateIt->shell && stateIt->shell->shellSurface()

--- a/src/daemon/overlayservice/cheatsheet.cpp
+++ b/src/daemon/overlayservice/cheatsheet.cpp
@@ -27,6 +27,26 @@
 
 namespace PlasmaZones {
 
+namespace {
+
+/// The sheet's whole content surface, in one place. Both entry points push the
+/// identical set, and a field added to one and not the other is a divergence
+/// the compiler cannot catch: the sheet would simply keep stale content after
+/// a live mode switch.
+void writeCheatsheetContent(QQuickItem* slot, const QVariantList& model, const QString& currentMode,
+                            bool autotileAvailable, bool scrollingAvailable, bool layoutsAvailable,
+                            bool layoutsAreTemplates)
+{
+    writeQmlProperty(slot, QStringLiteral("shortcuts"), model);
+    writeQmlProperty(slot, QStringLiteral("currentMode"), currentMode);
+    writeQmlProperty(slot, QStringLiteral("autotileAvailable"), autotileAvailable);
+    writeQmlProperty(slot, QStringLiteral("scrollingAvailable"), scrollingAvailable);
+    writeQmlProperty(slot, QStringLiteral("layoutsAvailable"), layoutsAvailable);
+    writeQmlProperty(slot, QStringLiteral("layoutsAreTemplates"), layoutsAreTemplates);
+}
+
+} // namespace
+
 void OverlayService::showCheatsheet(const QString& screenId, const QVariantList& model, const QString& currentMode,
                                     bool autotileAvailable, bool scrollingAvailable, bool layoutsAvailable,
                                     bool layoutsAreTemplates)
@@ -113,12 +133,8 @@ void OverlayService::showCheatsheet(const QString& screenId, const QVariantList&
     auto* shellSurface = state->shell->shellSurface();
     auto* shellWindow = state->shell->shellWindow();
 
-    writeQmlProperty(slot, QStringLiteral("shortcuts"), model);
-    writeQmlProperty(slot, QStringLiteral("currentMode"), currentMode);
-    writeQmlProperty(slot, QStringLiteral("autotileAvailable"), autotileAvailable);
-    writeQmlProperty(slot, QStringLiteral("scrollingAvailable"), scrollingAvailable);
-    writeQmlProperty(slot, QStringLiteral("layoutsAvailable"), layoutsAvailable);
-    writeQmlProperty(slot, QStringLiteral("layoutsAreTemplates"), layoutsAreTemplates);
+    writeCheatsheetContent(slot, model, currentMode, autotileAvailable, scrollingAvailable, layoutsAvailable,
+                           layoutsAreTemplates);
     writeFontProperties(slot, m_settings, /*includeLabelFontColor=*/false);
 
     // Same SurfaceDecoration host the picker uses, retargeted to the
@@ -157,7 +173,11 @@ void OverlayService::hideCheatsheet()
     if (!m_cheatsheetVisible) {
         // Always emit dismissed so the daemon's Escape-grab release path
         // runs even on idempotent calls — multiple call sites converge
-        // here (toggle re-press, backdrop, Escape).
+        // here (toggle re-press, backdrop, Escape). A deliberate exception to
+        // the emit-only-when-the-value-changed rule: the signal is carrying a
+        // grab release, not a state change, and making it conditional would
+        // strand the Escape grab on exactly the paths that converge here.
+        // Do not "fix" it to match the rule.
         Q_EMIT cheatsheetDismissed();
         return;
     }
@@ -215,12 +235,8 @@ void OverlayService::refreshCheatsheet(const QVariantList& model, const QString&
         return;
     }
     auto* slot = it->cheatsheetSlot();
-    writeQmlProperty(slot, QStringLiteral("shortcuts"), model);
-    writeQmlProperty(slot, QStringLiteral("currentMode"), currentMode);
-    writeQmlProperty(slot, QStringLiteral("autotileAvailable"), autotileAvailable);
-    writeQmlProperty(slot, QStringLiteral("scrollingAvailable"), scrollingAvailable);
-    writeQmlProperty(slot, QStringLiteral("layoutsAvailable"), layoutsAvailable);
-    writeQmlProperty(slot, QStringLiteral("layoutsAreTemplates"), layoutsAreTemplates);
+    writeCheatsheetContent(slot, model, currentMode, autotileAvailable, scrollingAvailable, layoutsAvailable,
+                           layoutsAreTemplates);
 }
 
 void OverlayService::onCheatsheetSlotHideCompleted(const QString& effectiveId)

--- a/src/daemon/overlayservice/osd.cpp
+++ b/src/daemon/overlayservice/osd.cpp
@@ -866,9 +866,8 @@ void OverlayService::onOsdSlotHideCompleted(const QString& effectiveId)
 
 // syncPassiveShellSurfaceState / syncPassiveShellSurfaceStateForSurface
 // are extracted to overlayservice/shellhost_bridge.cpp - they translate
-// PZ-content slot visibility into the booleans ShellHost::syncSurfaceState
-// expects, conceptually part of the shell-host bridge rather than the
-// OSD pipeline.
+// PZ-content state into the predicates ShellHost::syncSurfaceState expects,
+// conceptually part of the shell-host bridge rather than the OSD pipeline.
 
 void OverlayService::showNavigationOsd(bool success, const QString& action, const QString& reason,
                                        const QString& sourceZoneId, const QString& targetZoneId,

--- a/src/daemon/overlayservice/phosphor_roles.h
+++ b/src/daemon/overlayservice/phosphor_roles.h
@@ -58,10 +58,15 @@ inline const PhosphorLayer::Role ZoneSelector = PhosphorLayer::Role{PhosphorLaye
 inline const PhosphorLayer::Role Osd = PhosphorShellPatterns::Hud().withScopePrefix(QStringLiteral("plasmazones-osd"));
 
 /// Passive overlay shell - single per-screen wlr-layer-shell host that
-/// groups every kbd-None overlay (OSD, zone-selector, main zone overlay,
+/// groups every passive overlay (OSD, zone-selector, main zone overlay,
 /// and post-migration snap-assist + layout picker + cheatsheet) onto one
-/// wl_surface per screen. FullscreenOverlay primitive (AnchorAll, no keyboard,
-/// click-through). Hiding ONE slot never unmaps anything: the per-content
+/// wl_surface per screen. FullscreenOverlay primitive (AnchorAll, attached
+/// kbd-None, click-through).
+///
+/// The role's KeyboardInteractivity is the ATTACH value only.
+/// ShellHost::syncSurfaceState raises the live surface to Exclusive while a
+/// slot that has to type is up (today the cheatsheet's search field) and
+/// drops it back to None on the first edge of dismissal. Hiding ONE slot never unmaps anything: the per-content
 /// slots toggle visibility within the shared scene graph, and the shell's
 /// own show/hide is driven off the anyVisible aggregate, so the wl_surface
 /// only moves when the LAST visible slot goes.

--- a/src/daemon/overlayservice/rekey.cpp
+++ b/src/daemon/overlayservice/rekey.cpp
@@ -120,8 +120,15 @@ bool OverlayService::rekeyOverlayState(const QString& oldKey, const QString& new
         // rely on that.
         donor = m_screenStates.find(oldKey);
         if (donor == m_screenStates.end()) {
+            // Unlike the bail-outs above, the lib has already moved its shell
+            // to newKey by this point, so a bare return would leave the lib
+            // keyed where the daemon has no entry and the caller's recreate
+            // fallback would try to build a second shell there. Put the lib
+            // back before giving up, so the failure is the clean no-op the
+            // caller's contract expects.
             qCWarning(lcOverlay) << "rekeyOverlayState: donor" << oldKey
-                                 << "vanished during the target-side modal reset";
+                                 << "vanished during the target-side modal reset; reverting lib-side rekey";
+            m_shellHost->rekey(newKey, oldKey);
             return false;
         }
     }

--- a/src/daemon/overlayservice/rekey.cpp
+++ b/src/daemon/overlayservice/rekey.cpp
@@ -126,9 +126,20 @@ bool OverlayService::rekeyOverlayState(const QString& oldKey, const QString& new
             // fallback would try to build a second shell there. Put the lib
             // back before giving up, so the failure is the clean no-op the
             // caller's contract expects.
-            qCWarning(lcOverlay) << "rekeyOverlayState: donor" << oldKey
-                                 << "vanished during the target-side modal reset; reverting lib-side rekey";
-            m_shellHost->rekey(newKey, oldKey);
+            if (m_shellHost->rekey(newKey, oldKey)) {
+                qCWarning(lcOverlay) << "rekeyOverlayState: donor" << oldKey
+                                     << "vanished during the target-side modal reset; reverted lib-side rekey";
+            } else {
+                // Whatever removed the donor put a live shell at oldKey, so the
+                // lib refuses to move back onto it. The lib is left keyed at
+                // newKey with no daemon entry there, which the caller's
+                // recreate fallback will not repair. Say so rather than let the
+                // success wording above cover it.
+                qCWarning(lcOverlay) << "rekeyOverlayState: donor" << oldKey
+                                     << "vanished during the target-side modal reset AND the revert was refused; lib "
+                                        "is keyed"
+                                     << newKey << "with no daemon entry";
+            }
             return false;
         }
     }

--- a/src/daemon/overlayservice/rekey.cpp
+++ b/src/daemon/overlayservice/rekey.cpp
@@ -28,6 +28,8 @@
 #include <QSet>
 #include <QStringList>
 
+#include <utility>
+
 namespace PlasmaZones {
 
 bool OverlayService::rekeyOverlayState(const QString& oldKey, const QString& newKey)
@@ -110,6 +112,18 @@ bool OverlayService::rekeyOverlayState(const QString& oldKey, const QString& new
         // move the donor's still-live modal id onto newKey, and this reset
         // would then dismiss the sheet that actually survived the move.
         resetModalSingletonsForDestroyedId(newKey);
+        // That fired dismissal signals. No receiver touches m_screenStates
+        // today (they release shortcut grabs and nothing else), but the donor
+        // iterator has to survive to the move below, and an iterator held
+        // across a signal emission is the kind of thing that stays correct
+        // only until someone connects the wrong slot. Re-find rather than
+        // rely on that.
+        donor = m_screenStates.find(oldKey);
+        if (donor == m_screenStates.end()) {
+            qCWarning(lcOverlay) << "rekeyOverlayState: donor" << oldKey
+                                 << "vanished during the target-side modal reset";
+            return false;
+        }
     }
 
     PerScreenOverlayState state = std::move(donor.value());

--- a/src/daemon/overlayservice/rekey.cpp
+++ b/src/daemon/overlayservice/rekey.cpp
@@ -96,6 +96,20 @@ bool OverlayService::rekeyOverlayState(const QString& oldKey, const QString& new
     if (existing != m_screenStates.end()) {
         existing->shell = nullptr;
         m_screenStates.erase(existing);
+        // That erase destroyed a shell able to host a visible modal, so it is
+        // one of the teardown sites resetModalSingletonsForDestroyedId names.
+        // The clobber guard above only refuses on a non-null overlayPhysScreen,
+        // and that field is written solely by the main-overlay path, never by
+        // ensurePassiveShellFor - so a passive-only shell carrying a visible
+        // cheatsheet, picker or snap assist reaches here. Left alone, the
+        // modal's screen id would name a key with no state at all: the hide
+        // path's lookup fails, the slot is never hidden, and the visible flag
+        // stays set so the next toggle no-ops.
+        //
+        // This MUST run before the oldKey remap below. Remapping first would
+        // move the donor's still-live modal id onto newKey, and this reset
+        // would then dismiss the sheet that actually survived the move.
+        resetModalSingletonsForDestroyedId(newKey);
     }
 
     PerScreenOverlayState state = std::move(donor.value());
@@ -154,6 +168,28 @@ bool OverlayService::rekeyOverlayState(const QString& oldKey, const QString& new
     if (PhosphorScreens::ScreenIdentity::screensMatch(m_selectedStripScreenId, oldKey)) {
         m_selectedStripTarget = {};
         m_selectedStripScreenId.clear();
+    }
+    // The three modal singletons remember which screen they are up on, and
+    // those ids are map keys into m_screenStates. The state has just moved to
+    // newKey, so an id still naming oldKey addresses a key that no longer
+    // exists, and every path that would clean the modal up misses: the hide
+    // path's lookup fails, so the slot is never hidden and its surface keeps
+    // the input grab, while the cheatsheet's keyboard predicate (which compares
+    // its screen id against the id being synced) reads false under the new key
+    // and hands the keyboard back out from under a visible search field.
+    //
+    // Exact equality, not screensMatch: these are map keys, and every other
+    // reader compares them with ==. The fuzzy match above is for a target
+    // checked against a live cursor id, which is a different question.
+    // An id naming neither key belongs to another screen this rekey did not
+    // touch, so it is left alone.
+    //
+    // This has to happen before the conditional sync further down, which reads
+    // m_cheatsheetScreenId.
+    for (QString* modalScreenId : {&m_cheatsheetScreenId, &m_layoutPickerScreenId, &m_snapAssistScreenId}) {
+        if (*modalScreenId == oldKey) {
+            *modalScreenId = newKey;
+        }
     }
     // A hide in flight under oldKey cannot simply have its bit dropped. The
     // animator's track is keyed by {surface, item}, neither of which the rekey
@@ -294,6 +330,26 @@ void OverlayService::validateScreenStateInvariant(const QStringList& targetIds) 
             qCWarning(lcOverlay) << "validateScreenStateInvariant: live overlay" << it.key()
                                  << "is not in the current target set: orphan";
             Q_ASSERT_X(false, "OverlayService", "orphaned overlay entry");
+        }
+    }
+    // A modal singleton's screen id is a key into m_screenStates, and every
+    // path that hides or tears one down looks it up by that key. An id naming
+    // a key that no longer exists is therefore unrecoverable by any normal
+    // route: the slot stays visible, its surface keeps the input grab, and the
+    // visible flag stays set so the toggle no-ops. Nothing in the ordinary
+    // show/hide cycle can produce it, which is exactly why it is worth
+    // asserting here - the ways in are key migrations and teardowns, and those
+    // are the paths that have to remember to carry these three along.
+    const std::pair<const QString&, const char*> modalIds[] = {
+        {m_cheatsheetScreenId, "cheatsheet"},
+        {m_layoutPickerScreenId, "layout picker"},
+        {m_snapAssistScreenId, "snap assist"},
+    };
+    for (const auto& [modalScreenId, modalName] : modalIds) {
+        if (!modalScreenId.isEmpty() && !m_screenStates.contains(modalScreenId)) {
+            qCWarning(lcOverlay) << "validateScreenStateInvariant:" << modalName << "screen id" << modalScreenId
+                                 << "names a key with no screen state";
+            Q_ASSERT_X(false, "OverlayService", "modal singleton id names a dead screen key");
         }
     }
 #else

--- a/src/daemon/overlayservice/selector.cpp
+++ b/src/daemon/overlayservice/selector.cpp
@@ -729,8 +729,16 @@ void OverlayService::restoreZoneSelectorAfterHide(const QString& effectiveId)
     // picker), and the dismissed one's ANIMATED hide completion lands after
     // the replacement has already hidden this screen's selector for its own
     // show — an unguarded restore would re-show it under the live modal.
+    //
+    // The cheatsheet is listed for the same reason the other two are, even
+    // though the pair cannot currently be up together (the sheet refuses to
+    // open mid-drag, and the selector only shows during a drag). That
+    // suppression lives in another file, and this guard should not depend on
+    // it: the question here is whether an input-grabbing modal owns the
+    // screen, and all three of them do.
     if ((m_snapAssistVisible && m_snapAssistScreenId == effectiveId)
-        || (m_layoutPickerVisible && m_layoutPickerScreenId == effectiveId)) {
+        || (m_layoutPickerVisible && m_layoutPickerScreenId == effectiveId)
+        || (m_cheatsheetVisible && m_cheatsheetScreenId == effectiveId)) {
         return;
     }
     // The drag may still be active (m_zoneSelectorVisible stays true

--- a/src/daemon/overlayservice/shellhost_bridge.cpp
+++ b/src/daemon/overlayservice/shellhost_bridge.cpp
@@ -373,7 +373,22 @@ void OverlayService::syncPassiveShellSurfaceState(const QString& effectiveId)
     const bool anyInputGrabbing =
         isVisible(s.snapAssistSlot()) || isVisible(s.layoutPickerSlot()) || isVisible(s.cheatsheetSlot());
 
-    m_shellHost->syncSurfaceState(effectiveId, anyVisible, anyInputGrabbing);
+    // Keyboard grab: the cheatsheet alone, because its search field is the
+    // only overlay content that reads typed characters. Snap assist and the
+    // picker stay kbd-None on purpose — both answer only to global shortcuts,
+    // which KWin routes ahead of surface delivery, so taking the keyboard
+    // would buy them nothing and cost the focused window its input.
+    //
+    // Keyed on m_cheatsheetVisible, NOT on the slot's isVisible(): the slot
+    // item stays visible for the whole fade-out, and holding the session's
+    // keyboard across an animation would swallow whatever the user typed into
+    // the window they were returning to. The flag is cleared on the first edge
+    // of every dismissal path, which is the edge that should release. Escape
+    // itself is unaffected either way — it reaches the daemon through the
+    // ad-hoc global grab (daemon/cheatsheet.cpp), never through this surface.
+    const bool anyKeyboardGrabbing = m_cheatsheetVisible && m_cheatsheetScreenId == effectiveId;
+
+    m_shellHost->syncSurfaceState(effectiveId, anyVisible, anyInputGrabbing, anyKeyboardGrabbing);
 }
 
 void OverlayService::syncPassiveShellSurfaceStateForSurface(PhosphorLayer::Surface* surface)

--- a/src/daemon/overlayservice/shellhost_bridge.cpp
+++ b/src/daemon/overlayservice/shellhost_bridge.cpp
@@ -116,6 +116,13 @@ OverlayService::PerScreenOverlayState* OverlayService::ensurePassiveShellFor(con
     // overwrite this immediately via syncPassiveShellSurfaceState
     // (anyInputGrabbing=true), so the brief redundant write happens
     // entirely within a single event-loop tick.
+    //
+    // The keyboard axis deliberately gets no equivalent default here. It is
+    // owned solely by syncSurfaceState, which the modal-show paths call in the
+    // same tick, and unlike the input flag it has no stale-inheritance hazard
+    // to guard: the re-entry case this defends against keeps the same
+    // transport handle, and the only writer of that handle's interactivity is
+    // the sync itself.
     if (auto* window = shellState->shellWindow()) {
         window->setFlag(Qt::WindowTransparentForInput, true);
     }

--- a/src/daemon/overlayservice/shellhost_bridge.cpp
+++ b/src/daemon/overlayservice/shellhost_bridge.cpp
@@ -4,8 +4,11 @@
 // Bridge methods that wire OverlayService to PhosphorOverlay::ShellHost:
 // the post-create / pre-destroy callbacks, the per-screen shim wrappers
 // (ensurePassiveShellFor / destroyPassiveShell), the warm-up loop, and
-// the surface-mapped-state sync that translates PZ-content slot
-// visibility into the booleans ShellHost::syncSurfaceState expects.
+// the surface-mapped-state sync that computes the three predicates
+// ShellHost::syncSurfaceState expects. The first two come from PZ-content
+// slot visibility. The keyboard predicate deliberately does not, since it
+// has to release on the first edge of dismissal rather than when the
+// slot's fade finishes.
 //
 // Extracted from osd.cpp where these methods accumulated during the
 // Phase 2-4 ShellHost lift. They are not OSD-specific, they belong
@@ -14,7 +17,6 @@
 #include "internal.h"
 #include "daemon/overlayservice.h"
 #include "core/platform/logging.h"
-#include "core/utils/utils.h"
 #include "phosphor_roles.h"
 #include "phosphor_slot_keys.h"
 
@@ -228,8 +230,9 @@ void OverlayService::warmUpNotifications()
     int createdCount = 0;
     if (effectsEnabled) {
         for (const QString& sid : effectiveIds) {
-            QScreen* physScreen = m_screenManager ? m_screenManager->physicalScreenFor(sid).qscreen
-                                                  : Utils::findScreenAtPosition(QPoint(0, 0));
+            // effectiveIds is empty unless m_screenManager is non-null, so the
+            // loop body only runs when it is.
+            QScreen* physScreen = m_screenManager->physicalScreenFor(sid).qscreen;
             if (physScreen) {
                 auto* state = ensurePassiveShellFor(sid, physScreen);
                 if (state && state->shell && state->shell->shellSurface()) {
@@ -329,7 +332,7 @@ void OverlayService::syncPassiveShellSurfaceState(const QString& effectiveId)
     // Input-region rationale (Qt::WindowTransparentForInput): pre-shell-
     // migration each overlay had its own wl_surface sized to its visible
     // content, so clicks outside the toast / card naturally fell through
-    // to underlying windows. Post-shell every kbd-None overlay shares the
+    // to underlying windows. Post-shell every passive overlay shares the
     // screen-sized shell surface - there's no per-slot input region the
     // daemon can hand to the compositor. The pragmatic split: only MODAL
     // slots (snap-assist, layout picker, cheatsheet) grab input. OSD /
@@ -382,13 +385,20 @@ void OverlayService::syncPassiveShellSurfaceState(const QString& effectiveId)
     // Keyed on m_cheatsheetVisible, NOT on the slot's isVisible(): the slot
     // item stays visible for the whole fade-out, and holding the session's
     // keyboard across an animation would swallow whatever the user typed into
-    // the window they were returning to. The flag is cleared on the first edge
-    // of every dismissal path, which is the edge that should release. Escape
+    // the window they were returning to. The flag is cleared, and the surface
+    // re-synced, on the first edge of every dismissal path that keeps the
+    // surface alive. Teardown paths release implicitly instead, when the
+    // surface itself is destroyed. Escape
     // itself is unaffected either way — it reaches the daemon through the
     // ad-hoc global grab (daemon/cheatsheet.cpp), never through this surface.
     const bool anyKeyboardGrabbing = m_cheatsheetVisible && m_cheatsheetScreenId == effectiveId;
 
-    m_shellHost->syncSurfaceState(effectiveId, anyVisible, anyInputGrabbing, anyKeyboardGrabbing);
+    m_shellHost->syncSurfaceState(effectiveId,
+                                  {
+                                      .visible = anyVisible,
+                                      .inputGrabbing = anyInputGrabbing,
+                                      .keyboardGrabbing = anyKeyboardGrabbing,
+                                  });
 }
 
 void OverlayService::syncPassiveShellSurfaceStateForSurface(PhosphorLayer::Surface* surface)

--- a/src/daemon/resources.qrc
+++ b/src/daemon/resources.qrc
@@ -17,6 +17,9 @@
         <file alias="CheatsheetContent.qml">../ui/CheatsheetContent.qml</file>
         <file alias="PopupCardTitle.qml">../ui/PopupCardTitle.qml</file>
         <file alias="KeyChip.qml">../ui/KeyChip.qml</file>
+        <file alias="CheatsheetRow.qml">../ui/CheatsheetRow.qml</file>
+        <file alias="CheatsheetGroup.qml">../ui/CheatsheetGroup.qml</file>
+        <file alias="CheatsheetSearchField.qml">../ui/CheatsheetSearchField.qml</file>
         <file alias="ScrollDropIndicatorContent.qml">../ui/ScrollDropIndicatorContent.qml</file>
     </qresource>
 </RCC>

--- a/src/daemon/resources.qrc
+++ b/src/daemon/resources.qrc
@@ -1,4 +1,6 @@
 <!DOCTYPE RCC>
+<!-- SPDX-FileCopyrightText: 2026 fuddlesworth -->
+<!-- SPDX-License-Identifier: GPL-3.0-or-later -->
 <RCC version="1.0">
     <qresource prefix="/ui">
         <file alias="ZoneOverlayContent.qml">../ui/ZoneOverlayContent.qml</file>
@@ -15,11 +17,11 @@
         <file alias="SnapAssistContent.qml">../ui/SnapAssistContent.qml</file>
         <file alias="LayoutPickerContent.qml">../ui/LayoutPickerContent.qml</file>
         <file alias="CheatsheetContent.qml">../ui/CheatsheetContent.qml</file>
+        <file alias="CheatsheetGroup.qml">../ui/CheatsheetGroup.qml</file>
+        <file alias="CheatsheetRow.qml">../ui/CheatsheetRow.qml</file>
+        <file alias="CheatsheetSearchField.qml">../ui/CheatsheetSearchField.qml</file>
         <file alias="PopupCardTitle.qml">../ui/PopupCardTitle.qml</file>
         <file alias="KeyChip.qml">../ui/KeyChip.qml</file>
-        <file alias="CheatsheetRow.qml">../ui/CheatsheetRow.qml</file>
-        <file alias="CheatsheetGroup.qml">../ui/CheatsheetGroup.qml</file>
-        <file alias="CheatsheetSearchField.qml">../ui/CheatsheetSearchField.qml</file>
         <file alias="ScrollDropIndicatorContent.qml">../ui/ScrollDropIndicatorContent.qml</file>
     </qresource>
 </RCC>

--- a/src/ui/CheatsheetContent.qml
+++ b/src/ui/CheatsheetContent.qml
@@ -125,6 +125,22 @@ Item {
         root.dismissRequested();
     }
 
+    /// Whether a key's text is something a filter field should receive.
+    ///
+    /// `event.text` is non-empty for far more than typing: Escape carries
+    /// , Return \r and Backspace \b. Treating any non-empty text as
+    /// typing would insert control characters into the query and, worse,
+    /// swallow Escape — which is the sheet's dismiss key, and must reach the
+    /// daemon's global grab rather than being eaten here. Space is printable
+    /// and belongs in a multi-term query; a focused disclosure consumes it
+    /// first for its own toggle, so the two do not collide.
+    function _isPrintable(text) {
+        if (text.length === 0)
+            return false;
+        const code = text.charCodeAt(0);
+        return code > 0x1f && code !== 0x7f;
+    }
+
     function _toggleCategory(categoryOrder) {
         let next = {};
         for (const k in root.expandedCategories)
@@ -469,7 +485,7 @@ Item {
             } else if (event.key === Qt.Key_End && (event.modifiers & Qt.ControlModifier)) {
                 scroller.scrollToEnd(1);
                 event.accepted = true;
-            } else if (event.text.length > 0 && !searchField.fieldHasFocus) {
+            } else if (!searchField.fieldHasFocus && root._isPrintable(event.text)) {
                 // Typing anywhere on the sheet returns to the filter and keeps
                 // the character, rather than dropping it.
                 searchField.takeFocus();

--- a/src/ui/CheatsheetContent.qml
+++ b/src/ui/CheatsheetContent.qml
@@ -106,6 +106,13 @@ Item {
     /// Per-category disclosure state for the unassigned rollup, keyed on
     /// categoryOrder. Replaced wholesale rather than mutated so the bindings
     /// reading it actually re-evaluate.
+    ///
+    /// This survives a live re-push, which is correct: categoryOrder is a
+    /// compile-time sort key on the catalog's category table, so one value
+    /// always denotes the same category whatever the mode. A category still
+    /// present after a mode switch keeps the disclosure the user left it in,
+    /// and one that is gone leaves an entry nothing reads. A show does reset
+    /// it, since the Loader re-instantiates this component.
     property var expandedCategories: ({})
 
     signal dismissRequested
@@ -166,14 +173,31 @@ Item {
     /// cursor and a row could move out from under the eye that was reading
     /// it. The card's geometry is fixed by the mode filter alone, and the
     /// query only decides which rows stay at full contrast.
+    /// Lowercased search text per catalog id, built once per model push rather
+    /// than per keystroke. rowMatches is called for every row several times
+    /// over on each key (once for the counter, once for each row's own dim
+    /// state, once inside its group's heading state), and rebuilding and
+    /// case-folding the same strings each time was the bulk of the typing
+    /// cost. The catalog only changes when C++ re-pushes it.
+    readonly property var haystacks: {
+        let map = ({});
+        for (let i = 0; i < root.shortcuts.length; ++i) {
+            const row = root.shortcuts[i];
+            let hay = row.label + " " + row.category;
+            if (row.assigned)
+                hay += " " + row.triggers.join(" ");
+            map[row.id] = hay.toLocaleLowerCase();
+        }
+        return map;
+    }
+
     function rowMatches(row) {
         if (root.queryTerms.length === 0)
             return true;
 
-        let hay = row.label + " " + row.category;
-        if (row.assigned)
-            hay += " " + row.triggers.join(" ");
-        hay = hay.toLocaleLowerCase();
+        const hay = root.haystacks[row.id];
+        if (hay === undefined)
+            return false;
         for (let i = 0; i < root.queryTerms.length; ++i) {
             if (hay.indexOf(root.queryTerms[i]) < 0)
                 return false;
@@ -232,6 +256,12 @@ Item {
         return n;
     }
 
+    /// Rows answering the query, counted across the whole mode-filtered
+    /// catalog. Deliberately includes rows sitting behind a collapsed rollup:
+    /// the counter reports what the query found, not what is currently on
+    /// screen, and the rollup line says separately how many of the hidden ones
+    /// are its own. The two numbers come from different paths on purpose, so
+    /// do not "reconcile" them by subtracting one from the other.
     readonly property int matchedRowCount: {
         if (root.queryTerms.length === 0)
             return root.modeRowCount;

--- a/src/ui/CheatsheetContent.qml
+++ b/src/ui/CheatsheetContent.qml
@@ -180,7 +180,11 @@ Item {
     /// case-folding the same strings each time was the bulk of the typing
     /// cost. The catalog only changes when C++ re-pushes it.
     readonly property var haystacks: {
-        let map = ({});
+        // Prototype-free, matching the grouping map below: a catalog id equal
+        // to an Object.prototype member ("constructor", "toString") would
+        // otherwise resolve to a function, and the miss check in rowMatches
+        // would sail past it and throw on indexOf.
+        let map = Object.create(null);
         for (let i = 0; i < root.shortcuts.length; ++i) {
             const row = root.shortcuts[i];
             let hay = row.label + " " + row.category;
@@ -441,6 +445,39 @@ Item {
         // No container Accessible.name: the title label below is the single
         // announcement, matching LayoutPickerContent's card.
 
+        // Scrolling keys live on the CARD, not on the search field, so they
+        // keep working once Tab has moved focus to a disclosure line. Key
+        // events bubble up the item parent chain from whichever descendant
+        // holds focus, so one handler here covers every focus position on the
+        // sheet. Page keys rather than arrows: the field is single-line, so
+        // they have nothing to do in the editor and are unambiguous here.
+        //
+        // The printable fall-through is the other half of that. A disclosure
+        // is a tab stop but not a text sink, so without this a user who tabbed
+        // to one and started typing would have their keystrokes go nowhere,
+        // with the filter field visibly unchanged.
+        Keys.onPressed: event => {
+            if (event.key === Qt.Key_PageDown) {
+                scroller.scrollByPage(1);
+                event.accepted = true;
+            } else if (event.key === Qt.Key_PageUp) {
+                scroller.scrollByPage(-1);
+                event.accepted = true;
+            } else if (event.key === Qt.Key_Home && (event.modifiers & Qt.ControlModifier)) {
+                scroller.scrollToEnd(-1);
+                event.accepted = true;
+            } else if (event.key === Qt.Key_End && (event.modifiers & Qt.ControlModifier)) {
+                scroller.scrollToEnd(1);
+                event.accepted = true;
+            } else if (event.text.length > 0 && !searchField.fieldHasFocus) {
+                // Typing anywhere on the sheet returns to the filter and keeps
+                // the character, rather than dropping it.
+                searchField.takeFocus();
+                searchField.appendText(event.text);
+                event.accepted = true;
+            }
+        }
+
         // Absorb clicks inside the card so they never reach the backdrop —
         // same sibling z-order contract as LayoutPickerContent. Declared
         // FIRST so the interactive content below it (search field, disclosure
@@ -502,28 +539,7 @@ Item {
                 Component.onCompleted: takeFocus()
 
                 // The field is the only focusable item on the card, so it is
-                // also the only place these keys can be caught. Without this
-                // the clipped rows on a short screen are reachable by wheel
-                // and touch alone, and the scroll indicator points at content
-                // a keyboard user cannot get to. Page keys are unambiguous
-                // here (the field is single-line, so they have nothing to do
-                // in the editor), which is why they and not the arrows carry
-                // this.
-                Keys.onPressed: event => {
-                    if (event.key === Qt.Key_PageDown) {
-                        scroller.scrollByPage(1);
-                        event.accepted = true;
-                    } else if (event.key === Qt.Key_PageUp) {
-                        scroller.scrollByPage(-1);
-                        event.accepted = true;
-                    } else if (event.key === Qt.Key_Home && event.modifiers & Qt.ControlModifier) {
-                        scroller.scrollToEnd(-1);
-                        event.accepted = true;
-                    } else if (event.key === Qt.Key_End && event.modifiers & Qt.ControlModifier) {
-                        scroller.scrollToEnd(1);
-                        event.accepted = true;
-                    }
-                }
+                // also the only place these keys can be caught.
             }
 
             // Empty state. Reachable two ways now: a query that matches
@@ -557,7 +573,13 @@ Item {
                 // instead — hide the (empty) scroller so exactly one item owns
                 // it.
                 visible: root.groups.length > 0
-                contentWidth: width
+                // Normally the columns are sized to fit, so contentWidth is the
+                // viewport and there is nothing to pan. The exception is an
+                // output too narrow to honour the column minimum, where the
+                // card is clamped to the screen: taking the content width from
+                // the row there keeps the overflowing columns reachable by
+                // flick instead of clipping them away permanently.
+                contentWidth: Math.max(width, bucketsRow.implicitWidth)
                 contentHeight: bucketsRow.implicitHeight
                 clip: true
                 boundsBehavior: Flickable.StopAtBounds
@@ -587,6 +609,25 @@ Item {
                         return;
                     }
                     contentY = direction < 0 ? 0 : contentHeight - height;
+                }
+
+                // Bring a keyboard-focused item into view. A Flickable does
+                // not do this for its descendants, so a tab stop inside the
+                // clipped strip would otherwise be reachable but invisible.
+                // Only scrolls when the item is actually outside the viewport,
+                // so tabbing through what is already on screen does not jump.
+                function ensureVisible(target: Item) {
+                    if (!target || contentHeight <= height) {
+                        return;
+                    }
+                    const top = target.mapToItem(bucketsRow, 0, 0).y;
+                    const bottom = top + target.height;
+                    const margin = Kirigami.Units.largeSpacing;
+                    if (top < contentY) {
+                        contentY = Math.max(0, top - margin);
+                    } else if (bottom > contentY + height) {
+                        contentY = Math.min(contentHeight - height, bottom - height + margin);
+                    }
                 }
 
                 Row {
@@ -625,6 +666,7 @@ Item {
                                     fontFamily: root.fontFamily
                                     fontSizeScale: root.fontSizeScale
                                     onExpandToggled: root._toggleCategory(modelData.categoryOrder)
+                                    onFocusScrollRequested: target => scroller.ensureVisible(target)
                                     onLatchRequested: rowId => root.latchedRowId = rowId
                                     onLatchCleared: root.latchedRowId = ""
                                 }

--- a/src/ui/CheatsheetContent.qml
+++ b/src/ui/CheatsheetContent.qml
@@ -18,9 +18,9 @@ import org.plasmazones.common as QFZCommon
  * position of every row are fixed for as long as the sheet is open.
  *
  * Data arrives via the host slot's bindings (C++ pushes `shortcuts`,
- * `currentMode`, `autotileAvailable`, `scrollingAvailable`, and
- * `layoutsAvailable` onto cheatsheetSlot; live mode switches re-push and
- * the group filter re-evaluates reactively).
+ * `currentMode`, `autotileAvailable`, `scrollingAvailable`,
+ * `layoutsAvailable` and `layoutsAreTemplates` onto cheatsheetSlot; live mode
+ * switches re-push and the group filter re-evaluates reactively).
  *
  * Keyboard: unlike the shell's other slots, this one HOLDS keyboard focus for
  * its lifetime so the search field can be typed into. OverlayService flips the
@@ -41,9 +41,11 @@ Item {
     /// shortcut with id, label, category, categoryOrder, rowOrder (the
     /// in-category sort position, already applied to the model), triggers (list of
     /// display strings), assigned (bool), mode
-    /// ("all"|"snapping"|"autotile"|"scrolling"|"layouts"|"managed"), and description (translated
+    /// ("all"|"snapping"|"autotile"|"scrolling"|"layouts"|"managed"), description (translated
     /// plain-prose explanation for the row tooltip; empty when the action
-    /// needs none). "layouts" is a capability tag rather than a fourth
+    /// needs none), and templatesDescription (the same, worded for a screen
+    /// that consumes layouts as sizing templates; present only on rows whose
+    /// meaning changes there, and falling back to description otherwise). "layouts" is a capability tag rather than a fourth
     /// tiling mode: currentMode can never equal it, and rows carrying it
     /// are gated purely by layoutsAvailable, independent of currentMode.
     property var shortcuts: []
@@ -89,6 +91,14 @@ Item {
     /// every delegate, and an Item reference would strand the latch on a
     /// destroyed row.
     property string latchedRowId: ""
+
+    // A re-push can drop the latched row's category outright (a live mode
+    // switch does exactly that). Its delegate goes with it, and the latch then
+    // has no one left to clear it: the writers are a tap on some surviving
+    // row, a flick, or that delegate's own tooltip closing. Harmless while it
+    // sits there, but it never returns to empty for the rest of the sheet's
+    // life, so clear it at the edge that can strand it.
+    onShortcutsChanged: root.latchedRowId = ""
 
     /// Live filter text from the search field.
     property string query: ""
@@ -209,8 +219,10 @@ Item {
     }
 
     /// Rows the current mode offers at all, ignoring the query. The
-    /// denominator of the search field's counter, so an over-narrow query
-    /// reads as "0 of 94" rather than as an unexplained blank card.
+    /// denominator of the search field's counter, so a query that narrows the
+    /// sheet still says what it narrowed from. An over-narrow query does not
+    /// reach this: the field substitutes its own no-matches wording once the
+    /// numerator hits zero, rather than reading "0 of 94".
     readonly property int modeRowCount: {
         let n = 0;
         for (let i = 0; i < root.shortcuts.length; ++i) {
@@ -243,8 +255,10 @@ Item {
         return root.expandedCategories[group.categoryOrder] === true;
     }
 
-    /// How many of a category's collapsed unassigned rows answer the query.
-    /// Zero while no query is active.
+    /// How many of a category's unassigned rows answer the query. Counts them
+    /// whether or not the rollup is open, since it is also what tells an open
+    /// rollup's line that it still has something to say. Zero while no query
+    /// is active.
     function unassignedMatchCount(group) {
         if (root.queryTerms.length === 0)
             return 0;
@@ -362,7 +376,12 @@ Item {
         // than 0: on an extremely short screen a zero budget would collapse
         // the scroller and leave a bare title with no hint that content
         // exists.
-        readonly property int chromeHeight: titleLabel.implicitHeight + modeLabel.implicitHeight + searchField.implicitHeight + footerLabel.implicitHeight + cardLayout.spacing * 3
+        // Four gaps, not three: the column runs title, mode, field, scroller,
+        // footer. The mode label's negative top margin claws one gap most of
+        // the way back, so it is added here rather than left out — counting
+        // four gaps without it would over-correct by nearly a whole gap in the
+        // other direction.
+        readonly property int chromeHeight: titleLabel.implicitHeight + modeLabel.implicitHeight + searchField.implicitHeight + footerLabel.implicitHeight + cardLayout.spacing * 4 + modeLabel.Layout.topMargin
         readonly property int maxContentHeight: Math.max(Kirigami.Units.gridUnit * 3, Math.round(root.height * 0.85) - paddingSide * 2 - chromeHeight)
     }
 
@@ -381,8 +400,13 @@ Item {
         id: container
 
         anchors.centerIn: parent
-        width: metrics.contentWidth + metrics.paddingSide * 2
-        height: cardLayout.implicitHeight + metrics.paddingSide * 2
+        // Clamped to the screen as well as to the content. columnWidth carries
+        // a minimum so a column never becomes unreadably narrow, and on an
+        // output too small to honour it the card would otherwise be centred
+        // while overhanging both edges, taking the search field's counter off
+        // screen with it. Clipping the card is the better failure.
+        width: Math.min(root.width, metrics.contentWidth + metrics.paddingSide * 2)
+        height: Math.min(root.height, cardLayout.implicitHeight + metrics.paddingSide * 2)
 
         // No container Accessible.name: the title label below is the single
         // announcement, matching LayoutPickerContent's card.
@@ -446,6 +470,30 @@ Item {
                 // wait: the field is already the focus item when the window
                 // becomes active, and the first keystroke lands in it.
                 Component.onCompleted: takeFocus()
+
+                // The field is the only focusable item on the card, so it is
+                // also the only place these keys can be caught. Without this
+                // the clipped rows on a short screen are reachable by wheel
+                // and touch alone, and the scroll indicator points at content
+                // a keyboard user cannot get to. Page keys are unambiguous
+                // here (the field is single-line, so they have nothing to do
+                // in the editor), which is why they and not the arrows carry
+                // this.
+                Keys.onPressed: event => {
+                    if (event.key === Qt.Key_PageDown) {
+                        scroller.scrollByPage(1);
+                        event.accepted = true;
+                    } else if (event.key === Qt.Key_PageUp) {
+                        scroller.scrollByPage(-1);
+                        event.accepted = true;
+                    } else if (event.key === Qt.Key_Home && event.modifiers & Qt.ControlModifier) {
+                        scroller.scrollToEnd(-1);
+                        event.accepted = true;
+                    } else if (event.key === Qt.Key_End && event.modifiers & Qt.ControlModifier) {
+                        scroller.scrollToEnd(1);
+                        event.accepted = true;
+                    }
+                }
             }
 
             // Empty state. Reachable two ways now: a query that matches
@@ -493,6 +541,24 @@ Item {
                 // off.
                 ScrollIndicator.vertical: ScrollIndicator {}
 
+                // Driven from the search field's key handler, which owns focus
+                // for the sheet's lifetime. Clamped here rather than at the
+                // call site so both entry points get the same bounds.
+                function scrollByPage(direction: int) {
+                    if (contentHeight <= height) {
+                        return;
+                    }
+                    const step = height * 0.9;
+                    contentY = Math.max(0, Math.min(contentHeight - height, contentY + direction * step));
+                }
+
+                function scrollToEnd(direction: int) {
+                    if (contentHeight <= height) {
+                        return;
+                    }
+                    contentY = direction < 0 ? 0 : contentHeight - height;
+                }
+
                 Row {
                     id: bucketsRow
 
@@ -522,7 +588,6 @@ Item {
                                     expanded: root.categoryExpanded(modelData)
                                     latchedRowId: root.latchedRowId
                                     queryTerms: root.queryTerms
-                                    queryActive: root.queryTerms.length > 0
                                     unassignedMatches: root.unassignedMatchCount(modelData)
                                     matcher: root.rowMatches
                                     scrollerMoving: scroller.moving

--- a/src/ui/CheatsheetContent.qml
+++ b/src/ui/CheatsheetContent.qml
@@ -128,7 +128,7 @@ Item {
     /// Whether a key's text is something a filter field should receive.
     ///
     /// `event.text` is non-empty for far more than typing: Escape carries
-    /// , Return \r and Backspace \b. Treating any non-empty text as
+    /// \x1b, Return \r and Backspace \b. Treating any non-empty text as
     /// typing would insert control characters into the query and, worse,
     /// swallow Escape — which is the sheet's dismiss key, and must reach the
     /// daemon's global grab rather than being eaten here. Space is printable

--- a/src/ui/CheatsheetContent.qml
+++ b/src/ui/CheatsheetContent.qml
@@ -4,24 +4,35 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
-import QtQuick.Templates as T
 import org.kde.kirigami as Kirigami
 import org.plasmazones.common as QFZCommon
 
 /**
  * Shortcut cheatsheet content — Item-rooted body hosted in
- * PassiveOverlayShell's cheatsheetSlot. Display-only: a centered card
- * listing every global shortcut grouped by category, filtered by the
- * tiling mode and the layout capability of the screen the sheet opened on.
+ * PassiveOverlayShell's cheatsheetSlot. A centered card listing every global
+ * shortcut grouped by category, filtered by the tiling mode and the layout
+ * capability of the screen the sheet opened on.
+ *
+ * The search field EMPHASISES rather than filters: a query dims the rows that
+ * do not answer it and leaves them in place, so the card's size and the
+ * position of every row are fixed for as long as the sheet is open.
  *
  * Data arrives via the host slot's bindings (C++ pushes `shortcuts`,
  * `currentMode`, `autotileAvailable`, `scrollingAvailable`, and
  * `layoutsAvailable` onto cheatsheetSlot; live mode switches re-push and
  * the group filter re-evaluates reactively).
  *
- * Keyboard: the shell surface is kbd-None, so Escape routes via the
- * daemon's dedicated ad-hoc grab (start.cpp); QML Shortcuts can never
- * fire here. The backdrop MouseArea is the pointer dismiss path.
+ * Keyboard: unlike the shell's other slots, this one HOLDS keyboard focus for
+ * its lifetime so the search field can be typed into. OverlayService flips the
+ * shared surface to Exclusive keyboard interactivity on show and back to None
+ * on the first edge of dismissal (shellhost_bridge.cpp, cheatsheet.cpp).
+ * Escape still arrives daemon-side through its own ad-hoc global grab rather
+ * than through this surface, because KWin routes global shortcuts ahead of
+ * surface delivery, so a QML Shortcut here would still never fire. The
+ * backdrop MouseArea remains the pointer dismiss path.
+ *
+ * Rows and category blocks live in CheatsheetRow / CheatsheetGroup; this file
+ * owns the filter, the column packing and the card chrome.
  */
 Item {
     id: root
@@ -39,8 +50,8 @@ Item {
     /// Tiling mode of the screen the sheet opened on:
     /// "snapping" | "autotile" | "scrolling".
     property string currentMode: "snapping"
-    /// Global autotile feature gate. When off, the Autotile group hides in
-    /// every mode (the mode is unreachable, so its shortcuts are noise).
+    /// Global tiling feature gate. Required alongside currentMode because the
+    /// mode string is re-derived from the ENGINE's live per-screen set.
     property bool autotileAvailable: true
     /// Global scrolling feature gate, same contract as autotileAvailable.
     /// Required alongside currentMode because the mode string is re-derived
@@ -70,11 +81,22 @@ Item {
     /// it; the Loader re-instantiates this component on every show.
     property bool _dismissed: false
 
-    /// The one row whose tooltip is latched open by a touch long-press, or
-    /// null. Sheet-level identity rather than a per-row bool so a second
-    /// long-press on another row REPLACES the open tooltip instead of
-    /// stacking a second one that nothing on a touch device would close.
-    property Item latchedRow: null
+    /// Catalog id of the one row whose tooltip is latched open by a touch
+    /// long-press, or empty. Sheet-level so a second long-press REPLACES the
+    /// open tooltip instead of stacking a second one that nothing on a touch
+    /// device would close. Keyed on the catalog id rather than on delegate
+    /// identity because a live mode switch re-pushes the model and rebuilds
+    /// every delegate, and an Item reference would strand the latch on a
+    /// destroyed row.
+    property string latchedRowId: ""
+
+    /// Live filter text from the search field.
+    property string query: ""
+
+    /// Per-category disclosure state for the unassigned rollup, keyed on
+    /// categoryOrder. Replaced wholesale rather than mutated so the bindings
+    /// reading it actually re-evaluate.
+    property var expandedCategories: ({})
 
     signal dismissRequested
 
@@ -86,24 +108,24 @@ Item {
         root.dismissRequested();
     }
 
-    /// Key tokens of one display sequence, for the chip row. A trailing "+"
-    /// means the plus key itself is the final token, and a multi-step
-    /// sequence ("Ctrl+X, Ctrl+S" — unreachable via KGlobalAccel, defensive
-    /// only) flattens to the tokens of every step rather than producing a
-    /// garbled "X, Ctrl" token.
-    function keyTokens(seq) {
-        var tokens = [];
-        var steps = seq.split(", ");
-        for (var s = 0; s < steps.length; s++) {
-            var step = steps[s];
-            var parts = step.split("+").filter(function (p) {
-                return p.length > 0;
-            });
-            if (step.endsWith("+"))
-                parts.push("+");
-            tokens = tokens.concat(parts);
-        }
-        return tokens;
+    function _toggleCategory(categoryOrder) {
+        let next = {};
+        for (const k in root.expandedCategories)
+            next[k] = root.expandedCategories[k];
+        next[categoryOrder] = !next[categoryOrder];
+        root.expandedCategories = next;
+    }
+
+    /// Query split into lowercased terms. Every term must appear somewhere in
+    /// a row for it to survive, so "col width" finds "Increase Column Width"
+    /// without the user having to type the words in order.
+    readonly property var queryTerms: {
+        const trimmed = root.query.trim();
+        if (trimmed.length === 0)
+            return [];
+        return trimmed.toLocaleLowerCase().split(/\s+/).filter(function (t) {
+            return t.length > 0;
+        });
     }
 
     /// True when the given catalog row applies in the current mode.
@@ -124,19 +146,47 @@ Item {
         return true;
     }
 
-    /// Rows regrouped into [{name, rows}] preserving the model's category
-    /// order, with mode-inapplicable rows dropped. Recomputes reactively on
-    /// shortcuts / currentMode / autotileAvailable / scrollingAvailable /
-    /// layoutsAvailable changes.
+    /// True when the row answers the current filter. The key sequences are
+    /// part of the haystack, so "meta alt" answers "what is on this chord?"
+    /// as well as the action names do.
+    ///
+    /// This does NOT remove anything. The filter emphasises rather than
+    /// subtracts: dropping rows as the user typed repacked the columns and
+    /// resized the card on every keystroke, so the sheet flinched under the
+    /// cursor and a row could move out from under the eye that was reading
+    /// it. The card's geometry is fixed by the mode filter alone, and the
+    /// query only decides which rows stay at full contrast.
+    function rowMatches(row) {
+        if (root.queryTerms.length === 0)
+            return true;
+
+        let hay = row.label + " " + row.category;
+        if (row.assigned)
+            hay += " " + row.triggers.join(" ");
+        hay = hay.toLocaleLowerCase();
+        for (let i = 0; i < root.queryTerms.length; ++i) {
+            if (hay.indexOf(root.queryTerms[i]) < 0)
+                return false;
+        }
+        return true;
+    }
+
+    /// Rows regrouped into [{name, categoryOrder, assigned, unassigned}]
+    /// preserving the model's category order, with mode-inapplicable and
+    /// filtered-out rows dropped, and each category's bound rows separated
+    /// from its unbound ones. Recomputes reactively on shortcuts /
+    /// currentMode / availability / query changes.
     readonly property var groups: {
-        var byCat = [];
+        let byCat = [];
         // Keyed on categoryOrder (identity), never on the translated display
         // string: two categories whose translations collide in some locale
         // must not fuse into one group. Object.create(null): a plain {} would
         // let `in` walk the prototype chain.
-        var index = Object.create(null);
-        for (var i = 0; i < root.shortcuts.length; i++) {
-            var row = root.shortcuts[i];
+        let index = Object.create(null);
+        for (let i = 0; i < root.shortcuts.length; ++i) {
+            const row = root.shortcuts[i];
+            // Mode only. The query is applied per row at paint time (see
+            // rowMatches) so that typing never changes what the packer sees.
             if (!root.rowVisible(row))
                 continue;
 
@@ -144,88 +194,139 @@ Item {
                 index[row.categoryOrder] = byCat.length;
                 byCat.push({
                     name: row.category,
-                    rows: []
+                    categoryOrder: row.categoryOrder,
+                    assigned: [],
+                    unassigned: []
                 });
             }
-            byCat[index[row.categoryOrder]].rows.push(row);
+            const bucket = byCat[index[row.categoryOrder]];
+            if (row.assigned)
+                bucket.assigned.push(row);
+            else
+                bucket.unassigned.push(row);
         }
         return byCat;
     }
 
-    /// Total packing cost of all groups. A group costs its rows plus a
-    /// fixed heading + inter-group gap allowance; row units are all the
-    /// same height so counting rows is an honest proxy for pixels.
+    /// Rows the current mode offers at all, ignoring the query. The
+    /// denominator of the search field's counter, so an over-narrow query
+    /// reads as "0 of 94" rather than as an unexplained blank card.
+    readonly property int modeRowCount: {
+        let n = 0;
+        for (let i = 0; i < root.shortcuts.length; ++i) {
+            if (root.rowVisible(root.shortcuts[i]))
+                ++n;
+        }
+        return n;
+    }
+
+    readonly property int matchedRowCount: {
+        if (root.queryTerms.length === 0)
+            return root.modeRowCount;
+
+        let n = 0;
+        for (let i = 0; i < root.shortcuts.length; ++i) {
+            const row = root.shortcuts[i];
+            if (root.rowVisible(row) && root.rowMatches(row))
+                ++n;
+        }
+        return n;
+    }
+
+    /// True when the given category's unassigned rows are disclosed.
+    ///
+    /// A query never opens one on its own, for the same reason it never
+    /// removes a row: that would resize the card as the user typed. The
+    /// disclosure line reports its own hidden matches instead, so a match
+    /// behind it is still announced and opening it stays a deliberate click.
+    function categoryExpanded(group) {
+        return root.expandedCategories[group.categoryOrder] === true;
+    }
+
+    /// How many of a category's collapsed unassigned rows answer the query.
+    /// Zero while no query is active.
+    function unassignedMatchCount(group) {
+        if (root.queryTerms.length === 0)
+            return 0;
+
+        let n = 0;
+        for (let i = 0; i < group.unassigned.length; ++i) {
+            if (root.rowMatches(group.unassigned[i]))
+                ++n;
+        }
+        return n;
+    }
+
+    /// Packing cost of one group in row units: its bound rows plus a fixed
+    /// heading allowance, plus the unassigned rollup (one line collapsed, one
+    /// line per row when open). Row units are all roughly the same height, so
+    /// counting them is an honest proxy for pixels.
+    function groupUnits(group) {
+        let units = group.assigned.length + 2;
+        if (group.unassigned.length > 0)
+            units += root.categoryExpanded(group) ? group.unassigned.length + 1 : 1;
+        return units;
+    }
+
     readonly property int totalUnits: {
-        var t = 0;
-        for (var g = 0; g < root.groups.length; g++)
-            t += root.groups[g].rows.length + 2;
+        let t = 0;
+        for (let g = 0; g < root.groups.length; ++g)
+            t += root.groupUnits(root.groups[g]);
         return t;
     }
 
-    /// Groups flowed into `metrics.columns` buckets newspaper-style, in
-    /// display order. A group that straddles a column boundary splits: its
-    /// remaining rows continue at the top of the next column under a
-    /// repeated "(continued)" heading, so one huge group (Scrolling) no
-    /// longer forces its column to tower over the others. Each bucket entry
-    /// is {name, rows, continued}. Splits never orphan fewer than
-    /// `minChunk` rows on either side of the boundary.
+    /// Groups flowed into `metrics.columns` buckets in display order, each
+    /// group kept WHOLE.
+    ///
+    /// The previous packer split a group across a column boundary and
+    /// reprinted its heading as "(continued)", which meant reading order ran
+    /// vertically and then horizontally through severed sections, and on a
+    /// typical scrolling screen two of the three headings were continuations
+    /// rather than headings. Balance is worth less here than a block a reader
+    /// can trust, so a group now moves to the next column only when keeping it
+    /// in the current one would overshoot the target by more than half its own
+    /// height. A single oversized group (Scrolling) simply owns a tall column,
+    /// which the search field above is what actually makes tractable.
     readonly property var columnBuckets: {
-        var n = metrics.columns;
-        var buckets = [];
-        for (var c = 0; c < n; c++)
+        const n = metrics.columns;
+        let buckets = [];
+        for (let c = 0; c < n; ++c)
             buckets.push([]);
         if (root.groups.length === 0)
             return buckets;
 
-        var minChunk = 2;
-        // Every split repeats a heading, growing the true total by 2 units;
-        // budget for the worst case (one split per boundary) up front so the
-        // last column doesn't silently absorb the overhead.
-        var target = Math.ceil((root.totalUnits + 2 * (n - 1)) / n);
-        var col = 0;
-        var used = 0;
-        for (var g = 0; g < root.groups.length; g++) {
-            var group = root.groups[g];
-            var offset = 0;
-            while (offset < group.rows.length) {
-                var rowsLeft = group.rows.length - offset;
-                var space = target - used - 2;
-                var lastCol = col === n - 1;
-                if (!lastCol && space < minChunk && used > 0) {
-                    // Not even room for a heading plus a minimal chunk:
-                    // close this column and reconsider from the next.
-                    col++;
-                    used = 0;
-                    continue;
-                }
-                var take = lastCol ? rowsLeft : Math.min(rowsLeft, Math.max(minChunk, space));
-                var remainder = rowsLeft - take;
-                if (remainder > 0 && remainder < minChunk) {
-                    // Shrink this chunk rather than orphan a sliver in the
-                    // next column; if that would make this chunk a sliver
-                    // too, keep the group whole here instead.
-                    take = rowsLeft - minChunk >= minChunk ? rowsLeft - minChunk : rowsLeft;
-                }
-                buckets[col].push({
-                    name: group.name,
-                    rows: group.rows.slice(offset, offset + take),
-                    continued: offset > 0
-                });
-                used += take + 2;
-                offset += take;
-                if (!lastCol && used >= target) {
-                    col++;
-                    used = 0;
-                }
+        const target = root.totalUnits / n;
+        let col = 0;
+        let used = 0;
+        for (let g = 0; g < root.groups.length; ++g) {
+            const units = root.groupUnits(root.groups[g]);
+            // `used > 0` keeps a group taller than the whole target from
+            // being bounced out of an empty column forever.
+            if (col < n - 1 && used > 0 && used + units - target > units / 2) {
+                ++col;
+                used = 0;
             }
+            buckets[col].push(root.groups[g]);
+            used += units;
         }
-        // Drop trailing empty buckets: some group-size shapes (e.g. rows
-        // [2,3,2,3]) fill fewer columns than the clamp allowed, and an empty
-        // bucket would still reserve a column width plus spacing in
-        // metrics.contentWidth via renderedColumns.
+        // Drop trailing empty buckets: some group-size shapes fill fewer
+        // columns than the clamp allowed, and an empty bucket would still
+        // reserve a column width plus spacing in metrics.contentWidth.
         while (buckets.length > 1 && buckets[buckets.length - 1].length === 0)
             buckets.pop();
         return buckets;
+    }
+
+    /// The tiling mode's display name, for the subtitle. Kept in sync with the
+    /// settings pages' own headings ("Snapping" / "Tiling" / "Scrolling") —
+    /// note the catalog's internal tag for tiling is "autotile", which is not
+    /// a name any user-facing string uses.
+    readonly property string modeDisplayName: {
+        if (root.currentMode === "autotile")
+            return i18n("Tiling");
+        if (root.currentMode === "scrolling")
+            return i18n("Scrolling");
+        return i18n("Snapping");
     }
 
     // Metrics mirror LayoutPickerContent's card chrome exactly (paddingSide
@@ -235,12 +336,6 @@ Item {
         id: metrics
 
         readonly property int paddingSide: Kirigami.Units.gridUnit
-        // The category heading's de-emphasis. Opacity rather than
-        // disabledTextColor, because the heading is not disabled content;
-        // Kirigami has no named token for "secondary but enabled", so the
-        // number lives here, beside the other layout constants, instead of
-        // inline on the label.
-        readonly property real headingOpacity: 0.7
         // Preferred width, shrunk to the available screen width when even a
         // single column at the preferred size would push the card (content +
         // side padding) past the screen edge — narrow screens get a
@@ -249,24 +344,26 @@ Item {
         readonly property int columnSpacing: Kirigami.Units.gridUnit * 2
         readonly property int maxColumns: 3
         readonly property int columns: {
-            var avail = root.width * 0.9 - paddingSide * 2;
-            var fit = Math.floor((avail + columnSpacing) / (columnWidth + columnSpacing));
-            // Bound by content volume, not group count: groups split across
-            // column boundaries, so one long group can legitimately span
-            // several columns. One column per started ~8 units of content
-            // keeps short sheets from spreading into slivers (the packer's
-            // min-chunk rule still guarantees no column is near-empty).
-            var worthwhile = Math.max(1, Math.ceil(root.totalUnits / 8));
-            return Math.max(1, Math.min(maxColumns, Math.min(fit, worthwhile)));
+            const avail = root.width * 0.9 - paddingSide * 2;
+            const fit = Math.floor((avail + columnSpacing) / (columnWidth + columnSpacing));
+            // Bound by content volume, not group count alone: one column per
+            // started ~8 units of content keeps short sheets from spreading
+            // into slivers. Groups are no longer split, so the column count
+            // can also never usefully exceed the number of groups.
+            const worthwhile = Math.max(1, Math.ceil(root.totalUnits / 8));
+            return Math.max(1, Math.min(maxColumns, Math.min(fit, worthwhile), Math.max(1, root.groups.length)));
         }
         // Sized from the buckets the packer actually FILLED, not the column
         // clamp: the packer may leave the last allowed column empty.
         readonly property int renderedColumns: Math.max(1, root.columnBuckets.length)
         readonly property int contentWidth: renderedColumns * columnWidth + (renderedColumns - 1) * columnSpacing
-        // Floored at three grid units rather than 0: on an extremely short
-        // screen a zero budget would collapse the scroller and leave a bare
-        // title with no hint that content exists.
-        readonly property int maxContentHeight: Math.max(Kirigami.Units.gridUnit * 3, Math.round(root.height * 0.85) - paddingSide * 3 - titleLabel.height)
+        // Height budget left for the scrolling column strip once the card's
+        // fixed chrome is accounted for. Floored at three grid units rather
+        // than 0: on an extremely short screen a zero budget would collapse
+        // the scroller and leave a bare title with no hint that content
+        // exists.
+        readonly property int chromeHeight: titleLabel.implicitHeight + modeLabel.implicitHeight + searchField.implicitHeight + footerLabel.implicitHeight + cardLayout.spacing * 3
+        readonly property int maxContentHeight: Math.max(Kirigami.Units.gridUnit * 3, Math.round(root.height * 0.85) - paddingSide * 2 - chromeHeight)
     }
 
     // Backdrop — click outside to dismiss, same bare click-only backdrop
@@ -285,15 +382,15 @@ Item {
 
         anchors.centerIn: parent
         width: metrics.contentWidth + metrics.paddingSide * 2
-        // top padding + title + gap below title + content + bottom padding —
-        // same vertical rhythm as LayoutPickerContent.
-        height: titleLabel.height + scroller.height + metrics.paddingSide * 3
+        height: cardLayout.implicitHeight + metrics.paddingSide * 2
 
         // No container Accessible.name: the title label below is the single
         // announcement, matching LayoutPickerContent's card.
 
         // Absorb clicks inside the card so they never reach the backdrop —
-        // same sibling z-order contract as LayoutPickerContent.
+        // same sibling z-order contract as LayoutPickerContent. Declared
+        // FIRST so the interactive content below it (search field, disclosure
+        // lines) hit-tests ahead of it.
         MouseArea {
             anchors.fill: parent
             Accessible.ignored: true
@@ -302,274 +399,157 @@ Item {
             }
         }
 
-        // Title — shared popup-card typography (PopupCardTitle), anchored
-        // exactly like the picker's "Choose Layout".
-        PopupCardTitle {
-            id: titleLabel
+        ColumnLayout {
+            id: cardLayout
 
-            anchors.top: parent.top
-            anchors.topMargin: metrics.paddingSide
-            anchors.horizontalCenter: parent.horizontalCenter
-            text: i18n("Keyboard Shortcuts")
-            fontFamily: root.fontFamily
-            fontSizeScale: root.fontSizeScale
-        }
+            anchors.fill: parent
+            anchors.margins: metrics.paddingSide
+            spacing: Kirigami.Units.largeSpacing
 
-        // Empty-state fallback: every catalog row mode-filtered out. The
-        // General group is mode-independent so this is unreachable with the
-        // shipped taxonomy, but a data-driven guarantee is not a structural
-        // one — degrade to a legible line instead of a bare title.
-        Label {
-            id: emptyStateLabel
+            // Title — shared popup-card typography (PopupCardTitle), matching
+            // the picker's "Choose Layout".
+            PopupCardTitle {
+                id: titleLabel
 
-            anchors.top: titleLabel.bottom
-            anchors.topMargin: metrics.paddingSide
-            anchors.horizontalCenter: parent.horizontalCenter
-            width: metrics.contentWidth
-            wrapMode: Text.Wrap
-            horizontalAlignment: Text.AlignHCenter
-            text: i18n("No shortcuts apply in the current mode.")
-            color: Kirigami.Theme.disabledTextColor
-            visible: root.groups.length === 0
-            font.family: root.fontFamily.length > 0 ? root.fontFamily : Kirigami.Theme.defaultFont.family
-            font.pixelSize: Math.round(Kirigami.Theme.defaultFont.pixelSize * root.fontSizeScale)
-        }
+                Layout.alignment: Qt.AlignHCenter
+                text: i18n("Keyboard Shortcuts")
+                fontFamily: root.fontFamily
+                fontSizeScale: root.fontSizeScale
+            }
 
-        Flickable {
-            id: scroller
+            // The sheet has always been filtered by the bound screen's mode
+            // and never said so, which made an absent group look like a bug.
+            Label {
+                id: modeLabel
 
-            anchors.top: titleLabel.bottom
-            anchors.topMargin: metrics.paddingSide
-            anchors.horizontalCenter: parent.horizontalCenter
-            width: metrics.contentWidth
-            height: root.groups.length === 0 ? emptyStateLabel.height : Math.min(bucketsRow.implicitHeight, metrics.maxContentHeight)
-            // Empty state: the fallback label occupies this rect instead —
-            // hide the (empty) scroller so exactly one item owns the slot.
-            visible: root.groups.length > 0
-            contentWidth: width
-            contentHeight: bucketsRow.implicitHeight
-            clip: true
-            boundsBehavior: Flickable.StopAtBounds
-            // Column order carries meaning ("(continued)" points forward), so
-            // mirror the flow for right-to-left locales.
-            LayoutMirroring.enabled: Qt.application.layoutDirection === Qt.RightToLeft
-            LayoutMirroring.childrenInherit: true
+                Layout.alignment: Qt.AlignHCenter
+                Layout.topMargin: -Kirigami.Units.largeSpacing + Kirigami.Units.smallSpacing
+                text: i18nc("which placement mode the listed shortcuts belong to", "Filtered for %1 mode on this screen", root.modeDisplayName)
+                color: Kirigami.Theme.disabledTextColor
+                font.family: root.fontFamily.length > 0 ? root.fontFamily : Kirigami.Theme.defaultFont.family
+                font.pixelSize: Math.round(Kirigami.Theme.defaultFont.pixelSize * 0.9 * root.fontSizeScale)
+            }
 
-            // Non-interactive affordance: the sheet clips on short screens
-            // and nothing else tells the reader rows are cut off.
-            ScrollIndicator.vertical: ScrollIndicator {}
+            CheatsheetSearchField {
+                id: searchField
 
-            Row {
-                id: bucketsRow
+                Layout.fillWidth: true
+                shownCount: root.matchedRowCount
+                totalCount: root.modeRowCount
+                fontFamily: root.fontFamily
+                fontSizeScale: root.fontSizeScale
+                onTextChanged: root.query = searchField.text
 
-                spacing: metrics.columnSpacing
+                // The surface's keyboard grab is applied by OverlayService in
+                // the same show, but the compositor's focus-in arrives later.
+                // forceActiveFocus is a scene-local claim, so it survives that
+                // wait: the field is already the focus item when the window
+                // becomes active, and the first keystroke lands in it.
+                Component.onCompleted: takeFocus()
+            }
 
-                Repeater {
-                    model: root.columnBuckets
+            // Empty state. Reachable two ways now: a query that matches
+            // nothing (common), or every catalog row filtered out by mode
+            // (unreachable with the shipped taxonomy, since the General group
+            // is mode-independent, but a data-driven guarantee is not a
+            // structural one).
+            Label {
+                Layout.fillWidth: true
+                Layout.topMargin: Kirigami.Units.gridUnit
+                Layout.bottomMargin: Kirigami.Units.gridUnit
+                wrapMode: Text.Wrap
+                horizontalAlignment: Text.AlignHCenter
+                // Only the mode-filtered-everything-out case now. A query
+                // that matches nothing leaves the full sheet in place, dimmed,
+                // with the search field's counter reporting no matches.
+                text: i18n("No shortcuts apply in the current mode.")
+                color: Kirigami.Theme.disabledTextColor
+                visible: root.groups.length === 0
+                font.family: root.fontFamily.length > 0 ? root.fontFamily : Kirigami.Theme.defaultFont.family
+                font.pixelSize: Math.round(Kirigami.Theme.defaultFont.pixelSize * root.fontSizeScale)
+            }
 
-                    delegate: Column {
-                        id: bucketColumn
+            Flickable {
+                id: scroller
 
-                        required property var modelData
+                Layout.alignment: Qt.AlignHCenter
+                Layout.preferredWidth: metrics.contentWidth
+                Layout.preferredHeight: Math.min(bucketsRow.implicitHeight, metrics.maxContentHeight)
+                // Empty state: the fallback label above occupies the slot
+                // instead — hide the (empty) scroller so exactly one item owns
+                // it.
+                visible: root.groups.length > 0
+                contentWidth: width
+                contentHeight: bucketsRow.implicitHeight
+                clip: true
+                boundsBehavior: Flickable.StopAtBounds
+                // Column order carries meaning, so mirror the flow for
+                // right-to-left locales.
+                LayoutMirroring.enabled: Qt.application.layoutDirection === Qt.RightToLeft
+                LayoutMirroring.childrenInherit: true
 
-                        width: metrics.columnWidth
-                        spacing: Kirigami.Units.largeSpacing
+                // Non-interactive affordance: the sheet can still clip on a
+                // short screen and nothing else tells the reader rows are cut
+                // off.
+                ScrollIndicator.vertical: ScrollIndicator {}
 
-                        Repeater {
-                            model: bucketColumn.modelData
+                Row {
+                    id: bucketsRow
 
-                            delegate: Column {
-                                id: groupColumn
+                    spacing: metrics.columnSpacing
 
-                                required property var modelData
+                    Repeater {
+                        model: root.columnBuckets
 
-                                width: metrics.columnWidth
-                                spacing: Kirigami.Units.smallSpacing
+                        delegate: Column {
+                            id: bucketColumn
 
-                                // Plain styled Label rather than a
-                                // Kirigami.Heading: sibling overlay titles
-                                // all bind pixelSize on Labels, and a
-                                // Heading's level-driven pointSize would
-                                // fight an explicit pixelSize on the same
-                                // font. Sized 1.1x the row labels (the
-                                // level-4 heading factor), tracking the
-                                // user's overlay font like rows and caps.
-                                Label {
-                                    text: groupColumn.modelData.continued ? i18nc("category heading for a section that continues from the previous column", "%1 (continued)", groupColumn.modelData.name) : groupColumn.modelData.name
-                                    // textColor, not disabledTextColor: the
-                                    // heading is not disabled content, and the
-                                    // size/weight differentiation below carries
-                                    // the hierarchy without misusing the role.
-                                    color: Kirigami.Theme.textColor
-                                    opacity: metrics.headingOpacity
-                                    // Constrain to the column and wrap: a
-                                    // long translated category name grows a
-                                    // second line instead of overflowing
-                                    // into the neighbouring column.
-                                    width: groupColumn.width
-                                    wrapMode: Text.Wrap
-                                    font.family: root.fontFamily.length > 0 ? root.fontFamily : Kirigami.Theme.defaultFont.family
-                                    font.pixelSize: Math.round(Kirigami.Theme.defaultFont.pixelSize * 1.1 * root.fontSizeScale)
-                                }
+                            required property var modelData
 
-                                Repeater {
-                                    model: groupColumn.modelData.rows
+                            width: metrics.columnWidth
+                            spacing: Kirigami.Units.gridUnit
 
-                                    delegate: RowLayout {
-                                        id: shortcutRow
+                            Repeater {
+                                model: bucketColumn.modelData
 
-                                        required property var modelData
+                                delegate: CheatsheetGroup {
+                                    required property var modelData
 
-                                        width: metrics.columnWidth
-                                        spacing: Kirigami.Units.smallSpacing
-
-                                        Accessible.role: Accessible.StaticText
-                                        // Announces every binding, and composes
-                                        // the unassigned state from the SAME
-                                        // translated token the visible label
-                                        // shows, so a translator cannot make
-                                        // the two diverge.
-                                        Accessible.name: shortcutRow.modelData.assigned ? i18nc("shortcut row: action, keys", "%1, %2", shortcutRow.modelData.label, shortcutRow.modelData.triggers.join(", ")) : i18nc("shortcut row: action, state", "%1, %2", shortcutRow.modelData.label, unassignedLabel.text)
-                                        // Template-capability rows swap their
-                                        // tooltip wording; templatesDescription
-                                        // falls back to description in the
-                                        // model, so this stays a two-way pick.
-                                        readonly property string effectiveDescription: root.layoutsAreTemplates ? (shortcutRow.modelData.templatesDescription || shortcutRow.modelData.description || "") : (shortcutRow.modelData.description || "")
-
-                                        Accessible.description: shortcutRow.effectiveDescription
-
-                                        // Plain-prose explanation from the
-                                        // catalog, on hover (long-press on
-                                        // touch). Rows without one (empty
-                                        // description) show no tooltip.
-                                        HoverHandler {
-                                            id: rowHover
-
-                                            enabled: shortcutRow.effectiveDescription.length > 0
-                                        }
-
-                                        // Touch path: the sheet-level latch is
-                                        // folded into the SAME visible
-                                        // binding, never an imperative open()
-                                        // — a C++ open over a declarative
-                                        // binding would leave the tooltip
-                                        // stuck on touch devices, where no
-                                        // hover change ever re-runs the
-                                        // binding. A tap on the row, a
-                                        // long-press on another row, or a
-                                        // flick clears it.
-                                        TapHandler {
-                                            enabled: rowHover.enabled
-                                            onLongPressed: root.latchedRow = shortcutRow
-                                            onTapped: root.latchedRow = null
-                                        }
-
-                                        // An explicit per-row instance, not the
-                                        // attached ToolTip: the attached form
-                                        // shares one engine-wide popup (row-to-row
-                                        // moves can cancel the tooltip just shown)
-                                        // and cannot pin popupType, and on this
-                                        // layer-shell surface a style-driven
-                                        // promotion to a native popup window would
-                                        // hit the QPA's unreachable xdg_popup
-                                        // path. Popup.Item keeps it in-scene, the
-                                        // same pin the settings combos carry. A
-                                        // per-row instance also dies with its
-                                        // delegate, so a rebuild cannot strand an
-                                        // open tooltip.
-                                        ToolTip {
-                                            id: rowTip
-
-                                            popupType: T.Popup.Item
-                                            visible: (rowHover.hovered || root.latchedRow === shortcutRow) && !scroller.moving
-                                            onClosed: {
-                                                if (root.latchedRow === shortcutRow)
-                                                    root.latchedRow = null;
-                                            }
-                                            text: shortcutRow.effectiveDescription
-                                            delay: Kirigami.Units.toolTipDelay
-                                            font.family: root.fontFamily.length > 0 ? root.fontFamily : Kirigami.Theme.defaultFont.family
-                                            font.pixelSize: Math.round(Kirigami.Theme.defaultFont.pixelSize * root.fontSizeScale)
-                                        }
-
-                                        Label {
-                                            text: shortcutRow.modelData.label
-                                            // The row announces a composed
-                                            // "action, keys" Accessible.name;
-                                            // keep the visible children out of
-                                            // the a11y tree so screen readers
-                                            // don't announce them twice.
-                                            Accessible.ignored: true
-                                            // Wrap, never elide: the model ships
-                                            // group-contextual short labels sized
-                                            // to fit, and a pathological case
-                                            // (translation, custom font) grows a
-                                            // second line instead of losing text.
-                                            wrapMode: Text.Wrap
-                                            font.family: root.fontFamily.length > 0 ? root.fontFamily : Kirigami.Theme.defaultFont.family
-                                            font.pixelSize: Math.round(Kirigami.Theme.defaultFont.pixelSize * root.fontSizeScale)
-                                            Layout.fillWidth: true
-                                            // Never crushed to nothing by a long
-                                            // chip run in a narrow column; an
-                                            // overlong run overflows the row's
-                                            // width (clipped only at the card
-                                            // edge by the Flickable) rather
-                                            // than eating the label.
-                                            Layout.minimumWidth: Kirigami.Units.gridUnit * 3
-                                        }
-
-                                        // One chip row per BOUND SEQUENCE, so an
-                                        // alternate binding is visible instead of
-                                        // silently dropped (the C++ compression
-                                        // already declines to merge rows carrying
-                                        // alternates for the same reason).
-                                        Column {
-                                            spacing: Math.round(Kirigami.Units.smallSpacing / 2)
-                                            visible: shortcutRow.modelData.assigned
-
-                                            Repeater {
-                                                model: shortcutRow.modelData.assigned ? shortcutRow.modelData.triggers : []
-
-                                                delegate: Row {
-                                                    id: chipRow
-
-                                                    required property string modelData
-
-                                                    spacing: Math.round(Kirigami.Units.smallSpacing / 2)
-                                                    anchors.right: parent.right
-
-                                                    Repeater {
-                                                        model: root.keyTokens(chipRow.modelData)
-
-                                                        delegate: KeyChip {
-                                                            required property string modelData
-
-                                                            text: modelData
-                                                            fontFamily: root.fontFamily
-                                                            fontSizeScale: root.fontSizeScale
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-
-                                        Label {
-                                            id: unassignedLabel
-
-                                            text: i18n("Unassigned")
-                                            color: Kirigami.Theme.disabledTextColor
-                                            font.italic: true
-                                            visible: !shortcutRow.modelData.assigned
-                                            // Covered by the row's composed
-                                            // "%1, unassigned" Accessible.name.
-                                            Accessible.ignored: true
-                                        }
-                                    }
+                                    width: metrics.columnWidth
+                                    name: modelData.name
+                                    assignedRows: modelData.assigned
+                                    unassignedRows: modelData.unassigned
+                                    expanded: root.categoryExpanded(modelData)
+                                    latchedRowId: root.latchedRowId
+                                    queryTerms: root.queryTerms
+                                    queryActive: root.queryTerms.length > 0
+                                    unassignedMatches: root.unassignedMatchCount(modelData)
+                                    matcher: root.rowMatches
+                                    scrollerMoving: scroller.moving
+                                    layoutsAreTemplates: root.layoutsAreTemplates
+                                    fontFamily: root.fontFamily
+                                    fontSizeScale: root.fontSizeScale
+                                    onExpandToggled: root._toggleCategory(modelData.categoryOrder)
+                                    onLatchRequested: rowId => root.latchedRowId = rowId
+                                    onLatchCleared: root.latchedRowId = ""
                                 }
                             }
                         }
                     }
                 }
+            }
+
+            // Escape is a daemon-side global grab, so it closes the sheet
+            // outright rather than first clearing the filter; say so plainly
+            // instead of letting the user discover it.
+            Label {
+                id: footerLabel
+
+                Layout.alignment: Qt.AlignHCenter
+                text: i18n("Press Escape to close")
+                color: Kirigami.Theme.disabledTextColor
+                font.family: root.fontFamily.length > 0 ? root.fontFamily : Kirigami.Theme.defaultFont.family
+                font.pixelSize: Math.round(Kirigami.Theme.defaultFont.pixelSize * 0.85 * root.fontSizeScale)
             }
         }
     }

--- a/src/ui/CheatsheetGroup.qml
+++ b/src/ui/CheatsheetGroup.qml
@@ -27,7 +27,7 @@ Column {
     property bool expanded: false
     /// Catalog id of the row whose tooltip the sheet has latched open.
     property string latchedRowId: ""
-    property var queryTerms: []
+    property list<string> queryTerms: []
     /// True while the sheet has a filter typed into it. Splits "everything is
     /// relevant" from "this row happens to match", which look identical from a
     /// row's own point of view but should not render the same. Derived rather
@@ -57,8 +57,15 @@ Column {
     /// True when this row answers the query, or when there is no query. Rows
     /// that do not are dimmed rather than dropped.
     function rowMatched(row) {
-        if (!root.queryActive || !root.matcher)
+        if (!root.queryActive)
             return true;
+        // A query with no matcher would silently mark every row as answering
+        // it, while the sheet's own counter said zero. Treat it as the setup
+        // error it is rather than rendering a lie.
+        if (!root.matcher) {
+            console.warn("CheatsheetGroup: query active with no matcher; category", root.name);
+            return false;
+        }
         return root.matcher(row);
     }
 

--- a/src/ui/CheatsheetGroup.qml
+++ b/src/ui/CheatsheetGroup.qml
@@ -30,8 +30,10 @@ Column {
     property var queryTerms: []
     /// True while the sheet has a filter typed into it. Splits "everything is
     /// relevant" from "this row happens to match", which look identical from a
-    /// row's own point of view but should not render the same.
-    property bool queryActive: false
+    /// row's own point of view but should not render the same. Derived rather
+    /// than passed in alongside the terms, so a caller cannot set the two
+    /// inconsistently and leave the heading disagreeing with its own rows.
+    readonly property bool queryActive: root.queryTerms.length > 0
     /// How many of this category's collapsed unassigned rows answer the query.
     /// The disclosure line reports them, so a match hidden behind it is still
     /// announced without the sheet resizing itself to reveal it.
@@ -90,6 +92,14 @@ Column {
 
             anchors.left: parent.left
             anchors.verticalCenter: parent.verticalCenter
+            // Sized to its text, but capped so a long translated category
+            // cannot run past its column and paint over the neighbouring one.
+            // Width tracks the text rather than filling the row, because the
+            // rule anchors to this label's right edge and is what makes the
+            // heading read as the top of a block. The reserve keeps the rule
+            // visible even at the cap.
+            width: Math.min(implicitWidth, parent.width - Kirigami.Units.gridUnit)
+            elide: Text.ElideRight
             text: root.name
             // Capitalisation as a FONT property, not text.toUpperCase(): the
             // string stays intact for accessibility and for locales whose
@@ -156,7 +166,16 @@ Column {
         // With a query up, the line reports its own hidden matches instead of
         // its total, so the one thing worth clicking says so.
         text: root.expanded ? i18n("Hide unassigned actions") : (root.queryActive && root.unassignedMatches > 0 ? i18np("%n unassigned action matches", "%n unassigned actions match", root.unassignedMatches) : i18np("%n unassigned action", "%n unassigned actions", root.unassignedRows.length))
-        color: root.queryActive && root.unassignedMatches > 0 ? Kirigami.Theme.highlightColor : (disclosureArea.containsMouse ? Kirigami.Theme.textColor : Kirigami.Theme.disabledTextColor)
+        // Hover and keyboard focus both brighten it. The highlight state has
+        // its own hovered shade rather than dropping the feedback, since that
+        // is exactly the state where the line is worth activating.
+        readonly property bool disclosureHot: disclosureArea.containsMouse || disclosure.activeFocus
+        // Highlighted only while it is standing in for matches the reader
+        // cannot see. Once the rollup is open those rows are on screen and
+        // carry their own emphasis, so a highlighted "Hide unassigned actions"
+        // would be claiming to be a match itself.
+        readonly property bool disclosureStandsInForMatches: !root.expanded && root.queryActive && root.unassignedMatches > 0
+        color: disclosure.disclosureStandsInForMatches ? (disclosure.disclosureHot ? Qt.lighter(Kirigami.Theme.highlightColor, 1.25) : Kirigami.Theme.highlightColor) : (disclosure.disclosureHot ? Kirigami.Theme.textColor : Kirigami.Theme.disabledTextColor)
         // Dimmed along with the rest of a category that has nothing to offer
         // the query, but never below the rows it stands in for.
         opacity: !root.queryActive || root.unassignedMatches > 0 ? 1 : 0.35
@@ -165,6 +184,31 @@ Column {
         Accessible.role: Accessible.Button
         Accessible.name: disclosure.text
         Accessible.onPressAction: root.expandToggled()
+
+        // The rows behind this line are otherwise pointer-only. The sheet's
+        // search field takes focus on open and is the only other tab stop, so
+        // Tab walks field -> each disclosure in column order, which is also
+        // reading order. Space and Return activate, matching the button role
+        // already declared above.
+        activeFocusOnTab: true
+        Keys.onPressed: event => {
+            if (event.key === Qt.Key_Space || event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
+                root.expandToggled();
+                event.accepted = true;
+            }
+        }
+
+        // Focus needs to be visible, since the colour shift alone is easy to
+        // miss on a line that is already dim.
+        Rectangle {
+            anchors.fill: parent
+            anchors.margins: -Kirigami.Units.smallSpacing / 2
+            visible: disclosure.activeFocus
+            color: "transparent"
+            border.width: 1
+            border.color: Kirigami.Theme.highlightColor
+            radius: Kirigami.Units.smallSpacing / 2
+        }
 
         MouseArea {
             id: disclosureArea

--- a/src/ui/CheatsheetGroup.qml
+++ b/src/ui/CheatsheetGroup.qml
@@ -50,6 +50,10 @@ Column {
     signal expandToggled
     signal latchRequested(string rowId)
     signal latchCleared
+    /// Emitted when an item inside this group takes keyboard focus, so the
+    /// sheet can scroll it into view. The group cannot do it itself: the
+    /// Flickable that clips it belongs to the sheet.
+    signal focusScrollRequested(Item target)
 
     readonly property string effectiveFamily: fontFamily.length > 0 ? fontFamily : Kirigami.Theme.defaultFont.family
     readonly property int rowFontSize: Math.round(Kirigami.Theme.defaultFont.pixelSize * fontSizeScale)
@@ -104,8 +108,9 @@ Column {
             // Width tracks the text rather than filling the row, because the
             // rule anchors to this label's right edge and is what makes the
             // heading read as the top of a block. The reserve keeps the rule
-            // visible even at the cap.
-            width: Math.min(implicitWidth, parent.width - Kirigami.Units.gridUnit)
+            // visible even at the cap. Floored at 0 for the first frame,
+            // before the column has a width to subtract from.
+            width: Math.max(0, Math.min(implicitWidth, parent.width - Kirigami.Units.gridUnit))
             elide: Text.ElideRight
             text: root.name
             // Capitalisation as a FONT property, not text.toUpperCase(): the
@@ -198,6 +203,14 @@ Column {
         // reading order. Space and Return activate, matching the button role
         // already declared above.
         activeFocusOnTab: true
+        // A Flickable does not bring a focused descendant into view, and these
+        // sit inside the clipped column strip. Without this, Tab on a short
+        // screen can land on a focus ring below the fold and nothing appears
+        // to happen. The sheet owns the scroller, so ask rather than reach.
+        onActiveFocusChanged: {
+            if (disclosure.activeFocus)
+                root.focusScrollRequested(disclosure);
+        }
         Keys.onPressed: event => {
             if (event.key === Qt.Key_Space || event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
                 root.expandToggled();

--- a/src/ui/CheatsheetGroup.qml
+++ b/src/ui/CheatsheetGroup.qml
@@ -1,0 +1,198 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import QtQuick
+import QtQuick.Controls
+import org.kde.kirigami as Kirigami
+
+/**
+ * One category block on the cheatsheet: a heading, the category's bound rows,
+ * and a disclosure line standing in for its unbound ones.
+ *
+ * Groups are never split across columns (see the packer in
+ * CheatsheetContent), so a block is always whole and its heading always
+ * introduces the rows directly beneath it.
+ */
+Column {
+    id: root
+
+    /// Translated category name.
+    required property string name
+    /// Catalog rows in this category that have at least one binding.
+    required property var assignedRows
+    /// Catalog rows in this category with no binding. Collapsed behind a
+    /// count line unless `expanded`.
+    required property var unassignedRows
+    /// Whether the unassigned rows are currently disclosed.
+    property bool expanded: false
+    /// Catalog id of the row whose tooltip the sheet has latched open.
+    property string latchedRowId: ""
+    property var queryTerms: []
+    /// True while the sheet has a filter typed into it. Splits "everything is
+    /// relevant" from "this row happens to match", which look identical from a
+    /// row's own point of view but should not render the same.
+    property bool queryActive: false
+    /// How many of this category's collapsed unassigned rows answer the query.
+    /// The disclosure line reports them, so a match hidden behind it is still
+    /// announced without the sheet resizing itself to reveal it.
+    property int unassignedMatches: 0
+    /// The sheet's row-matching predicate, borrowed rather than reimplemented
+    /// so the heading, the rows and the counter can never disagree about what
+    /// counts as a match.
+    property var matcher: null
+    property bool scrollerMoving: false
+    property bool layoutsAreTemplates: false
+    property string fontFamily: ""
+    property real fontSizeScale: 1
+
+    signal expandToggled
+    signal latchRequested(string rowId)
+    signal latchCleared
+
+    readonly property string effectiveFamily: fontFamily.length > 0 ? fontFamily : Kirigami.Theme.defaultFont.family
+    readonly property int rowFontSize: Math.round(Kirigami.Theme.defaultFont.pixelSize * fontSizeScale)
+
+    /// True when this row answers the query, or when there is no query. Rows
+    /// that do not are dimmed rather than dropped.
+    function rowMatched(row) {
+        if (!root.queryActive || !root.matcher)
+            return true;
+        return root.matcher(row);
+    }
+
+    /// Whether anything in this category answers the query. Drives the
+    /// heading, so a category with nothing to offer recedes as a block
+    /// instead of standing at full accent over a wall of dimmed rows.
+    readonly property bool hasMatch: {
+        if (!root.queryActive)
+            return true;
+        if (root.unassignedMatches > 0)
+            return true;
+        for (let i = 0; i < root.assignedRows.length; ++i) {
+            if (root.rowMatched(root.assignedRows[i]))
+                return true;
+        }
+        return false;
+    }
+
+    spacing: Kirigami.Units.smallSpacing
+
+    // Heading — a rule running to the column edge, so a two-row category
+    // reads as a block rather than dissolving into its neighbours. The
+    // previous heading was a 0.7-opacity Label with nothing but vertical gap
+    // separating one group from the next, which left short groups invisible.
+    Item {
+        width: root.width
+        height: headingLabel.implicitHeight
+
+        Label {
+            id: headingLabel
+
+            anchors.left: parent.left
+            anchors.verticalCenter: parent.verticalCenter
+            text: root.name
+            // Capitalisation as a FONT property, not text.toUpperCase(): the
+            // string stays intact for accessibility and for locales whose
+            // case mapping is not a round trip.
+            font.capitalization: Font.AllUppercase
+            font.family: root.effectiveFamily
+            font.pixelSize: Math.round(Kirigami.Theme.defaultFont.pixelSize * 0.85 * root.fontSizeScale)
+            font.bold: true
+            // Uppercase set solid needs the tracking back; without it the
+            // caps crowd at small sizes.
+            font.letterSpacing: 0.8
+            color: Kirigami.Theme.highlightColor
+            opacity: root.hasMatch ? 1 : 0.3
+            Accessible.role: Accessible.Heading
+            Accessible.name: root.name
+        }
+
+        Rectangle {
+            anchors.left: headingLabel.right
+            anchors.leftMargin: Kirigami.Units.smallSpacing
+            anchors.right: parent.right
+            anchors.verticalCenter: headingLabel.verticalCenter
+            height: 1
+            color: Qt.alpha(Kirigami.Theme.textColor, 0.15)
+            opacity: root.hasMatch ? 1 : 0.3
+            // Purely a rule; the heading label carries the announcement.
+            Accessible.ignored: true
+            // A very long translated category can consume the whole column
+            // width, at which point the rule has nowhere to go.
+            visible: width > 0
+        }
+    }
+
+    Repeater {
+        model: root.assignedRows
+
+        delegate: CheatsheetRow {
+            // `modelData` is CheatsheetRow's own required property; the
+            // Repeater fills it. Re-declaring it here would shadow the row's
+            // and self-assign.
+            width: root.width
+            queryTerms: root.queryTerms
+            matched: root.rowMatched(modelData)
+            latched: root.latchedRowId.length > 0 && root.latchedRowId === modelData.id
+            scrollerMoving: root.scrollerMoving
+            layoutsAreTemplates: root.layoutsAreTemplates
+            fontFamily: root.fontFamily
+            fontSizeScale: root.fontSizeScale
+            onLatchRequested: root.latchRequested(modelData.id)
+            onLatchCleared: root.latchCleared()
+        }
+    }
+
+    // Unassigned disclosure. Six italic "Unassigned" rows at the same weight
+    // as bound ones padded the Scrolling column while telling the reader
+    // nothing, but hiding them outright would lose the answer to "is there a
+    // key for this?" — so they collapse to one line and open on click.
+    Label {
+        id: disclosure
+
+        visible: root.unassignedRows.length > 0
+        width: root.width
+        wrapMode: Text.Wrap
+        // With a query up, the line reports its own hidden matches instead of
+        // its total, so the one thing worth clicking says so.
+        text: root.expanded ? i18n("Hide unassigned actions") : (root.queryActive && root.unassignedMatches > 0 ? i18np("%n unassigned action matches", "%n unassigned actions match", root.unassignedMatches) : i18np("%n unassigned action", "%n unassigned actions", root.unassignedRows.length))
+        color: root.queryActive && root.unassignedMatches > 0 ? Kirigami.Theme.highlightColor : (disclosureArea.containsMouse ? Kirigami.Theme.textColor : Kirigami.Theme.disabledTextColor)
+        // Dimmed along with the rest of a category that has nothing to offer
+        // the query, but never below the rows it stands in for.
+        opacity: !root.queryActive || root.unassignedMatches > 0 ? 1 : 0.35
+        font.family: root.effectiveFamily
+        font.pixelSize: Math.round(root.rowFontSize * 0.9)
+        Accessible.role: Accessible.Button
+        Accessible.name: disclosure.text
+        Accessible.onPressAction: root.expandToggled()
+
+        MouseArea {
+            id: disclosureArea
+
+            anchors.fill: parent
+            hoverEnabled: true
+            cursorShape: Qt.PointingHandCursor
+            onClicked: root.expandToggled()
+        }
+    }
+
+    Repeater {
+        model: root.expanded ? root.unassignedRows : []
+
+        delegate: CheatsheetRow {
+            // `modelData` is CheatsheetRow's own required property; the
+            // Repeater fills it. Re-declaring it here would shadow the row's
+            // and self-assign.
+            width: root.width
+            queryTerms: root.queryTerms
+            matched: root.rowMatched(modelData)
+            latched: root.latchedRowId.length > 0 && root.latchedRowId === modelData.id
+            scrollerMoving: root.scrollerMoving
+            layoutsAreTemplates: root.layoutsAreTemplates
+            fontFamily: root.fontFamily
+            fontSizeScale: root.fontSizeScale
+            onLatchRequested: root.latchRequested(modelData.id)
+            onLatchCleared: root.latchCleared()
+        }
+    }
+}

--- a/src/ui/CheatsheetRow.qml
+++ b/src/ui/CheatsheetRow.qml
@@ -129,7 +129,14 @@ RowLayout {
     }
 
     spacing: Kirigami.Units.smallSpacing
-    opacity: root.matched ? 1 : 0.32
+    // The row's opacity composites over its whole subtree, so it MULTIPLIES
+    // with the chips' own alphas rather than replacing them: a modifier cap
+    // already drawn at 0.6 text alpha lands at 0.6 x this. At 0.32 that put
+    // modifier text near 0.19 effective alpha, which is under any usable
+    // contrast floor. Raising the floor here rather than flattening the chip
+    // alphas keeps the recede-the-modifiers relationship exactly as designed
+    // and fixes the composition instead.
+    opacity: root.matched ? 1 : 0.5
     // Short enough not to lag the typing it responds to, long enough that the
     // sheet reads as re-weighting itself rather than flickering.
     Behavior on opacity {
@@ -143,7 +150,15 @@ RowLayout {
     // Announces every binding, and composes the unassigned state from the
     // SAME translated token the visible label shows, so a translator cannot
     // make the two diverge.
-    Accessible.name: root.modelData.assigned ? i18nc("shortcut row: action, keys", "%1, %2", root.modelData.label, root.modelData.triggers.join(", ")) : i18nc("shortcut row: action, state", "%1, %2", root.modelData.label, unassignedLabel.text)
+    readonly property string accessibleRowText: root.modelData.assigned ? i18nc("shortcut row: action, keys", "%1, %2", root.modelData.label, root.modelData.triggers.join(", ")) : i18nc("shortcut row: action, state", "%1, %2", root.modelData.label, unassignedLabel.text)
+    // While a query is up, the row's answer to it is carried in the name
+    // rather than in opacity alone. Dimming and the bold runs inside the label
+    // are the sighted signal, and neither reaches the accessibility tree: the
+    // label is deliberately ignored below, and opacity is not announced. So
+    // without this a screen-reader user typing a query hears the whole sheet
+    // read back unchanged. Only matching rows are marked, so the common case
+    // adds nothing to what is spoken.
+    Accessible.name: (root.queryTerms.length > 0 && root.matched) ? i18nc("a shortcut row that answers the current search, then the row itself", "Match, %1", root.accessibleRowText) : root.accessibleRowText
     Accessible.description: root.effectiveDescription
 
     // Plain-prose explanation from the catalog, on hover (long-press on
@@ -238,6 +253,12 @@ RowLayout {
                         required property int index
 
                         text: modelData
+                        // The key text is part of the search haystack, so a
+                        // query like "meta alt" matches on chips alone. The
+                        // label's bold runs cannot show that, and without this
+                        // such a query left its matched rows at full contrast
+                        // with nothing marked on them.
+                        highlighted: root.queryTerms.length > 0 && root.matched && root.queryTerms.some(term => modelData.toLocaleLowerCase().indexOf(term) >= 0)
                         // Positional, never a name match against a modifier
                         // list: these tokens come from QKeySequence in NATIVE
                         // text, so "Meta" is localised and may render as a

--- a/src/ui/CheatsheetRow.qml
+++ b/src/ui/CheatsheetRow.qml
@@ -26,7 +26,7 @@ RowLayout {
     required property var modelData
     /// Lowercased query terms currently filtering the sheet, used to bold the
     /// matched runs of the label. Empty when no filter is active.
-    property var queryTerms: []
+    property list<string> queryTerms: []
     /// False when a filter is active and this row does not answer it. The row
     /// still occupies its place, so the card's geometry never changes as the
     /// user types; it simply recedes. Non-matching rows stay legible enough to
@@ -139,6 +139,12 @@ RowLayout {
     opacity: root.matched ? 1 : 0.5
     // Short enough not to lag the typing it responds to, long enough that the
     // sheet reads as re-weighting itself rather than flickering.
+    //
+    // A Behavior animates on CHANGE, not on re-evaluation, so this does not
+    // cost an animation per row per keystroke. Measured on a 94-row sheet: the
+    // first keystroke starts 84 legs as most rows drop out together, and a
+    // further keystroke that does not change which rows match starts none.
+    // The burst is the transition into a query, and it happens once.
     Behavior on opacity {
         NumberAnimation {
             duration: Kirigami.Units.shortDuration
@@ -201,12 +207,21 @@ RowLayout {
     }
 
     Label {
-        text: root.markUpLabel(root.modelData.label, root.queryTerms)
+        // Only matching rows are marked up. A dimmed row has already failed at
+        // least one term and is not what the reader is being pointed at, so
+        // bolding whatever fragments it does contain adds noise rather than
+        // signal — and it is also the bulk of the per-keystroke work, since the
+        // dimmed rows are the majority on any narrow query.
+        text: root.matched ? root.markUpLabel(root.modelData.label, root.queryTerms) : root.markUpLabel(root.modelData.label, [])
         // StyledText unconditionally, not "rich only while filtering": the
         // markUpLabel escape pass runs in both cases, so a label containing a
         // literal ampersand or angle bracket renders identically whether or
         // not a query is active. Switching textFormat with the query would
-        // make that one label change shape as the user types.
+        // make that one label change shape as the user types. The trade is
+        // that StyledText also collapses whitespace runs, so a translated
+        // label carrying a double space or a newline sets differently than it
+        // would as PlainText. No shipped label does, and one that did would be
+        // a catalog bug rather than something to work around here.
         textFormat: Text.StyledText
         // The row announces a composed "action, keys" Accessible.name; keep
         // the visible children out of the a11y tree so screen readers don't

--- a/src/ui/CheatsheetRow.qml
+++ b/src/ui/CheatsheetRow.qml
@@ -1,0 +1,271 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import QtQuick.Templates as T
+import org.kde.kirigami as Kirigami
+
+/**
+ * One shortcut row on the cheatsheet: an action label on the left, its bound
+ * key sequences as chip runs on the right, or an "Unassigned" marker when the
+ * action has no binding.
+ *
+ * Split out of CheatsheetContent so the sheet's packing and filtering logic
+ * is readable without four levels of delegate nesting under it. The row owns
+ * only its own presentation; the tooltip LATCH lives on the sheet, because a
+ * long-press on a second row has to close the first one's tooltip and no row
+ * can see its siblings.
+ */
+RowLayout {
+    id: root
+
+    /// One catalog row from ShortcutManager::cheatsheetModel(). See the
+    /// `shortcuts` docs on CheatsheetContent for the field list.
+    required property var modelData
+    /// Lowercased query terms currently filtering the sheet, used to bold the
+    /// matched runs of the label. Empty when no filter is active.
+    property var queryTerms: []
+    /// False when a filter is active and this row does not answer it. The row
+    /// still occupies its place, so the card's geometry never changes as the
+    /// user types; it simply recedes. Non-matching rows stay legible enough to
+    /// read if the eye lands on one, rather than being greyed to nothing.
+    property bool matched: true
+    /// True when this row's tooltip is the one the sheet has latched open
+    /// from a touch long-press.
+    property bool latched: false
+    /// Suppresses the tooltip while the column strip is being flicked.
+    property bool scrollerMoving: false
+    /// True when the bound screen consumes layouts as sizing templates, which
+    /// changes the wording of some rows' tooltips.
+    property bool layoutsAreTemplates: false
+    property string fontFamily: ""
+    property real fontSizeScale: 1
+
+    /// Emitted on a touch long-press / tap so the sheet can move its latch.
+    signal latchRequested
+    signal latchCleared
+
+    readonly property string effectiveFamily: fontFamily.length > 0 ? fontFamily : Kirigami.Theme.defaultFont.family
+    readonly property int rowFontSize: Math.round(Kirigami.Theme.defaultFont.pixelSize * fontSizeScale)
+
+    /// Template-capability rows swap their tooltip wording;
+    /// templatesDescription falls back to description in the model, so this
+    /// stays a two-way pick.
+    readonly property string effectiveDescription: root.layoutsAreTemplates ? (root.modelData.templatesDescription || root.modelData.description || "") : (root.modelData.description || "")
+
+    /// The label with every run matching a query term wrapped in <b>, as
+    /// Text.StyledText markup. Bold rather than a colour: the markup would
+    /// have to carry a literal hex value, and a theme colour serialised into
+    /// HTML is exactly the kind of hardcoded colour the sheet otherwise
+    /// avoids. Weight reads as well and costs nothing in either theme.
+    function markUpLabel(text, terms) {
+        function escaped(s) {
+            return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+        }
+        if (terms.length === 0)
+            return escaped(text);
+
+        const lower = text.toLocaleLowerCase();
+        // Case folding is not always length-preserving (Turkish dotted I is
+        // the standard example), and the index arithmetic below assumes it
+        // is. Rather than mark the wrong characters, drop the emphasis and
+        // keep the label truthful; the row still matched and still shows.
+        if (lower.length !== text.length)
+            return escaped(text);
+
+        let marks = [];
+        for (let i = 0; i < text.length; ++i)
+            marks.push(false);
+        for (let t = 0; t < terms.length; ++t) {
+            const term = terms[t];
+            if (term.length === 0)
+                continue;
+
+            // Advance by one, not by the term length: overlapping occurrences
+            // of a repeated term must all light up.
+            let from = 0;
+            let idx = lower.indexOf(term, from);
+            while (idx >= 0) {
+                for (let k = idx; k < idx + term.length; ++k)
+                    marks[k] = true;
+                from = idx + 1;
+                idx = lower.indexOf(term, from);
+            }
+        }
+
+        let out = "";
+        let pos = 0;
+        while (pos < text.length) {
+            const start = pos;
+            const on = marks[pos];
+            while (pos < text.length && marks[pos] === on)
+                ++pos;
+            const chunk = escaped(text.substring(start, pos));
+            out += on ? "<b>" + chunk + "</b>" : chunk;
+        }
+        return out;
+    }
+
+    /// Key tokens of one display sequence, for the chip row. A trailing "+"
+    /// means the plus key itself is the final token, and a multi-step
+    /// sequence ("Ctrl+X, Ctrl+S" — unreachable via KGlobalAccel, defensive
+    /// only) flattens to the tokens of every step rather than producing a
+    /// garbled "X, Ctrl" token.
+    function keyTokens(seq) {
+        let tokens = [];
+        const steps = seq.split(", ");
+        for (let s = 0; s < steps.length; ++s) {
+            const step = steps[s];
+            let parts = step.split("+").filter(function (p) {
+                return p.length > 0;
+            });
+            if (step.endsWith("+"))
+                parts.push("+");
+            tokens = tokens.concat(parts);
+        }
+        return tokens;
+    }
+
+    spacing: Kirigami.Units.smallSpacing
+    opacity: root.matched ? 1 : 0.32
+    // Short enough not to lag the typing it responds to, long enough that the
+    // sheet reads as re-weighting itself rather than flickering.
+    Behavior on opacity {
+        NumberAnimation {
+            duration: Kirigami.Units.shortDuration
+            easing.type: Easing.OutCubic
+        }
+    }
+
+    Accessible.role: Accessible.StaticText
+    // Announces every binding, and composes the unassigned state from the
+    // SAME translated token the visible label shows, so a translator cannot
+    // make the two diverge.
+    Accessible.name: root.modelData.assigned ? i18nc("shortcut row: action, keys", "%1, %2", root.modelData.label, root.modelData.triggers.join(", ")) : i18nc("shortcut row: action, state", "%1, %2", root.modelData.label, unassignedLabel.text)
+    Accessible.description: root.effectiveDescription
+
+    // Plain-prose explanation from the catalog, on hover (long-press on
+    // touch). Rows without one (empty description) show no tooltip.
+    HoverHandler {
+        id: rowHover
+
+        enabled: root.effectiveDescription.length > 0
+    }
+
+    // Touch path: the sheet-level latch is folded into the SAME visible
+    // binding, never an imperative open() — a C++ open over a declarative
+    // binding would leave the tooltip stuck on touch devices, where no hover
+    // change ever re-runs the binding. A tap on the row, a long-press on
+    // another row, or a flick clears it.
+    TapHandler {
+        enabled: rowHover.enabled
+        onLongPressed: root.latchRequested()
+        onTapped: root.latchCleared()
+    }
+
+    // An explicit per-row instance, not the attached ToolTip: the attached
+    // form shares one engine-wide popup (row-to-row moves can cancel the
+    // tooltip just shown) and cannot pin popupType, and on this layer-shell
+    // surface a style-driven promotion to a native popup window would hit the
+    // QPA's unreachable xdg_popup path. Popup.Item keeps it in-scene, the same
+    // pin the settings combos carry. A per-row instance also dies with its
+    // delegate, so a rebuild cannot strand an open tooltip.
+    ToolTip {
+        popupType: T.Popup.Item
+        visible: (rowHover.hovered || root.latched) && !root.scrollerMoving
+        onClosed: {
+            if (root.latched)
+                root.latchCleared();
+        }
+        text: root.effectiveDescription
+        delay: Kirigami.Units.toolTipDelay
+        font.family: root.effectiveFamily
+        font.pixelSize: root.rowFontSize
+    }
+
+    Label {
+        text: root.markUpLabel(root.modelData.label, root.queryTerms)
+        // StyledText unconditionally, not "rich only while filtering": the
+        // markUpLabel escape pass runs in both cases, so a label containing a
+        // literal ampersand or angle bracket renders identically whether or
+        // not a query is active. Switching textFormat with the query would
+        // make that one label change shape as the user types.
+        textFormat: Text.StyledText
+        // The row announces a composed "action, keys" Accessible.name; keep
+        // the visible children out of the a11y tree so screen readers don't
+        // announce them twice.
+        Accessible.ignored: true
+        // Wrap, never elide: the model ships group-contextual short labels
+        // sized to fit, and a pathological case (translation, custom font)
+        // grows a second line instead of losing text.
+        wrapMode: Text.Wrap
+        font.family: root.effectiveFamily
+        font.pixelSize: root.rowFontSize
+        Layout.fillWidth: true
+        // Never crushed to nothing by a long chip run in a narrow column; an
+        // overlong run overflows the row's width (clipped only at the card
+        // edge by the Flickable) rather than eating the label.
+        Layout.minimumWidth: Kirigami.Units.gridUnit * 3
+    }
+
+    // One chip row per BOUND SEQUENCE, so an alternate binding is visible
+    // instead of silently dropped (the C++ compression already declines to
+    // merge rows carrying alternates for the same reason).
+    Column {
+        spacing: Math.round(Kirigami.Units.smallSpacing / 2)
+        visible: root.modelData.assigned
+
+        Repeater {
+            model: root.modelData.assigned ? root.modelData.triggers : []
+
+            delegate: Row {
+                id: chipRow
+
+                required property string modelData
+
+                readonly property var tokens: root.keyTokens(chipRow.modelData)
+
+                spacing: Math.round(Kirigami.Units.smallSpacing / 2)
+                anchors.right: parent.right
+
+                Repeater {
+                    model: chipRow.tokens
+
+                    delegate: KeyChip {
+                        required property string modelData
+                        required property int index
+
+                        text: modelData
+                        // Positional, never a name match against a modifier
+                        // list: these tokens come from QKeySequence in NATIVE
+                        // text, so "Meta" is localised and may render as a
+                        // glyph. In a key sequence the last token is always
+                        // the key and everything before it is a modifier, so
+                        // position answers the question without knowing any
+                        // of the names. (A multi-step sequence flattens to
+                        // one run and would dim its interior key too; that
+                        // path is unreachable through KGlobalAccel.)
+                        dimmed: index < chipRow.tokens.length - 1
+                        fontFamily: root.fontFamily
+                        fontSizeScale: root.fontSizeScale
+                    }
+                }
+            }
+        }
+    }
+
+    Label {
+        id: unassignedLabel
+
+        text: i18n("Unassigned")
+        color: Kirigami.Theme.disabledTextColor
+        font.italic: true
+        font.family: root.effectiveFamily
+        font.pixelSize: root.rowFontSize
+        visible: !root.modelData.assigned
+        // Covered by the row's composed "%1, unassigned" Accessible.name.
+        Accessible.ignored: true
+    }
+}

--- a/src/ui/CheatsheetSearchField.qml
+++ b/src/ui/CheatsheetSearchField.qml
@@ -45,9 +45,10 @@ Rectangle {
     readonly property int rowFontSize: Math.round(Kirigami.Theme.defaultFont.pixelSize * fontSizeScale)
     readonly property string effectiveFamily: fontFamily.length > 0 ? fontFamily : Kirigami.Theme.defaultFont.family
 
-    /// Focus the field. Called by the host once the content is mounted; the
-    /// surface's keyboard grab lands asynchronously, so the host also
-    /// re-arms this on activeFocus changes rather than relying on one shot.
+    /// Focus the field. Called by the host once the content is mounted. One
+    /// shot is enough: forceActiveFocus is a scene-local claim, so the field
+    /// is already the scene's focus item by the time the compositor's
+    /// focus-in arrives, and the first keystroke lands here.
     function takeFocus() {
         field.forceActiveFocus();
     }
@@ -62,8 +63,8 @@ Rectangle {
         id: layout
 
         anchors.fill: parent
-        anchors.leftMargin: Kirigami.Units.smallSpacing * 1.5
-        anchors.rightMargin: Kirigami.Units.smallSpacing * 1.5
+        anchors.leftMargin: Math.round(Kirigami.Units.smallSpacing * 1.5)
+        anchors.rightMargin: Math.round(Kirigami.Units.smallSpacing * 1.5)
         spacing: Kirigami.Units.smallSpacing
 
         Kirigami.Icon {

--- a/src/ui/CheatsheetSearchField.qml
+++ b/src/ui/CheatsheetSearchField.qml
@@ -53,6 +53,18 @@ Rectangle {
         field.forceActiveFocus();
     }
 
+    /// True while the field itself owns focus. The sheet uses this to tell
+    /// "the user is typing into the filter" from "the user has tabbed to a
+    /// disclosure line", which decides whether a printable key belongs here.
+    readonly property bool fieldHasFocus: field.activeFocus
+
+    /// Append a character the sheet caught on the user's behalf, after
+    /// handing focus back here. Keeps the keystroke that started the typing
+    /// instead of swallowing it.
+    function appendText(t: string) {
+        field.insert(field.length, t);
+    }
+
     implicitHeight: layout.implicitHeight + Kirigami.Units.smallSpacing * 2
     radius: Kirigami.Units.smallSpacing
     color: Qt.alpha(Kirigami.Theme.textColor, 0.06)

--- a/src/ui/CheatsheetSearchField.qml
+++ b/src/ui/CheatsheetSearchField.qml
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import org.kde.kirigami as Kirigami
+
+/**
+ * The cheatsheet's filter field, with a leading search glyph and a trailing
+ * "shown of total" counter.
+ *
+ * This is the ONE piece of the sheet that needs the shell surface to hold
+ * keyboard focus. The passive shell is kbd-None for every other slot, and
+ * OverlayService flips it to Exclusive for the cheatsheet's lifetime alone
+ * (see the anyKeyboardGrabbing derivation in shellhost_bridge.cpp). Two
+ * consequences worth knowing when reading this file:
+ *
+ *  - Escape never arrives here. It is bound as a daemon-side global grab
+ *    (daemon/cheatsheet.cpp), and KWin routes global shortcuts before any
+ *    surface sees the key, so Escape always closes the sheet outright rather
+ *    than first clearing the query. The footer tells the user as much.
+ *  - Every other PlasmaZones shortcut stays live while the field has focus,
+ *    for the same reason. Typing plain text is unaffected; a chord is not.
+ */
+Rectangle {
+    id: root
+
+    /// Live query text. The host binds this rather than reading the field
+    /// directly so the filter has a single source.
+    property alias text: field.text
+    /// Rows answering the filter, and the total the current mode offers.
+    ///
+    /// The filter dims rather than removes, so this counter is the only place
+    /// the sheet says how well a query landed. It matters most at the extreme:
+    /// a query nothing answers leaves a full but uniformly dimmed card, which
+    /// on its own could read as a rendering fault rather than as no matches.
+    property int shownCount: 0
+    property int totalCount: 0
+    readonly property bool hasQuery: field.text.trim().length > 0
+    readonly property bool noMatches: hasQuery && shownCount === 0
+    property string fontFamily: ""
+    property real fontSizeScale: 1
+
+    readonly property int rowFontSize: Math.round(Kirigami.Theme.defaultFont.pixelSize * fontSizeScale)
+    readonly property string effectiveFamily: fontFamily.length > 0 ? fontFamily : Kirigami.Theme.defaultFont.family
+
+    /// Focus the field. Called by the host once the content is mounted; the
+    /// surface's keyboard grab lands asynchronously, so the host also
+    /// re-arms this on activeFocus changes rather than relying on one shot.
+    function takeFocus() {
+        field.forceActiveFocus();
+    }
+
+    implicitHeight: layout.implicitHeight + Kirigami.Units.smallSpacing * 2
+    radius: Kirigami.Units.smallSpacing
+    color: Qt.alpha(Kirigami.Theme.textColor, 0.06)
+    border.width: 1
+    border.color: root.noMatches ? Kirigami.Theme.negativeTextColor : (field.activeFocus ? Kirigami.Theme.highlightColor : Qt.alpha(Kirigami.Theme.textColor, 0.15))
+
+    RowLayout {
+        id: layout
+
+        anchors.fill: parent
+        anchors.leftMargin: Kirigami.Units.smallSpacing * 1.5
+        anchors.rightMargin: Kirigami.Units.smallSpacing * 1.5
+        spacing: Kirigami.Units.smallSpacing
+
+        Kirigami.Icon {
+            // "edit-find" is the name the rest of the tree uses for this, and
+            // it is a Breeze action icon rather than a themed alias, so it
+            // resolves without a fallback.
+            source: "edit-find"
+            // Sized off the row type rather than a Units icon constant so the
+            // glyph tracks the user's overlay font scale like everything else
+            // on the card does.
+            implicitWidth: root.rowFontSize
+            implicitHeight: root.rowFontSize
+            opacity: 0.55
+            Accessible.ignored: true
+        }
+
+        TextField {
+            id: field
+
+            Layout.fillWidth: true
+            placeholderText: i18n("Filter shortcuts")
+            // The card is the whole UI; a second frame inside it reads as a
+            // nested control. The parent Rectangle draws the field's chrome.
+            background: null
+            padding: 0
+            color: Kirigami.Theme.textColor
+            font.family: root.effectiveFamily
+            font.pixelSize: root.rowFontSize
+            // A shortcut sheet is a reference, not a form: nothing here
+            // benefits from the shell guessing at completions.
+            inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase
+            Accessible.name: i18n("Filter shortcuts")
+            Accessible.role: Accessible.EditableText
+            // The counter beside the field is the only surface that reports
+            // how a query landed, and it is kept out of the a11y tree so it
+            // does not fire on every keystroke. Carrying its text here instead
+            // means a screen reader reaches the result on demand rather than
+            // being read a running tally.
+            Accessible.description: counter.text
+        }
+
+        Label {
+            id: counter
+
+            // Counter, not a result summary: it is a running state readout
+            // that changes on every keystroke, so it stays terse. The
+            // no-matches case gets words rather than a bare zero, since it is
+            // the one state the dimmed card cannot express by itself.
+            text: root.noMatches ? i18n("No matches") : i18nc("matching shortcuts out of the total", "%1 of %2", root.shownCount, root.totalCount)
+            color: root.noMatches ? Kirigami.Theme.negativeTextColor : Kirigami.Theme.disabledTextColor
+            font.family: root.effectiveFamily
+            font.pixelSize: Math.round(root.rowFontSize * 0.85)
+            // Announced by the empty state and by each row; a live counter
+            // read out on every keystroke would drown both.
+            Accessible.ignored: true
+        }
+    }
+}

--- a/src/ui/CheatsheetSearchField.qml
+++ b/src/ui/CheatsheetSearchField.qml
@@ -106,6 +106,32 @@ Rectangle {
             Accessible.description: counter.text
         }
 
+        // Clearing is otherwise Backspace or Ctrl+A, since Escape closes the
+        // sheet outright rather than emptying the field. One visible way back
+        // to the full card, on the one control that changes what it shows.
+        Kirigami.Icon {
+            source: "edit-clear"
+            implicitWidth: root.rowFontSize
+            implicitHeight: root.rowFontSize
+            visible: root.hasQuery
+            opacity: clearArea.containsMouse ? 1 : 0.6
+            Accessible.role: Accessible.Button
+            Accessible.name: i18n("Clear the filter")
+            Accessible.onPressAction: field.clear()
+
+            MouseArea {
+                id: clearArea
+
+                anchors.fill: parent
+                hoverEnabled: true
+                cursorShape: Qt.PointingHandCursor
+                onClicked: {
+                    field.clear();
+                    field.forceActiveFocus();
+                }
+            }
+        }
+
         Label {
             id: counter
 

--- a/src/ui/CheatsheetSearchField.qml
+++ b/src/ui/CheatsheetSearchField.qml
@@ -61,8 +61,13 @@ Rectangle {
     /// Append a character the sheet caught on the user's behalf, after
     /// handing focus back here. Keeps the keystroke that started the typing
     /// instead of swallowing it.
+    ///
+    /// The caret follows the insert. Without that, a caret left mid-query
+    /// before the user tabbed away would stay there while this character
+    /// landed at the end, so the NEXT character would arrive before it.
     function appendText(t: string) {
         field.insert(field.length, t);
+        field.cursorPosition = field.length;
     }
 
     implicitHeight: layout.implicitHeight + Kirigami.Units.smallSpacing * 2

--- a/src/ui/KeyChip.qml
+++ b/src/ui/KeyChip.qml
@@ -20,13 +20,20 @@ Rectangle {
     /// labels at every scale.
     property string fontFamily: ""
     property real fontSizeScale: 1
+    /// Draw as a leading modifier rather than the key the row is really
+    /// about: no fill, dimmer text. A cheatsheet repeats the same two or
+    /// three modifiers on nearly every row, and at uniform weight the eye
+    /// has to parse the whole run to find the one token that differs.
+    /// Recessing the modifiers leaves the terminal cap as the only thing
+    /// at full contrast, so a row can be read by its last chip alone.
+    property bool dimmed: false
 
     implicitWidth: Math.max(keyLabel.implicitWidth + Kirigami.Units.smallSpacing * 2, implicitHeight)
     implicitHeight: keyLabel.implicitHeight + Kirigami.Units.smallSpacing
     radius: Kirigami.Units.smallSpacing
-    color: Qt.alpha(Kirigami.Theme.textColor, 0.08)
+    color: root.dimmed ? "transparent" : Qt.alpha(Kirigami.Theme.textColor, 0.08)
     border.width: 1
-    border.color: Qt.alpha(Kirigami.Theme.textColor, 0.25)
+    border.color: Qt.alpha(Kirigami.Theme.textColor, root.dimmed ? 0.16 : 0.25)
 
     Label {
         id: keyLabel
@@ -34,7 +41,7 @@ Rectangle {
         anchors.centerIn: parent
         font.family: root.fontFamily.length > 0 ? root.fontFamily : Kirigami.Theme.defaultFont.family
         font.pixelSize: Math.round(Kirigami.Theme.defaultFont.pixelSize * 0.9 * root.fontSizeScale)
-        color: Kirigami.Theme.textColor
+        color: root.dimmed ? Qt.alpha(Kirigami.Theme.textColor, 0.6) : Kirigami.Theme.textColor
         // The hosting shortcut row announces a composed "action, keys" name;
         // the per-token caps must not be announced a second time.
         Accessible.ignored: true

--- a/src/ui/KeyChip.qml
+++ b/src/ui/KeyChip.qml
@@ -28,12 +28,18 @@ Rectangle {
     /// at full contrast, so a row can be read by its last chip alone.
     property bool dimmed: false
 
+    /// True when this cap's text answers the sheet's current query. The chip
+    /// picks up the accent the way a matched run of a label picks up bold,
+    /// which is the only way a query typed against key text can show where it
+    /// landed.
+    property bool highlighted: false
+
     implicitWidth: Math.max(keyLabel.implicitWidth + Kirigami.Units.smallSpacing * 2, implicitHeight)
     implicitHeight: keyLabel.implicitHeight + Kirigami.Units.smallSpacing
     radius: Kirigami.Units.smallSpacing
-    color: root.dimmed ? "transparent" : Qt.alpha(Kirigami.Theme.textColor, 0.08)
+    color: root.highlighted ? Qt.alpha(Kirigami.Theme.highlightColor, 0.22) : Qt.alpha(Kirigami.Theme.textColor, root.dimmed ? 0 : 0.08)
     border.width: 1
-    border.color: Qt.alpha(Kirigami.Theme.textColor, root.dimmed ? 0.16 : 0.25)
+    border.color: root.highlighted ? Qt.alpha(Kirigami.Theme.highlightColor, 0.7) : Qt.alpha(Kirigami.Theme.textColor, root.dimmed ? 0.16 : 0.25)
 
     Label {
         id: keyLabel

--- a/src/ui/KeyChip.qml
+++ b/src/ui/KeyChip.qml
@@ -20,6 +20,17 @@ Rectangle {
     /// labels at every scale.
     property string fontFamily: ""
     property real fontSizeScale: 1
+
+    /// Same two derivations as CheatsheetRow, CheatsheetGroup and
+    /// CheatsheetSearchField. Each of the four takes the sheet's raw font
+    /// inputs and resolves them itself, because each is a component with its
+    /// own boundary rather than a member of a shared scope. Factoring them out
+    /// would mean a new QML singleton, which this qrc-loaded tree has no
+    /// mechanism for; naming them the same way in every file is the part that
+    /// actually keeps them honest.
+    readonly property string effectiveFamily: fontFamily.length > 0 ? fontFamily : Kirigami.Theme.defaultFont.family
+    readonly property int rowFontSize: Math.round(Kirigami.Theme.defaultFont.pixelSize * fontSizeScale)
+
     /// Draw as a leading modifier rather than the key the row is really
     /// about: no fill, dimmer text. A cheatsheet repeats the same two or
     /// three modifiers on nearly every row, and at uniform weight the eye
@@ -45,8 +56,8 @@ Rectangle {
         id: keyLabel
 
         anchors.centerIn: parent
-        font.family: root.fontFamily.length > 0 ? root.fontFamily : Kirigami.Theme.defaultFont.family
-        font.pixelSize: Math.round(Kirigami.Theme.defaultFont.pixelSize * 0.9 * root.fontSizeScale)
+        font.family: root.effectiveFamily
+        font.pixelSize: Math.round(root.rowFontSize * 0.9)
         color: root.dimmed ? Qt.alpha(Kirigami.Theme.textColor, 0.6) : Kirigami.Theme.textColor
         // The hosting shortcut row announces a composed "action, keys" name;
         // the per-token caps must not be announced a second time.


### PR DESCRIPTION
## Why

The shortcut cheatsheet listed around ninety shortcuts across three dense columns with no way to look one up, so finding a key meant reading the whole card. Alongside that, the column packer split categories across boundaries and reprinted their headings as "(continued)", which left most headings pointing at the middle of a section rather than the start of one.

## Search, by emphasis rather than subtraction

A filter field at the top, focused as soon as the sheet opens, matching action names, category names and the key text itself, so "column width" and "meta alt" both land.

It highlights rather than removes. Dropping non-matching rows repacked the columns and resized the card on every keystroke, so the sheet flinched under the cursor and a row could move out from under the eye that was reading it. The packer now sees only the mode filter, so the card's size, its column count and every row's position are fixed for as long as the sheet is open. The query decides contrast alone: matched runs of a label go bold, chips whose key text answers the query take the accent, and non-matching rows fade back so the ones that answered stand out.

A query nothing answers leaves a full but uniformly dimmed card, which on its own could read as a rendering fault, so the counter switches to "No matches" and the field's border goes to `negativeTextColor`.

## Keyboard focus, the one non-cosmetic part

The search field needs the shell surface to hold keyboard focus, and the passive shell is a single per-screen surface shared by every overlay. `ShellHost::syncSurfaceState` gains a third predicate driving layer-shell keyboard interactivity at runtime, asserted for the cheatsheet alone.

Snap assist and the layout picker stay kbd-None deliberately. Both answer only global shortcuts, which KWin routes ahead of surface delivery, so taking the keyboard would cost the focused window its input and buy them nothing. For the same reason Escape still reaches the daemon through its own ad-hoc global grab and never through this surface, so it closes the sheet outright rather than first clearing the query. The footer says so.

The grab is released on the first edge of dismissal rather than on hide completion, because the slot stays visible for the whole fade-out and holding the session's keyboard across an animation would swallow keystrokes aimed at the window the user was returning to.

## The rest

- **Categories are kept whole.** One oversized group (Scrolling) simply owns a tall column, which the search field is what actually makes tractable.
- **Headings make blocks.** Uppercase, accent-tinted, with a rule running to the column edge, so a two-row category like Zones stops dissolving into its neighbours.
- **Modifiers recede.** Leading caps are drawn outlined and dim, the terminal cap solid, so a row can be read by its last chip. Position decides which is which, never a name match, because these tokens come from `QKeySequence` in native text where "Meta" is localised and may be a glyph.
- **Unassigned rolls up.** One line per category, opened by a click or by Space when tabbed to. A query never opens one on its own, since that would resize the card; the line reports its own hidden matches instead.
- **The sheet names its mode.** It has always been filtered by the mode of the screen it opens on and never mentioned it, which made an absent group look like a bug.

`CheatsheetContent.qml` is split into `CheatsheetRow`, `CheatsheetGroup` and `CheatsheetSearchField`; all four are well under the size ceiling.

## What the audit changed

`/code-audit` ran over this branch: eight read-only passes across four domain reviewers against a frozen baseline, then one remediation and three confirmation rounds. Eighty findings, six of which were refuted on closer reading and seventy-four fixed. The substantive ones, in the order they matter:

**A rekey could strand the sheet.** This is pre-existing and the only thing here that was not cosmetic. `rekeyOverlayState` migrates per-screen state to a new key but never rewrote the three modal singleton screen ids, so after a rekey the sheet's id named a key that no longer existed. Every path that would clean it up looks the state up by that key and missed: the slot was never hidden, its surface kept the pointer grab, and the visible flag stayed set so the next toggle press did nothing. The same erase can also destroy a passive-only shell that is hosting a visible modal, since the clobber guard only refuses on a main-overlay screen. Both arms are handled where the state moves, target-side reset before the remap, because remapping first would dismiss the sheet that actually survived. A debug invariant now asserts every modal id names a live screen key, which is what would have caught this in the first place. The keyboard axis is what made a latent bug visible, so it is fixed here rather than left for its own PR.

**The sheet now answers the keyboard and the screen reader.** The search field was the only focusable item, which left the unassigned rows unreachable without a pointer and, on a screen short enough to clip the card, left the scroll indicator pointing at content no key could reach. Disclosure lines are tab stops answering Space and Return; the card handles the page keys and Ctrl+Home/End; and typing anywhere on the sheet returns focus to the filter and keeps the character. A query also never reached the accessibility tree, since matching is drawn as dimming and bold and neither is announced, so matched rows now say so in their own name.

**The dim was too deep once composed.** Row opacity multiplies over the whole subtree, so a modifier cap already drawn at 0.6 text alpha landed near 0.19 against the background. The row floor moved rather than the chip alphas, which keeps the recede-the-modifiers relationship the chips were designed around.

**The keyboard predicate had no test.** It fails silently in both directions: a grab that never lands means the field never receives a keystroke, one that never releases means the focused window stops receiving them, and neither raises an error. `test_overlay_smoke` now drives `syncSurfaceState` over a real `PhosphorLayer::Surface` backed by phosphor-layer's recording mock, which needs one include-directory line rather than a live Wayland connection. Deleting the keyboard write and deleting the teardown release each make it fail.

**`syncSurfaceState` takes a struct.** Three adjacent same-typed bools at the call site, where a transposition compiles cleanly and produces exactly the failure the header spends a paragraph warning about.

Smaller: the card clamps to the screen, since the column minimum could otherwise push it past both edges and carry the counter off with it; a long translated heading elides instead of painting into the next column; the filter gains a clear button, since Escape closes the sheet rather than emptying the field; search haystacks are built once per model push rather than rebuilt on every keystroke; and the library README's usage example no longer shows a signature that would not compile.

Two findings were closed as measurements rather than defects. The opacity `Behavior` does not cost an animation per row per keystroke, since it animates on change: a 94-row sheet starts 84 legs on the first keystroke and none on a later one that does not change which rows match. And the rollup state surviving a live re-push is correct, because `categoryOrder` is a compile-time sort key, so one value always denotes the same category whatever the mode.

The changelog entry was rewritten. It claimed typing a query "narrows the card as you go", which is precisely the behaviour this PR rejected.

## Testing

Clean build with no new warnings, 419/419 tests pass.

The keyboard axis and the sheet's key routing are covered by tests rather than by reading. The routing cases were driven through the real key path under `qmltestrunner`, which is also how two review claims were settled: Escape, Return and Backspace carry non-empty `event.text` and would have been typed into the filter, while Ctrl+Home and Ctrl+End reach the card handler and do not move the caret, so nothing was lost by moving that handler off the field.

Still worth checking on install, because only a running compositor will tell the truth about them: that the field takes the first keystroke without a click, that the focused window gets the keyboard straight back on dismiss, and that Escape and `Meta+Alt+/` both still close the sheet. Nothing here exercises the real `set_keyboard_interactivity` request, since the mock stops at the transport, so whether a compositor honours a runtime change after the initial configure is still unverified outside a live session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011rHxnX3Zp8XGwd54iiBCYW
