### PR TITLE
fix(scrolling): center a dropped column when the policy says always

### DIFF
--- a/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/ScrollStrip.h
+++ b/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/ScrollStrip.h
@@ -695,16 +695,20 @@ public:
     /// just-dropped ACTIVE column at the on-screen position the drop
     /// indicator promised — its strip position minus @p oldViewOffset, the
     /// view offset captured BEFORE the commit's insert — then move the view
-    /// the MINIMUM that makes the column fully visible (the Never fit),
-    /// regardless of the configured centering policy. The policy's OnOverflow
-    /// arm centers a column too wide to share the viewport with either
-    /// neighbour, which after a drop hides every other window and reads as
-    /// the drop having flown away; the minimal fit keeps whatever neighbour
-    /// still fits on screen beside it. A maximized-to-edges column keeps its
-    /// one correct position (focusAnchorFor's reason). SETS the detach
-    /// latch: the drop owns the view the way a pan does, or the applyLayout
-    /// the commit runs next would hand it straight back to the centering
-    /// policy; the next focus change re-attaches as usual.
+    /// the MINIMUM that makes the column fully visible (the Never fit). The
+    /// policy's OnOverflow arm centers a column too wide to share the viewport
+    /// with either neighbour, which after a drop hides every other window and
+    /// reads as the drop having flown away, and the minimal fit keeps whatever
+    /// neighbour still fits on screen beside it. A maximized-to-edges column
+    /// keeps its one correct position (focusAnchorFor's reason). This arm SETS
+    /// the detach latch, so the drop owns the view the way a pan does and the
+    /// centering policy cannot take it back until the next focus change.
+    ///
+    /// The EXCEPTION is a policy that pins the focused column to the middle
+    /// whatever put it there — CenterFocusedColumn::Always, and the
+    /// lone-column rule (isCenteringActiveColumn). There the drop centers
+    /// through centerActiveColumn and leaves the view ATTACHED, which is the
+    /// same verdict an open, a move-to-last or a plain focus step reaches.
     void reanchorForDropCommit(int oldViewOffset, const ScrollLayoutParams& params);
     /// Drag-begin settle (ScrollEngine::beginDragInsertPreview): after the
     /// detach take shortens the strip, pull a view that now hangs past the

--- a/libs/phosphor-scroll-engine/src/scrollengine/drag_preview.cpp
+++ b/libs/phosphor-scroll-engine/src/scrollengine/drag_preview.cpp
@@ -428,11 +428,14 @@ void ScrollEngine::commitDragInsertPreview()
     }
     // The dropped window is the one the user is looking at.
     strip.focusWindow(p.windowId, params);
-    // Override the insert's own policy reanchor: land the dropped column at
-    // the position the indicator promised, moved only as far as full
-    // visibility requires. The policy verdict (OnOverflow centering an
-    // over-wide column) hid every neighbour after a drop; the minimal fit
-    // keeps the strip context the user dropped into on screen.
+    // Settle the view over the insert's own policy reanchor. Under every
+    // policy but Always (and the lone-column rule) that means landing the
+    // dropped column at the position the indicator promised, moved only as far
+    // as full visibility requires: the policy verdict (OnOverflow centering an
+    // over-wide column) hid every neighbour after a drop, and the minimal fit
+    // keeps the strip context the user dropped into on screen. Always is the
+    // user asking for the middle in so many words, so there the drop centers
+    // instead — see reanchorForDropCommit.
     strip.reanchorForDropCommit(preDropViewOffset, params);
     m_states.setKeyForWindow(p.windowId, p.targetKey);
 

--- a/libs/phosphor-scroll-engine/src/scrollstrip_relayout.cpp
+++ b/libs/phosphor-scroll-engine/src/scrollstrip_relayout.cpp
@@ -588,14 +588,36 @@ void ScrollStrip::reanchorForDropCommit(int oldViewOffset, const ScrollLayoutPar
         m_viewDetached = false;
         return;
     }
+    // ALWAYS centering is the user asking, in so many words, for the focused
+    // column to sit in the middle whatever put it there. A drop is one of the
+    // things that puts it there, so the policy wins over the fit below and the
+    // view stays ATTACHED — the same verdict the arrival re-anchor already
+    // reaches for an open, a move-to-last, or a plain focus step onto the same
+    // column. Without this a window dropped into a new slot at the end of the
+    // strip landed flush against the trailing edge and stayed there until the
+    // user focused away and back, which is what re-derived the anchor.
+    //
+    // The minimal fit below still owns every other policy, and with it the
+    // regression this function was written for: under OnOverflow a column too
+    // wide to share the viewport centers on focus, which after a drop pushed
+    // every neighbour off screen and read as the window flying away from the
+    // strip. That column reaches the fit arm exactly as before.
+    if (isCenteringActiveColumn(params)) {
+        // Through the verb, so the re-attach and the anchor stay one decision
+        // (it clears the latch itself). mainExtent's degenerate case is
+        // handled inside centeredAnchorFor, which keeps the persisted anchor.
+        centerActiveColumn(params);
+        return;
+    }
     // The drop OWNS the view the way a pan does, so the latch is SET, not
     // cleared — and above the degenerate-area guard, for
     // reanchorAfterFocusChange's reason (the latch answers "who owns the
     // view", which needs no layout maths). Without it the applyLayout the
     // commit runs immediately afterwards re-applies the centering policy
-    // through updateViewForFocus and undoes this anchor on the same pass —
-    // under Always unconditionally, and under OnOverflow for exactly the
-    // over-wide column this function exists to keep beside its neighbour.
+    // through updateViewForFocus and undoes this anchor on the same pass,
+    // under OnOverflow for exactly the over-wide column this function exists
+    // to keep beside its neighbour. (Always never reaches here — it took the
+    // centering arm above, which keeps the view attached on purpose.)
     // The next focus change re-attaches through reanchorAfterFocusChange,
     // same as any pan.
     m_viewDetached = true;

--- a/libs/phosphor-scroll-engine/src/scrollstrip_relayout.cpp
+++ b/libs/phosphor-scroll-engine/src/scrollstrip_relayout.cpp
@@ -612,14 +612,19 @@ void ScrollStrip::reanchorForDropCommit(int oldViewOffset, const ScrollLayoutPar
     // The drop OWNS the view the way a pan does, so the latch is SET, not
     // cleared — and above the degenerate-area guard, for
     // reanchorAfterFocusChange's reason (the latch answers "who owns the
-    // view", which needs no layout maths). Without it the applyLayout the
-    // commit runs immediately afterwards re-applies the centering policy
-    // through updateViewForFocus and undoes this anchor on the same pass,
-    // under OnOverflow for exactly the over-wide column this function exists
-    // to keep beside its neighbour. (Always never reaches here — it took the
-    // centering arm above, which keeps the view attached on purpose.)
-    // The next focus change re-attaches through reanchorAfterFocusChange,
-    // same as any pan.
+    // view", which needs no layout maths). Always never reaches here — it took
+    // the centering arm above, which keeps the view attached on purpose.
+    //
+    // The commit's own applyLayout is NOT what the latch defends against on
+    // this pass: the fit below always leaves the column fully visible, and
+    // updateViewForFocus's own fully-visible early-return covers that for
+    // every non-centering policy (a probe that cleared the latch here still
+    // left commitLandsTheDropWhereTheIndicatorPromised's view at 0). What the
+    // latch buys is every LATER pass — a work-area change, a neighbour
+    // closing, any relayout that leaves the column no longer fully visible
+    // would otherwise re-apply the policy and undo the drop's position under
+    // a user who has not touched the strip since. The next focus change
+    // re-attaches through reanchorAfterFocusChange, same as any pan.
     m_viewDetached = true;
     // Degenerate-area guard, same as clampedAnchor's (the rationale lives
     // there): every arm below would write garbage over the persisted anchor.

--- a/libs/phosphor-scroll-engine/tests/test_scrollengine_draginsert.cpp
+++ b/libs/phosphor-scroll-engine/tests/test_scrollengine_draginsert.cpp
@@ -103,6 +103,7 @@ private Q_SLOTS:
     void beginSettlesTheViewOverRealColumns();
     void cancelRestoresThePreDragView();
     void commitLandsTheDropWhereTheIndicatorPromised();
+    void commitCentersTheDropUnderAlwaysCentering();
     void focusReportsAreDroppedWhileAPreviewSteersTheView();
 
 private:
@@ -2071,9 +2072,13 @@ void TestScrollEngineDragInsert::commitLandsTheDropWhereTheIndicatorPromised()
     QObject owner;
     auto* settings = new ScrollTestUtils::StubScrollSettings(&owner);
     // 900px columns on the 1200px viewport: no two fit together, which is
-    // exactly the overflow the centering arms fire on.
+    // exactly the overflow the centering arm fires on. OnOverflow rather than
+    // Always, because Always is the user asking for the middle in so many
+    // words and the drop honours it (commitCentersTheDropUnderAlwaysCentering);
+    // this policy is the one whose centering is a WIDTH verdict, and that is
+    // the verdict the drop overrides.
     settings->widthValue = 0.75;
-    settings->centerFocused = static_cast<int>(PhosphorScrollEngine::CenterFocusedColumn::Always);
+    settings->centerFocused = static_cast<int>(PhosphorScrollEngine::CenterFocusedColumn::OnOverflow);
     ScrollEngine* engine = makeProviderEngine(&owner, {QStringLiteral("S1")});
     engine->setEngineSettings(settings);
     engine->refreshConfigFromSettings();
@@ -2091,8 +2096,8 @@ void TestScrollEngineDragInsert::commitLandsTheDropWhereTheIndicatorPromised()
     engine->commitDragInsertPreview();
 
     QCOMPARE(state->strip().columnOfWindow(QStringLiteral("b")), 0);
-    // Flush left, as promised — NOT centered (Always centering would put the
-    // anchor at 150 and the view at -150, with "a" entirely off screen).
+    // Flush left, as promised — NOT centered (the overflow verdict would put
+    // the anchor at 150 and the view at -150, with "a" entirely off screen).
     // And it survives the commit's own applyLayout: the drop owns the view
     // the way a pan does, so updateViewForFocus cannot hand it back to the
     // policy on the same pass.
@@ -2103,6 +2108,45 @@ void TestScrollEngineDragInsert::commitLandsTheDropWhereTheIndicatorPromised()
     const QRect neighbour = tileRect(engine, QStringLiteral("S1"), QStringLiteral("a"));
     QVERIFY(!neighbour.isNull());
     QCOMPARE(Ax::mainPos(neighbour), 900);
+}
+
+void TestScrollEngineDragInsert::commitCentersTheDropUnderAlwaysCentering()
+{
+    // The other half of the drop's view contract, and the bug it fixes: with
+    // "center focused column" set to Always, a window dropped into a new slot
+    // at the END of the strip landed flush against the trailing edge and only
+    // centered once the user focused another column and came back. Always
+    // means the focused column sits in the middle whatever put it there, a
+    // drop included, so the policy wins here and the view stays attached.
+    QObject owner;
+    auto* settings = new ScrollTestUtils::StubScrollSettings(&owner);
+    // 600px columns on the 1200px viewport: two fit, so nothing here is the
+    // over-wide case the fit arm exists for — only the policy is in play.
+    settings->widthValue = 0.5;
+    settings->centerFocused = static_cast<int>(PhosphorScrollEngine::CenterFocusedColumn::Always);
+    ScrollEngine* engine = makeProviderEngine(&owner, {QStringLiteral("S1")});
+    engine->setEngineSettings(settings);
+    engine->refreshConfigFromSettings();
+    openWindows(engine, QStringLiteral("S1"), {QStringLiteral("a"), QStringLiteral("b"), QStringLiteral("c")});
+    ScrollState* state = stateFor(engine, QStringLiteral("S1"));
+    QVERIFY(state);
+
+    QVERIFY(engine->beginDragInsertPreview(QStringLiteral("a"), QStringLiteral("S1")));
+    DragTarget target;
+    target.primary = state->strip().columnCount();
+    target.newSlot = true;
+    engine->updateDragInsertPreview(target);
+    engine->commitDragInsertPreview();
+
+    QCOMPARE(state->strip().windowsInOrder(),
+             (QStringList{QStringLiteral("b"), QStringLiteral("c"), QStringLiteral("a")}));
+    // The trailing column starts at 1200 on a 1200px viewport, so centering
+    // its 600px puts the view at 900 — 300px of dead space past the end of
+    // the strip, which is exactly what a centered last column looks like.
+    QCOMPARE(viewX(engine, QStringLiteral("S1")), 900);
+    // Attached, unlike the fit arm: the policy owns this view, so the next
+    // relayout re-deriving it is the point rather than a hazard.
+    QVERIFY(!state->strip().viewDetached());
 }
 
 void TestScrollEngineDragInsert::focusReportsAreDroppedWhileAPreviewSteersTheView()

--- a/libs/phosphor-scroll-engine/tests/test_scrollengine_draginsert.cpp
+++ b/libs/phosphor-scroll-engine/tests/test_scrollengine_draginsert.cpp
@@ -2098,10 +2098,13 @@ void TestScrollEngineDragInsert::commitLandsTheDropWhereTheIndicatorPromised()
     QCOMPARE(state->strip().columnOfWindow(QStringLiteral("b")), 0);
     // Flush left, as promised — NOT centered (the overflow verdict would put
     // the anchor at 150 and the view at -150, with "a" entirely off screen).
-    // And it survives the commit's own applyLayout: the drop owns the view
-    // the way a pan does, so updateViewForFocus cannot hand it back to the
-    // policy on the same pass.
     QCOMPARE(viewX(engine, QStringLiteral("S1")), 0);
+    // And the drop owns the view the way a pan does. The anchor above would
+    // survive this pass without the latch (the fit leaves the column fully
+    // visible, which is updateViewForFocus's own early-return), so the latch
+    // is pinned here on its own: it is what stops a LATER relayout — one that
+    // leaves the column no longer fully visible — from handing the view back
+    // to the centering policy.
     QVERIFY(state->strip().viewDetached());
     // The neighbour's near edge is on screen (its column starts at 900 on a
     // 1200px viewport), which is what "the strip did not fly away" means.


### PR DESCRIPTION
## The bug

With **Settings → Scrolling → Center focused column = Always**, a window dragged into a new slot at the **end of the strip** did not center. It landed flush against the trailing edge and stayed there until you focused another column and came back, which is what re-derived the anchor.

## Cause

`ScrollStrip::reanchorForDropCommit` overrode the centering policy after every drop. It pinned the dropped column where the drag indicator promised, moved only as far as full visibility required, and set the pan-detach latch so the commit's own `applyLayout` could not hand the view back to the policy. At the end of the strip that fit is the trailing edge, and the latch held it there.

The override was written for a real regression: under `OnOverflow` a column too wide to share the viewport centers on focus, and after a drop that pushed every neighbour off screen.

## The fix

`Always` means the focused column sits in the middle whatever put it there, and a drop is one of the things that puts it there. The commit now takes the centering arm under that policy (and under the lone-column rule), through `centerActiveColumn` so the re-attach and the anchor stay one decision, and leaves the view attached for the next relayout to re-derive.

Every other policy keeps the fit and the detach, so the over-wide-column regression stays fixed.

## Verified

The other placement paths were checked and were already correct: opening a window at the end of the strip, `moveColumnToLast`, and opening after a pan all center. Only the drop was wrong.

- `commitLandsTheDropWhereTheIndicatorPromised` drove its over-wide case through `Always`; it moves to `OnOverflow`, the policy whose centering really is a width verdict and the one the drop should still override.
- New `commitCentersTheDropUnderAlwaysCentering` covers a drop into a fresh trailing slot under `Always`: view at 900 on the 1200px fixture, view not detached.
- `ctest`: 462/462 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017hUAerPAq3vVVHATQaNgM4