### PR TITLE
fix(scroll-engine): re-emit the clamped rect after a resize that overshoots the work area

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **A window on a scrolling screen no longer stays over the bottom gap after its edge is dragged past the work area**: dragging a tiled window's bottom edge down into the gap under it left the window there, covering the gap, until some later change happened to move it. The engine accepted the new height and worked out the corrected rect, but that rect matched the one it had already sent, so the correction was never sent to the compositor. A width change or a shrink happened to move the rect and so was corrected, which is why the problem came and went and looked like an autohide panel issue. The engine now records where the window actually sits after a resize, so the correction is always sent and the window snaps back to the work area. ([#1066](https://github.com/fuddlesworth/PlasmaZones/pull/1066))
+
 ## [3.4.12] - 2026-09-05
 
 ### Fixed

--- a/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/ScrollEngine.h
+++ b/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/ScrollEngine.h
@@ -1475,8 +1475,14 @@ private:
     /// openColumnPlacement rule and remembered positions outrank it).
     ScrollInsertPosition m_insertPosition = ScrollInsertPosition::RightOfActive;
 
-    /// The exact rect last APPLIED per window while strip-managed (float-back
-    /// poison guard; see PlacementEngineBase::lastManagedRect).
+    /// The rect the compositor is currently believed to show per window while
+    /// strip-managed: the exact rect applyLayout last APPLIED, or, between an
+    /// accepted user resize and the next relayout, the frame the user
+    /// settled on (onWindowResized's accepted arm rewrites the entry to
+    /// newFrame, since the window sits there now and the emit-on-change gate
+    /// must compare the corrective relayout against that, not against the
+    /// rect it displaced). Also the float-back poison guard's comparand; see
+    /// PlacementEngineBase::lastManagedRect.
     QHash<QString, QRect> m_lastAppliedRect;
     /// Windows whose last EMITTED batch entry carried windowedFullscreen —
     /// the flag's own leg of applyLayout's emit-on-change gate (a toggle

--- a/libs/phosphor-scroll-engine/src/scrollengine/engine_minsize.cpp
+++ b/libs/phosphor-scroll-engine/src/scrollengine/engine_minsize.cpp
@@ -175,6 +175,19 @@ void ScrollEngine::onWindowResized(const QString& rawWindowId, const QRect& oldF
         // reconcileWindowSize returns true only on a genuine change, so
         // emit-on-change holds.
         Q_EMIT placementChanged(key.screenId);
+        // The window now SITS at newFrame, not at the rect this map still
+        // remembers, so the memory is rewritten to where the window truly
+        // is. Without this the accepted arm shared the refused arm's stale-
+        // memory hole from the other direction: a resize the relayout
+        // CLAMPS straight back (a bottom edge dragged into the outer gap, a
+        // lone window pulled past the work area) resolved to exactly the
+        // rect already remembered, applyLayout's emit-on-change gate read
+        // "nothing moved" and stayed silent, and the window was stranded
+        // at the overshoot with the gap swallowed. The stale memory was
+        // only harmless when the retile happened to shift the rect anyway
+        // (a width change recentres, a shrink recentres across), which is
+        // why the report read as intermittent.
+        m_lastAppliedRect.insert(windowId, newFrame);
         if (currentContext) {
             scheduleRetileForScreen(key.screenId);
         }

--- a/libs/phosphor-scroll-engine/tests/test_scrollengine_boundary.cpp
+++ b/libs/phosphor-scroll-engine/tests/test_scrollengine_boundary.cpp
@@ -500,6 +500,60 @@ private Q_SLOTS:
         QVERIFY2(!namesB(QJsonDocument::fromJson(strips.last().at(1).toString().toUtf8()).array()),
                  "a fully parked tabbed column must not leave an orphan tab bar at the edge");
     }
+
+    // A user resize that overshoots the work area ACROSS the strip (the
+    // bottom edge dragged into the outer gap) is clamped straight back by
+    // the relayout, which resolves to the very rect the window held before.
+    // That corrective rect MUST still reach the compositor: the window is
+    // sitting at the overshoot now, so "same rect as last time" is not
+    // "nothing moved". The emit-on-change gate used to swallow exactly this
+    // batch and leave the window stranded over the gap.
+    void crossAxisOvershootResizeIsCommittedBackToTheWorkArea()
+    {
+        QObject owner;
+        auto* settings = makeBoundarySettings(&owner);
+        const QRect screen = defaultScreenRect();
+        // A work area inset ACROSS the strip only, standing in for the
+        // bottom gap the report's user reserves for a panel.
+        const QRect inset = Ax::t(QRect(0, 0, 1200, 700));
+        ScrollEngine* engine = makeProviderEngine(
+            &owner, {kS1},
+            [screen](const QString&) {
+                return screen;
+            },
+            [inset](const QString&) {
+                return inset;
+            });
+        engine->setEngineSettings(settings);
+        engine->refreshConfigFromSettings();
+
+        QSignalSpy tiled(engine, &ScrollEngine::windowsTiled);
+        engine->windowOpened(QStringLiteral("app|a"), kS1, 0, 0);
+        engine->retile(kS1);
+        QCoreApplication::processEvents();
+
+        const auto rectOfEntry = [](const QJsonObject& o) {
+            return QRect(o.value(QLatin1String("x")).toInt(), o.value(QLatin1String("y")).toInt(),
+                         o.value(QLatin1String("width")).toInt(), o.value(QLatin1String("height")).toInt());
+        };
+        const QRect applied = rectOfEntry(lastEntryFor(tiled, QStringLiteral("app|a")));
+        QVERIFY2(!applied.isEmpty(), "precondition: a is committed before the resize");
+        QCOMPARE(Ax::crossEnd(applied), Ax::crossEnd(inset));
+
+        // The settled frame: the same rect grown 60px past the work area's
+        // cross edge, in role space and transposed with the arm.
+        QRect overshoot = Ax::t(applied);
+        overshoot.setHeight(overshoot.height() + 60);
+        overshoot = Ax::t(overshoot);
+        const int before = tiled.count();
+        engine->onWindowResized(QStringLiteral("app|a"), applied, overshoot, kS1);
+        QCoreApplication::processEvents();
+
+        QVERIFY2(tiled.count() > before, "the clamped-back rect must be re-emitted, not gated as unchanged");
+        const QRect corrected = rectOfEntry(lastEntryFor(tiled, QStringLiteral("app|a")));
+        QCOMPARE(Ax::crossEnd(corrected), Ax::crossEnd(inset));
+        QCOMPARE(corrected, applied);
+    }
 };
 
 QTEST_GUILESS_MAIN(TestScrollEngineBoundary)

--- a/libs/phosphor-scroll-engine/tests/test_scrollengine_boundary.cpp
+++ b/libs/phosphor-scroll-engine/tests/test_scrollengine_boundary.cpp
@@ -81,6 +81,13 @@ QJsonObject lastEntryFor(QSignalSpy& tiled, const QString& windowId)
     return {};
 }
 
+/// The committed rect a windowsTiled batch entry describes.
+QRect rectOfEntry(const QJsonObject& o)
+{
+    return QRect(o.value(QLatin1String("x")).toInt(), o.value(QLatin1String("y")).toInt(),
+                 o.value(QLatin1String("width")).toInt(), o.value(QLatin1String("height")).toInt());
+}
+
 } // namespace
 
 class TestScrollEngineBoundary : public QObject
@@ -125,10 +132,6 @@ private Q_SLOTS:
         engine->windowOpened(QStringLiteral("app|c"), kS1, 0, 0);
         QVERIFY(tiled.count() > 0);
 
-        const auto rectOfEntry = [](const QJsonObject& o) {
-            return QRect(o.value(QLatin1String("x")).toInt(), o.value(QLatin1String("y")).toInt(),
-                         o.value(QLatin1String("width")).toInt(), o.value(QLatin1String("height")).toInt());
-        };
         const QRect landscapeA = rectOfEntry(lastEntryFor(tiled, QStringLiteral("app|a")));
         QVERIFY2(!landscapeA.isEmpty(), "precondition: a is committed before the rotation");
         QVERIFY2(landscapeA.height() >= landscapeA.width(),
@@ -532,10 +535,6 @@ private Q_SLOTS:
         engine->retile(kS1);
         QCoreApplication::processEvents();
 
-        const auto rectOfEntry = [](const QJsonObject& o) {
-            return QRect(o.value(QLatin1String("x")).toInt(), o.value(QLatin1String("y")).toInt(),
-                         o.value(QLatin1String("width")).toInt(), o.value(QLatin1String("height")).toInt());
-        };
         const QRect applied = rectOfEntry(lastEntryFor(tiled, QStringLiteral("app|a")));
         QVERIFY2(!applied.isEmpty(), "precondition: a is committed before the resize");
         QCOMPARE(Ax::crossEnd(applied), Ax::crossEnd(inset));


### PR DESCRIPTION
## Summary

Scrolling mode: dragging a tiled window's bottom edge into the bottom gap left it there. The engine accepted the resize, the relayout clamped the height back to the work area, but the clamped rect was identical to the last one `m_lastAppliedRect` remembered, so `applyLayout`'s emit-on-change gate never sent the correction to KWin. A width change or a vertical shrink happened to shift the rect and so got corrected, which is why the report read as intermittent and got blamed on autohide panels.

From the user's support report (`plasmazones-report-20260905-232116`):

```
23:12:26 windowResized "zen|..."     QRect(257,5 1156x869) -> QRect(257,5 1156x934)   (no correction sent)
23:20:55 windowResized "equibop|..." QRect(155,5 1360x869) -> QRect(155,5 1360x899)   (no correction sent)
23:20:57 windowResized "equibop|..." QRect(155,5 1360x899) -> QRect(155,5 1360x857)   (shrink, recentred to y=11: corrected)
```

Every other settled rect in the log honours the 5px top and 65px bottom gaps, and the 80px column gap held across both horizontal resizes, so the "gaps between columns differ" part of the report is not reproduced.

## Fix

The accepted arm of `ScrollEngine::onWindowResized` now rewrites `m_lastAppliedRect` to the frame the window actually sits at, the same stale-memory repair the refused arm already performed. The corrective retile then compares against reality and emits.

## Test

`crossAxisOvershootResizeIsCommittedBackToTheWorkArea` in `test_scrollengine_boundary.cpp` grows a lone window 60px past an inset work area and asserts a fresh emission puts it back at the work-area edge. Mutation-checked: fails in both axis arms with the one line removed.

Full build clean with zero warnings. All 38 `phosphorscrollengine` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnASX5b9vUY35MdT9FD9z3
