### PR TITLE
fix(pointer): keep the trail alive while another effect draws the cursor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **The pointer trail disappeared when you shook the mouse**: shaking the pointer is the gesture that ought to draw the longest trail, and instead the whole trail blinked out in a single frame and stayed out until the shake ended. Plasma magnifies the pointer during a shake by hiding the system cursor and drawing its own larger copy, and PlasmaZones read that hidden system cursor as "there is no pointer here to decorate", so it threw the trail away on every mouse move for as long as the magnification lasted. It now looks at whether there is a cursor image at all, which is the signal that separates a pointer that has genuinely gone from one that another effect is drawing. Under Plasma's zoom the trail still follows the unmagnified pointer rather than the magnified copy, which needs a fix of its own. ([#1097](https://github.com/fuddlesworth/PlasmaZones/pull/1097))
+
 ## [3.4.17] - 2026-09-10
 
 ### Added

--- a/kwin-effect/pointer/pointerdecorationpaint.cpp
+++ b/kwin-effect/pointer/pointerdecorationpaint.cpp
@@ -437,9 +437,12 @@ void PointerDecorationPass::paintOutput(const KWin::RenderTarget& renderTarget, 
     if (!m_engaged || !screen || screen != m_output || suppressedOn(screen) || !KWin::effects) {
         return;
     }
-    if (cursorHiddenElsewhere()) {
-        // Someone else hid the sprite (a software KVM forwarding this desktop's
-        // pointer to another machine, a client that installed a null cursor).
+    if (cursorSpriteGone()) {
+        // There is no sprite left to decorate (a software KVM forwarding this
+        // desktop's pointer to another machine, a client that installed a null
+        // cursor). An effect that merely hides KWin's cursor to composite its
+        // own — shakecursor, zoom — does NOT come through here; see the
+        // header on cursorSpriteGone.
         // Drawing nothing here IS the erase: the compositor is already
         // repainting this region, so the previous frame's trail goes with it.
         // Tested after the output identity check rather than beside it so the

--- a/kwin-effect/pointer/pointerdecorationpass.cpp
+++ b/kwin-effect/pointer/pointerdecorationpass.cpp
@@ -227,7 +227,7 @@ void PointerDecorationPass::notePointer(const QPointF& pos, const QPointF& oldPo
         return;
     }
     const qint64 nowMs = ShaderInternal::shaderClockNowMs();
-    if (cursorHiddenElsewhere()) {
+    if (cursorSpriteGone()) {
         // The sprite is gone but the pointer is still being driven (a software
         // KVM forwarding motion to another machine). Write no history and
         // request no repaint beyond the one that clears what is already
@@ -469,7 +469,7 @@ void PointerDecorationPass::scheduleRepaints()
         return;
     }
     const qint64 nowMs = ShaderInternal::shaderClockNowMs();
-    if (cursorHiddenElsewhere()) {
+    if (cursorSpriteGone()) {
         // The sprite went while the pointer sat still, so no pointer event is
         // coming to notice it — a client that hides the cursor after an idle
         // timeout is the ordinary case, and it hides precisely because motion
@@ -509,22 +509,18 @@ bool PointerDecorationPass::cursorOnOutput(KWin::LogicalOutput* screen) const
     return screen && KWin::effects && KWin::effects->screenAt(KWin::effects->cursorPos().toPoint()) == screen;
 }
 
-bool PointerDecorationPass::cursorHiddenElsewhere() const
+bool PointerDecorationPass::cursorSpriteGone() const
 {
     if (!KWin::effects) {
         return false;
     }
-    // Two independent mechanisms, either of which counts, so the order below
-    // decides nothing but which read is skipped when the first already
-    // answered. A client-installed blank cursor empties the IMAGE and leaves
-    // the hide counter alone, which is why it is a test of its own rather
-    // than a fallback: it is the one signal still legible while this pass
-    // holds a hide, where the counter can only speak for an owner that is
-    // not us.
-    if (KWin::effects->cursorImage().isNull()) {
-        return true;
-    }
-    return KWin::effects->isCursorHidden() && !m_cursorHidden;
+    // The IMAGE, and only the image — see the header for why the hide counter
+    // is not consulted here. An empty image is a client-installed blank cursor
+    // (or a KVM that took the sprite away): nothing is on screen to decorate.
+    // A non-empty one may still be composited by another effect rather than by
+    // KWin, which is a pointer the user can see and so a pointer worth
+    // decorating.
+    return KWin::effects->cursorImage().isNull();
 }
 
 bool PointerDecorationPass::hideCursorForPass(KWin::LogicalOutput* screen)
@@ -548,9 +544,8 @@ void PointerDecorationPass::updateCursorHiding()
     if (!m_cursorHidden) {
         return;
     }
-    const bool stillLive = m_engaged && m_anyAboveLayer && m_output && !suppressedOn(m_output)
-        && !cursorHiddenElsewhere() && cursorOnOutput(m_output)
-        && m_history.isLive(ShaderInternal::shaderClockNowMs(), m_maxTrailSeconds);
+    const bool stillLive = m_engaged && m_anyAboveLayer && m_output && !suppressedOn(m_output) && !cursorSpriteGone()
+        && cursorOnOutput(m_output) && m_history.isLive(ShaderInternal::shaderClockNowMs(), m_maxTrailSeconds);
     if (stillLive) {
         return;
     }

--- a/kwin-effect/pointer/pointerdecorationpass.cpp
+++ b/kwin-effect/pointer/pointerdecorationpass.cpp
@@ -346,15 +346,15 @@ bool PointerDecorationPass::isLive() const
     // It leaves holdsCursorHide() to keep the effect in the chain long enough
     // to hand a hide of our own back.
     //
-    // A sprite hidden by someone else deliberately does NOT read that way.
+    // A sprite that has gone away deliberately does NOT read that way.
     // This verdict is what isActive() puts the effect in the chain on, and an
     // effect dropped from the chain gets neither paintOutput nor
     // scheduleRepaints — so answering false the moment the sprite goes would
     // retire the pass BEFORE anything damaged the trail it left on screen,
     // freezing the last frame there. setSuppressedOutputs has a signal to do
-    // that tidy-up on; a hide has none, so the pass stays live until the
-    // scheduleRepaints that drops the trail, and the emptied history is what
-    // ends liveness one cycle later.
+    // that tidy-up on; a vanishing sprite has none, so the pass stays live
+    // until the scheduleRepaints that drops the trail, and the emptied history
+    // is what ends liveness one cycle later.
     if (!m_engaged || suppressedOn(m_output)) {
         return false;
     }

--- a/kwin-effect/pointer/pointerdecorationpass.h
+++ b/kwin-effect/pointer/pointerdecorationpass.h
@@ -51,12 +51,13 @@ namespace PlasmaZones {
 /// timer and no spring: the only wake-ups are slotMouseChanged (notePointer)
 /// and, while live, the pass's own per-frame repaint request.
 ///
-/// A burst also ends early when the sprite it decorates goes away, whoever
-/// took it (cursorSpriteGone). The trail is then DROPPED rather than
-/// merely left unpainted: dropTrail damages the band the last frame covered
-/// and empties the history, and it is the emptied history — not the hide —
-/// that ends liveness, so the pass is still in the paint chain for the cycle
-/// that performs the erase.
+/// A burst also ends early when the sprite it decorates goes away entirely
+/// (cursorSpriteGone), which is NOT the same as another effect hiding KWin's
+/// cursor in order to composite its own copy. The trail is then DROPPED rather
+/// than merely left unpainted: dropTrail damages the band the last frame
+/// covered and empties the history, and it is the emptied history — not the
+/// missing sprite — that ends liveness, so the pass is still in the paint
+/// chain for the cycle that performs the erase.
 ///
 /// COST RULE. A chain with no live layer must cost nothing per frame. Every
 /// entry point early-returns on `m_engaged`, a cached verdict rebuilt only
@@ -432,7 +433,7 @@ private:
     /// `EffectsHandler::isCursorHidden()`. That counter does not mean "the
     /// user cannot see a pointer"; it means "KWin is not compositing the
     /// pointer itself", which is equally what an effect that hides the cursor
-    /// in order to draw its OWN copy leaves behind. KWin ships two:
+    /// in order to draw its OWN copy leaves behind. KWin ships at least two:
     /// `shakecursor`, which magnifies the pointer while the user shakes it,
     /// and `zoom` in its scaled-pointer mode. Reading the counter here meant
     /// that shaking the mouse — the very gesture that draws the longest trail

--- a/kwin-effect/pointer/pointerdecorationpass.h
+++ b/kwin-effect/pointer/pointerdecorationpass.h
@@ -52,7 +52,7 @@ namespace PlasmaZones {
 /// and, while live, the pass's own per-frame repaint request.
 ///
 /// A burst also ends early when the sprite it decorates goes away, whoever
-/// took it (cursorHiddenElsewhere). The trail is then DROPPED rather than
+/// took it (cursorSpriteGone). The trail is then DROPPED rather than
 /// merely left unpainted: dropTrail damages the band the last frame covered
 /// and empties the history, and it is the emptied history — not the hide —
 /// that ends liveness, so the pass is still in the paint chain for the cycle
@@ -418,7 +418,7 @@ private:
 
     // ── pointerdecorationpass.cpp ───────────────────────────────────────────
 
-    /// Is the compositor's cursor hidden by something other than this pass?
+    /// Is there no cursor sprite left to decorate?
     ///
     /// A pointer decoration decorates a pointer. When the sprite is gone the
     /// trail has nothing under it, and drawing one anyway paints a comet
@@ -428,14 +428,32 @@ private:
     /// desktop so the remote motion mirrors, so `cursorPos` stays live and
     /// every liveness test still passes.
     ///
-    /// Two mechanisms hide a cursor and both count. KWin's own hide is what
-    /// `isCursorHidden` reports, and this pass takes that same hide for an
-    /// `above` chain, hence the `m_cursorHidden` exclusion — our own hide must
-    /// not read as a reason to stop drawing. A client that installs a null
-    /// cursor surface leaves the hide counter alone and empties the image
-    /// instead, which is why the image is tested independently rather than as
-    /// a fallback: that one is legible even while we hold a hide of our own.
-    bool cursorHiddenElsewhere() const;
+    /// The test is the cursor IMAGE, and deliberately NOT
+    /// `EffectsHandler::isCursorHidden()`. That counter does not mean "the
+    /// user cannot see a pointer"; it means "KWin is not compositing the
+    /// pointer itself", which is equally what an effect that hides the cursor
+    /// in order to draw its OWN copy leaves behind. KWin ships two:
+    /// `shakecursor`, which magnifies the pointer while the user shakes it,
+    /// and `zoom` in its scaled-pointer mode. Reading the counter here meant
+    /// that shaking the mouse — the very gesture that draws the longest trail
+    /// — took `dropTrail` on every pointer event for as long as the
+    /// magnification lasted, so the whole trail blinked out mid-sweep and
+    /// stayed out for seconds while the pointer was, if anything, more visible
+    /// than usual. A client that installs a null cursor surface leaves the
+    /// counter alone and empties the image instead, so the image is the signal
+    /// that actually separates the two cases, and it stays legible while this
+    /// pass holds a hide of its own.
+    ///
+    /// This does NOT weaken the `above`-layer arbitration: `hideCursorForPass`
+    /// tests `isCursorHidden()` itself and refuses to take a second hide, so a
+    /// chain that would draw its own sprite still stands down for whoever
+    /// asked first.
+    ///
+    /// Known gap: under `zoom`'s scaled pointer the scene is transformed and
+    /// this pass's trail is not, so the stroke sits off the magnified cursor.
+    /// The counter used to mask that by accident. Fixing it properly needs a
+    /// screen-transform gate, not a cursor-visibility one.
+    bool cursorSpriteGone() const;
 
     /// Drop the live trail because the pointer stopped being a pointer worth
     /// decorating, repainting away what is still on screen first. @p next


### PR DESCRIPTION
## The bug

Shaking the mouse — circling it vigorously, the gesture that ought to draw the longest trail — blanked the whole pointer trail mid-sweep and kept it blank for as long as the shake magnification lasted. It vanished in a single frame rather than decaying from the tail, and no amount of further movement brought it back until the magnification ended.

Screencast evidence: the trail is a full bright loop in one frame and completely absent in the next, while the window decorations (glass, border, motes) keep painting untouched across the same frames — so the effect was alive and only the pointer pass had stopped.

## Cause

KWin's `shakecursor` effect calls `effects->hideCursor()` while it magnifies the pointer and composites its own scaled copy. `PointerDecorationPass::cursorHiddenElsewhere()` read `effects->isCursorHidden()` as "there is no pointer left to decorate", so `notePointer()` took `dropTrail()` on **every pointer event** for the duration: history reset, the painted band damaged away, nothing re-accumulating. `paintOutput()` and `scheduleRepaints()` bailed on the same test.

That counter does not mean the user cannot see a pointer. It means KWin is not the one compositing it, which is equally true of `shakecursor` and of `zoom`'s scaled-pointer mode.

Confirmed live by unloading `shakecursor` (`qdbus6 org.kde.KWin /Effects org.kde.kwin.Effects.unloadEffect shakecursor`) and failing to reproduce.

## Ruled out

The obvious suspect was the 32-slot ring overflowing under fast motion. It isn't: `PointerHistory` compiled standalone and driven through a 3 s / 4000 px/s sweep wraps the ring repeatedly with `trailCount` pinned at 32 and the live run decaying 30 → 27 → 24 → … → 0 across the 0.9 s lifetime, exactly as designed. The sampler cannot produce a cliff.

## The fix

`cursorHiddenElsewhere()` becomes `cursorSpriteGone()` and tests only `cursorImage().isNull()`. That is the signal that actually separates a genuinely absent sprite (a client-installed null cursor, a software KVM that took it away — the case the original code was written for) from one another effect is drawing.

The `above`-layer arbitration is unaffected: `hideCursorForPass()` tests `isCursorHidden()` itself and still refuses to take a second hide, so a chain that would draw its own sprite continues to stand down for whoever asked first.

## Known gap

Under `zoom`'s scaled pointer the scene is transformed and this pass's trail is not, so the stroke now sits off the magnified cursor where the hide counter masked it by accident. Documented on the new method. Fixing it properly needs a screen-transform gate rather than a cursor-visibility one, which is out of scope here.

## Testing

- `cmake --build build --parallel 6` clean, no new warnings on the changed files
- `ctest` 550/550 pass
- Not yet verified on a live session: the `.so` needs install plus a logout to reload before the shake test means anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J94sCuAXD7iMRWF1kwibfj
