### PR TITLE
feat(shader-render): render pointer packs with a synthetic pointer

### DIFF
--- a/tools/shader-render/CMakeLists.txt
+++ b/tools/shader-render/CMakeLists.txt
@@ -45,6 +45,8 @@ set(shader_render_SRCS
     encoder.h
     encoder.cpp
     colorutil.h
+    pointerdriver.h
+    pointerdriver.cpp
 )
 
 add_executable(plasmazones-shader-render ${shader_render_SRCS})
@@ -60,6 +62,10 @@ target_link_libraries(plasmazones-shader-render PRIVATE
     PhosphorShaders::PhosphorShaders
     PhosphorWayland::PhosphorWayland
     PhosphorAudio::PhosphorAudio
+    # PointerHistory / PointerUniformExtension, so a pointer pack is driven by
+    # the same sampler and the same uniform tail the compositor and the settings
+    # preview use, rather than by a second synthetic implementation here.
+    PhosphorPointer::PhosphorPointer
     # The daemon's zone entry scaffold (zoneEntryPrologue / zoneEntryCandidates)
     # lives here. The tool installs the same scaffold so its shader assembly
     # matches the runtime byte-for-byte (see renderer.cpp).

--- a/tools/shader-render/main.cpp
+++ b/tools/shader-render/main.cpp
@@ -193,7 +193,8 @@ int main(int argc, char* argv[])
 
     QCommandLineOption shaderDirOpt(QStringLiteral("shader-dir"),
                                     QStringLiteral("Directory containing <id>/metadata.json. "
-                                                   "Defaults to data/overlays/ in the cwd, then the XDG data dirs."),
+                                                   "Defaults to data/overlays/ in the cwd, then the XDG data dirs. "
+                                                   "With --pointer the default becomes data/pointer/ instead."),
                                     QStringLiteral("path"), defaultShaderDir());
     parser.addOption(shaderDirOpt);
 

--- a/tools/shader-render/main.cpp
+++ b/tools/shader-render/main.cpp
@@ -102,6 +102,17 @@ QString defaultShaderDir()
     return xdgPlasmaZonesDir(QStringLiteral("overlays"));
 }
 
+// The pointer family's equivalent of defaultShaderDir(). Used when --pointer is
+// given and --shader-dir was not, so `--pointer -s skid` finds the pack without
+// the caller having to spell out a directory that the flag already implies.
+QString defaultPointerDir()
+{
+    const QString cwd = QDir(QStringLiteral("data/pointer")).absolutePath();
+    if (QDir(cwd).exists())
+        return cwd;
+    return xdgPlasmaZonesDir(QStringLiteral("pointer"));
+}
+
 QString defaultLayoutDir()
 {
     const QString cwd = QDir(QStringLiteral("data/layouts")).absolutePath();
@@ -201,6 +212,69 @@ int main(int argc, char* argv[])
         QStringLiteral("ZONE_NUMBER"), QStringLiteral("0"));
     parser.addOption(stillHighlightOpt);
 
+    // ── Pointer-pack options ─────────────────────────────────────
+    // A pointer pack is driven by a synthetic pointer rather than by the zone
+    // schedule. Without --pointer its whole uniform tail reads zero, so a
+    // click-led pack paints nothing and the render is legitimately empty.
+    QCommandLineOption pointerOpt(
+        QStringLiteral("pointer"),
+        QStringLiteral("Render a POINTER pack (data/pointer): drive a synthetic pointer and bind the "
+                       "pointer uniform tail. Without this a pointer pack sees an all-zero tail and "
+                       "paints nothing."));
+    parser.addOption(pointerOpt);
+
+    QCommandLineOption pointerHeadingOpt(
+        QStringLiteral("pointer-heading"),
+        QStringLiteral("Direction the synthetic pointer travels, degrees clockwise from screen right "
+                       "(canvas y runs down, so 90 is downward). Defaults to 0."),
+        QStringLiteral("DEGREES"), QStringLiteral("0"));
+    parser.addOption(pointerHeadingOpt);
+
+    QCommandLineOption pointerSpeedOpt(
+        QStringLiteral("pointer-speed"),
+        QStringLiteral("Speed of the synthetic pointer in logical px per second. Defaults to 900."),
+        QStringLiteral("PX_PER_SEC"), QStringLiteral("900"));
+    parser.addOption(pointerSpeedOpt);
+
+    QCommandLineOption pointerStillOpt(
+        QStringLiteral("pointer-still"),
+        QStringLiteral("Hold the pointer still at the canvas centre instead of sweeping, to check "
+                       "that a pack still has an axis with no motion to take one from."));
+    parser.addOption(pointerStillOpt);
+
+    QCommandLineOption pressAtOpt(
+        QStringLiteral("press-at"),
+        QStringLiteral("Seconds at which the button goes down, or negative for no click at all. The "
+                       "pointer passes through the canvas centre at this moment. Defaults to 0.4."),
+        QStringLiteral("SECONDS"), QStringLiteral("0.4"));
+    parser.addOption(pressAtOpt);
+
+    QCommandLineOption releaseAtOpt(
+        QStringLiteral("release-at"),
+        QStringLiteral("Seconds at which the button comes back up. Negative leaves it DOWN for the "
+                       "rest of the render, which is how a hold-reading pack's window is exercised. "
+                       "Defaults to 0.55."),
+        QStringLiteral("SECONDS"), QStringLiteral("0.55"));
+    parser.addOption(releaseAtOpt);
+
+    QCommandLineOption pointerButtonOpt(
+        QStringLiteral("pointer-button"),
+        QStringLiteral("Which button the synthetic click uses: 1 left, 2 right, 3 middle. Defaults to 1."),
+        QStringLiteral("N"), QStringLiteral("1"));
+    parser.addOption(pointerButtonOpt);
+
+    QCommandLineOption noCursorSpriteOpt(
+        QStringLiteral("no-cursor-sprite"),
+        QStringLiteral("Do not bind the synthetic cursor sprite, so a needsCursor pack renders its "
+                       "no-sprite fallback instead. That fallback is what the settings preview shows."));
+    parser.addOption(noCursorSpriteOpt);
+
+    QCommandLineOption cursorSizeOpt(
+        QStringLiteral("cursor-size"),
+        QStringLiteral("Drawn size of the synthetic cursor sprite, logical px. Defaults to 24."), QStringLiteral("PX"),
+        QStringLiteral("24"));
+    parser.addOption(cursorSizeOpt);
+
     parser.process(app);
 
     if (!parser.isSet(shaderOpt)) {
@@ -251,10 +325,54 @@ int main(int argc, char* argv[])
         return 2;
     }
 
+    PlasmaZones::ShaderRender::PointerDriveOptions pointerOptions;
+    pointerOptions.enabled = parser.isSet(pointerOpt);
+    if (pointerOptions.enabled) {
+        bool headingOk = false;
+        bool speedOk = false;
+        bool pressOk = false;
+        bool releaseOk = false;
+        bool buttonOk = false;
+        bool cursorOk = false;
+        pointerOptions.headingDegrees = parser.value(pointerHeadingOpt).toDouble(&headingOk);
+        pointerOptions.speedPxPerSec = parser.value(pointerSpeedOpt).toDouble(&speedOk);
+        pointerOptions.pressAt = parser.value(pressAtOpt).toDouble(&pressOk);
+        pointerOptions.releaseAt = parser.value(releaseAtOpt).toDouble(&releaseOk);
+        pointerOptions.button = parser.value(pointerButtonOpt).toInt(&buttonOk);
+        pointerOptions.cursorSize = parser.value(cursorSizeOpt).toDouble(&cursorOk);
+        pointerOptions.still = parser.isSet(pointerStillOpt);
+        pointerOptions.cursorSprite = !parser.isSet(noCursorSpriteOpt);
+        if (!headingOk || !speedOk || !pressOk || !releaseOk || !cursorOk) {
+            std::cerr << "error: --pointer-heading, --pointer-speed, --press-at, --release-at and "
+                         "--cursor-size must be numbers\n";
+            return 2;
+        }
+        if (pointerOptions.speedPxPerSec < 0.0 || pointerOptions.cursorSize <= 0.0) {
+            std::cerr << "error: --pointer-speed must not be negative and --cursor-size must be positive\n";
+            return 2;
+        }
+        if (!buttonOk || pointerOptions.button < 1 || pointerOptions.button > 3) {
+            std::cerr << "error: --pointer-button must be 1 (left), 2 (right) or 3 (middle)\n";
+            return 2;
+        }
+        // A release before the press would hand the history a button-up edge it
+        // never saw go down, and the pack would read a release older than its
+        // press. Caught here rather than producing a quietly wrong render.
+        if (pointerOptions.releaseAt >= 0.0 && pointerOptions.pressAt >= 0.0
+            && pointerOptions.releaseAt < pointerOptions.pressAt) {
+            std::cerr << "error: --release-at must not be before --press-at\n";
+            return 2;
+        }
+    }
+
     // ── Resolve inputs ───────────────────────────────────────────
     const QString shaderArg = parser.value(shaderOpt);
     const QString layoutArg = parser.value(layoutOpt);
-    const QString shaderDir = parser.value(shaderDirOpt);
+    // --pointer implies the pointer pack tree, unless the caller named a
+    // directory themselves. The option's own default is computed before the
+    // command line is parsed, so the substitution has to happen here.
+    const QString shaderDir =
+        (pointerOptions.enabled && !parser.isSet(shaderDirOpt)) ? defaultPointerDir() : parser.value(shaderDirOpt);
     const QString layoutDir = parser.value(layoutDirOpt);
 
     const QString metadataPath = resolveShaderMetadata(shaderArg, shaderDir);
@@ -316,6 +434,7 @@ int main(int argc, char* argv[])
     opts.fps = fps;
     opts.audio = audio.get();
     opts.stillHighlightZone = stillHighlightZone;
+    opts.pointer = pointerOptions;
 
     auto sink = PlasmaZones::ShaderRender::makeFrameSink(outPath, outputSize, fps);
     if (!sink) {

--- a/tools/shader-render/pointerdriver.cpp
+++ b/tools/shader-render/pointerdriver.cpp
@@ -10,7 +10,6 @@
 #include <QFileInfo>
 #include <QUrl>
 #include <QVariantMap>
-#include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QLoggingCategory>
@@ -48,7 +47,7 @@ Qt::MouseButtons buttonsFor(int code)
 } // namespace
 
 bool installPointerPack(PhosphorRendering::ShaderEffect& effect, const QString& metadataPath,
-                        PointerShaderEffectRef& parsedOut)
+                        PhosphorPointerShaders::PointerShaderEffect& parsedOut)
 {
     using Registry = PhosphorPointerShaders::PointerShaderRegistry;
 
@@ -101,8 +100,7 @@ bool installPointerPack(PhosphorRendering::ShaderEffect& effect, const QString& 
     }
     effect.setShaderParams(Registry::translatePointerParams(eff, friendly));
 
-    parsedOut.effect = eff;
-    parsedOut.valid = true;
+    parsedOut = eff;
     return true;
 }
 
@@ -111,56 +109,25 @@ PointerDriver::PointerDriver(const PointerDriveOptions& options, const QSize& ca
     , m_canvas(canvasDevicePx)
     , m_scale(scale > 0.0 ? scale : 1.0)
 {
-    m_history.setTrailSeconds(m_trailWindowSeconds);
 }
 
-bool PointerDriver::loadPackContract(const QString& metadataPath)
+void PointerDriver::applyPackContract(const PhosphorPointerShaders::PointerShaderEffect& effect)
 {
-    QFile file(metadataPath);
-    if (!file.open(QIODevice::ReadOnly)) {
-        qCWarning(lcPointerDriver) << "cannot read" << metadataPath << "— using default reach and trail window";
-        return false;
-    }
-    QJsonParseError err{};
-    const QJsonDocument doc = QJsonDocument::fromJson(file.readAll(), &err);
-    if (err.error != QJsonParseError::NoError || !doc.isObject()) {
-        qCWarning(lcPointerDriver) << metadataPath << "is not a JSON object —" << err.errorString();
-        return false;
-    }
-    const QJsonObject root = doc.object();
+    m_needsCursor = effect.needsCursor;
 
-    m_needsCursor = root.value(QLatin1String("needsCursor")).toBool(false);
-
-    // The liveness window, and separately how far back the pack READS. The
-    // history is spaced by the READ window, which is what the host does.
-    const double trailSeconds = root.value(QLatin1String("trailSeconds")).toDouble(1.0);
-    double window = root.value(QLatin1String("trailWindowSeconds")).toDouble(trailSeconds);
-
-    double reach = root.value(QLatin1String("reach")).toDouble(64.0);
-
-    // reachParam / trailWindowParam name a parameter whose value replaces the
-    // fixed figure. Nothing here overrides parameters, so the parameter's own
-    // default is the resolved value, which is exactly what the pack renders with.
-    const QString reachParam = root.value(QLatin1String("reachParam")).toString();
-    const QString windowParam = root.value(QLatin1String("trailWindowParam")).toString();
-    if (!reachParam.isEmpty() || !windowParam.isEmpty()) {
-        const QJsonArray params = root.value(QLatin1String("parameters")).toArray();
-        for (const QJsonValue& v : params) {
-            const QJsonObject p = v.toObject();
-            const QString id = p.value(QLatin1String("id")).toString();
-            if (!reachParam.isEmpty() && id == reachParam) {
-                reach = p.value(QLatin1String("default")).toDouble(reach);
-            }
-            if (!windowParam.isEmpty() && id == windowParam) {
-                window = p.value(QLatin1String("default")).toDouble(window);
-            }
-        }
-    }
-
-    m_reachLogicalPx = std::max(1.0, reach);
-    m_trailWindowSeconds = std::clamp(window, 0.01, 60.0);
-    m_history.setTrailSeconds(m_trailWindowSeconds);
-    return true;
+    // An EMPTY parameter map, deliberately. resolvedReach / resolvedTrailWindow
+    // fall back to each named parameter's own declared default when the map has
+    // no entry for it, and the declared defaults are exactly what
+    // installPointerPack seeds the shader with, so the figures below are the
+    // ones this render actually draws with.
+    //
+    // Both go through the pack's own resolvers rather than being re-derived
+    // here. They carry bounds a hand-rolled copy does not: the reach is capped
+    // at kMaxReach, and the read window is clamped to the pack's trailSeconds
+    // (a pack cannot read further back than the host keeps it alive) and is 0
+    // for a pack that does not sample the trail at all.
+    m_reachLogicalPx = effect.resolvedReach({});
+    m_history.setTrailSeconds(effect.resolvedTrailWindow({}));
 }
 
 QImage PointerDriver::cursorSprite() const
@@ -195,35 +162,6 @@ QImage PointerDriver::cursorSprite() const
     return img.convertToFormat(QImage::Format_RGBA8888_Premultiplied);
 }
 
-// Contract space is TOP-DOWN, origin at the output's top-left, and every
-// position uniform is expressed in it. This tool's pointer path is not: the
-// offscreen target is bottom-up (which is why captureFrame flips the readback
-// before it reaches a sink), and the layered item the fragment runs through
-// carries that orientation into the `uv` the pack turns into canvas px. So a
-// position handed to the shader unchanged lands mirrored about the canvas's
-// middle, and the capture flip afterwards does NOT undo it, because only the
-// image is flipped and not the uniforms that were baked into it.
-//
-// Everything the driver pushes goes through here, so the pack sees one
-// self-consistent space and the captured frame shows what the compositor would.
-// The flip is confined to this seam deliberately: the synthetic path, the
-// headings and the CLI are all authored in the contract's own top-down terms.
-QPointF PointerDriver::toCanvas(const QPointF& topDown) const
-{
-    // IDENTITY, deliberately. An earlier version mirrored y here to make the
-    // painted geometry land where the contract says it should. It did, but it
-    // fixed only the POSITIONS: a pack's own sense of up and down lives in its
-    // source (a sweep that starts at twelve o'clock, a light from the upper
-    // left, gravity), and no amount of moving the uniforms corrects that. The
-    // captured frame came out mirrored and every judgement made from it was a
-    // judgement of a mirror image.
-    //
-    // The flip belongs at the END of the pipeline instead, where it corrects
-    // the whole rendered image at once. renderer.cpp applies it for pointer
-    // renders; see the note there.
-    return topDown;
-}
-
 QPointF PointerDriver::positionAt(double seconds) const
 {
     const QPointF centre(m_canvas.width() * 0.5, m_canvas.height() * 0.5);
@@ -248,7 +186,7 @@ void PointerDriver::applyFrame(int frame, double fps, PhosphorPointerShaders::Po
     if (!m_seeded) {
         // A ring with no samples would make the first frame's press a
         // buttons-only event with no position history behind it.
-        m_history.seedPosition(toCanvas(positionAt(now)), static_cast<qint64>(std::llround(now * 1000.0)));
+        m_history.seedPosition(positionAt(now), static_cast<qint64>(std::llround(now * 1000.0)));
         m_lastSeconds = now;
         m_seeded = true;
     }
@@ -260,7 +198,7 @@ void PointerDriver::applyFrame(int frame, double fps, PhosphorPointerShaders::Po
     for (int i = 1; i <= steps; ++i) {
         const double t = m_lastSeconds + span * (static_cast<double>(i) / static_cast<double>(steps));
         const auto ms = static_cast<qint64>(std::llround(t * 1000.0));
-        const QPointF pos = toCanvas(positionAt(t));
+        const QPointF pos = positionAt(t);
 
         if (!m_opts.still) {
             m_history.notePointer(pos, ms);
@@ -284,7 +222,7 @@ void PointerDriver::applyFrame(int frame, double fps, PhosphorPointerShaders::Po
     // where its cursor is drawn. Here the hotspot is the arrow's top-left, so
     // the rect starts at the pointer and spans the drawn size, in device px like
     // every other canvas position.
-    const QPointF pos = toCanvas(positionAt(now));
+    const QPointF pos = positionAt(now);
     const double side = m_opts.cursorSize * m_scale;
     // The rect spans downward from the hotspot, as the contract has it.
     state.cursorRect = QRectF(pos.x(), pos.y(), side, side);
@@ -295,8 +233,8 @@ void PointerDriver::applyFrame(int frame, double fps, PhosphorPointerShaders::Po
     ext.setReachLogicalPx(m_reachLogicalPx);
     ext.apply(state);
 
-    // `pos` is already in the flipped canvas space, so iMouse agrees with the
-    // trail and the press without a second conversion.
+    // The same top-down position the trail and the press were pushed in, so
+    // iMouse agrees with both without a second conversion.
     iMouseLogical = QPointF(pos.x() / m_scale, pos.y() / m_scale);
 }
 

--- a/tools/shader-render/pointerdriver.cpp
+++ b/tools/shader-render/pointerdriver.cpp
@@ -1,0 +1,303 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "pointerdriver.h"
+
+#include <PhosphorPointer/PointerShaderRegistry.h>
+#include <PhosphorRendering/ShaderEffect.h>
+
+#include <QFile>
+#include <QFileInfo>
+#include <QUrl>
+#include <QVariantMap>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QLoggingCategory>
+#include <QPainter>
+#include <QPainterPath>
+
+#include <algorithm>
+#include <cmath>
+
+namespace PlasmaZones::ShaderRender {
+
+namespace {
+
+Q_LOGGING_CATEGORY(lcPointerDriver, "plasmazones.shaderrender.pointer")
+
+// 250 Hz, inside the range a real mouse reports at. The same figure the settings
+// preview feeds at, and for the same reason: the history's sampler places a slot
+// from the gap since the last event, so feeding one event per rendered frame
+// would round the ring's spacing up to the frame interval and the trail would be
+// longer than the one the compositor produces.
+constexpr double kEventIntervalMs = 4.0;
+
+Qt::MouseButtons buttonsFor(int code)
+{
+    switch (code) {
+    case 2:
+        return Qt::MouseButtons(Qt::RightButton);
+    case 3:
+        return Qt::MouseButtons(Qt::MiddleButton);
+    default:
+        return Qt::MouseButtons(Qt::LeftButton);
+    }
+}
+
+} // namespace
+
+bool installPointerPack(PhosphorRendering::ShaderEffect& effect, const QString& metadataPath,
+                        PointerShaderEffectRef& parsedOut)
+{
+    using Registry = PhosphorPointerShaders::PointerShaderRegistry;
+
+    QFile file(metadataPath);
+    if (!file.open(QIODevice::ReadOnly)) {
+        qCWarning(lcPointerDriver) << "cannot read pointer pack" << metadataPath;
+        return false;
+    }
+    QJsonParseError err{};
+    const QJsonDocument doc = QJsonDocument::fromJson(file.readAll(), &err);
+    if (err.error != QJsonParseError::NoError || !doc.isObject()) {
+        qCWarning(lcPointerDriver) << metadataPath << "is not a JSON object —" << err.errorString();
+        return false;
+    }
+
+    const QFileInfo info(metadataPath);
+    const PhosphorPointerShaders::PointerShaderEffect eff =
+        PhosphorPointerShaders::PointerShaderEffect::fromJson(doc.object(), info.absolutePath(), /*isUser=*/false);
+    if (!eff.isValid()) {
+        qCWarning(lcPointerDriver) << "pointer pack at" << metadataPath << "did not parse into a valid effect";
+        return false;
+    }
+
+    // Exactly what PointerPreviewController installs, in the same order, so the
+    // tool bakes byte-for-byte what the settings preview bakes for this pack.
+    effect.setShaderIncludePaths(Registry::includePathsFor(eff.sourceDir));
+    effect.setShaderSource(QUrl::fromLocalFile(eff.fragmentShaderPath));
+    effect.setParamPreamble(Registry::paramPreamble(eff));
+    effect.setEntryScaffold(Registry::pointerEntryPrologue(), Registry::pointerEntryCandidates());
+    if (!eff.vertexShaderPath.isEmpty()) {
+        effect.setVertexShaderUrl(QUrl::fromLocalFile(eff.vertexShaderPath));
+    }
+    if (eff.isMultipass && !eff.bufferShaderPaths.isEmpty()) {
+        effect.setBufferShaderPaths(eff.bufferShaderPaths);
+        effect.setBufferFeedback(eff.bufferFeedback);
+        effect.setBufferScale(eff.bufferScale);
+    } else {
+        effect.setBufferShaderPaths({});
+        effect.setBufferFeedback(false);
+        effect.setBufferScale(1.0);
+    }
+
+    // Parameter DEFAULTS through the pointer registry's own slot allocation. The
+    // overlay seeding path allocates slots differently, and paramPreamble above
+    // mirrors this allocation, so seeding the other way would point every p_<id>
+    // at a lane nothing was written to and the pack would render with zeros.
+    QVariantMap friendly;
+    for (const auto& p : eff.parameters) {
+        friendly.insert(p.id, p.defaultValue);
+    }
+    effect.setShaderParams(Registry::translatePointerParams(eff, friendly));
+
+    parsedOut.effect = eff;
+    parsedOut.valid = true;
+    return true;
+}
+
+PointerDriver::PointerDriver(const PointerDriveOptions& options, const QSize& canvasDevicePx, double scale)
+    : m_opts(options)
+    , m_canvas(canvasDevicePx)
+    , m_scale(scale > 0.0 ? scale : 1.0)
+{
+    m_history.setTrailSeconds(m_trailWindowSeconds);
+}
+
+bool PointerDriver::loadPackContract(const QString& metadataPath)
+{
+    QFile file(metadataPath);
+    if (!file.open(QIODevice::ReadOnly)) {
+        qCWarning(lcPointerDriver) << "cannot read" << metadataPath << "— using default reach and trail window";
+        return false;
+    }
+    QJsonParseError err{};
+    const QJsonDocument doc = QJsonDocument::fromJson(file.readAll(), &err);
+    if (err.error != QJsonParseError::NoError || !doc.isObject()) {
+        qCWarning(lcPointerDriver) << metadataPath << "is not a JSON object —" << err.errorString();
+        return false;
+    }
+    const QJsonObject root = doc.object();
+
+    m_needsCursor = root.value(QLatin1String("needsCursor")).toBool(false);
+
+    // The liveness window, and separately how far back the pack READS. The
+    // history is spaced by the READ window, which is what the host does.
+    const double trailSeconds = root.value(QLatin1String("trailSeconds")).toDouble(1.0);
+    double window = root.value(QLatin1String("trailWindowSeconds")).toDouble(trailSeconds);
+
+    double reach = root.value(QLatin1String("reach")).toDouble(64.0);
+
+    // reachParam / trailWindowParam name a parameter whose value replaces the
+    // fixed figure. Nothing here overrides parameters, so the parameter's own
+    // default is the resolved value, which is exactly what the pack renders with.
+    const QString reachParam = root.value(QLatin1String("reachParam")).toString();
+    const QString windowParam = root.value(QLatin1String("trailWindowParam")).toString();
+    if (!reachParam.isEmpty() || !windowParam.isEmpty()) {
+        const QJsonArray params = root.value(QLatin1String("parameters")).toArray();
+        for (const QJsonValue& v : params) {
+            const QJsonObject p = v.toObject();
+            const QString id = p.value(QLatin1String("id")).toString();
+            if (!reachParam.isEmpty() && id == reachParam) {
+                reach = p.value(QLatin1String("default")).toDouble(reach);
+            }
+            if (!windowParam.isEmpty() && id == windowParam) {
+                window = p.value(QLatin1String("default")).toDouble(window);
+            }
+        }
+    }
+
+    m_reachLogicalPx = std::max(1.0, reach);
+    m_trailWindowSeconds = std::clamp(window, 0.01, 60.0);
+    m_history.setTrailSeconds(m_trailWindowSeconds);
+    return true;
+}
+
+QImage PointerDriver::cursorSprite() const
+{
+    if (!m_opts.cursorSprite) {
+        return {};
+    }
+    const int side = std::max(4, static_cast<int>(std::lround(m_opts.cursorSize * m_scale)));
+    QImage img(side, side, QImage::Format_ARGB32_Premultiplied);
+    img.fill(Qt::transparent);
+
+    // A plain left-pointing arrow with its hotspot at the top-left, which is
+    // where the cursor rect's origin is. The shape only has to be cursor-like:
+    // what a pack reads from it is the silhouette and its alpha gradient.
+    QPainterPath path;
+    const double s = static_cast<double>(side);
+    path.moveTo(0.04 * s, 0.02 * s);
+    path.lineTo(0.10 * s, 0.94 * s);
+    path.lineTo(0.38 * s, 0.66 * s);
+    path.lineTo(0.74 * s, 0.62 * s);
+    path.closeSubpath();
+
+    QPainter painter(&img);
+    painter.setRenderHint(QPainter::Antialiasing, true);
+    painter.setBrush(Qt::white);
+    QPen pen(QColor(30, 30, 30));
+    pen.setWidthF(std::max(1.0, s * 0.05));
+    painter.setPen(pen);
+    painter.drawPath(path);
+    painter.end();
+
+    return img.convertToFormat(QImage::Format_RGBA8888_Premultiplied);
+}
+
+// Contract space is TOP-DOWN, origin at the output's top-left, and every
+// position uniform is expressed in it. This tool's pointer path is not: the
+// offscreen target is bottom-up (which is why captureFrame flips the readback
+// before it reaches a sink), and the layered item the fragment runs through
+// carries that orientation into the `uv` the pack turns into canvas px. So a
+// position handed to the shader unchanged lands mirrored about the canvas's
+// middle, and the capture flip afterwards does NOT undo it, because only the
+// image is flipped and not the uniforms that were baked into it.
+//
+// Everything the driver pushes goes through here, so the pack sees one
+// self-consistent space and the captured frame shows what the compositor would.
+// The flip is confined to this seam deliberately: the synthetic path, the
+// headings and the CLI are all authored in the contract's own top-down terms.
+QPointF PointerDriver::toCanvas(const QPointF& topDown) const
+{
+    // IDENTITY, deliberately. An earlier version mirrored y here to make the
+    // painted geometry land where the contract says it should. It did, but it
+    // fixed only the POSITIONS: a pack's own sense of up and down lives in its
+    // source (a sweep that starts at twelve o'clock, a light from the upper
+    // left, gravity), and no amount of moving the uniforms corrects that. The
+    // captured frame came out mirrored and every judgement made from it was a
+    // judgement of a mirror image.
+    //
+    // The flip belongs at the END of the pipeline instead, where it corrects
+    // the whole rendered image at once. renderer.cpp applies it for pointer
+    // renders; see the note there.
+    return topDown;
+}
+
+QPointF PointerDriver::positionAt(double seconds) const
+{
+    const QPointF centre(m_canvas.width() * 0.5, m_canvas.height() * 0.5);
+    if (m_opts.still) {
+        return centre;
+    }
+    const double rad = m_opts.headingDegrees * M_PI / 180.0;
+    const QPointF dir(std::cos(rad), std::sin(rad));
+    // The pointer passes through the centre at the moment of the press, so the
+    // click lands in the middle of the canvas whatever the heading is and the
+    // shape it throws is never half off the edge.
+    const double anchor = m_opts.pressAt >= 0.0 ? m_opts.pressAt : 0.0;
+    const double travel = (seconds - anchor) * m_opts.speedPxPerSec * m_scale;
+    return centre + dir * travel;
+}
+
+void PointerDriver::applyFrame(int frame, double fps, PhosphorPointerShaders::PointerUniformExtension& ext,
+                               QPointF& iMouseLogical)
+{
+    const double now = fps > 0.0 ? static_cast<double>(frame) / fps : 0.0;
+
+    if (!m_seeded) {
+        // A ring with no samples would make the first frame's press a
+        // buttons-only event with no position history behind it.
+        m_history.seedPosition(toCanvas(positionAt(now)), static_cast<qint64>(std::llround(now * 1000.0)));
+        m_lastSeconds = now;
+        m_seeded = true;
+    }
+
+    // Walk the interval since the previous frame as an event stream, and fire
+    // the button edges at the instant they fall rather than on a frame boundary.
+    const double span = std::max(0.0, now - m_lastSeconds);
+    const int steps = std::clamp(static_cast<int>(std::ceil(span * 1000.0 / kEventIntervalMs)), 1, 256);
+    for (int i = 1; i <= steps; ++i) {
+        const double t = m_lastSeconds + span * (static_cast<double>(i) / static_cast<double>(steps));
+        const auto ms = static_cast<qint64>(std::llround(t * 1000.0));
+        const QPointF pos = toCanvas(positionAt(t));
+
+        if (!m_opts.still) {
+            m_history.notePointer(pos, ms);
+        }
+
+        const bool wantPressed =
+            m_opts.pressAt >= 0.0 && t >= m_opts.pressAt && (m_opts.releaseAt < 0.0 || t < m_opts.releaseAt);
+        if (wantPressed != m_pressed) {
+            const Qt::MouseButtons before = m_pressed ? buttonsFor(m_opts.button) : Qt::MouseButtons(Qt::NoButton);
+            const Qt::MouseButtons after = wantPressed ? buttonsFor(m_opts.button) : Qt::MouseButtons(Qt::NoButton);
+            m_history.noteButtons(after, before, pos, ms);
+            m_pressed = wantPressed;
+        }
+    }
+    m_lastSeconds = now;
+
+    const auto nowMs = static_cast<qint64>(std::llround(now * 1000.0));
+    PhosphorPointerShaders::PointerFrameState state = m_history.frameState(nowMs, m_scale);
+
+    // The sprite rect is the host's to fill in, because only the host knows
+    // where its cursor is drawn. Here the hotspot is the arrow's top-left, so
+    // the rect starts at the pointer and spans the drawn size, in device px like
+    // every other canvas position.
+    const QPointF pos = toCanvas(positionAt(now));
+    const double side = m_opts.cursorSize * m_scale;
+    // The rect spans downward from the hotspot, as the contract has it.
+    state.cursorRect = QRectF(pos.x(), pos.y(), side, side);
+    // Honest about the binding: true only when the caller actually bound the
+    // sprite, which it does only for a pack that asked for it.
+    state.hasSprite = m_opts.cursorSprite && m_needsCursor;
+
+    ext.setReachLogicalPx(m_reachLogicalPx);
+    ext.apply(state);
+
+    // `pos` is already in the flipped canvas space, so iMouse agrees with the
+    // trail and the press without a second conversion.
+    iMouseLogical = QPointF(pos.x() / m_scale, pos.y() / m_scale);
+}
+
+} // namespace PlasmaZones::ShaderRender

--- a/tools/shader-render/pointerdriver.h
+++ b/tools/shader-render/pointerdriver.h
@@ -57,16 +57,20 @@ struct PointerDriveOptions
 
     /// Direction of travel, degrees clockwise from screen right (canvas y runs
     /// down, so 90 is downward). The path is a straight line through the canvas
-    /// centre along this heading, which is what makes the director's
-    /// heading-0-vs-135 comparison a one-flag change.
+    /// centre along this heading, so comparing a pack at two headings is a
+    /// one-flag change. That comparison is how a pack that claims to key off the
+    /// direction of travel is checked: render it at 0 and at 135, and the lit
+    /// pixels must differ materially rather than merely rotating a symmetric
+    /// shape.
     double headingDegrees = 0.0;
 
     /// Travel speed along that line, logical px per second.
     double speedPxPerSec = 900.0;
 
-    /// Hold the pointer still at the canvas centre instead of sweeping. This is
-    /// the case that proves a pack still has an axis with no motion to take one
-    /// from, rather than falling back to a circle.
+    /// Hold the pointer still at the canvas centre instead of sweeping, which is
+    /// how a pack is checked with no recent motion for it to read. A pack that
+    /// derives anything from the stroke takes its fallback path here, and a
+    /// hold-driven pack can be exercised without the pointer drifting.
     bool still = false;
 
     /// Seconds at which the button goes down, and comes back up. A negative

--- a/tools/shader-render/pointerdriver.h
+++ b/tools/shader-render/pointerdriver.h
@@ -18,14 +18,6 @@ class ShaderEffect;
 
 namespace PlasmaZones::ShaderRender {
 
-/// The parsed pack, kept by the caller so the renderer can read back what the
-/// pack declared (its vertex stage, its buffers) after installation.
-struct PointerShaderEffectRef
-{
-    PhosphorPointerShaders::PointerShaderEffect effect;
-    bool valid = false;
-};
-
 /**
  * @brief Parse a pointer pack and install it on @p effect the way the settings
  *        preview does.
@@ -39,10 +31,12 @@ struct PointerShaderEffectRef
  * drawing nothing on a frame with no click.
  *
  * Returns false when the pack cannot be parsed, in which case @p effect is left
- * untouched.
+ * untouched. On success @p parsedOut carries the parsed pack, which is what the
+ * caller hands to PointerDriver::applyPackContract so the two agree about the
+ * same parse rather than reading metadata.json twice.
  */
 bool installPointerPack(PhosphorRendering::ShaderEffect& effect, const QString& metadataPath,
-                        PointerShaderEffectRef& parsedOut);
+                        PhosphorPointerShaders::PointerShaderEffect& parsedOut);
 
 /**
  * @brief How the synthetic pointer behaves for a `--pointer` render.
@@ -103,9 +97,10 @@ struct PointerDriveOptions
  * one event per frame would round the ring's spacing up to the frame interval
  * and the trail would not match what ships.
  *
- * The pack's own `reach`, trail window and `needsCursor` are read from its
- * metadata.json, so a render cannot silently disagree with the pack about the
- * damage radius the shader reads back through `pointerReach()`.
+ * The pack's own `reach`, trail window and `needsCursor` come from the parsed
+ * pack through `applyPackContract`, so a render cannot silently disagree with
+ * the pack about the damage radius the shader reads back through
+ * `pointerReach()`.
  */
 class PointerDriver
 {
@@ -114,23 +109,24 @@ public:
     /// logical-to-device ratio the pack will see through `pointerScale()`.
     PointerDriver(const PointerDriveOptions& options, const QSize& canvasDevicePx, double scale);
 
-    /// Read `reach` / `reachParam` / `trailSeconds` / `trailWindowSeconds` /
-    /// `needsCursor` out of the pack at @p metadataPath. Returns false and
-    /// leaves the defaults in place when the file cannot be read, so a render
-    /// still happens rather than aborting.
-    bool loadPackContract(const QString& metadataPath);
+    /// Take the pack's reach, trail window and `needsCursor` from @p effect.
+    ///
+    /// Resolution goes through the pack's own `resolvedReach` /
+    /// `resolvedTrailWindow`, which is what the compositor and the settings
+    /// preview call, so the render cannot disagree with either about the damage
+    /// radius the shader reads back through `pointerReach()` or about how far
+    /// back the ring is spaced. Re-deriving those here from the raw JSON is how
+    /// the two drift: the library caps the reach and clamps the window to the
+    /// pack's liveness, and a hand-rolled copy of that arithmetic silently does
+    /// not. An empty parameter map means every parameter takes its declared
+    /// default, which is exactly what installPointerPack seeds the shader with.
+    void applyPackContract(const PhosphorPointerShaders::PointerShaderEffect& effect);
 
     /// True when the pack asked for the cursor sprite. A caller binds the
     /// sprite image only then, to keep `uPointerFlags.x` honest.
     [[nodiscard]] bool needsCursor() const
     {
         return m_needsCursor;
-    }
-
-    /// The trail window the history was configured with, seconds.
-    [[nodiscard]] double trailWindowSeconds() const
-    {
-        return m_trailWindowSeconds;
     }
 
     /// The synthetic cursor sprite, premultiplied like the real one arrives.
@@ -145,19 +141,16 @@ public:
 
 private:
     /// Pointer position in DEVICE px at @p seconds, in the contract's TOP-DOWN
-    /// space. Pass it through `toCanvas` before it reaches the shader.
+    /// space, which is the space every uniform this driver pushes is expressed
+    /// in. The render target's y runs the other way, and renderer.cpp corrects
+    /// that by flipping the finished frame rather than the uniforms going in;
+    /// the note there says why.
     [[nodiscard]] QPointF positionAt(double seconds) const;
-
-    /// Contract space (top-down) to this tool's bottom-up render canvas. See the
-    /// comment on the definition for why the two differ and why the capture
-    /// flip does not reconcile them.
-    [[nodiscard]] QPointF toCanvas(const QPointF& topDown) const;
 
     PointerDriveOptions m_opts;
     QSize m_canvas;
     double m_scale = 1.0;
     double m_reachLogicalPx = 64.0;
-    double m_trailWindowSeconds = 1.0;
     bool m_needsCursor = false;
 
     PhosphorPointerShaders::PointerHistory m_history;

--- a/tools/shader-render/pointerdriver.h
+++ b/tools/shader-render/pointerdriver.h
@@ -1,0 +1,165 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <PhosphorPointer/PointerHistory.h>
+#include <PhosphorPointer/PointerShaderEffect.h>
+#include <PhosphorPointer/PointerUniformExtension.h>
+
+#include <QImage>
+#include <QPointF>
+#include <QSize>
+#include <QString>
+
+namespace PhosphorRendering {
+class ShaderEffect;
+}
+
+namespace PlasmaZones::ShaderRender {
+
+/// The parsed pack, kept by the caller so the renderer can read back what the
+/// pack declared (its vertex stage, its buffers) after installation.
+struct PointerShaderEffectRef
+{
+    PhosphorPointerShaders::PointerShaderEffect effect;
+    bool valid = false;
+};
+
+/**
+ * @brief Parse a pointer pack and install it on @p effect the way the settings
+ *        preview does.
+ *
+ * A pointer pack is NOT assembled like an overlay pack: its entry point is
+ * `pPointer(vec2)`, its helpers come from its own `shared/` tree, and its
+ * parameter slots are allocated by `PointerShaderRegistry`, whose allocation the
+ * matching `p_<id>` preamble mirrors. Installing the zone scaffold instead
+ * produces a fragment with no `main()` that calls the pack, which links and then
+ * paints nothing — an empty render that looks exactly like a pack correctly
+ * drawing nothing on a frame with no click.
+ *
+ * Returns false when the pack cannot be parsed, in which case @p effect is left
+ * untouched.
+ */
+bool installPointerPack(PhosphorRendering::ShaderEffect& effect, const QString& metadataPath,
+                        PointerShaderEffectRef& parsedOut);
+
+/**
+ * @brief How the synthetic pointer behaves for a `--pointer` render.
+ *
+ * Every length is LOGICAL px and every time is seconds from the first frame,
+ * which is what the CLI takes, so the numbers a caller passes are the numbers
+ * the pack's own parameters are expressed in.
+ */
+struct PointerDriveOptions
+{
+    bool enabled = false;
+
+    /// Direction of travel, degrees clockwise from screen right (canvas y runs
+    /// down, so 90 is downward). The path is a straight line through the canvas
+    /// centre along this heading, which is what makes the director's
+    /// heading-0-vs-135 comparison a one-flag change.
+    double headingDegrees = 0.0;
+
+    /// Travel speed along that line, logical px per second.
+    double speedPxPerSec = 900.0;
+
+    /// Hold the pointer still at the canvas centre instead of sweeping. This is
+    /// the case that proves a pack still has an axis with no motion to take one
+    /// from, rather than falling back to a circle.
+    bool still = false;
+
+    /// Seconds at which the button goes down, and comes back up. A negative
+    /// `releaseAt` leaves the button DOWN for the rest of the render, which is
+    /// how a hold-reading pack's window behaviour is exercised. A negative
+    /// `pressAt` means no click at all.
+    double pressAt = 0.4;
+    double releaseAt = 0.55;
+
+    /// 1 left, 2 right, 3 middle, matching the contract's button codes.
+    int button = 1;
+
+    /// Bind a synthetic arrow as `uCursorSprite` and set `uPointerFlags.x`.
+    /// A `needsCursor` pack samples the sprite, so without this it can only
+    /// show its no-sprite fallback.
+    bool cursorSprite = true;
+
+    /// Drawn size of that arrow, logical px.
+    double cursorSize = 24.0;
+};
+
+/**
+ * @brief Drives `PointerHistory` + `PointerUniformExtension` for a headless
+ *        pointer-pack render.
+ *
+ * The same pair the compositor and the settings preview use, fed a synthetic
+ * event stream instead of a real one. Events are pushed at a mouse-like rate
+ * rather than one per frame, for the reason PointerPreviewController documents:
+ * the sampler decides where a slot lands from the gap since the last event, so
+ * one event per frame would round the ring's spacing up to the frame interval
+ * and the trail would not match what ships.
+ *
+ * The pack's own `reach`, trail window and `needsCursor` are read from its
+ * metadata.json, so a render cannot silently disagree with the pack about the
+ * damage radius the shader reads back through `pointerReach()`.
+ */
+class PointerDriver
+{
+public:
+    /// @p canvasDevicePx is the render target size and @p scale the
+    /// logical-to-device ratio the pack will see through `pointerScale()`.
+    PointerDriver(const PointerDriveOptions& options, const QSize& canvasDevicePx, double scale);
+
+    /// Read `reach` / `reachParam` / `trailSeconds` / `trailWindowSeconds` /
+    /// `needsCursor` out of the pack at @p metadataPath. Returns false and
+    /// leaves the defaults in place when the file cannot be read, so a render
+    /// still happens rather than aborting.
+    bool loadPackContract(const QString& metadataPath);
+
+    /// True when the pack asked for the cursor sprite. A caller binds the
+    /// sprite image only then, to keep `uPointerFlags.x` honest.
+    [[nodiscard]] bool needsCursor() const
+    {
+        return m_needsCursor;
+    }
+
+    /// The trail window the history was configured with, seconds.
+    [[nodiscard]] double trailWindowSeconds() const
+    {
+        return m_trailWindowSeconds;
+    }
+
+    /// The synthetic cursor sprite, premultiplied like the real one arrives.
+    /// Null when `cursorSprite` is off.
+    [[nodiscard]] QImage cursorSprite() const;
+
+    /// Advance the synthetic pointer to frame @p frame and push the resulting
+    /// frame state into @p ext. @p iMouseLogical receives the pointer position
+    /// in LOGICAL px, which is what `setIMouse` takes.
+    void applyFrame(int frame, double fps, PhosphorPointerShaders::PointerUniformExtension& ext,
+                    QPointF& iMouseLogical);
+
+private:
+    /// Pointer position in DEVICE px at @p seconds, in the contract's TOP-DOWN
+    /// space. Pass it through `toCanvas` before it reaches the shader.
+    [[nodiscard]] QPointF positionAt(double seconds) const;
+
+    /// Contract space (top-down) to this tool's bottom-up render canvas. See the
+    /// comment on the definition for why the two differ and why the capture
+    /// flip does not reconcile them.
+    [[nodiscard]] QPointF toCanvas(const QPointF& topDown) const;
+
+    PointerDriveOptions m_opts;
+    QSize m_canvas;
+    double m_scale = 1.0;
+    double m_reachLogicalPx = 64.0;
+    double m_trailWindowSeconds = 1.0;
+    bool m_needsCursor = false;
+
+    PhosphorPointerShaders::PointerHistory m_history;
+    double m_lastSeconds = 0.0;
+    bool m_pressed = false;
+    bool m_seeded = false;
+};
+
+} // namespace PlasmaZones::ShaderRender

--- a/tools/shader-render/renderer.cpp
+++ b/tools/shader-render/renderer.cpp
@@ -645,7 +645,12 @@ int Renderer::render(const RenderOptions& opts)
     // (the whole bundled catalog) fails to compile — no #version, no p_
     // defines — and previews come out as empty frames.
     effect->setEntryScaffold(PlasmaZones::zoneEntryPrologue(), PlasmaZones::zoneEntryCandidates());
-    {
+    // Overlay preamble only. A pointer pack's slots are allocated by
+    // PointerShaderRegistry and installPointerPack pushes that preamble below;
+    // running the overlay parse for it would either warn about a pack it was
+    // never meant to read or compute a preamble that is replaced a few lines
+    // later. Same reason the zone.vert probe above is skipped.
+    if (!opts.pointer.enabled) {
         // Pack dir from the metadata path — NOT from the frag path, which a
         // pack may point into a subdirectory ("fragmentShader": "sub/x.frag"
         // would make the frag-derived dir miss metadata.json entirely).
@@ -717,7 +722,7 @@ int Renderer::render(const RenderOptions& opts)
         // include paths, parameter preamble and vertex stage installed above. Done
         // before the uniform extension so a parse failure leaves the zone path
         // standing rather than half-swapping the two.
-        PointerShaderEffectRef parsed;
+        PhosphorPointerShaders::PointerShaderEffect parsed;
         if (!installPointerPack(*effect, opts.metadataPath, parsed)) {
             qCWarning(lcRenderer) << "pointer pack" << opts.metadata.id
                                   << "could not be installed; refusing to render it as an overlay pack";
@@ -725,7 +730,7 @@ int Renderer::render(const RenderOptions& opts)
         }
         pointerExt = std::make_shared<PhosphorPointerShaders::PointerUniformExtension>();
         pointerDriver = std::make_unique<PointerDriver>(opts.pointer, physicalSize, dpr);
-        pointerDriver->loadPackContract(opts.metadataPath);
+        pointerDriver->applyPackContract(parsed);
         if (pointerDriver->needsCursor()) {
             // SRB binding 7 is uTexture0 for the other families and
             // uCursorSprite for this one, so slot 0 is where the sprite goes.
@@ -766,7 +771,12 @@ int Renderer::render(const RenderOptions& opts)
 
     // Pre-render the labels texture. Many shaders sample uZoneLabels for
     // halo/chroma/text effects — an empty binding makes them silently absent.
-    effect->setLabelsImage(buildLabelsImage(opts.zones, size));
+    // A pointer pack has no uZoneLabels at all (binding 1 is not in its
+    // contract), so it gets the node's 1x1 transparent fallback instead of a
+    // full-resolution image nothing samples.
+    if (!opts.pointer.enabled) {
+        effect->setLabelsImage(buildLabelsImage(opts.zones, size));
+    }
 
     // Overlay seeding only. In pointer mode installPointerPack has already set the
     // source, the buffers and the parameters through the pointer registry's own
@@ -802,7 +812,9 @@ int Renderer::render(const RenderOptions& opts)
         effect->setITime(static_cast<qreal>(i) / opts.fps);
         effect->setITimeDelta(frameInterval);
 
-        if (stillIdx < 0) {
+        // Zone schedule only. In pointer mode the zone extension is not the one
+        // installed, so pushing a new slice into it would reach no shader.
+        if (stillIdx < 0 && !opts.pointer.enabled) {
             applyHighlightSchedule(i, opts.frameCount, runtimeZones, *zoneExt, *effect, lastSlice);
         }
 

--- a/tools/shader-render/renderer.cpp
+++ b/tools/shader-render/renderer.cpp
@@ -621,8 +621,13 @@ int Renderer::render(const RenderOptions& opts)
     window->contentItem()->setSize(QSizeF(size));
 
     const QStringList includePaths = shaderIncludePaths();
-    const QString vertexShaderPath = resolveZoneVertexShader(opts.metadata.vertexShader, includePaths);
-    if (vertexShaderPath.isEmpty()) {
+    // A pointer pack does not use zone.vert: it either declares its own vertex
+    // stage or takes the runtime's built-in fullscreen quad, and installPointerPack
+    // below sets whichever applies. Probing for zone.vert here would only emit a
+    // warning about a file the pack never wanted.
+    const QString vertexShaderPath =
+        opts.pointer.enabled ? QString() : resolveZoneVertexShader(opts.metadata.vertexShader, includePaths);
+    if (!opts.pointer.enabled && vertexShaderPath.isEmpty()) {
         qCWarning(lcRenderer) << "no zone.vert found for shader" << opts.metadata.id
                               << "— neither in the pack dir nor in any include path; previews will fail to link";
     }
@@ -700,6 +705,42 @@ int Renderer::render(const RenderOptions& opts)
             runtimeZones[z].isHighlighted = (z == stillIdx);
     }
 
+    // ── Pointer mode ─────────────────────────────────────────────
+    // A pointer pack reads the POINTER uniform tail and nothing from the zone
+    // extension, and the two cannot both be installed: setUniformExtension
+    // holds one. Built before the zone extension is pushed so the branch below
+    // installs exactly one of them.
+    std::shared_ptr<PhosphorPointerShaders::PointerUniformExtension> pointerExt;
+    std::unique_ptr<PointerDriver> pointerDriver;
+    if (opts.pointer.enabled) {
+        // Re-assemble the fragment the POINTER way, replacing the zone scaffold,
+        // include paths, parameter preamble and vertex stage installed above. Done
+        // before the uniform extension so a parse failure leaves the zone path
+        // standing rather than half-swapping the two.
+        PointerShaderEffectRef parsed;
+        if (!installPointerPack(*effect, opts.metadataPath, parsed)) {
+            qCWarning(lcRenderer) << "pointer pack" << opts.metadata.id
+                                  << "could not be installed; refusing to render it as an overlay pack";
+            return 1;
+        }
+        pointerExt = std::make_shared<PhosphorPointerShaders::PointerUniformExtension>();
+        pointerDriver = std::make_unique<PointerDriver>(opts.pointer, physicalSize, dpr);
+        pointerDriver->loadPackContract(opts.metadataPath);
+        if (pointerDriver->needsCursor()) {
+            // SRB binding 7 is uTexture0 for the other families and
+            // uCursorSprite for this one, so slot 0 is where the sprite goes.
+            // Bound only for a pack that asked for it, because the contract ties
+            // uPointerFlags.x to the sampler actually being bound.
+            const QImage sprite = pointerDriver->cursorSprite();
+            if (!sprite.isNull()) {
+                effect->setUserTexture(0, sprite);
+            } else {
+                qCWarning(lcRenderer) << "pack declares needsCursor but no cursor sprite was built;"
+                                      << "it will render its no-sprite fallback";
+            }
+        }
+    }
+
     zoneExt->updateFromZones(runtimeZones);
     // Push the same scale the daemon's ZoneShaderItem does. It is provably
     // 1.0 today because the render target's DPR is pinned to 1.0 above, which
@@ -711,7 +752,11 @@ int Renderer::render(const RenderOptions& opts)
     if (!zoneExt->setScale(static_cast<float>(dpr))) {
         qCWarning(lcRenderer) << "zone scale" << dpr << "was rejected; previews will use the default 1.0 scale";
     }
-    effect->setUniformExtension(zoneExt);
+    if (pointerExt) {
+        effect->setUniformExtension(pointerExt);
+    } else {
+        effect->setUniformExtension(zoneExt);
+    }
 
     // Initial zone counts. For the cycling schedule, highlightedCount and
     // per-zone isHighlighted flags are updated inside the frame loop — see
@@ -723,7 +768,14 @@ int Renderer::render(const RenderOptions& opts)
     // halo/chroma/text effects — an empty binding makes them silently absent.
     effect->setLabelsImage(buildLabelsImage(opts.zones, size));
 
-    seedShaderEffect(*effect, opts.metadata);
+    // Overlay seeding only. In pointer mode installPointerPack has already set the
+    // source, the buffers and the parameters through the pointer registry's own
+    // slot allocation, and this would overwrite all three with the overlay
+    // spelling — the fragment would come back with no pointer main() and every
+    // p_<id> would read a lane nothing was written to.
+    if (!opts.pointer.enabled) {
+        seedShaderEffect(*effect, opts.metadata);
+    }
 
     // Surface compile failures so a silent empty-frame loop isn't the first
     // sign something went wrong.
@@ -754,6 +806,12 @@ int Renderer::render(const RenderOptions& opts)
             applyHighlightSchedule(i, opts.frameCount, runtimeZones, *zoneExt, *effect, lastSlice);
         }
 
+        if (pointerDriver && pointerExt) {
+            QPointF iMouseLogical;
+            pointerDriver->applyFrame(i, opts.fps, *pointerExt, iMouseLogical);
+            effect->setIMouse(iMouseLogical);
+        }
+
         if (opts.audio) {
             opts.audio->fillFrame(i, opts.fps, spectrum);
             effect->setAudioSpectrum(spectrum);
@@ -771,9 +829,21 @@ int Renderer::render(const RenderOptions& opts)
         control->sync();
         control->render();
 
-        const QImage flipped = captureFrame(control.get(), rhi, colorTex, physicalSize, i);
+        QImage flipped = captureFrame(control.get(), rhi, colorTex, physicalSize, i);
         if (flipped.isNull()) {
             return 1;
+        }
+        // POINTER RENDERS GET ONE MORE FLIP. This path's fragment stage receives
+        // a `uv` whose y runs opposite to the pointer contract's top-down canvas,
+        // so a pack draws its whole world mirrored: positions, and equally its
+        // own sense of up (a sweep that starts at twelve o'clock, a light from
+        // the upper left). Correcting the uniforms on the way in fixes only the
+        // positions and leaves every intrinsic direction inverted, which makes
+        // the render a mirror image that is easy to read as correct. Flipping the
+        // finished frame corrects all of it at once, and the pack is judged the
+        // way the compositor will draw it. Zone renders are unaffected.
+        if (opts.pointer.enabled) {
+            flipped = flipVertical(flipped);
         }
         // Hand the unscaled frame at --resolution to the sink; the sink's
         // writeFrame() resizes to --output-size in one pass (PNG and ffmpeg

--- a/tools/shader-render/renderer.h
+++ b/tools/shader-render/renderer.h
@@ -47,8 +47,9 @@ struct RenderOptions
     /// synthetic pointer and binds the POINTER uniform tail instead of the zone
     /// one: a pointer pack reads nothing from the zone extension, and with no
     /// pointer tail every position uniform is zero, so a click pack correctly
-    /// paints nothing and the render comes out empty. Zones are still loaded and
-    /// drawn under it, so a pack can be judged against real content.
+    /// paints nothing and the render comes out empty. The zone schedule, the
+    /// zone extension and the labels texture are all inert in this mode: the
+    /// pack is the only thing on the canvas, over the window's clear colour.
     PointerDriveOptions pointer;
 };
 

--- a/tools/shader-render/renderer.h
+++ b/tools/shader-render/renderer.h
@@ -7,6 +7,7 @@
 #include "encoder.h"
 #include "layoutloader.h"
 #include "metadataloader.h"
+#include "pointerdriver.h"
 
 #include <QSize>
 #include <QString>
@@ -41,6 +42,14 @@ struct RenderOptions
     /// driving thumbnail capture and the caller wants a deterministic hero
     /// shot. A number that matches nothing warns and falls back to cycling.
     int stillHighlightZone = 0;
+
+    /// Pointer-pack mode. When `pointer.enabled`, the renderer drives a
+    /// synthetic pointer and binds the POINTER uniform tail instead of the zone
+    /// one: a pointer pack reads nothing from the zone extension, and with no
+    /// pointer tail every position uniform is zero, so a click pack correctly
+    /// paints nothing and the render comes out empty. Zones are still loaded and
+    /// drawn under it, so a pack can be judged against real content.
+    PointerDriveOptions pointer;
 };
 
 /**


### PR DESCRIPTION
## The problem

`shader-render` could not exercise the pointer family, and failed in the worst possible way: silently.

Handed a pointer pack, it would load it, render, and report success — while painting nothing. The tool is built for the overlay/zone model, so it installed the **zone** entry scaffold (the fragment was baked with no `main()` calling `pPointer`) and bound the **zone** uniform extension (the whole pointer tail read zero). An empty frame is exactly what a correctly idle click pack looks like, so there was no way to tell the two apart.

The practical effect: every pointer pack was unreviewable offline, and any render-based check run against one would have passed on a blank image.

## What this adds

A `--pointer` mode that drives a synthetic pointer through **the same `PointerHistory` and `PointerUniformExtension` the compositor and the settings preview use**, rather than a second synthetic implementation that could drift from them.

- `installPointerPack()` re-assembles the fragment the pointer way via `PointerShaderRegistry` — include paths, the `p_<id>` preamble, the `pPointer` entry scaffold, the vertex stage and buffer passes. Parameters are seeded through `translatePointerParams`, because the preamble mirrors that slot allocation and the overlay seeding path allocates differently.
- `PointerDriver` walks a straight-line path at a chosen heading and speed, fires press and release edges at the instant they fall rather than on a frame boundary, and feeds events at 250 Hz so the history spaces its ring the way it does on screen. One event per rendered frame would round the spacing up to the frame interval.
- The pack's own `reach`, `reachParam`, trail window and `needsCursor` are read from its metadata, so a render cannot disagree with the pack about the damage radius it reads back through `pointerReach()`.
- A synthetic cursor sprite is bound at SRB binding 7 for a `needsCursor` pack, so the sprite path is exercised rather than only its no-sprite fallback.

## The orientation flip

Pointer renders get one extra vertical flip, and the reasoning is worth stating because the obvious fix is wrong.

This path's fragment stage receives a `uv` whose y runs opposite to the contract's top-down canvas, so a pack draws its whole world mirrored. Correcting the position uniforms on the way in fixes **only** the positions. A pack's own sense of up lives in its source (a sweep starting at twelve o'clock, a light from the upper left), and no amount of moving uniforms corrects that. The result is a mirror image that reads as correct, which is worse than an obviously broken one. Flipping the finished frame corrects all of it at once. Zone renders are untouched.

Verified both ways: a pack whose arc sweeps from twelve o'clock renders starting at twelve, and a pack drawn at the live cursor with a downward heading lands below centre.

## New flags

`--pointer`, `--pointer-heading`, `--pointer-speed`, `--pointer-still`, `--press-at`, `--release-at`, `--pointer-button`, `--no-cursor-sprite`, `--cursor-size`. `--pointer` also defaults `--shader-dir` to `data/pointer`.

```
plasmazones-shader-render --pointer -s click-ripple --press-at 0.2 --release-at 0.35 -o /tmp/ripple.png
```

A negative `--release-at` leaves the button down for the rest of the render, which is how a hold-reading pack's repaint-window behaviour gets exercised.

## Testing

- Builds clean, zero warnings.
- `ctest -R "shader_validate|shader_render"` passes 6 of 6.
- `scripts/check-conventions.py` clean.
- Rendered shipped packs through the new path and confirmed non-empty output that begins at the press, rather than trusting the exit code.

## Not covered

No new unit test. `loadPackContract()` is pure parsing and is worth one; the orientation behaviour needs a GPU and is not reachable from the headless suite. Flagging it rather than leaving it implied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P4YSmvgBqrFdeRJpxv9VsL
