### PR TITLE
fix(scroll-engine): adopt the final activation echo when the strip disagrees with it

### DIFF
--- a/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/ScrollEngine.h
+++ b/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/ScrollEngine.h
@@ -1270,10 +1270,12 @@ private:
     /// (applyLayout's focusWindowAfter arm) whose windowFocused report has
     /// not come back yet — the self-activation echo filter. The full
     /// consume/clear contract is documented on windowFocused's drain
-    /// (engine_lifecycle.cpp).
+    /// (engine_focus.cpp).
     QStringList m_pendingSelfActivations;
     /// Append to m_pendingSelfActivations and trim to the cap — the single
-    /// producer path (applyLayout's focus arm and the verb TU's switch).
+    /// producer path, shared by all three emitters (applyLayout's focus arm,
+    /// the declined-open rewind in engine_lifecycle.cpp, and the verb TU's
+    /// float-to-tiling switch).
     void queueSelfActivation(const QString& windowId);
     /// Cap for m_pendingSelfActivations (enforced in queueSelfActivation).
     static constexpr int kMaxPendingSelfActivations = 16;

--- a/libs/phosphor-scroll-engine/src/scrollengine/engine_focus.cpp
+++ b/libs/phosphor-scroll-engine/src/scrollengine/engine_focus.cpp
@@ -22,6 +22,10 @@ void ScrollEngine::windowFocused(const QString& rawWindowId, const QString& scre
     if (!screenId.isEmpty() && m_scrollingScreens.contains(screenId)) {
         m_activeScreen = screenId;
     }
+    // Resolved once, ahead of the echo filter: its adopt arm reads the
+    // strip's active slot, and every arm below works on the same state.
+    PhosphorEngine::PlacementStateKey key;
+    ScrollState* state = stateForWindow(windowId, &key);
     // Self-activation echo filter, m_pendingSelfActivations' consume side
     // and the home of its contract: the effect reports EVERY activation
     // back through notifyWindowFocused, including ones this engine
@@ -71,9 +75,7 @@ void ScrollEngine::windowFocused(const QString& rawWindowId, const QString& scre
         // Stripping the reclaim (995f135ea) fixed the anchor ping-pong by
         // making the echo invisible; this keeps it invisible whenever a later
         // echo is still due, and lets only the final one speak.
-        PhosphorEngine::PlacementStateKey echoKey;
-        const ScrollState* echoState = stateForWindow(windowId, &echoKey);
-        const bool stripAgrees = !echoState || echoState->strip().activeWindowId() == windowId;
+        const bool stripAgrees = !state || state->strip().activeWindowId() == windowId;
         if (!expired && (!m_pendingSelfActivations.isEmpty() || stripAgrees)) {
             // The swallow is silent to every other observer; without this
             // line a report eaten here is indistinguishable in the journal
@@ -112,8 +114,6 @@ void ScrollEngine::windowFocused(const QString& rawWindowId, const QString& scre
     // removeAll, and the kMaxPendingSelfActivations cap all still run — and
     // the dropped-echo case the reclaim used to (over-)serve is now handled
     // precisely by the per-entry expiry at the match above.
-    PhosphorEngine::PlacementStateKey key;
-    ScrollState* state = stateForWindow(windowId, &key);
     if (!state) {
         return;
     }

--- a/libs/phosphor-scroll-engine/src/scrollengine/engine_focus.cpp
+++ b/libs/phosphor-scroll-engine/src/scrollengine/engine_focus.cpp
@@ -52,7 +52,29 @@ void ScrollEngine::windowFocused(const QString& rawWindowId, const QString& scre
             stampIt = m_pendingSelfActivations.contains(stampIt.key()) ? std::next(stampIt)
                                                                        : m_pendingSelfActivationQueuedAt.erase(stampIt);
         }
-        if (!expired) {
+        // A LIVE echo is still the compositor's word on where focus ended
+        // up, and the swallow is only safe while something later settles the
+        // question. The rapid focus scroll it exists for leaves later
+        // entries in the queue (the strip advanced by queueing another
+        // activation), so the trailing echo lands on the column the strip
+        // already calls active and focusWindow refuses it anyway. The close
+        // path is the other ordering: the compositor's own successor pick
+        // is reported BEFORE this engine's competing activation (windowClosed
+        // → applyLayout's focusWindowAfter), so the genuine report moves the
+        // strip onto the compositor's pick, and the echo of the engine's pick
+        // is the LAST word — the window really holding focus now. Swallowing
+        // it left the strip centred on the compositor's interim pick while
+        // the focus ring sat on the engine's (close the middle of three under
+        // CenterFocusedColumn: the right column took focus, the left one was
+        // centred). The queue's tail being empty and the strip's active slot
+        // disagreeing with the echo is exactly that state, so adopt it.
+        // Stripping the reclaim (995f135ea) fixed the anchor ping-pong by
+        // making the echo invisible; this keeps it invisible whenever a later
+        // echo is still due, and lets only the final one speak.
+        PhosphorEngine::PlacementStateKey echoKey;
+        const ScrollState* echoState = stateForWindow(windowId, &echoKey);
+        const bool stripAgrees = !echoState || echoState->strip().activeWindowId() == windowId;
+        if (!expired && (!m_pendingSelfActivations.isEmpty() || stripAgrees)) {
             // The swallow is silent to every other observer; without this
             // line a report eaten here is indistinguishable in the journal
             // from one that never arrived.

--- a/libs/phosphor-scroll-engine/tests/CMakeLists.txt
+++ b/libs/phosphor-scroll-engine/tests/CMakeLists.txt
@@ -152,8 +152,8 @@ pse_add_test(test_scrollengine_snapshot test_scrollengine_snapshot.cpp)
 pse_add_test(test_scrollengine_boundary test_scrollengine_boundary.cpp scrollstubsettings.h)
 pse_add_test(test_scrollengine_verbs test_scrollengine_verbs.cpp)
 # The compositor focus-report protocol: which self-activation echoes the
-# filter swallows and which it adopts. Split from the verbs suite, which is
-# past the size ceiling.
+# filter swallows and which it adopts. Its own file rather than more of the
+# verbs suite, which is past the size ceiling.
 pse_add_test(test_scrollengine_focusreport test_scrollengine_focusreport.cpp)
 # The close-settle reflow hold's observable contract (deferred windowsTiled
 # batch, deadline push, zero-delay immediacy). Needs the settings stub: the

--- a/libs/phosphor-scroll-engine/tests/CMakeLists.txt
+++ b/libs/phosphor-scroll-engine/tests/CMakeLists.txt
@@ -151,6 +151,10 @@ pse_add_test(test_scrollengine_draginsert test_scrollengine_draginsert.cpp scrol
 pse_add_test(test_scrollengine_snapshot test_scrollengine_snapshot.cpp)
 pse_add_test(test_scrollengine_boundary test_scrollengine_boundary.cpp scrollstubsettings.h)
 pse_add_test(test_scrollengine_verbs test_scrollengine_verbs.cpp)
+# The compositor focus-report protocol: which self-activation echoes the
+# filter swallows and which it adopts. Split from the verbs suite, which is
+# past the size ceiling.
+pse_add_test(test_scrollengine_focusreport test_scrollengine_focusreport.cpp)
 # The close-settle reflow hold's observable contract (deferred windowsTiled
 # batch, deadline push, zero-delay immediacy). Needs the settings stub: the
 # interface default is 0, so without one the hold never arms.

--- a/libs/phosphor-scroll-engine/tests/test_scrollengine_focusreport.cpp
+++ b/libs/phosphor-scroll-engine/tests/test_scrollengine_focusreport.cpp
@@ -1,0 +1,138 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+// The compositor focus-report protocol (engine_focus.cpp): which reports the
+// self-activation echo filter swallows and which it adopts. Its own file
+// rather than more of the verbs suite, which is past the size ceiling and
+// whose subject is the verbs themselves, not the report ordering underneath
+// them.
+//
+// Every case here runs on the BARE fixture (no auto-echo): the whole subject
+// is the ORDER in which the engine's own activation echo and the compositor's
+// genuine reports land, and makeProviderEngine's synchronous echo collapses
+// that ordering before an assertion can observe it.
+
+#include <PhosphorScrollEngine/ScrollEngine.h>
+#include <PhosphorScrollEngine/ScrollState.h>
+#include <PhosphorScrollEngine/ScrollStrip.h>
+
+#include "scrollstriptestutils.h"
+
+#include <QSignalSpy>
+#include <QtTest>
+
+using namespace PhosphorScrollEngine;
+
+namespace {
+
+const QString kS1 = QStringLiteral("S1");
+
+} // namespace
+
+class TestScrollEngineFocusReport : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void initTestCase()
+    {
+        AX_GUARD_SUITE();
+    }
+
+    void closeEchoAfterTheCompositorsOwnPickWinsTheStrip();
+    void staleEchoWithALaterActivationQueuedIsStillSwallowed();
+
+private:
+    /// a | b | c as three columns on S1, focus on c (arrival order), with REAL
+    /// geometry providers (applyLayout bails at its work-area guard without
+    /// one, long before the activation this suite observes) but WITHOUT
+    /// makeProviderEngine's auto-echo.
+    static ScrollEngine* threeWindows(QObject* parent)
+    {
+        auto* engine = new ScrollEngine(nullptr, nullptr, parent);
+        const ScrollTestUtils::GeometryFn geometry = [](const QString&) {
+            return ScrollTestUtils::defaultScreenRect();
+        };
+        engine->setScreenGeometryProviders(geometry, geometry);
+        engine->setActiveScreens({kS1});
+        engine->windowOpened(QStringLiteral("app|a"), kS1, 0, 0);
+        engine->windowOpened(QStringLiteral("app|b"), kS1, 0, 0);
+        engine->windowOpened(QStringLiteral("app|c"), kS1, 0, 0);
+        // Each open activated its arrival and queued the echo. Drain them in
+        // order, as the compositor would, so the queue is empty when a case
+        // starts and the reports it hand-delivers land against known state.
+        engine->windowFocused(QStringLiteral("app|a"), kS1);
+        engine->windowFocused(QStringLiteral("app|b"), kS1);
+        engine->windowFocused(QStringLiteral("app|c"), kS1);
+        return engine;
+    }
+
+    static ScrollState* stateFor(ScrollEngine* engine)
+    {
+        return static_cast<ScrollState*>(engine->stateForScreen(kS1));
+    }
+};
+
+void TestScrollEngineFocusReport::closeEchoAfterTheCompositorsOwnPickWinsTheStrip()
+{
+    // The close of the middle column races two activations: the compositor
+    // picks its own successor and reports it, and the engine asks for the
+    // right neighbour. The compositor's report is in flight first (it is
+    // queued before the daemon even hears the close), so the strip moves onto
+    // its pick; the engine's activation then really takes focus, and its echo
+    // is the last word. The echo filter must let that final echo through.
+    // Swallowing it left the strip centred on the compositor's pick while the
+    // focus ring sat on the engine's (the "right one has focus, left one is
+    // centred" report).
+    QObject owner;
+    ScrollEngine* engine = threeWindows(&owner);
+    ScrollState* state = stateFor(engine);
+    QVERIFY(state);
+    engine->windowFocused(QStringLiteral("app|b"), kS1);
+    QCOMPARE(state->strip().activeWindowId(), QStringLiteral("app|b"));
+
+    QSignalSpy activate(engine, &PhosphorEngine::PlacementEngineBase::activateWindowRequested);
+    engine->windowClosed(QStringLiteral("app|b"));
+    QCOMPARE(activate.count(), 1);
+    QCOMPARE(activate.last().at(0).toString(), QStringLiteral("app|c"));
+    QCOMPARE(state->strip().activeWindowId(), QStringLiteral("app|c"));
+
+    // The compositor's own successor pick lands first and is genuine focus.
+    engine->windowFocused(QStringLiteral("app|a"), kS1);
+    QCOMPARE(state->strip().activeWindowId(), QStringLiteral("app|a"));
+
+    // The engine's activation echo: nothing later is queued and the strip
+    // disagrees with it, so it is adopted rather than swallowed.
+    engine->windowFocused(QStringLiteral("app|c"), kS1);
+    QCOMPARE(state->strip().activeWindowId(), QStringLiteral("app|c"));
+}
+
+void TestScrollEngineFocusReport::staleEchoWithALaterActivationQueuedIsStillSwallowed()
+{
+    // The swallow the filter exists for: a rapid focus scroll queues a second
+    // activation before the first echo lands, and that stale first echo must
+    // NOT rewind the strip (the next step would then advance from the rewound
+    // column and skip one). The adopt arm above is gated on the queue's tail
+    // being EMPTY precisely so this case keeps its swallow.
+    QObject owner;
+    ScrollEngine* engine = threeWindows(&owner);
+    ScrollState* state = stateFor(engine);
+    QVERIFY(state);
+    QCOMPARE(state->strip().activeWindowId(), QStringLiteral("app|c"));
+
+    QSignalSpy activate(engine, &PhosphorEngine::PlacementEngineBase::activateWindowRequested);
+    engine->focusColumnPlain(-1, kS1); // c -> b
+    engine->focusColumnPlain(-1, kS1); // b -> a
+    QCOMPARE(activate.count(), 2);
+    QCOMPARE(state->strip().activeWindowId(), QStringLiteral("app|a"));
+
+    // Stale echo of the first step, with the second's still due: swallowed.
+    engine->windowFocused(QStringLiteral("app|b"), kS1);
+    QCOMPARE(state->strip().activeWindowId(), QStringLiteral("app|a"));
+    // Final echo agrees with the strip: nothing to do either way.
+    engine->windowFocused(QStringLiteral("app|a"), kS1);
+    QCOMPARE(state->strip().activeWindowId(), QStringLiteral("app|a"));
+}
+
+QTEST_GUILESS_MAIN(TestScrollEngineFocusReport)
+#include "test_scrollengine_focusreport.moc"


### PR DESCRIPTION
## Summary

Closing the middle of three columns with a centred focused column left the right column holding focus while the strip centred the left one (M/S report, 3.4.12).

The close races two activations. KWin reports its own successor pick (the focus-chain neighbour, the left column) first, and that genuine report moves the strip onto it. The engine's competing right-neighbour activation then really takes focus, but its echo matched the pending self-activation queue and was swallowed, so the strip never learned focus had moved on.

995f135ea made that echo invisible on purpose to cure the post-close anchor ping-pong. This is the flip side of the same ordering.

## Fix

A live echo is swallowed only while a later self-activation is still queued (the rapid focus-scroll case the filter exists for) or when the strip already calls the echoed window active. With the queue tail empty and the strip disagreeing, the echo is the compositor's last word on focus and is adopted. `windowFocused` never re-activates, so adopting it cannot restart the ping-pong.

## Tests

New suite `test_scrollengine_focusreport` on a no-echo fixture with real geometry providers:
- the close ordering (genuine report first, engine echo last) now lands the strip on the focused window
- the rapid-scroll stale echo with a later activation queued is still swallowed

Mutation check: against the unfixed engine the close case fails with the strip stuck on the left window. All 40 scroll-engine tests pass in both axis arms, no build warnings.

The suite is its own file because the verbs suite is already past the size ceiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MoH9zWxdaWEa4PJHcPgW7b
