### PR TITLE
fix: multipass decoration stages stuck through OSD legs, and frozen frame-driven animation previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Glass and blur decorations on the OSD and popups fade out with them again**: with a pack from the glass or blur family on an OSD or a popup, the card faded in and out but the decoration itself stayed on screen at full strength until the card was gone. Those packs render in several passes, and each of them was given a private drawing layer on the theory that their passes needed one. That layer is drawn by a helper item Qt puts beside the stage, and the fade animation hides and animates the stage while leaving the helper where it was. The passes never needed the layer, so it is gone, and every decoration now fades with the card it decorates. ([#1087](https://github.com/fuddlesworth/PlasmaZones/pull/1087))
+- **Animation previews that drift or spin no longer hold still**: in the animation pack preview, packs that move a little every frame on their own clock, such as the vortex spin, the matrix and fire drift and the noise in the desktop switch packs, sat frozen except for the open or close sweep. The preview drove the sweep but never told the pack how much time had passed since the last frame or which frame it was on, and those packs add their motion up from exactly that. The preview now advances both every frame, the way the compositor does. ([#1087](https://github.com/fuddlesworth/PlasmaZones/pull/1087))
 - **Pressing the float shortcut a second time puts a tiled window back in the layout**: in tiling mode the shortcut floated a window and then refused to take it back, so the window stayed floating however many times you pressed. The engine asked the layout state to flip the window's floating bit and read the answer as whether the flip had worked, but the answer was the bit's new value, so the press that turned floating back off read as a failure. The flip itself had already landed. Everything that follows it, re-tiling the screen and telling the rest of PlasmaZones the window came back, was skipped, which left the layout believing the window was tiled while the window stayed floating on screen. ([#1076](https://github.com/fuddlesworth/PlasmaZones/discussions/1076), [#1085](https://github.com/fuddlesworth/PlasmaZones/pull/1085))
 
 ## [3.4.15] - 2026-09-07
@@ -2425,7 +2427,8 @@ Initial packaged release. Wayland-only (X11 support removed). Requires KDE Plasm
 - Session restoration and rotation after login ([#66])
 - Window tracking: snap/restore behavior, zone clearing, startup timing, rotation zone ID matching, floating window exclusion ([#67])
 
-[Unreleased]: https://github.com/fuddlesworth/PlasmaZones/compare/v3.4.14...HEAD
+[Unreleased]: https://github.com/fuddlesworth/PlasmaZones/compare/v3.4.15...HEAD
+[3.4.15]: https://github.com/fuddlesworth/PlasmaZones/compare/v3.4.14...v3.4.15
 [3.4.14]: https://github.com/fuddlesworth/PlasmaZones/compare/v3.4.13...v3.4.14
 [3.4.13]: https://github.com/fuddlesworth/PlasmaZones/compare/v3.4.12...v3.4.13
 [3.4.12]: https://github.com/fuddlesworth/PlasmaZones/compare/v3.4.11...v3.4.12

--- a/src/settings/pages/animationpreviewcontroller.cpp
+++ b/src/settings/pages/animationpreviewcontroller.cpp
@@ -257,12 +257,19 @@ QVariantMap AnimationPreviewController::packInfo(const QString& packId) const
 }
 
 bool AnimationPreviewController::configurePreviewItem(QQuickItem* item, const QString& packId,
-                                                      const QVariantMap& friendlyParams) const
+                                                      const QVariantMap& friendlyParams)
 {
     auto* shaderItem = qobject_cast<PhosphorRendering::ShaderEffect*>(item);
     if (!shaderItem) {
         return false;
     }
+    // A configure is a leg boundary: driveFrameClock's next push on this
+    // item reports iFrame 0 again. Keyed here rather than only on the item
+    // pointer changing, because the pane tears its item down and creates a
+    // new one at every rebuild and the allocator may hand the new item the
+    // old address, which would carry the old count into the new leg.
+    m_clockItem = nullptr;
+    m_clockFrame = 0;
     PhosphorAnimationShaders::AnimationShaderEffect effect;
     QStringList includePaths;
     if (!resolvePreviewEffect(m_registry, packId, effect, includePaths)) {
@@ -484,8 +491,9 @@ void AnimationPreviewController::driveFrameClock(QQuickItem* item, qreal dtMs)
     const qreal deltaSecs =
         qMin(qMax(0.0, dtMs) / 1000.0, static_cast<qreal>(PhosphorAnimation::Limits::MaxShaderTimeDeltaSeconds));
     shaderItem->setITimeDelta(deltaSecs);
-    // Post-increment: the first push after a (re)configure reports 0,
-    // matching the compositor's `transition.frameCount++`.
+    // Post-increment: the first push after a (re)configure (which resets
+    // the counter) or an item change reports 0, matching the compositor's
+    // `transition.frameCount++`.
     shaderItem->setIFrame(m_clockFrame++);
 }
 

--- a/src/settings/pages/animationpreviewcontroller.cpp
+++ b/src/settings/pages/animationpreviewcontroller.cpp
@@ -8,6 +8,7 @@
 #include "core/types/cavaoptions.h"
 #include "phosphor_i18n.h"
 
+#include <PhosphorAnimation/AnimationLimits.h>
 #include <PhosphorAnimation/AnimationShaderEffect.h>
 #include <PhosphorAnimation/AnimationShaderItemConfig.h>
 #include <PhosphorAnimation/AnimationShaderRegistry.h>
@@ -465,6 +466,27 @@ void AnimationPreviewController::driveMoveState(QQuickItem* item, qreal x, qreal
     }
     ext->setIMoveMesh(mesh);
     m_moveLastOrigin = origin;
+}
+
+void AnimationPreviewController::driveFrameClock(QQuickItem* item, qreal dtMs)
+{
+    auto* shaderItem = qobject_cast<PhosphorRendering::ShaderEffect*>(item);
+    if (!shaderItem) {
+        return;
+    }
+    if (m_clockItem != item) {
+        m_clockItem = item;
+        m_clockFrame = 0;
+    }
+    // Same cap as paint_shader_window and the SurfaceAnimator: a stalled
+    // pane (suspended window, dragged dialog) must not hand a dt-integrated
+    // pack one multi-second step.
+    const qreal deltaSecs =
+        qMin(qMax(0.0, dtMs) / 1000.0, static_cast<qreal>(PhosphorAnimation::Limits::MaxShaderTimeDeltaSeconds));
+    shaderItem->setITimeDelta(deltaSecs);
+    // Post-increment: the first push after a (re)configure reports 0,
+    // matching the compositor's `transition.frameCount++`.
+    shaderItem->setIFrame(m_clockFrame++);
 }
 
 void AnimationPreviewController::bindClassTextures(QQuickItem* item, const QString& eventClass) const

--- a/src/settings/pages/animationpreviewcontroller.h
+++ b/src/settings/pages/animationpreviewcontroller.h
@@ -115,6 +115,20 @@ public:
     /// glide loop wrapping), so the wrap does not read as a violent yank.
     Q_INVOKABLE void driveMoveState(QQuickItem* item, qreal x, qreal y, qreal w, qreal h, qreal dtMs);
 
+    /// Advance the per-frame book-keeping uniforms by one pane frame:
+    /// `iTimeDelta` (seconds, capped at Limits::MaxShaderTimeDeltaSeconds
+    /// like every other push site) and `iFrame` (post-incremented, so the
+    /// first push after a (re)configure reports 0). The compositor advances
+    /// both on every paint of every transition regardless of class, and
+    /// packs in every class integrate on them (phosphor-vortex's spin,
+    /// matrix and fire's drift, the desktop packs' noise advance). The
+    /// pane's class clocks only sweep `iTime`, so without this pump those
+    /// packs sit still in the preview. Resets the frame counter when the
+    /// item changes. Not for the strip class: its item free-runs through
+    /// `playing`, whose auto-tick already advances all three and treats
+    /// manual writes as additive.
+    Q_INVOKABLE void driveFrameClock(QQuickItem* item, qreal dtMs);
+
     /// Push the transition-class scalars for the current clock frame onto
     /// an already-configured item's uniform extension. Recognised keys:
     /// `switchDelta` / `stripMotion` (vector4d), `stripAxis` (vector2d),
@@ -237,6 +251,11 @@ private:
     std::array<QPointF, 16> m_moveTrail{};
     QPointF m_moveLastOrigin;
     double m_moveTrailAccumMs = 0.0;
+
+    // driveFrameClock's per-leg frame counter. Same one-item-at-a-time
+    // shape as the move sim; the QObject* is only compared, never dereferenced.
+    QObject* m_clockItem = nullptr;
+    int m_clockFrame = 0;
 };
 
 } // namespace PlasmaZones

--- a/src/settings/pages/animationpreviewcontroller.h
+++ b/src/settings/pages/animationpreviewcontroller.h
@@ -5,7 +5,7 @@
 
 // The kwin-effect's wobble-lattice spring integrator, included by relative
 // path on purpose: this controller is compiled into the settings app AND
-// eleven animation test executables, and a quote-include resolves against
+// twelve animation test executables, and a quote-include resolves against
 // this file so none of those targets needs the kwin-effect include dir.
 // Both trees are GPL-3.0, so no license boundary is crossed.
 #include "../../../kwin-effect/plasmazoneseffect/mesh_sim.h"
@@ -123,10 +123,11 @@ public:
     /// packs in every class integrate on them (phosphor-vortex's spin,
     /// matrix and fire's drift, the desktop packs' noise advance). The
     /// pane's class clocks only sweep `iTime`, so without this pump those
-    /// packs sit still in the preview. Resets the frame counter when the
-    /// item changes. Not for the strip class: its item free-runs through
-    /// `playing`, whose auto-tick already advances all three and treats
-    /// manual writes as additive.
+    /// packs sit still in the preview. The frame counter restarts at 0
+    /// when configurePreviewItem runs and when the item changes. Not for
+    /// the strip class: its item free-runs through `playing`, whose
+    /// auto-tick already advances all three and treats manual writes as
+    /// additive.
     Q_INVOKABLE void driveFrameClock(QQuickItem* item, qreal dtMs);
 
     /// Push the transition-class scalars for the current clock frame onto
@@ -163,9 +164,10 @@ public:
     /// the shared animation.vert fallback, mirroring SurfaceAnimator's
     /// runLeg), seed iTime / isReversed for a show leg, and upload the
     /// translated parameters. Returns false — leaving the item unconfigured
-    /// — for an unknown, invalid or compositor-only pack.
-    Q_INVOKABLE bool configurePreviewItem(QQuickItem* item, const QString& packId,
-                                          const QVariantMap& friendlyParams) const;
+    /// — for an unknown, invalid or compositor-only pack. Either way the
+    /// call restarts driveFrameClock's frame counter: a configure is a leg
+    /// boundary.
+    Q_INVOKABLE bool configurePreviewItem(QQuickItem* item, const QString& packId, const QVariantMap& friendlyParams);
 
     /// Re-translate and upload @p friendlyParams onto an already-configured
     /// item, for live parameter editing in the detail dialog.
@@ -253,7 +255,9 @@ private:
     double m_moveTrailAccumMs = 0.0;
 
     // driveFrameClock's per-leg frame counter. Same one-item-at-a-time
-    // shape as the move sim; the QObject* is only compared, never dereferenced.
+    // shape as the move sim; the QObject* is only compared, never
+    // dereferenced. configurePreviewItem clears it, so a rebuilt item that
+    // lands on the old address still starts its leg at 0.
     QObject* m_clockItem = nullptr;
     int m_clockFrame = 0;
 };

--- a/src/settings/qml/pages/shaders/AnimationPreviewPane.qml
+++ b/src/settings/qml/pages/shaders/AnimationPreviewPane.qml
@@ -632,11 +632,19 @@ Item {
                             duration: 650
                         }
                     }
-                    // The simulation tick. Runs through the pauses too —
-                    // that is when the lattice visibly settles, which is
-                    // half of what wobble IS. ~60 Hz like the zone pane's
-                    // clock; the controller derives the trail cadence from
-                    // the accumulated delta, not the tick rate.
+                    // The frame tick. The class clocks above only sweep
+                    // iTime; the compositor also advances iTimeDelta and
+                    // iFrame on every paint, and packs in every class
+                    // integrate on those (vortex's spin, matrix and fire's
+                    // drift, the desktop packs' noise). So this runs for
+                    // every clock-driven class, and for move it also steps
+                    // the simulation — through the pauses too, since that
+                    // is when the lattice visibly settles, which is half of
+                    // what wobble IS. ~60 Hz like the zone pane's clock;
+                    // the controller derives the trail cadence from the
+                    // accumulated delta, not the tick rate. Strip is
+                    // excluded: its item free-runs through `playing`, whose
+                    // auto-tick already advances all three uniforms.
                     Timer {
                         // Measured wall-clock delta, like the zone pane's
                         // clock: under load the timer fires late, and
@@ -646,7 +654,7 @@ Item {
                         // suspended window) steps the spring stably.
                         property double lastTickMs: 0
 
-                        running: field.configured && root.animating && root._class === "move"
+                        running: field.configured && root.animating && root._class !== "strip"
                         interval: 16
                         repeat: true
                         onRunningChanged: lastTickMs = Date.now()
@@ -656,7 +664,9 @@ Item {
                             var now = Date.now();
                             var dt = Math.min(100, Math.max(1, now - lastTickMs));
                             lastTickMs = now;
-                            root.previewController.driveMoveState(shaderItem, cardHolder.x + field.canvasPad, cardHolder.y + field.canvasPad, field.innerW, field.innerH, dt);
+                            root.previewController.driveFrameClock(shaderItem, dt);
+                            if (root._class === "move")
+                                root.previewController.driveMoveState(shaderItem, cardHolder.x + field.canvasPad, cardHolder.y + field.canvasPad, field.innerW, field.innerH, dt);
                         }
                     }
 

--- a/src/shared/SurfaceDecoration.qml
+++ b/src/shared/SurfaceDecoration.qml
@@ -142,7 +142,8 @@ Item {
     /// zone/overlay preview has always had.
     property bool animationsPaused: false
 
-    /// Route EVERY stage through a layer texture, not just the multipass ones.
+    /// Route the LAST stage, the one that reaches the screen, through a layer
+    /// texture.
     ///
     /// Mandatory for a host that applies a transform to this component or
     /// relies on an ancestor's `clip`. A SurfaceShaderItem stage is a
@@ -151,20 +152,23 @@ Item {
     /// viewport from `item->width() * devicePixelRatio` and the item's mapped
     /// ORIGIN — so a scaled ancestor moves the stage but does not resize it,
     /// and the node overwrites the scissor Qt set for the clip. A scaled host
-    /// therefore gets full-size stages drawn at scaled positions, spilling
-    /// over whatever is beside them.
+    /// therefore gets a full-size stage drawn at a scaled position, spilling
+    /// over whatever is beside it.
     ///
     /// Layering removes the problem rather than working around it: the node
     /// renders into an FBO sized to its own item (which is what it thinks it
     /// is drawing at anyway), and the scene graph composites THAT texture with
-    /// the full transform and clip, like any other textured node. Multipass
-    /// stages already take this path for their own reasons, which is why the
-    /// blur family survived a scaled host while every single-pass pack escaped
-    /// its bounds.
+    /// the full transform and clip, like any other textured node. Only the
+    /// last stage needs it: every intermediate stage already renders into the
+    /// next stage's `tap` FBO and never reaches the screen directly, and
+    /// layering one would draw its opaque layer sibling under the composite
+    /// (see the stage's layer.enabled below for why a captured stage must
+    /// never be layered).
     ///
     /// False by default: the daemon's overlay surfaces are drawn untransformed
-    /// at 1:1, and a layer per stage there would be a canvas-sized FBO for
-    /// nothing.
+    /// at 1:1, and a layer there would be a canvas-sized FBO for nothing, and
+    /// the animator captures the last stage for the show / hide legs, which a
+    /// layer would break.
     property bool layeredStages: false
 
     /// Drives `uSurfaceFocused` on every stage. A pack that distinguishes an
@@ -800,10 +804,10 @@ Item {
                 // sampled and building them is pure cost, which is what the
                 // daemon's overlay surfaces would be paying.
                 //
-                // And only on the LAST stage. An intermediate stage's layer
-                // texture is never composited by the scene graph — the next
-                // stage's `tap` captures it instead — so its mip chain would be
-                // rebuilt every frame for a texture nothing samples through it.
+                // And only on the LAST stage, which is the only stage that is
+                // ever layered (see layer.enabled above); an intermediate
+                // stage is captured by the next stage's `tap` and has no layer
+                // for a mip chain to belong to.
                 layer.mipmap: root.layeredStages && stage.isLast
                 layer.smooth: root.layeredStages && stage.isLast
                 // iTime driver: only a stage whose pack declares "animated"

--- a/src/shared/SurfaceDecoration.qml
+++ b/src/shared/SurfaceDecoration.qml
@@ -735,17 +735,38 @@ Item {
                 // precision, so opting out is the deliberate act.
                 halfFloatBuffers: stage.stageData.halfFloatBuffers !== false
 
-                // Multipass REQUIRES a private layer FBO: the render node
-                // drives its own buffer passes, and without an isolated target
-                // the scene graph's batch renderer desynchronizes its internal
-                // pass tracking (the rationale ZoneShaderRenderer.qml documents
-                // for the overlay path — same render node, same constraint).
-                // Gated on the stage actually being multipass so a plain border
-                // or glow stage pays no extra canvas-sized FBO. The intermediate
-                // taps below still capture a layered stage: layer.enabled
-                // changes where the item renders, not whether it renders, so
-                // the hide-source fold is unaffected.
-                layer.enabled: (stage.stageData.multipass === true || root.layeredStages) && root.decorationActive
+                // NEVER layer a stage that a hide-source capture folds — which
+                // is every stage here: the intermediate ones are captured by
+                // the next stage's `tap`, and the last one by SurfaceAnimator
+                // for the show / hide legs. A Qt item layer draws the item
+                // through its OWN ShaderEffectSource, a sibling Qt parents next
+                // to the item at the item's rect, and `hideSource` on the item
+                // hides the item's scene-graph subtree only. The layer sibling
+                // keeps compositing the stage on screen, opaque and unanimated,
+                // under whatever the capture consumer draws. That is exactly
+                // what made every multipass pack (the glass and blur family)
+                // stick through the OSD fade: the fade shader faded the
+                // captured composite while the layer sibling of the glass
+                // stage sat behind it at full opacity until the slot hid.
+                //
+                // Multipass used to be layered here on the theory that the
+                // render node's buffer passes need an isolated target. They do
+                // not: ShaderNodeRhi issues them from prepare(), before the
+                // scene graph begins its own pass, which is where Qt puts
+                // offscreen passes, and an intermediate stage already renders
+                // into the tap's layer FBO regardless. Verified live in a
+                // nested session with ink-glass first and last in the chain:
+                // unlayered, both orders render upright and both legs fade.
+                //
+                // The preview host's LAST stage is the one exception. It
+                // composes at one size and displays the result scaled
+                // (layeredStages), so the composited output is layered for the
+                // mip chain below, and that host never hands its stages to the
+                // animator. Its intermediate stages stay unlayered for the
+                // same reason as everywhere else: a layered intermediate stage
+                // would draw its opaque layer sibling under a translucent
+                // final composite.
+                layer.enabled: root.layeredStages && stage.isLast && root.decorationActive
                 // Qt's DEFAULT mirroring (MirrorVertically), which differs from
                 // the NoMirroring ZoneShaderRenderer.qml sets. That difference
                 // is NOT a designed distinction between the two hosts: the zone

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -1583,11 +1583,11 @@ target_link_libraries(test_tiling_algorithm_controller PRIVATE Qt6::Test Qt6::Co
 target_compile_definitions(test_tiling_algorithm_controller PRIVATE "P_SOURCE_DIR=\"${PROJECT_SOURCE_DIR}\"")
 add_test(NAME test_tiling_algorithm_controller COMMAND test_tiling_algorithm_controller)
 
-# Animations-controller sources shared by the eleven test executables below
-# (page controller / QML contracts / profile-store sync / motion sets / presets /
-# shader overrides / shader param writes / group writes / group write bounds /
-# suppression mirror / stale params). One list so a new controller source file
-# cannot silently miss one of the eleven.
+# Animations-controller sources shared by the twelve test executables below
+# (page controller / preview controller / QML contracts / profile-store sync /
+# motion sets / presets / shader overrides / shader param writes / group writes /
+# group write bounds / suppression mirror / stale params). One list so a new
+# controller source file cannot silently miss one of the twelve.
 set(_animations_ctrl_SRCS
     ${CMAKE_SOURCE_DIR}/src/settings/pages/animationspagecontroller.cpp
     ${CMAKE_SOURCE_DIR}/src/settings/pages/animationpreviewcontroller.cpp
@@ -1628,6 +1628,27 @@ target_link_libraries(test_animations_page_controller
         plasmazones_core
 )
 add_test(NAME test_animations_page_controller COMMAND test_animations_page_controller)
+
+# AnimationPreviewController's per-frame drive (driveFrameClock) against a
+# real PhosphorRendering::ShaderEffect item, off-window: the iTimeDelta cap,
+# the 0-first iFrame counter, and its resets on configure and item change.
+add_executable(test_animation_preview_controller
+    settings/pages/test_animation_preview_controller.cpp
+    ${_animations_ctrl_SRCS}
+)
+target_link_libraries(test_animation_preview_controller
+    PRIVATE
+        Qt6::Test
+        Qt6::Core
+        Qt6::Gui
+        Qt6::Quick
+        PhosphorAnimation::PhosphorAnimation
+        PhosphorAudio::PhosphorAudio  # AnimationPreviewController's CAVA provider
+        PhosphorControl::PhosphorControl
+        PhosphorRendering::PhosphorRendering
+        plasmazones_core
+)
+add_test(NAME test_animation_preview_controller COMMAND test_animation_preview_controller)
 
 # The stock-animation suppression mirror, split out of the sibling above
 # when it crossed the 1150-line hard ceiling.

--- a/tests/unit/settings/pages/test_animation_preview_controller.cpp
+++ b/tests/unit/settings/pages/test_animation_preview_controller.cpp
@@ -1,0 +1,129 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_animation_preview_controller.cpp
+ * @brief AnimationPreviewController's per-frame drive against a real
+ *        PhosphorRendering::ShaderEffect item, off-window.
+ *
+ * The pane's frame tick hands driveFrameClock a wall-clock delta every ~16 ms
+ * and the controller turns it into the two book-keeping uniforms the
+ * compositor advances on every paint: iTimeDelta (seconds, capped) and iFrame
+ * (post-incremented, so a leg's first push reports 0). These are the numbers
+ * every dt-integrating pack adds its motion up from, so the contract is pinned
+ * here rather than left to the eye: the cap, the 0-first counter, and the two
+ * resets that start a fresh leg (a configure, and a different item).
+ *
+ * The controller is built with no registry, which is its documented degraded
+ * construction: configurePreviewItem then returns false, and that is enough
+ * to exercise the reset, which happens before the registry lookup.
+ */
+
+#include "settings/pages/animationpreviewcontroller.h"
+
+#include <PhosphorAnimation/AnimationLimits.h>
+#include <PhosphorRendering/ShaderEffect.h>
+
+#include <QObject>
+#include <QVariantMap>
+#include <QtTest/QtTest>
+
+using namespace PlasmaZones;
+
+class TestAnimationPreviewController : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void frameClockStartsAtZeroAndCounts();
+    void frameClockCapsTheDelta();
+    void frameClockRestartsOnConfigure();
+    void frameClockRestartsOnItemChange();
+    void frameClockIgnoresNonShaderItems();
+};
+
+void TestAnimationPreviewController::frameClockStartsAtZeroAndCounts()
+{
+    AnimationPreviewController c;
+    PhosphorRendering::ShaderEffect item;
+
+    c.driveFrameClock(&item, 16.0);
+    QCOMPARE(item.iFrame(), 0);
+    QCOMPARE(item.iTimeDelta(), 0.016);
+
+    c.driveFrameClock(&item, 16.0);
+    QCOMPARE(item.iFrame(), 1);
+    c.driveFrameClock(&item, 16.0);
+    QCOMPARE(item.iFrame(), 2);
+}
+
+void TestAnimationPreviewController::frameClockCapsTheDelta()
+{
+    AnimationPreviewController c;
+    PhosphorRendering::ShaderEffect item;
+
+    // A stalled pane must not hand a dt-integrated pack one multi-second
+    // step: the same cap as every other push site.
+    c.driveFrameClock(&item, 5000.0);
+    QCOMPARE(item.iTimeDelta(), static_cast<qreal>(PhosphorAnimation::Limits::MaxShaderTimeDeltaSeconds));
+
+    // A negative delta (clock going backwards) is floored at zero, not
+    // passed through as a reverse step.
+    c.driveFrameClock(&item, -40.0);
+    QCOMPARE(item.iTimeDelta(), 0.0);
+}
+
+void TestAnimationPreviewController::frameClockRestartsOnConfigure()
+{
+    AnimationPreviewController c;
+    PhosphorRendering::ShaderEffect item;
+
+    c.driveFrameClock(&item, 16.0);
+    c.driveFrameClock(&item, 16.0);
+    c.driveFrameClock(&item, 16.0);
+    QCOMPARE(item.iFrame(), 2);
+
+    // The SAME item, reconfigured: a leg boundary, so the counter restarts
+    // even though the item pointer never changed. (No registry, so the
+    // configure itself reports failure; the reset precedes the lookup.)
+    QVERIFY(!c.configurePreviewItem(&item, QStringLiteral("no-such-pack"), QVariantMap{}));
+    c.driveFrameClock(&item, 16.0);
+    QCOMPARE(item.iFrame(), 0);
+    c.driveFrameClock(&item, 16.0);
+    QCOMPARE(item.iFrame(), 1);
+}
+
+void TestAnimationPreviewController::frameClockRestartsOnItemChange()
+{
+    AnimationPreviewController c;
+    PhosphorRendering::ShaderEffect first;
+    PhosphorRendering::ShaderEffect second;
+
+    c.driveFrameClock(&first, 16.0);
+    c.driveFrameClock(&first, 16.0);
+    QCOMPARE(first.iFrame(), 1);
+
+    c.driveFrameClock(&second, 16.0);
+    QCOMPARE(second.iFrame(), 0);
+    // The first item is left where it was: the clock is one-item-at-a-time.
+    QCOMPARE(first.iFrame(), 1);
+}
+
+void TestAnimationPreviewController::frameClockIgnoresNonShaderItems()
+{
+    AnimationPreviewController c;
+    PhosphorRendering::ShaderEffect item;
+    QQuickItem plain;
+
+    c.driveFrameClock(&item, 16.0);
+    c.driveFrameClock(&item, 16.0);
+    QCOMPARE(item.iFrame(), 1);
+
+    // A non-shader item is a no-op that does not disturb the running leg.
+    c.driveFrameClock(&plain, 16.0);
+    c.driveFrameClock(&item, 16.0);
+    QCOMPARE(item.iFrame(), 2);
+}
+
+QTEST_MAIN(TestAnimationPreviewController)
+#include "test_animation_preview_controller.moc"


### PR DESCRIPTION
## Summary

Two rendering fixes.

**Multipass decoration stages no longer stick through the OSD show/hide legs.** Every multipass surface pack (ink-glass, blur, glass, frosted-glass) stayed opaque through the OSD fade-out and popped in without a fade on show, while single-pass stages faded normally. It looked like the border and shadow stages dropping out. The real cause was one stage that never stopped: `SurfaceDecoration.qml` set `layer.enabled` on multipass stages, and a Qt item layer draws the item through its own ShaderEffectSource sibling at the item's rect. The hide-source captures that fold the chain (the inter-stage tap, the SurfaceAnimator leg capture) hide the item's subtree only, so the layer sibling of the glass stage kept compositing under the fading composite until the slot hid. The rationale for layering multipass stages was stale: the buffer passes run in `ShaderNodeRhi::prepare()`, before the scene graph's own pass, and intermediate stages already render into the tap's layer. Only the scaled preview host keeps a layer, on its last stage, for the mip chain.

**Animation previews now advance `iTimeDelta` and `iFrame`.** The compositor, overlay path and SurfaceAnimator bump both on every paint, and packs in every class integrate on them (phosphor-vortex spins off `iFrame`; matrix, fire and the desktop packs drift on it). The settings preview only swept `iTime`, so those packs sat still. The preview controller gains a per-tick frame clock matching the compositor's post-increment semantics, and the pane's tick runs for every clock-driven class. Strip is excluded because its item already free-runs through `playing`.

## Verification

- Nested `kwin_wayland --virtual` session with the host config and user packs seeded, the navigation OSD raised over D-Bus, ScreenShot2 captured at ~30 fps and scored by card brightness through the hide. Before: flat at full brightness then a cliff, with ink-glass first or last in the chain. After: smooth ramp to zero for ink-glass first, ink-glass last, and the shipped `ink-glass, border-ink, shadow` chain, on Vulkan. The glass stage renders upright and bordered when it draws straight to the window.
- Instrumented `ShaderNodeRhi` prepare/render counts during the leg to rule the render node out before touching the QML: the multipass node never drew to the swapchain.
- Full `ctest` suite: 457 of 457 pass. No new build warnings. clang-format and qmlformat hooks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TRtTVTb597BLdAXfAHcHYc
