### PR TITLE
fix(kwin-effect): release the strip pass cursor hide before the effect leaves the paint chain

### DIFF
--- a/kwin-effect/plasmazoneseffect/plasmazoneseffect.cpp
+++ b/kwin-effect/plasmazoneseffect/plasmazoneseffect.cpp
@@ -185,6 +185,13 @@ bool PlasmaZonesEffect::isActive() const
     // design — see StripTransitionManager::paintOutput). Keep both: the
     // spring clause is not a substitute for the fade tail, and the pass
     // clause is not a substitute for the pack-less spring.
+    // `m_stripTransition.holdsCursorHide()` outlives the pass clause by one
+    // frame on purpose: the strip pass hides KWin's cursor while it paints
+    // and, on the settle path, releases it only from our paint hooks (the
+    // off-paint kill paths release it themselves), so the effect must stay
+    // in the chain until that release has run. Without it, a settle fade that
+    // closes between two frames dropped the effect with the cursor still
+    // hidden, and nothing ever showed it again (see the accessor's doc).
     // The compositor-drawn tab pills exist only while this effect is in the
     // paint chain: they are blitted from paintWindow (at the anchor slot) or
     // paintScreen (the post-walk fallback), so on an
@@ -200,12 +207,6 @@ bool PlasmaZonesEffect::isActive() const
     // effect in the chain (the spring settling mid-fade dropped it, jumping
     // the corpse by the frozen offset). O(1); entries are bounded by corpse
     // lifetime (sole erase at windowDeleted).
-    // `m_stripTransition.holdsCursorHide()` outlives the pass clause by one
-    // frame on purpose: the strip pass hides KWin's cursor while it paints
-    // and releases it only from our paint hooks, so the effect must stay in
-    // the chain until that release has run. Without it, a settle fade that
-    // closes between two frames dropped the effect with the cursor still
-    // hidden, and nothing ever showed it again (see the accessor's doc).
     return m_dragTracker->isDragging() || m_windowAnimator->hasActiveAnimations() || !m_shaderManager.empty()
         || !m_windowDecorations.isEmpty() || m_desktopTransition.isRunning()
         || m_stripViewAnimator->hasActiveAnimations() || m_stripTransition.isRunning()

--- a/kwin-effect/plasmazoneseffect/plasmazoneseffect.cpp
+++ b/kwin-effect/plasmazoneseffect/plasmazoneseffect.cpp
@@ -200,10 +200,17 @@ bool PlasmaZonesEffect::isActive() const
     // effect in the chain (the spring settling mid-fade dropped it, jumping
     // the corpse by the frozen offset). O(1); entries are bounded by corpse
     // lifetime (sole erase at windowDeleted).
+    // `m_stripTransition.holdsCursorHide()` outlives the pass clause by one
+    // frame on purpose: the strip pass hides KWin's cursor while it paints
+    // and releases it only from our paint hooks, so the effect must stay in
+    // the chain until that release has run. Without it, a settle fade that
+    // closes between two frames dropped the effect with the cursor still
+    // hidden, and nothing ever showed it again (see the accessor's doc).
     return m_dragTracker->isDragging() || m_windowAnimator->hasActiveAnimations() || !m_shaderManager.empty()
         || !m_windowDecorations.isEmpty() || m_desktopTransition.isRunning()
         || m_stripViewAnimator->hasActiveAnimations() || m_stripTransition.isRunning()
-        || m_scrollTabPainter->hasAnyIndicators() || !m_scrollCorpseFreeze.isEmpty();
+        || m_stripTransition.holdsCursorHide() || m_scrollTabPainter->hasAnyIndicators()
+        || !m_scrollCorpseFreeze.isEmpty();
 }
 
 void PlasmaZonesEffect::pointerMotion(KWin::PointerMotionEvent* event)

--- a/kwin-effect/transitions/striptransitionmanager.h
+++ b/kwin-effect/transitions/striptransitionmanager.h
@@ -138,6 +138,23 @@ public:
     /// entry check.
     bool isRunningForOutput(KWin::LogicalOutput* screen) const;
 
+    /// True while this manager holds the compositor's cursor hidden (see
+    /// hideCursorForPass). Feeds PlasmaZonesEffect::isActive() SEPARATELY
+    /// from isRunning(): the hide is released only from the effect's paint
+    /// hooks (paintOutput's settle frame, postPaintScreen's reap), and
+    /// isRunning() goes false the instant the settle fade's window closes.
+    /// When that happens between the last fade frame and the next frame's
+    /// chain build, an isActive() built on isRunning() alone drops the
+    /// effect from the chain with the cursor still hidden and no hook left
+    /// to show it again — the pointer stays invisible until a later leg
+    /// happens to run the release. This keeps the effect in the chain for
+    /// the one extra frame (the last fade frame always damages the output)
+    /// that runs updateCursorHiding.
+    bool holdsCursorHide() const
+    {
+        return m_cursorHidden;
+    }
+
     /// Paint one output's strip pass. Returns true when the decorated scene
     /// was drawn (the caller must then SKIP the normal scene paint for this
     /// output); false when the output is not armed, its spring has settled,

--- a/kwin-effect/transitions/striptransitionmanager.h
+++ b/kwin-effect/transitions/striptransitionmanager.h
@@ -140,9 +140,11 @@ public:
 
     /// True while this manager holds the compositor's cursor hidden (see
     /// hideCursorForPass). Feeds PlasmaZonesEffect::isActive() SEPARATELY
-    /// from isRunning(): the hide is released only from the effect's paint
-    /// hooks (paintOutput's settle frame, postPaintScreen's reap), and
-    /// isRunning() goes false the instant the settle fade's window closes.
+    /// from isRunning(): on the settle path the hide is released only from
+    /// the effect's paint hooks (paintOutput's settle frame, postPaintScreen's
+    /// reap; the off-paint kill paths outputRemoved and reset release it
+    /// themselves), and isRunning() goes false the instant the settle fade's
+    /// window closes.
     /// When that happens between the last fade frame and the next frame's
     /// chain build, an isActive() built on isRunning() alone drops the
     /// effect from the chain with the cursor still hidden and no hook left


### PR DESCRIPTION
## Summary

A user reported the pointer disappearing completely. The only compositor cursor hide/show in the tree is the scrolling strip shader pass (`StripTransitionManager`), so this is scrolling mode with a strip pack assigned.

The pass hides KWin's cursor while it paints and blits its own copy, and releases the hide only from the effect's paint hooks. `isActive()` gated the pass on `isRunning()`, which goes false the instant the settle fade's 200 ms window closes. When that lands between the last fade frame and the next frame's chain build, KWin drops the effect from the chain with the cursor still hidden and nothing ever calls `showCursor()` again. Decorations or tab pills mask the bug by keeping the effect active permanently, which is why it only bites some users.

## Fix

- `StripTransitionManager::holdsCursorHide()` exposes the existing hide flag.
- `PlasmaZonesEffect::isActive()` includes it, so the effect stays in the chain for the one extra frame (the last fade frame always damages the output) that runs `updateCursorHiding()`.

## Testing

- Effect plugin builds clean (Debug, `BUILD_TESTING=ON`).
- `test_strip_motion_sampler` passes.
- The race is only reachable in a live compositor. Live check: scrolling mode, strip pack set, no decorations and no tab indicators, fling the strip repeatedly and confirm the cursor comes back every time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JyWSsd4pWmk2QGf3DE9vYA
